### PR TITLE
Refactor: eliminate code duplication and use stdlib helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Extract duplicated `status_code_suffix` and `status_code_to_int_pattern` into shared `oaspec/util/http` module
+- Replace hand-rolled `list_last` and `list_length` helpers with `gleam/list` stdlib equivalents
+- Simplify CLI flag parsing with `result.unwrap` instead of verbose case expressions
+
 ## [0.3.0] - 2026-04-08
 
 ### Changed

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -2,6 +2,7 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/option.{Some}
+import gleam/result
 import glint
 import oaspec/codegen/context
 import oaspec/codegen/validate
@@ -47,20 +48,9 @@ fn generate_command() -> glint.Command(Nil) {
       "Generate Gleam code from an OpenAPI specification",
       fn() {
         glint.command(fn(_named_args, _args, flags) {
-          let config_path = case config_path(flags) {
-            Ok(p) -> p
-            Error(_) -> "./oaspec.yaml"
-          }
-
-          let mode_str = case mode(flags) {
-            Ok(m) -> m
-            Error(_) -> "both"
-          }
-
-          let output_str = case output(flags) {
-            Ok(o) -> o
-            Error(_) -> ""
-          }
+          let config_path = config_path(flags) |> result.unwrap("./oaspec.yaml")
+          let mode_str = mode(flags) |> result.unwrap("both")
+          let output_str = output(flags) |> result.unwrap("")
 
           run_generate(config_path, mode_str, output_str)
         })

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -225,7 +225,7 @@ fn run_generate(
       io.println("")
       io.println(
         "Successfully generated "
-        <> int.to_string(list_length(files))
+        <> int.to_string(list.length(files))
         <> " files",
       )
     }
@@ -239,11 +239,3 @@ fn run_generate(
 /// Exit the process with a status code.
 @external(erlang, "erlang", "halt")
 fn halt(code: Int) -> Nil
-
-/// Get list length.
-fn list_length(items: List(a)) -> Int {
-  case items {
-    [] -> 0
-    [_, ..rest] -> 1 + list_length(rest)
-  }
-}

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -9,6 +9,7 @@ import oaspec/openapi/schema.{
   Inline, IntegerSchema, NumberSchema, Reference, StringSchema,
 }
 import oaspec/openapi/spec
+import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
 
@@ -621,14 +622,14 @@ fn generate_client_function(
         "response_types."
         <> naming.schema_to_type_name(op_id)
         <> "Response"
-        <> status_code_suffix(status_code)
+        <> http.status_code_suffix(status_code)
       let content_entries = dict.to_list(response.content)
       case content_entries {
         [] ->
           sb
           |> se.indent(
             4,
-            status_code_to_int_pattern(status_code)
+            http.status_code_to_int_pattern(status_code)
               <> " -> Ok("
               <> variant_name
               <> ")",
@@ -641,7 +642,7 @@ fn generate_client_function(
               sb
               |> se.indent(
                 4,
-                status_code_to_int_pattern(status_code) <> " -> {",
+                http.status_code_to_int_pattern(status_code) <> " -> {",
               )
               |> se.indent(5, "case " <> decode_expr <> " {")
               |> se.indent(
@@ -659,7 +660,7 @@ fn generate_client_function(
               sb
               |> se.indent(
                 4,
-                status_code_to_int_pattern(status_code)
+                http.status_code_to_int_pattern(status_code)
                   <> " -> Ok("
                   <> variant_name
                   <> ")",
@@ -896,35 +897,9 @@ fn get_response_decode_expr(
         "decode_"
         <> naming.to_snake_case(op_id)
         <> "_response_"
-        <> naming.to_snake_case(status_code_suffix(status_code))
+        <> naming.to_snake_case(http.status_code_suffix(status_code))
       "decode." <> fn_name <> "(resp.body)"
     }
-  }
-}
-
-/// Get a status code suffix for type names.
-fn status_code_suffix(code: String) -> String {
-  case code {
-    "200" -> "Ok"
-    "201" -> "Created"
-    "204" -> "NoContent"
-    "400" -> "BadRequest"
-    "401" -> "Unauthorized"
-    "403" -> "Forbidden"
-    "404" -> "NotFound"
-    "409" -> "Conflict"
-    "422" -> "UnprocessableEntity"
-    "500" -> "InternalServerError"
-    "default" -> "Default"
-    other -> "Status" <> other
-  }
-}
-
-/// Convert a status code string to an int pattern for case matching.
-fn status_code_to_int_pattern(code: String) -> String {
-  case code {
-    "default" -> "_"
-    _ -> code
   }
 }
 

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -11,6 +11,7 @@ import oaspec/openapi/schema.{
   Reference, StringSchema,
 }
 import oaspec/openapi/spec
+import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
 
@@ -131,7 +132,7 @@ fn generate_anonymous_response_decoders(
       [#(_, media_type), ..] ->
         case media_type.schema {
           Some(Inline(schema_obj)) -> {
-            let suffix = "Response" <> status_code_suffix(status_code)
+            let suffix = "Response" <> http.status_code_suffix(status_code)
             generate_anonymous_schema_decoder(
               sb,
               op_id,
@@ -188,24 +189,6 @@ fn generate_anonymous_schema_decoder(
   let name = naming.to_snake_case(op_id) <> "_" <> naming.to_snake_case(suffix)
   let schema_ref = Inline(schema_obj)
   generate_decoder(sb, name, schema_ref, ctx)
-}
-
-/// Status code suffix for anonymous type naming (shared with types.gleam).
-fn status_code_suffix(code: String) -> String {
-  case code {
-    "200" -> "Ok"
-    "201" -> "Created"
-    "204" -> "NoContent"
-    "400" -> "BadRequest"
-    "401" -> "Unauthorized"
-    "403" -> "Forbidden"
-    "404" -> "NotFound"
-    "409" -> "Conflict"
-    "422" -> "UnprocessableEntity"
-    "500" -> "InternalServerError"
-    "default" -> "Default"
-    other -> "Status" <> other
-  }
 }
 
 /// Generate inline enum decoders found in object/allOf properties.

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -10,6 +10,7 @@ import oaspec/openapi/schema.{
   Reference, StringSchema,
 }
 import oaspec/openapi/spec
+import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
 
@@ -332,7 +333,7 @@ fn generate_anonymous_response_types(
             generate_anonymous_type_for_schema(
               sb,
               op_id,
-              "Response" <> status_code_suffix(status_code),
+              "Response" <> http.status_code_suffix(status_code),
               schema_obj,
               ctx,
             )
@@ -474,24 +475,6 @@ fn generate_anonymous_type_for_schema(
       generate_schema_type(sb, type_name, raw_name, merged_schema, ctx)
     }
     _ -> sb
-  }
-}
-
-/// Get a status code suffix for anonymous type names.
-fn status_code_suffix(code: String) -> String {
-  case code {
-    "200" -> "Ok"
-    "201" -> "Created"
-    "204" -> "NoContent"
-    "400" -> "BadRequest"
-    "401" -> "Unauthorized"
-    "403" -> "Forbidden"
-    "404" -> "NotFound"
-    "409" -> "Conflict"
-    "422" -> "UnprocessableEntity"
-    "500" -> "InternalServerError"
-    "default" -> "Default"
-    other -> "Status" <> other
   }
 }
 
@@ -785,7 +768,8 @@ fn generate_response_type(
             [#(_media_type, media_type), ..] ->
               case media_type.schema {
                 Some(ref) -> {
-                  let suffix = "Response" <> status_code_suffix(status_code)
+                  let suffix =
+                    "Response" <> http.status_code_suffix(status_code)
                   let inner_type =
                     schema_ref_to_type_qualified(ref, op_id, suffix, ctx)
                   sb
@@ -806,21 +790,7 @@ fn generate_response_type(
 /// Convert an HTTP status code to a Gleam variant name.
 /// Prefixed with the type name to avoid duplicate constructors across types.
 fn status_code_to_variant(code: String, type_name: String) -> String {
-  let suffix = case code {
-    "200" -> "Ok"
-    "201" -> "Created"
-    "204" -> "NoContent"
-    "400" -> "BadRequest"
-    "401" -> "Unauthorized"
-    "403" -> "Forbidden"
-    "404" -> "NotFound"
-    "409" -> "Conflict"
-    "422" -> "UnprocessableEntity"
-    "500" -> "InternalServerError"
-    "default" -> "Default"
-    other -> "Status" <> other
-  }
-  type_name <> suffix
+  type_name <> http.status_code_suffix(code)
 }
 
 /// Collect all operations from the spec with their IDs, paths, and methods.

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
@@ -169,15 +170,8 @@ pub fn validate_output_package_match(config: Config) -> Result(Nil, ConfigError)
 fn basename(path: String) -> String {
   path
   |> string.split("/")
-  |> list_last
-}
-
-fn list_last(items: List(String)) -> String {
-  case items {
-    [] -> ""
-    [last] -> last
-    [_, ..rest] -> list_last(rest)
-  }
+  |> list.last
+  |> result.unwrap("")
 }
 
 /// Convert config error to a human-readable string.

--- a/src/oaspec/openapi/resolver.gleam
+++ b/src/oaspec/openapi/resolver.gleam
@@ -21,7 +21,7 @@ pub type ResolveError {
 pub fn ref_to_name(ref: String) -> String {
   ref
   |> string.split("/")
-  |> list_last
+  |> list.last
   |> result.unwrap("Unknown")
 }
 
@@ -137,13 +137,4 @@ fn resolve_one_ref(schema_ref: SchemaRef, spec: OpenApiSpec) -> SchemaRef {
 /// Map a list of schema refs, resolving each.
 fn list_map_ref(refs: List(SchemaRef), spec: OpenApiSpec) -> List(SchemaRef) {
   list.map(refs, fn(r) { resolve_one_ref(r, spec) })
-}
-
-/// Get the last element of a list.
-fn list_last(items: List(String)) -> Result(String, Nil) {
-  case items {
-    [] -> Error(Nil)
-    [last] -> Ok(last)
-    [_, ..rest] -> list_last(rest)
-  }
 }

--- a/src/oaspec/util/http.gleam
+++ b/src/oaspec/util/http.gleam
@@ -1,0 +1,28 @@
+/// Shared HTTP status code utilities for code generation.
+/// Get a human-readable suffix for a given HTTP status code.
+/// Used to build anonymous type names like "ListPetsResponseOk".
+pub fn status_code_suffix(code: String) -> String {
+  case code {
+    "200" -> "Ok"
+    "201" -> "Created"
+    "204" -> "NoContent"
+    "400" -> "BadRequest"
+    "401" -> "Unauthorized"
+    "403" -> "Forbidden"
+    "404" -> "NotFound"
+    "409" -> "Conflict"
+    "422" -> "UnprocessableEntity"
+    "500" -> "InternalServerError"
+    "default" -> "Default"
+    other -> "Status" <> other
+  }
+}
+
+/// Convert a status code string to an integer pattern for case matching.
+/// The "default" status maps to "_" (catch-all).
+pub fn status_code_to_int_pattern(code: String) -> String {
+  case code {
+    "default" -> "_"
+    _ -> code
+  }
+}


### PR DESCRIPTION
## Summary

- Extract duplicated `status_code_suffix` and `status_code_to_int_pattern` functions (copied across 3 modules) into a new shared `oaspec/util/http` module
- Replace hand-rolled `list_last` and `list_length` helpers with `list.last` and `list.length` from the Gleam standard library
- Simplify CLI flag parsing by replacing verbose `case` expressions with `result.unwrap`

Net result: **-69 lines** (58 added, 127 removed) with no behavioral changes.

## Changes

| Commit | Description |
|--------|-------------|
| `9289aee` | Extract `status_code_suffix` / `status_code_to_int_pattern` into `util/http.gleam` |
| `dd2cd9b` | Replace `list_last` / `list_length` with `gleam/list` stdlib |
| `7b54cb3` | Simplify flag parsing with `result.unwrap` |
| `95ba054` | Update CHANGELOG |

## Test plan

- [x] `just all` passes (format, typecheck, build, unit tests, shellspec, integration tests, escript)
- [x] No new dependencies added
- [x] Generated code output is unchanged (verified via integration tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog documenting recent internal refactoring improvements.

* **Refactor**
  * Consolidated duplicate HTTP status code helper functions scattered across multiple modules into a centralized shared utility for improved code consistency and maintainability.
  * Replaced custom list utilities with standard library equivalents throughout the codebase.
  * Simplified CLI flag parsing by leveraging standard library functions instead of verbose pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->