### PR TITLE
enforce support format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,40 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-#### Architecture (Phase 0)
-- Schema hoisting pre-processing pass: inline complex schemas (objects, allOf, oneOf, anyOf, complex array items) are auto-extracted to `components.schemas` with `$ref` references
-- Name collision auto-resolution: property names, enum variants, and function/type names get `_2`, `_3` suffixes instead of hard errors
 - `ContentType` type abstraction for extensible content type handling
-
-#### High-impact features (Phase 1)
-- Array parameters in query/header/cookie: generates `List(T)` types with comma-separated serialization
+- Schema hoisting pre-processing pass: inline complex schemas auto-extracted to `components.schemas` with `$ref` references
 - Percent-encoding for all path/query/cookie parameter values via `uri.percent_encode`
 - `text/plain` response content type: body returned as `String` directly without JSON decoding
-
-#### Core features (Phase 2)
-- Typed `additionalProperties`: generates `Dict(String, T)` fields with dict decoder/encoder
-- Untyped `additionalProperties: true`: generates `Dict(String, Dynamic)` (decode-only)
-- `multipart/form-data` request bodies with boundary-based multipart encoding
-
-#### Extensions (Phase 3)
-- `style: deepObject` query parameters with flattened key serialization (`filter[status]=active`)
-- Complex schema parameters (object/allOf/oneOf/anyOf) serialized as JSON strings in query params
-- OAuth2 security schemes parsed and applied as Bearer token headers
-- `apiKey` in cookie position: generates cookie headers
-
-#### Low-priority items (Phase 4)
+- Typed `additionalProperties`: generates `Dict(String, T)` fields with dict decoder/encoder (known keys excluded from dict)
+- Untyped `additionalProperties: true`: generates `Dict(String, Dynamic)` (decode-only, known keys excluded)
+- `multipart/form-data` request bodies with boundary-based multipart encoding (optional fields handled)
+- `apiKey` in cookie position: generates cookie headers (appends, does not overwrite)
 - HTTP Basic and Digest authentication support
 - Validation constraint guard functions (minLength, maxLength, minimum, maximum, minItems, maxItems)
-- Callbacks safely ignored by the generator
-- allOf with non-object sub-schemas: primitives silently skipped
+- Validation for unsupported HTTP security schemes (e.g. hoba, negotiate) and OAuth2
+
+### Fixed
+
+- Guard generation: missing `gleam/list` import, incomplete min+max checks, float validation stub
+- Typed `additionalProperties` decoder no longer forces value decoder on known fields with incompatible types
+- `multipart/form-data` client handles optional fields with case/Some/None instead of raw concatenation
+- `allOf` merge now preserves `additionalProperties` from sub-schemas
+- Cookie `apiKey` auth appends to existing cookie header instead of overwriting
+- `text/plain` response types always use `String` regardless of schema type
 
 ### Changed
 
 - Extract duplicated `status_code_suffix` and `status_code_to_int_pattern` into shared `oaspec/util/http` module
 - Replace hand-rolled `list_last` and `list_length` helpers with `gleam/list` stdlib equivalents
 - Simplify CLI flag parsing with `result.unwrap` instead of verbose case expressions
-- Property name, enum variant, and function/type name collisions now auto-resolved instead of hard errors
-- Validation for unsupported features significantly reduced (most patterns now supported)
 
 ## [0.3.0] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-08
+
 ### Added
 
 - `ContentType` type abstraction for extensible content type handling
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `text/plain` response content type: body returned as `String` directly without JSON decoding
 - Typed `additionalProperties`: generates `Dict(String, T)` fields with dict decoder/encoder (known keys excluded from dict)
 - Untyped `additionalProperties: true`: generates `Dict(String, Dynamic)` (decode-only, known keys excluded)
-- `multipart/form-data` request bodies with boundary-based multipart encoding (optional fields handled)
+- `multipart/form-data` request bodies with boundary-based multipart encoding
 - `apiKey` in cookie position: generates cookie headers (appends, does not overwrite)
 - HTTP Basic and Digest authentication support
 - Validation constraint guard functions (minLength, maxLength, minimum, maximum, minItems, maxItems)
@@ -25,10 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Guard generation: missing `gleam/list` import, incomplete min+max checks, float validation stub
 - Typed `additionalProperties` decoder no longer forces value decoder on known fields with incompatible types
-- `multipart/form-data` client handles optional fields with case/Some/None instead of raw concatenation
+- Typed `additionalProperties` decoder now fails on invalid extra values instead of silently dropping them
+- `multipart/form-data` client handles optional fields and scalar `$ref` fields instead of raw concatenation
+- `multipart/form-data` validation rejects unstringifiable object-like fields before code generation
 - `allOf` merge now preserves `additionalProperties` from sub-schemas
 - Cookie `apiKey` auth appends to existing cookie header instead of overwriting
 - `text/plain` response types always use `String` regardless of schema type
+- Referenced unsupported parameter schemas are rejected during validation
+- Hoisted schema names avoid collisions after case normalization
+- `text/plain` request bodies are rejected during validation
+- `just all` no longer emits `BASH_ENV` shell warnings or integration `todo` warnings
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+#### Architecture (Phase 0)
+- Schema hoisting pre-processing pass: inline complex schemas (objects, allOf, oneOf, anyOf, complex array items) are auto-extracted to `components.schemas` with `$ref` references
+- Name collision auto-resolution: property names, enum variants, and function/type names get `_2`, `_3` suffixes instead of hard errors
+- `ContentType` type abstraction for extensible content type handling
+
+#### High-impact features (Phase 1)
+- Array parameters in query/header/cookie: generates `List(T)` types with comma-separated serialization
+- Percent-encoding for all path/query/cookie parameter values via `uri.percent_encode`
+- `text/plain` response content type: body returned as `String` directly without JSON decoding
+
+#### Core features (Phase 2)
+- Typed `additionalProperties`: generates `Dict(String, T)` fields with dict decoder/encoder
+- Untyped `additionalProperties: true`: generates `Dict(String, Dynamic)` (decode-only)
+- `multipart/form-data` request bodies with boundary-based multipart encoding
+
+#### Extensions (Phase 3)
+- `style: deepObject` query parameters with flattened key serialization (`filter[status]=active`)
+- Complex schema parameters (object/allOf/oneOf/anyOf) serialized as JSON strings in query params
+- OAuth2 security schemes parsed and applied as Bearer token headers
+- `apiKey` in cookie position: generates cookie headers
+
+#### Low-priority items (Phase 4)
+- HTTP Basic and Digest authentication support
+- Validation constraint guard functions (minLength, maxLength, minimum, maximum, minItems, maxItems)
+- Callbacks safely ignored by the generator
+- allOf with non-object sub-schemas: primitives silently skipped
+
 ### Changed
 
 - Extract duplicated `status_code_suffix` and `status_code_to_int_pattern` into shared `oaspec/util/http` module
 - Replace hand-rolled `list_last` and `list_length` helpers with `gleam/list` stdlib equivalents
 - Simplify CLI flag parsing with `result.unwrap` instead of verbose case expressions
+- Property name, enum variant, and function/type name collisions now auto-resolved instead of hard errors
+- Validation for unsupported features significantly reduced (most patterns now supported)
 
 ## [0.3.0] - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - Client typed body (auto-encoded) and typed response (auto-decoded)
 - `default` response handling in client
 - Top-level security inheritance (operation-level overrides, `security: []` opts out)
-- Security schemes: `apiKey` in header/query/cookie, HTTP bearer (first OR alternative applied; AND within one alternative supported)
+- Security schemes: `apiKey` in header/query/cookie, HTTP bearer/basic/digest (first OR alternative applied; AND within one alternative supported)
 - `text/plain` response content type: body returned as `String` directly
 - Typed `additionalProperties`: `Dict(String, T)` with dict decoder/encoder (known keys excluded)
 - Untyped `additionalProperties: true`: `Dict(String, Dynamic)` (decode-only, known keys excluded)
-- `multipart/form-data` request bodies with boundary-based encoding
+- `multipart/form-data` request bodies with boundary-based encoding (optional fields handled)
 - Validation constraint guards (minLength, maxLength, minimum, maximum, minItems, maxItems)
 - Duplicate operationId detection
 - Function/type name collision detection after case conversion
@@ -214,7 +214,6 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 These are detected before code generation. The generator prints an error and exits non-zero.
 
 - `style: deepObject` query parameters
-- `multipart/form-data` request bodies (only `application/json`)
 - Inline oneOf/anyOf schemas (variants must be `$ref`)
 - Nested inline object/allOf in properties (use `$ref`)
 - Array parameters (query/header/cookie with `type: array`)
@@ -231,8 +230,8 @@ These are detected before code generation. The generator prints an error and exi
 
 - Validation constraints enforcement at runtime (guards are generated but not auto-called)
 - Callbacks: ignored by the generator
-- OAuth2 / OpenID Connect: rejected at parse time
-- HTTP Basic / Digest: rejected at parse time (only bearer supported)
+- OAuth2 / OpenID Connect: rejected at validation time
+- Unsupported HTTP security schemes (e.g. hoba, negotiate): rejected at validation time
 - allOf with non-object sub-schemas
 - `additionalProperties` with inline complex schemas
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,21 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - Client typed body (auto-encoded) and typed response (auto-decoded)
 - `default` response handling in client
 - Top-level security inheritance (operation-level overrides, `security: []` opts out)
-- Security schemes: `apiKey` in header/query, HTTP bearer (first OR alternative applied; AND within one alternative supported)
+- Security schemes: `apiKey` in header/query/cookie, HTTP bearer/basic/digest, OAuth2 (first OR alternative applied; AND within one alternative supported)
+- Schema hoisting: inline complex schemas auto-extracted to `components.schemas` with `$ref`
+- Name collision auto-resolution: property names, enum variants, function/type names get `_2`, `_3` suffixes
+- Array parameters (query/header/cookie with `type: array`): `List(T)` with comma-separated serialization
+- Percent-encoding for path/query/cookie parameter values via `uri.percent_encode`
+- `text/plain` response content type: body returned as `String` directly
+- Typed `additionalProperties`: `Dict(String, T)` with dict decoder/encoder
+- Untyped `additionalProperties: true`: `Dict(String, Dynamic)` (decode-only)
+- `multipart/form-data` request bodies with boundary-based encoding
+- `style: deepObject` query parameters with flattened key serialization (`filter[status]=active`)
+- Complex schema parameters (object/allOf/oneOf/anyOf in query/header/cookie): JSON-serialized
+- Validation constraint guards (minLength, maxLength, minimum, maximum, minItems, maxItems)
+- Callbacks: safely ignored by the generator
+- allOf with non-object sub-schemas: primitives silently skipped
 - Duplicate operationId detection
-- Function/type name collision detection after case conversion
 - Config validation: output directory basename must match package name
 - Gleam keyword escaping in generated field names
 
@@ -205,32 +217,8 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 
 These are detected before code generation. The generator prints an error and exits non-zero.
 
-- `style: deepObject` query parameters
-- `multipart/form-data` request bodies (only `application/json`)
-- `additionalProperties: true` (untyped map)
-- Typed `additionalProperties`
-- Inline oneOf/anyOf schemas (variants must be `$ref`)
-- Nested inline object/allOf in properties (use `$ref`)
-- Array parameters (query/header/cookie with `type: array`)
-- Complex schema parameters (object/allOf/oneOf/anyOf in query/header/cookie)
-- Inline complex array items (object/allOf/oneOf/anyOf; use `$ref`)
-- Duplicate operationId
-- Function/type name collisions after case conversion
-- Property name collisions after snake_case conversion
-- Enum variant collisions after PascalCase conversion
-- Non-JSON response content types (only `application/json`)
-- Path parameters with `required: false`
-
-### Not yet supported
-
-- Percent-encoding for path/query/cookie parameter values: values are inserted as-is; reserved characters may break URLs
-- Validation constraints (minLength, maxLength, pattern, minimum, maximum): parsed but not enforced
-- Callbacks: ignored by the generator
-- OAuth2 / OpenID Connect: rejected at parse time
-- `apiKey` in cookie: rejected at parse time
-- HTTP Basic / Digest: rejected at parse time (only bearer supported)
-- allOf with non-object sub-schemas
-- `text/plain` and other non-JSON response types
+- Duplicate operationId (OpenAPI spec violation)
+- Path parameters with `required: false` (OpenAPI spec requires `required: true`)
 
 ### Schema-to-type mapping
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - Paths and operations (GET, POST, PUT, DELETE, PATCH)
 - Path, query, header, cookie parameters (path-level merged by `(name, in)`)
 - Parameter serialization for Bool, Float, Int, String, `$ref` enum types
+- Percent-encoding for path/query/cookie parameter values via `uri.percent_encode`
 - Cookie parameters combined into single header
 - Request bodies with `$ref` resolution (typed, auto-encoded)
 - allOf in request body (property merging from `$ref` + inline objects)
@@ -195,21 +196,16 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - Client typed body (auto-encoded) and typed response (auto-decoded)
 - `default` response handling in client
 - Top-level security inheritance (operation-level overrides, `security: []` opts out)
-- Security schemes: `apiKey` in header/query/cookie, HTTP bearer/basic/digest, OAuth2 (first OR alternative applied; AND within one alternative supported)
-- Schema hoisting: inline complex schemas auto-extracted to `components.schemas` with `$ref`
-- Name collision auto-resolution: property names, enum variants, function/type names get `_2`, `_3` suffixes
-- Array parameters (query/header/cookie with `type: array`): `List(T)` with comma-separated serialization
-- Percent-encoding for path/query/cookie parameter values via `uri.percent_encode`
+- Security schemes: `apiKey` in header/query/cookie, HTTP bearer (first OR alternative applied; AND within one alternative supported)
 - `text/plain` response content type: body returned as `String` directly
-- Typed `additionalProperties`: `Dict(String, T)` with dict decoder/encoder
-- Untyped `additionalProperties: true`: `Dict(String, Dynamic)` (decode-only)
+- Typed `additionalProperties`: `Dict(String, T)` with dict decoder/encoder (known keys excluded)
+- Untyped `additionalProperties: true`: `Dict(String, Dynamic)` (decode-only, known keys excluded)
 - `multipart/form-data` request bodies with boundary-based encoding
-- `style: deepObject` query parameters with flattened key serialization (`filter[status]=active`)
-- Complex schema parameters (object/allOf/oneOf/anyOf in query/header/cookie): JSON-serialized
 - Validation constraint guards (minLength, maxLength, minimum, maximum, minItems, maxItems)
-- Callbacks: safely ignored by the generator
-- allOf with non-object sub-schemas: primitives silently skipped
 - Duplicate operationId detection
+- Function/type name collision detection after case conversion
+- Property name collision detection after snake_case conversion
+- Enum variant collision detection after PascalCase conversion
 - Config validation: output directory basename must match package name
 - Gleam keyword escaping in generated field names
 
@@ -217,8 +213,28 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 
 These are detected before code generation. The generator prints an error and exits non-zero.
 
-- Duplicate operationId (OpenAPI spec violation)
-- Path parameters with `required: false` (OpenAPI spec requires `required: true`)
+- `style: deepObject` query parameters
+- `multipart/form-data` request bodies (only `application/json`)
+- Inline oneOf/anyOf schemas (variants must be `$ref`)
+- Nested inline object/allOf in properties (use `$ref`)
+- Array parameters (query/header/cookie with `type: array`)
+- Complex schema parameters (object/allOf/oneOf/anyOf in query/header/cookie)
+- Inline complex array items (object/allOf/oneOf/anyOf; use `$ref`)
+- Duplicate operationId
+- Function/type name collisions after case conversion
+- Property name collisions after snake_case conversion
+- Enum variant collisions after PascalCase conversion
+- Non-JSON response content types (only `application/json` and `text/plain`)
+- Path parameters with `required: false`
+
+### Not yet supported
+
+- Validation constraints enforcement at runtime (guards are generated but not auto-called)
+- Callbacks: ignored by the generator
+- OAuth2 / OpenID Connect: rejected at parse time
+- HTTP Basic / Digest: rejected at parse time (only bearer supported)
+- allOf with non-object sub-schemas
+- `additionalProperties` with inline complex schemas
 
 ### Schema-to-type mapping
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ These are detected before code generation. The generator prints an error and exi
 - Inline oneOf/anyOf schemas (variants must be `$ref`)
 - Nested inline object/allOf in properties (use `$ref`)
 - Array parameters (query/header/cookie with `type: array`)
-- Complex schema parameters (object/allOf/oneOf/anyOf in query/header/cookie)
+- Complex schema parameters (object/allOf/oneOf/anyOf in path/query/header/cookie)
 - Inline complex array items (object/allOf/oneOf/anyOf; use `$ref`)
 - Duplicate operationId
 - Function/type name collisions after case conversion
@@ -231,10 +231,11 @@ These are detected before code generation. The generator prints an error and exi
 
 - Validation constraints enforcement at runtime (guards are generated but not auto-called)
 - Callbacks: ignored by the generator
-- OAuth2 / OpenID Connect: rejected at validation time
+- OAuth2: rejected at validation time
+- OpenID Connect: rejected at parse time
 - Unsupported HTTP security schemes (e.g. hoba, negotiate): rejected at validation time
-- allOf with non-object sub-schemas
-- `additionalProperties` with inline complex schemas
+- `allOf` merge only supports object sub-schemas (non-object entries are ignored)
+- `additionalProperties` with inline complex schemas is not handled explicitly; use primitives or `$ref`
 
 ### Schema-to-type mapping
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Gleam code from OpenAPI 3.x specifications.
 - Server handler stubs
 - Client SDK with parameter serialization and response decoding
 - Middleware (logging, retry)
-- Security scheme support (apiKey header/query, Bearer token)
+- Security scheme support (`apiKey` header/query/cookie, HTTP bearer/basic/digest)
 - OpenAPI descriptions as doc comments
 
 ## Install
@@ -176,7 +176,7 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - Parameter serialization for Bool, Float, Int, String, `$ref` enum types
 - Percent-encoding for path/query/cookie parameter values via `uri.percent_encode`
 - Cookie parameters combined into single header
-- Request bodies with `$ref` resolution (typed, auto-encoded)
+- `application/json` request bodies with `$ref` resolution (typed, auto-encoded)
 - allOf in request body (property merging from `$ref` + inline objects)
 - Responses with status codes, `$ref` responses from `components.responses`
 - `$ref` resolution for parameters, requestBodies, responses, schemas
@@ -200,7 +200,7 @@ pub fn retry(max_retries: Int) -> Middleware(req, res)
 - `text/plain` response content type: body returned as `String` directly
 - Typed `additionalProperties`: `Dict(String, T)` with dict decoder/encoder (known keys excluded)
 - Untyped `additionalProperties: true`: `Dict(String, Dynamic)` (decode-only, known keys excluded)
-- `multipart/form-data` request bodies with boundary-based encoding (optional fields handled)
+- `multipart/form-data` request bodies with boundary-based encoding for string/integer/number/boolean/binary/string-enum fields (optional fields handled)
 - Validation constraint guards (minLength, maxLength, minimum, maximum, minItems, maxItems)
 - Duplicate operationId detection
 - Function/type name collision detection after case conversion
@@ -223,6 +223,7 @@ These are detected before code generation. The generator prints an error and exi
 - Function/type name collisions after case conversion
 - Property name collisions after snake_case conversion
 - Enum variant collisions after PascalCase conversion
+- Non-JSON/non-multipart request body content types (only `application/json` and `multipart/form-data`)
 - Non-JSON response content types (only `application/json` and `text/plain`)
 - Path parameters with `required: false`
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "oaspec"
-version = "0.3.0"
+version = "0.4.0"
 target = "erlang"
 description = "Generate Gleam code from OpenAPI 3.x specifications"
 licences = ["MIT"]

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -203,17 +203,17 @@ import api/response_types
 
 pub fn get_user(req: request_types.GetUserRequest) -> response_types.GetUserResponse {
   let _ = req
-  todo
+  panic as "complex_test stub"
 }
 
 pub fn post_search(req: request_types.PostSearchRequest) -> response_types.PostSearchResponse {
   let _ = req
-  todo
+  panic as "complex_test stub"
 }
 
 pub fn post_webhook(req: request_types.PostWebhookRequest) -> response_types.PostWebhookResponse {
   let _ = req
-  todo
+  panic as "complex_test stub"
 }
 GLEAM_EOF
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set shell := ["bash", "-cu"]
+set shell := ["sh", "-cu"]
 
 default:
   @just --list

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -34,7 +34,7 @@ Describe 'oaspec generate'
       When run generate --config=test/fixtures/oaspec.yaml
       The status should be success
       The output should include 'Successfully generated'
-      The output should include '15 files'
+      The output should include '17 files'
     End
   End
 
@@ -316,17 +316,8 @@ Describe 'oaspec generate'
       The output should include 'deepObject'
     End
 
-    It 'reports multipart/form-data as unsupported'
-      When run generate --config=test/fixtures/broken-oaspec.yaml
-      The status should be failure
-      The output should include 'multipart/form-data'
-    End
-
-    It 'reports additionalProperties as unsupported'
-      When run generate --config=test/fixtures/broken-oaspec.yaml
-      The status should be failure
-      The output should include 'additionalProperties'
-    End
+    # multipart/form-data and additionalProperties are now supported,
+    # so they are no longer reported as unsupported.
 
     It 'reports inline oneOf primitives as unsupported'
       When run generate --config=test/fixtures/broken-oaspec.yaml
@@ -375,7 +366,7 @@ Describe 'oaspec generate'
     # Inline object in response
 
     It 'generates anonymous type for inline response object'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchResponseOk {'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchResponse200 {'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'results: Option(List(User))'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'total: Option(Int)'
     End
@@ -383,15 +374,15 @@ Describe 'oaspec generate'
     # oneOf with $ref in response
 
     It 'generates oneOf type with $ref variants'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type GetUserResponseOk {'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponseOkAdminUser(AdminUser)'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponseOkRegularUser(RegularUser)'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type GetUserResponse200 {'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponse200AdminUser(AdminUser)'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponse200RegularUser(RegularUser)'
     End
 
     # allOf merged requestBody
 
     It 'generates merged allOf type for request body'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchRequestBody {'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchRequest {'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'page: Option(Int)'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'query: Option(String)'
     End
@@ -399,14 +390,14 @@ Describe 'oaspec generate'
     # Response types reference anonymous types
 
     It 'response types reference anonymous types correctly'
-      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'PostSearchResponseOk(types.PostSearchResponseOk)'
-      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'GetUserResponseOk(types.GetUserResponseOk)'
+      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'PostSearchResponseOk(types.PostSearchResponse200)'
+      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'GetUserResponseOk(types.GetUserResponse200)'
     End
 
     # Request types reference merged allOf type
 
     It 'request types reference merged allOf body type'
-      The contents of file "$TEST_OUTPUT_DIR/api/request_types.gleam" should include 'body: types.PostSearchRequestBody'
+      The contents of file "$TEST_OUTPUT_DIR/api/request_types.gleam" should include 'body: types.PostSearchRequest'
     End
   End
 End

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -8,6 +8,7 @@ import oaspec/codegen/context
 import oaspec/codegen/validate
 import oaspec/codegen/writer
 import oaspec/config
+import oaspec/openapi/hoist
 import oaspec/openapi/parser
 import simplifile
 
@@ -189,6 +190,9 @@ fn run_generate(
   }
 
   io.println("Spec loaded: " <> spec.info.title <> " v" <> spec.info.version)
+
+  // Hoist inline complex schemas into components.schemas
+  let spec = hoist.hoist(spec)
 
   // Create generation context
   let ctx = context.new(spec, cfg)

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -929,6 +929,14 @@ fn param_to_string_expr(
           <> param_name
           <> ")"
         }
+        Ok(schema.ArraySchema(items:, ..)) -> {
+          let item_to_str = array_item_to_string_fn(items, ctx)
+          "string.join(list.map("
+          <> param_name
+          <> ", "
+          <> item_to_str
+          <> "), \",\")"
+        }
         Ok(IntegerSchema(..)) -> "int.to_string(" <> param_name <> ")"
         Ok(NumberSchema(..)) -> "float.to_string(" <> param_name <> ")"
         Ok(schema.BooleanSchema(..)) -> "bool.to_string(" <> param_name <> ")"
@@ -964,6 +972,10 @@ fn to_str_for_optional_value(param: spec.Parameter, ctx: Context) -> String {
         Ok(StringSchema(enum_values:, ..)) if enum_values != [] -> {
           let name = resolver.ref_to_name(ref)
           "encode.encode_" <> naming.to_snake_case(name) <> "_to_string(v)"
+        }
+        Ok(schema.ArraySchema(items:, ..)) -> {
+          let item_to_str = array_item_to_string_fn(items, ctx)
+          "string.join(list.map(v, " <> item_to_str <> "), \",\")"
         }
         Ok(IntegerSchema(..)) -> "int.to_string(v)"
         Ok(NumberSchema(..)) -> "float.to_string(v)"

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -44,6 +44,13 @@ fn generate_client(ctx: Context) -> String {
         _ -> False
       }
     })
+  let needs_list =
+    list.any(all_params, fn(p) {
+      case p.schema {
+        Some(Inline(schema.ArraySchema(..))) -> True
+        _ -> False
+      }
+    })
 
   // dyn_decode + json needed for inline primitive response decoding
   let needs_dyn_decode =
@@ -184,6 +191,10 @@ fn generate_client(ctx: Context) -> String {
   }
   let imports = case needs_float {
     True -> ["gleam/float", ..imports]
+    False -> imports
+  }
+  let imports = case needs_list {
+    True -> ["gleam/list", ..imports]
     False -> imports
   }
 
@@ -736,6 +747,18 @@ fn param_to_type(param: spec.Parameter, _ctx: Context) -> String {
     Some(Inline(IntegerSchema(..))) -> "Int"
     Some(Inline(schema.NumberSchema(..))) -> "Float"
     Some(Inline(schema.BooleanSchema(..))) -> "Bool"
+    Some(Inline(schema.ArraySchema(items:, ..))) -> {
+      let item_type = case items {
+        Inline(StringSchema(..)) -> "String"
+        Inline(IntegerSchema(..)) -> "Int"
+        Inline(schema.NumberSchema(..)) -> "Float"
+        Inline(schema.BooleanSchema(..)) -> "Bool"
+        Reference(ref:) ->
+          "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
+        _ -> "String"
+      }
+      "List(" <> item_type <> ")"
+    }
     Some(Reference(ref:)) ->
       "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
     _ -> "String"
@@ -757,6 +780,14 @@ fn param_to_string_expr(
     Some(Inline(NumberSchema(..))) -> "float.to_string(" <> param_name <> ")"
     Some(Inline(schema.BooleanSchema(..))) ->
       "bool.to_string(" <> param_name <> ")"
+    Some(Inline(schema.ArraySchema(items:, ..))) -> {
+      let item_to_str = array_item_to_string_fn(items, ctx)
+      "string.join(list.map("
+      <> param_name
+      <> ", "
+      <> item_to_str
+      <> "), \",\")"
+    }
     Some(Reference(ref:) as schema_ref) -> {
       // Resolve the $ref to determine the actual schema type
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
@@ -794,6 +825,10 @@ fn to_str_for_optional_value(param: spec.Parameter, ctx: Context) -> String {
     Some(Inline(IntegerSchema(..))) -> "int.to_string(v)"
     Some(Inline(NumberSchema(..))) -> "float.to_string(v)"
     Some(Inline(schema.BooleanSchema(..))) -> "bool.to_string(v)"
+    Some(Inline(schema.ArraySchema(items:, ..))) -> {
+      let item_to_str = array_item_to_string_fn(items, ctx)
+      "string.join(list.map(v, " <> item_to_str <> "), \",\")"
+    }
     Some(Reference(ref:) as schema_ref) -> {
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
         Ok(StringSchema(enum_values:, ..)) if enum_values != [] -> {
@@ -913,5 +948,33 @@ fn inline_schema_to_decoder(s: schema.SchemaObject) -> String {
     schema.NumberSchema(..) -> "dyn_decode.float"
     schema.BooleanSchema(..) -> "dyn_decode.bool"
     _ -> "dyn_decode.string"
+  }
+}
+
+/// Return a function expression that converts an array item to String.
+/// Used in generated code: `list.map(param, <fn>)`.
+fn array_item_to_string_fn(
+  items: schema.SchemaRef,
+  ctx: Context,
+) -> String {
+  case items {
+    Inline(IntegerSchema(..)) -> "int.to_string"
+    Inline(NumberSchema(..)) -> "float.to_string"
+    Inline(schema.BooleanSchema(..)) -> "bool.to_string"
+    Inline(StringSchema(..)) -> "fn(x) { x }"
+    Reference(ref:) -> {
+      case resolver.resolve_schema_ref(items, ctx.spec) {
+        Ok(StringSchema(enum_values:, ..)) if enum_values != [] -> {
+          let name = resolver.ref_to_name(ref)
+          "encode.encode_" <> naming.to_snake_case(name) <> "_to_string"
+        }
+        Ok(IntegerSchema(..)) -> "int.to_string"
+        Ok(NumberSchema(..)) -> "float.to_string"
+        Ok(schema.BooleanSchema(..)) -> "bool.to_string"
+        Ok(StringSchema(..)) -> "fn(x) { x }"
+        _ -> "fn(x) { x }"
+      }
+    }
+    _ -> "fn(x) { x }"
   }
 }

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -59,14 +59,19 @@ fn generate_client(ctx: Context) -> String {
       list.any(dict.to_list(operation.responses), fn(entry) {
         let #(_, response) = entry
         list.any(dict.to_list(response.content), fn(ce) {
-          let #(_, mt) = ce
-          case mt.schema {
-            Some(Inline(schema.ArraySchema(items: Inline(_), ..))) -> True
-            Some(Inline(schema.StringSchema(..))) -> True
-            Some(Inline(schema.IntegerSchema(..))) -> True
-            Some(Inline(schema.NumberSchema(..))) -> True
-            Some(Inline(schema.BooleanSchema(..))) -> True
-            _ -> False
+          let #(media_type_name, mt) = ce
+          // text/plain responses don't need dyn_decode (body returned directly)
+          case media_type_name {
+            "text/plain" -> False
+            _ ->
+              case mt.schema {
+                Some(Inline(schema.ArraySchema(items: Inline(_), ..))) -> True
+                Some(Inline(schema.StringSchema(..))) -> True
+                Some(Inline(schema.IntegerSchema(..))) -> True
+                Some(Inline(schema.NumberSchema(..))) -> True
+                Some(Inline(schema.BooleanSchema(..))) -> True
+                _ -> False
+              }
           }
         })
       })
@@ -195,6 +200,17 @@ fn generate_client(ctx: Context) -> String {
   }
   let imports = case needs_list {
     True -> ["gleam/list", ..imports]
+    False -> imports
+  }
+
+  // uri module needed for percent-encoding parameter values
+  let needs_uri =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      !list.is_empty(operation.parameters)
+    })
+  let imports = case needs_uri {
+    True -> ["gleam/uri", ..imports]
     False -> imports
   }
 
@@ -381,9 +397,9 @@ fn generate_client_function(
         1,
         "let path = string.replace(path, \"{"
           <> p.name
-          <> "}\", "
+          <> "}\", uri.percent_encode("
           <> to_string_expr
-          <> ")",
+          <> "))",
       )
     })
 
@@ -403,9 +419,9 @@ fn generate_client_function(
                 1,
                 "let query_parts = [\""
                   <> p.name
-                  <> "=\" <> "
+                  <> "=\" <> uri.percent_encode("
                   <> to_str
-                  <> ", ..query_parts]",
+                  <> "), ..query_parts]",
               )
             }
             False -> {
@@ -416,9 +432,9 @@ fn generate_client_function(
                 2,
                 "Some(v) -> [\""
                   <> p.name
-                  <> "=\" <> "
+                  <> "=\" <> uri.percent_encode("
                   <> to_str
-                  <> ", ..query_parts]",
+                  <> "), ..query_parts]",
               )
               |> se.indent(2, "None -> query_parts")
               |> se.indent(1, "}")
@@ -519,9 +535,9 @@ fn generate_client_function(
                 1,
                 "let cookie_parts = [\""
                   <> p.name
-                  <> "=\" <> "
+                  <> "=\" <> uri.percent_encode("
                   <> to_str
-                  <> ", ..cookie_parts]",
+                  <> "), ..cookie_parts]",
               )
             }
             False -> {
@@ -532,9 +548,9 @@ fn generate_client_function(
                 2,
                 "Some(v) -> [\""
                   <> p.name
-                  <> "=\" <> "
+                  <> "=\" <> uri.percent_encode("
                   <> to_str
-                  <> ", ..cookie_parts]",
+                  <> "), ..cookie_parts]",
               )
               |> se.indent(2, "None -> cookie_parts")
               |> se.indent(1, "}")
@@ -645,37 +661,68 @@ fn generate_client_function(
               <> variant_name
               <> ")",
           )
-        [#(_media_type, media_type), ..] ->
-          case media_type.schema {
-            Some(schema_ref) -> {
-              let decode_expr =
-                get_response_decode_expr(schema_ref, op_id, status_code, ctx)
-              sb
-              |> se.indent(
-                4,
-                http.status_code_to_int_pattern(status_code) <> " -> {",
-              )
-              |> se.indent(5, "case " <> decode_expr <> " {")
-              |> se.indent(
-                6,
-                "Ok(decoded) -> Ok(" <> variant_name <> "(decoded))",
-              )
-              |> se.indent(
-                6,
-                "Error(_) -> Error(DecodeError(detail: \"Failed to decode response body\"))",
-              )
-              |> se.indent(5, "}")
-              |> se.indent(4, "}")
-            }
+        [#(media_type_name, media_type), ..] ->
+          case media_type_name {
+            // text/plain responses: return the body string directly
+            "text/plain" ->
+              case media_type.schema {
+                Some(_) ->
+                  sb
+                  |> se.indent(
+                    4,
+                    http.status_code_to_int_pattern(status_code)
+                      <> " -> Ok("
+                      <> variant_name
+                      <> "(resp.body))",
+                  )
+                _ ->
+                  sb
+                  |> se.indent(
+                    4,
+                    http.status_code_to_int_pattern(status_code)
+                      <> " -> Ok("
+                      <> variant_name
+                      <> ")",
+                  )
+              }
+            // JSON and other content types: decode the response body
             _ ->
-              sb
-              |> se.indent(
-                4,
-                http.status_code_to_int_pattern(status_code)
-                  <> " -> Ok("
-                  <> variant_name
-                  <> ")",
-              )
+              case media_type.schema {
+                Some(schema_ref) -> {
+                  let decode_expr =
+                    get_response_decode_expr(
+                      schema_ref,
+                      op_id,
+                      status_code,
+                      ctx,
+                    )
+                  sb
+                  |> se.indent(
+                    4,
+                    http.status_code_to_int_pattern(status_code) <> " -> {",
+                  )
+                  |> se.indent(5, "case " <> decode_expr <> " {")
+                  |> se.indent(
+                    6,
+                    "Ok(decoded) -> Ok(" <> variant_name <> "(decoded))",
+                  )
+                  |> se.indent(
+                    6,
+                    "Error(_) -> Error(DecodeError(detail: \"Failed to decode response body\"))",
+                  )
+                  |> se.indent(5, "}")
+                  |> se.indent(4, "}")
+                }
+                _ ->
+                  sb
+                  |> se.indent(
+                    4,
+                    http.status_code_to_int_pattern(status_code)
+                      <> " -> Ok("
+                      <> variant_name
+                      <> ")",
+                  )
+              }
           }
       }
     })

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -6,7 +6,8 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/types as type_gen
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
-  Inline, IntegerSchema, NumberSchema, Reference, StringSchema,
+  AllOfSchema, AnyOfSchema, Inline, IntegerSchema, NumberSchema, ObjectSchema,
+  OneOfSchema, Reference, StringSchema,
 }
 import oaspec/openapi/spec
 import oaspec/util/http
@@ -422,34 +423,42 @@ fn generate_client_function(
       let sb =
         list.fold(query_params, sb, fn(sb, p) {
           let param_name = naming.to_snake_case(p.name)
-          case p.required {
-            True -> {
-              let to_str = to_str_for_required(p, param_name, ctx)
-              sb
-              |> se.indent(
-                1,
-                "let query_parts = [\""
-                  <> p.name
-                  <> "=\" <> uri.percent_encode("
-                  <> to_str
-                  <> "), ..query_parts]",
-              )
-            }
-            False -> {
-              let to_str = to_str_for_optional_value(p, ctx)
-              sb
-              |> se.indent(1, "let query_parts = case " <> param_name <> " {")
-              |> se.indent(
-                2,
-                "Some(v) -> [\""
-                  <> p.name
-                  <> "=\" <> uri.percent_encode("
-                  <> to_str
-                  <> "), ..query_parts]",
-              )
-              |> se.indent(2, "None -> query_parts")
-              |> se.indent(1, "}")
-            }
+          // deepObject style with ObjectSchema: generate flattened key serialization
+          case is_deep_object_param(p) {
+            True -> build_deep_object_query_parts(sb, p, param_name)
+            False ->
+              case p.required {
+                True -> {
+                  let to_str = to_str_for_required(p, param_name, ctx)
+                  sb
+                  |> se.indent(
+                    1,
+                    "let query_parts = [\""
+                      <> p.name
+                      <> "=\" <> uri.percent_encode("
+                      <> to_str
+                      <> "), ..query_parts]",
+                  )
+                }
+                False -> {
+                  let to_str = to_str_for_optional_value(p, ctx)
+                  sb
+                  |> se.indent(
+                    1,
+                    "let query_parts = case " <> param_name <> " {",
+                  )
+                  |> se.indent(
+                    2,
+                    "Some(v) -> [\""
+                      <> p.name
+                      <> "=\" <> uri.percent_encode("
+                      <> to_str
+                      <> "), ..query_parts]",
+                  )
+                  |> se.indent(2, "None -> query_parts")
+                  |> se.indent(1, "}")
+                }
+              }
           }
         })
       let sb =
@@ -636,7 +645,19 @@ fn generate_client_function(
               |> se.indent(2, "}")
               |> se.indent(2, "None -> req")
               |> se.indent(1, "}")
-            Ok(spec.HttpScheme(scheme: "bearer", ..)) ->
+            Ok(spec.ApiKeyScheme(name: cookie_name, in_: "cookie")) ->
+              sb
+              |> se.indent(1, "let req = case config." <> field_name <> " {")
+              |> se.indent(
+                2,
+                "Some(value) -> request.set_header(req, \"cookie\", \""
+                  <> cookie_name
+                  <> "=\" <> value)",
+              )
+              |> se.indent(2, "None -> req")
+              |> se.indent(1, "}")
+            Ok(spec.HttpScheme(scheme: "bearer", ..))
+            | Ok(spec.OAuth2Scheme(..)) ->
               sb
               |> se.indent(1, "let req = case config." <> field_name <> " {")
               |> se.indent(
@@ -809,7 +830,7 @@ fn build_param_list(
 }
 
 /// Convert a parameter to its Gleam type string.
-fn param_to_type(param: spec.Parameter, _ctx: Context) -> String {
+fn param_to_type(param: spec.Parameter, ctx: Context) -> String {
   let base = case param.schema {
     Some(Inline(StringSchema(..))) -> "String"
     Some(Inline(IntegerSchema(..))) -> "Int"
@@ -827,6 +848,15 @@ fn param_to_type(param: spec.Parameter, _ctx: Context) -> String {
       }
       "List(" <> item_type <> ")"
     }
+    // Object schema parameters (used by deepObject style or JSON-serialized)
+    Some(Inline(ObjectSchema(..))) -> "String"
+    // Complex schema parameters: resolve allOf/oneOf/anyOf to get type name
+    Some(Inline(AllOfSchema(schemas:, ..))) ->
+      resolve_complex_param_type(schemas, ctx)
+    Some(Inline(OneOfSchema(schemas:, ..))) ->
+      resolve_complex_param_type(schemas, ctx)
+    Some(Inline(AnyOfSchema(schemas:, ..))) ->
+      resolve_complex_param_type(schemas, ctx)
     Some(Reference(ref:)) ->
       "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
     _ -> "String"
@@ -834,6 +864,52 @@ fn param_to_type(param: spec.Parameter, _ctx: Context) -> String {
   case param.required {
     True -> base
     False -> "Option(" <> base <> ")"
+  }
+}
+
+/// Resolve the type name for a complex schema parameter (allOf/oneOf/anyOf).
+/// If the first sub-schema is a $ref, use its type name; otherwise fallback to String.
+fn resolve_complex_param_type(
+  schemas: List(schema.SchemaRef),
+  _ctx: Context,
+) -> String {
+  case schemas {
+    [Reference(ref:), ..] ->
+      "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
+    _ -> "String"
+  }
+}
+
+/// Check if a parameter uses deepObject style with an object schema.
+fn is_deep_object_param(param: spec.Parameter) -> Bool {
+  case param.style, param.schema {
+    Some("deepObject"), Some(Inline(ObjectSchema(..))) -> True
+    _, _ -> False
+  }
+}
+
+/// Build query parts for a deepObject-style parameter.
+/// The parameter is typed as String and should contain pre-serialized
+/// deep object query parts (e.g. "filter[status]=active&filter[type]=dog").
+/// The value is appended directly to query_parts without adding a key= prefix.
+fn build_deep_object_query_parts(
+  sb: se.StringBuilder,
+  param: spec.Parameter,
+  param_name: String,
+) -> se.StringBuilder {
+  case param.required {
+    True ->
+      sb
+      |> se.indent(
+        1,
+        "let query_parts = [" <> param_name <> ", ..query_parts]",
+      )
+    False ->
+      sb
+      |> se.indent(1, "let query_parts = case " <> param_name <> " {")
+      |> se.indent(2, "Some(v) -> [v, ..query_parts]")
+      |> se.indent(2, "None -> query_parts")
+      |> se.indent(1, "}")
   }
 }
 

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -1038,22 +1038,24 @@ fn generate_multipart_body(
 ) -> se.StringBuilder {
   let boundary = "----oaspec-boundary"
   let content_entries = dict.to_list(rb.content)
-  let properties = case content_entries {
+  let #(properties, required_fields) = case content_entries {
     [#(_, media_type), ..] ->
       case media_type.schema {
-        Some(Inline(schema.ObjectSchema(properties:, ..))) ->
-          dict.to_list(properties)
+        Some(Inline(schema.ObjectSchema(properties:, required:, ..))) -> #(
+          dict.to_list(properties),
+          required,
+        )
         Some(Reference(ref:) as schema_ref) ->
           case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-            Ok(schema.ObjectSchema(properties:, ..)) -> {
+            Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
               let _ = ref
-              dict.to_list(properties)
+              #(dict.to_list(properties), required)
             }
-            _ -> []
+            _ -> #([], [])
           }
-        _ -> []
+        _ -> #([], [])
       }
-    _ -> []
+    _ -> #([], [])
   }
 
   let sb =
@@ -1065,46 +1067,71 @@ fn generate_multipart_body(
     list.fold(properties, sb, fn(sb, prop) {
       let #(field_name, field_schema) = prop
       let gleam_field = naming.to_snake_case(field_name)
+      let is_required = list.contains(required_fields, field_name)
       let is_binary = case field_schema {
         Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
         _ -> False
       }
-      let value_expr = case is_binary {
-        True -> "body." <> gleam_field
+      // Convert value to string for multipart encoding
+      let to_string_fn = case is_binary {
+        True -> ""
         False ->
           case field_schema {
-            Inline(schema.IntegerSchema(..)) ->
-              "int.to_string(body." <> gleam_field <> ")"
-            Inline(schema.NumberSchema(..)) ->
-              "float.to_string(body." <> gleam_field <> ")"
-            Inline(schema.BooleanSchema(..)) ->
-              "bool.to_string(body." <> gleam_field <> ")"
-            _ -> "body." <> gleam_field
+            Inline(schema.IntegerSchema(..)) -> "int.to_string"
+            Inline(schema.NumberSchema(..)) -> "float.to_string"
+            Inline(schema.BooleanSchema(..)) -> "bool.to_string"
+            _ -> ""
           }
       }
-      case is_binary {
-        True ->
+      let part_header_binary =
+        "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+        <> field_name
+        <> "\\\"; filename=\\\""
+        <> field_name
+        <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\""
+      let part_header_text =
+        "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+        <> field_name
+        <> "\\\"\\r\\n\\r\\n\""
+      let part_header = case is_binary {
+        True -> part_header_binary
+        False -> part_header_text
+      }
+      case is_required {
+        True -> {
+          let value_expr = case to_string_fn {
+            "" -> "body." <> gleam_field
+            fn_name -> fn_name <> "(body." <> gleam_field <> ")"
+          }
           sb
           |> se.indent(
             1,
-            "let parts = [\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
-              <> field_name
-              <> "\\\"; filename=\\\""
-              <> field_name
-              <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\" <> "
+            "let parts = ["
+              <> part_header
+              <> " <> "
               <> value_expr
               <> " <> \"\\r\\n\", ..parts]",
           )
-        False ->
+        }
+        False -> {
+          // Optional field: wrap in case body.<field> { Some(v) -> ... None -> parts }
+          let value_expr = case to_string_fn {
+            "" -> "v"
+            fn_name -> fn_name <> "(v)"
+          }
           sb
+          |> se.indent(1, "let parts = case body." <> gleam_field <> " {")
           |> se.indent(
-            1,
-            "let parts = [\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
-              <> field_name
-              <> "\\\"\\r\\n\\r\\n\" <> "
+            2,
+            "Some(v) -> ["
+              <> part_header
+              <> " <> "
               <> value_expr
               <> " <> \"\\r\\n\", ..parts]",
           )
+          |> se.indent(2, "None -> parts")
+          |> se.indent(1, "}")
+        }
       }
     })
 

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -226,6 +226,29 @@ fn generate_client(ctx: Context) -> String {
     False -> imports
   }
 
+  // result module needed for cookie-based apiKey security (reading existing cookie header)
+  let has_cookie_api_key = case ctx.spec.components {
+    Some(c) ->
+      list.any(dict.to_list(c.security_schemes), fn(entry) {
+        case entry {
+          #(_, spec.ApiKeyScheme(in_: "cookie", ..)) -> True
+          _ -> False
+        }
+      })
+    _ -> False
+  }
+  let imports = case has_cookie_api_key {
+    True -> {
+      // Need gleam/list for list.key_find and gleam/result for result.unwrap
+      let imports = case needs_list {
+        True -> imports
+        False -> ["gleam/list", ..imports]
+      }
+      ["gleam/result", ..imports]
+    }
+    False -> imports
+  }
+
   let sb =
     se.file_header(context.version)
     |> se.imports(imports)
@@ -648,12 +671,18 @@ fn generate_client_function(
             Ok(spec.ApiKeyScheme(name: cookie_name, in_: "cookie")) ->
               sb
               |> se.indent(1, "let req = case config." <> field_name <> " {")
+              |> se.indent(2, "Some(value) -> {")
               |> se.indent(
-                2,
-                "Some(value) -> request.set_header(req, \"cookie\", \""
-                  <> cookie_name
-                  <> "=\" <> value)",
+                3,
+                "let existing = list.key_find(req.headers, \"cookie\") |> result.unwrap(\"\")",
               )
+              |> se.indent(3, "let cookie_val = \"" <> cookie_name <> "=\" <> value")
+              |> se.indent(3, "let new_cookie = case existing {")
+              |> se.indent(4, "\"\" -> cookie_val")
+              |> se.indent(4, "_ -> existing <> \"; \" <> cookie_val")
+              |> se.indent(3, "}")
+              |> se.indent(3, "request.set_header(req, \"cookie\", new_cookie)")
+              |> se.indent(2, "}")
               |> se.indent(2, "None -> req")
               |> se.indent(1, "}")
             Ok(spec.HttpScheme(scheme: "basic", ..)) ->

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -6,8 +6,7 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/types as type_gen
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
-  AllOfSchema, AnyOfSchema, Inline, IntegerSchema, NumberSchema, ObjectSchema,
-  OneOfSchema, Reference, StringSchema,
+  Inline, IntegerSchema, NumberSchema, Reference, StringSchema,
 }
 import oaspec/openapi/spec
 import oaspec/util/http
@@ -446,42 +445,37 @@ fn generate_client_function(
       let sb =
         list.fold(query_params, sb, fn(sb, p) {
           let param_name = naming.to_snake_case(p.name)
-          // deepObject style with ObjectSchema: generate flattened key serialization
-          case is_deep_object_param(p) {
-            True -> build_deep_object_query_parts(sb, p, param_name)
-            False ->
-              case p.required {
-                True -> {
-                  let to_str = to_str_for_required(p, param_name, ctx)
-                  sb
-                  |> se.indent(
-                    1,
-                    "let query_parts = [\""
-                      <> p.name
-                      <> "=\" <> uri.percent_encode("
-                      <> to_str
-                      <> "), ..query_parts]",
-                  )
-                }
-                False -> {
-                  let to_str = to_str_for_optional_value(p, ctx)
-                  sb
-                  |> se.indent(
-                    1,
-                    "let query_parts = case " <> param_name <> " {",
-                  )
-                  |> se.indent(
-                    2,
-                    "Some(v) -> [\""
-                      <> p.name
-                      <> "=\" <> uri.percent_encode("
-                      <> to_str
-                      <> "), ..query_parts]",
-                  )
-                  |> se.indent(2, "None -> query_parts")
-                  |> se.indent(1, "}")
-                }
-              }
+          case p.required {
+            True -> {
+              let to_str = to_str_for_required(p, param_name, ctx)
+              sb
+              |> se.indent(
+                1,
+                "let query_parts = [\""
+                  <> p.name
+                  <> "=\" <> uri.percent_encode("
+                  <> to_str
+                  <> "), ..query_parts]",
+              )
+            }
+            False -> {
+              let to_str = to_str_for_optional_value(p, ctx)
+              sb
+              |> se.indent(
+                1,
+                "let query_parts = case " <> param_name <> " {",
+              )
+              |> se.indent(
+                2,
+                "Some(v) -> [\""
+                  <> p.name
+                  <> "=\" <> uri.percent_encode("
+                  <> to_str
+                  <> "), ..query_parts]",
+              )
+              |> se.indent(2, "None -> query_parts")
+              |> se.indent(1, "}")
+            }
           }
         })
       let sb =
@@ -877,7 +871,7 @@ fn build_param_list(
 }
 
 /// Convert a parameter to its Gleam type string.
-fn param_to_type(param: spec.Parameter, ctx: Context) -> String {
+fn param_to_type(param: spec.Parameter, _ctx: Context) -> String {
   let base = case param.schema {
     Some(Inline(StringSchema(..))) -> "String"
     Some(Inline(IntegerSchema(..))) -> "Int"
@@ -895,15 +889,6 @@ fn param_to_type(param: spec.Parameter, ctx: Context) -> String {
       }
       "List(" <> item_type <> ")"
     }
-    // Object schema parameters (used by deepObject style or JSON-serialized)
-    Some(Inline(ObjectSchema(..))) -> "String"
-    // Complex schema parameters: resolve allOf/oneOf/anyOf to get type name
-    Some(Inline(AllOfSchema(schemas:, ..))) ->
-      resolve_complex_param_type(schemas, ctx)
-    Some(Inline(OneOfSchema(schemas:, ..))) ->
-      resolve_complex_param_type(schemas, ctx)
-    Some(Inline(AnyOfSchema(schemas:, ..))) ->
-      resolve_complex_param_type(schemas, ctx)
     Some(Reference(ref:)) ->
       "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
     _ -> "String"
@@ -911,52 +896,6 @@ fn param_to_type(param: spec.Parameter, ctx: Context) -> String {
   case param.required {
     True -> base
     False -> "Option(" <> base <> ")"
-  }
-}
-
-/// Resolve the type name for a complex schema parameter (allOf/oneOf/anyOf).
-/// If the first sub-schema is a $ref, use its type name; otherwise fallback to String.
-fn resolve_complex_param_type(
-  schemas: List(schema.SchemaRef),
-  _ctx: Context,
-) -> String {
-  case schemas {
-    [Reference(ref:), ..] ->
-      "types." <> naming.schema_to_type_name(resolver.ref_to_name(ref))
-    _ -> "String"
-  }
-}
-
-/// Check if a parameter uses deepObject style with an object schema.
-fn is_deep_object_param(param: spec.Parameter) -> Bool {
-  case param.style, param.schema {
-    Some("deepObject"), Some(Inline(ObjectSchema(..))) -> True
-    _, _ -> False
-  }
-}
-
-/// Build query parts for a deepObject-style parameter.
-/// The parameter is typed as String and should contain pre-serialized
-/// deep object query parts (e.g. "filter[status]=active&filter[type]=dog").
-/// The value is appended directly to query_parts without adding a key= prefix.
-fn build_deep_object_query_parts(
-  sb: se.StringBuilder,
-  param: spec.Parameter,
-  param_name: String,
-) -> se.StringBuilder {
-  case param.required {
-    True ->
-      sb
-      |> se.indent(
-        1,
-        "let query_parts = [" <> param_name <> ", ..query_parts]",
-      )
-    False ->
-      sb
-      |> se.indent(1, "let query_parts = case " <> param_name <> " {")
-      |> se.indent(2, "Some(v) -> [v, ..query_parts]")
-      |> se.indent(2, "None -> query_parts")
-      |> se.indent(1, "}")
   }
 }
 

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -1080,20 +1080,11 @@ fn generate_multipart_body(
       let #(field_name, field_schema) = prop
       let gleam_field = naming.to_snake_case(field_name)
       let is_required = list.contains(required_fields, field_name)
-      let is_binary = case field_schema {
-        Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
-        _ -> False
-      }
+      let is_binary = multipart_field_is_binary(field_schema, ctx)
       // Convert value to string for multipart encoding
       let to_string_fn = case is_binary {
         True -> ""
-        False ->
-          case field_schema {
-            Inline(schema.IntegerSchema(..)) -> "int.to_string"
-            Inline(schema.NumberSchema(..)) -> "float.to_string"
-            Inline(schema.BooleanSchema(..)) -> "bool.to_string"
-            _ -> ""
-          }
+        False -> multipart_field_to_string_fn(field_schema, ctx)
       }
       let part_header_binary =
         "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
@@ -1157,6 +1148,44 @@ fn generate_multipart_body(
     "let req = request.set_header(req, \"content-type\", \"multipart/form-data; boundary=\" <> boundary)",
   )
   |> se.indent(1, "let req = request.set_body(req, body_str)")
+}
+
+fn multipart_field_is_binary(
+  field_schema: schema.SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case field_schema {
+    Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
+    Reference(_) as schema_ref ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema.StringSchema(format: Some("binary"), ..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
+}
+
+fn multipart_field_to_string_fn(
+  field_schema: schema.SchemaRef,
+  ctx: Context,
+) -> String {
+  case field_schema {
+    Inline(schema.IntegerSchema(..)) -> "int.to_string"
+    Inline(schema.NumberSchema(..)) -> "float.to_string"
+    Inline(schema.BooleanSchema(..)) -> "bool.to_string"
+    Reference(ref:) as schema_ref ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema.StringSchema(enum_values:, ..)) if enum_values != [] -> {
+          let name = resolver.ref_to_name(ref)
+          "encode.encode_" <> naming.to_snake_case(name) <> "_to_string"
+        }
+        Ok(schema.IntegerSchema(..)) -> "int.to_string"
+        Ok(schema.NumberSchema(..)) -> "float.to_string"
+        Ok(schema.BooleanSchema(..)) -> "bool.to_string"
+        _ -> ""
+      }
+    _ -> ""
+  }
 }
 
 /// Get the decode expression for a response body.

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -461,10 +461,7 @@ fn generate_client_function(
             False -> {
               let to_str = to_str_for_optional_value(p, ctx)
               sb
-              |> se.indent(
-                1,
-                "let query_parts = case " <> param_name <> " {",
-              )
+              |> se.indent(1, "let query_parts = case " <> param_name <> " {")
               |> se.indent(
                 2,
                 "Some(v) -> [\""
@@ -670,7 +667,10 @@ fn generate_client_function(
                 3,
                 "let existing = list.key_find(req.headers, \"cookie\") |> result.unwrap(\"\")",
               )
-              |> se.indent(3, "let cookie_val = \"" <> cookie_name <> "=\" <> value")
+              |> se.indent(
+                3,
+                "let cookie_val = \"" <> cookie_name <> "=\" <> value",
+              )
               |> se.indent(3, "let new_cookie = case existing {")
               |> se.indent(4, "\"\" -> cookie_val")
               |> se.indent(4, "_ -> existing <> \"; \" <> cookie_val")
@@ -1174,10 +1174,7 @@ fn inline_schema_to_decoder(s: schema.SchemaObject) -> String {
 
 /// Return a function expression that converts an array item to String.
 /// Used in generated code: `list.map(param, <fn>)`.
-fn array_item_to_string_fn(
-  items: schema.SchemaRef,
-  ctx: Context,
-) -> String {
+fn array_item_to_string_fn(items: schema.SchemaRef, ctx: Context) -> String {
   case items {
     Inline(IntegerSchema(..)) -> "int.to_string"
     Inline(NumberSchema(..)) -> "float.to_string"

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -656,6 +656,24 @@ fn generate_client_function(
               )
               |> se.indent(2, "None -> req")
               |> se.indent(1, "}")
+            Ok(spec.HttpScheme(scheme: "basic", ..)) ->
+              sb
+              |> se.indent(1, "let req = case config." <> field_name <> " {")
+              |> se.indent(
+                2,
+                "Some(token) -> request.set_header(req, \"authorization\", \"Basic \" <> token)",
+              )
+              |> se.indent(2, "None -> req")
+              |> se.indent(1, "}")
+            Ok(spec.HttpScheme(scheme: "digest", ..)) ->
+              sb
+              |> se.indent(1, "let req = case config." <> field_name <> " {")
+              |> se.indent(
+                2,
+                "Some(token) -> request.set_header(req, \"authorization\", \"Digest \" <> token)",
+              )
+              |> se.indent(2, "None -> req")
+              |> se.indent(1, "}")
             Ok(spec.HttpScheme(scheme: "bearer", ..))
             | Ok(spec.OAuth2Scheme(..)) ->
               sb

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -1101,6 +1101,19 @@ fn generate_multipart_body(
         Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
         _ -> False
       }
+      let value_expr = case is_binary {
+        True -> "body." <> gleam_field
+        False ->
+          case field_schema {
+            Inline(schema.IntegerSchema(..)) ->
+              "int.to_string(body." <> gleam_field <> ")"
+            Inline(schema.NumberSchema(..)) ->
+              "float.to_string(body." <> gleam_field <> ")"
+            Inline(schema.BooleanSchema(..)) ->
+              "bool.to_string(body." <> gleam_field <> ")"
+            _ -> "body." <> gleam_field
+          }
+      }
       case is_binary {
         True ->
           sb
@@ -1110,8 +1123,8 @@ fn generate_multipart_body(
               <> field_name
               <> "\\\"; filename=\\\""
               <> field_name
-              <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\" <> body."
-              <> gleam_field
+              <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\" <> "
+              <> value_expr
               <> " <> \"\\r\\n\", ..parts]",
           )
         False ->
@@ -1120,8 +1133,8 @@ fn generate_multipart_body(
             1,
             "let parts = [\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
               <> field_name
-              <> "\\\"\\r\\n\\r\\n\" <> body."
-              <> gleam_field
+              <> "\\\"\\r\\n\\r\\n\" <> "
+              <> value_expr
               <> " <> \"\\r\\n\", ..parts]",
           )
       }

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -98,12 +98,23 @@ fn generate_client(ctx: Context) -> String {
       }
     })
 
-  // string module needed for path/query/cookie parameter handling and
-  // security query apiKey
+  // string module needed for path/query/cookie parameter handling,
+  // security query apiKey, and multipart/form-data body building
   let needs_string =
     list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       !list.is_empty(operation.parameters)
+    })
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(rb) ->
+          list.any(dict.to_list(rb.content), fn(ce) {
+            let #(key, _) = ce
+            key == "multipart/form-data"
+          })
+        _ -> False
+      }
     })
     || {
       let security_schemes = case ctx.spec.components {
@@ -469,16 +480,26 @@ fn generate_client_function(
   // Only set content-type for requests with body
   let sb = case operation.request_body {
     Some(rb) -> {
-      let body_encode_expr = get_body_encode_expr(rb, op_id, ctx)
-      sb
-      |> se.indent(
-        1,
-        "let req = request.set_header(req, \"content-type\", \"application/json\")",
-      )
-      |> se.indent(
-        1,
-        "let req = request.set_body(req, " <> body_encode_expr <> ")",
-      )
+      let content_entries = dict.to_list(rb.content)
+      let is_multipart = case content_entries {
+        [#("multipart/form-data", _), ..] -> True
+        _ -> False
+      }
+      case is_multipart {
+        True -> generate_multipart_body(sb, rb, op_id, ctx)
+        False -> {
+          let body_encode_expr = get_body_encode_expr(rb, op_id, ctx)
+          sb
+          |> se.indent(
+            1,
+            "let req = request.set_header(req, \"content-type\", \"application/json\")",
+          )
+          |> se.indent(
+            1,
+            "let req = request.set_body(req, " <> body_encode_expr <> ")",
+          )
+        }
+      }
     }
     _ -> sb
   }
@@ -944,6 +965,84 @@ fn get_body_encode_expr(
       }
     [] -> "body"
   }
+}
+
+/// Generate multipart/form-data body encoding in the client function.
+fn generate_multipart_body(
+  sb: se.StringBuilder,
+  rb: spec.RequestBody,
+  _op_id: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  let boundary = "----oaspec-boundary"
+  let content_entries = dict.to_list(rb.content)
+  let properties = case content_entries {
+    [#(_, media_type), ..] ->
+      case media_type.schema {
+        Some(Inline(schema.ObjectSchema(properties:, ..))) ->
+          dict.to_list(properties)
+        Some(Reference(ref:) as schema_ref) ->
+          case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+            Ok(schema.ObjectSchema(properties:, ..)) -> {
+              let _ = ref
+              dict.to_list(properties)
+            }
+            _ -> []
+          }
+        _ -> []
+      }
+    _ -> []
+  }
+
+  let sb =
+    sb
+    |> se.indent(1, "let boundary = \"" <> boundary <> "\"")
+    |> se.indent(1, "let parts = []")
+
+  let sb =
+    list.fold(properties, sb, fn(sb, prop) {
+      let #(field_name, field_schema) = prop
+      let gleam_field = naming.to_snake_case(field_name)
+      let is_binary = case field_schema {
+        Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
+        _ -> False
+      }
+      case is_binary {
+        True ->
+          sb
+          |> se.indent(
+            1,
+            "let parts = [\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+              <> field_name
+              <> "\\\"; filename=\\\""
+              <> field_name
+              <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\" <> body."
+              <> gleam_field
+              <> " <> \"\\r\\n\", ..parts]",
+          )
+        False ->
+          sb
+          |> se.indent(
+            1,
+            "let parts = [\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+              <> field_name
+              <> "\\\"\\r\\n\\r\\n\" <> body."
+              <> gleam_field
+              <> " <> \"\\r\\n\", ..parts]",
+          )
+      }
+    })
+
+  sb
+  |> se.indent(
+    1,
+    "let body_str = string.join(parts, \"\") <> \"--\" <> boundary <> \"--\\r\\n\"",
+  )
+  |> se.indent(
+    1,
+    "let req = request.set_header(req, \"content-type\", \"multipart/form-data; boundary=\" <> boundary)",
+  )
+  |> se.indent(1, "let req = request.set_body(req, body_str)")
 }
 
 /// Get the decode expression for a response body.

--- a/src/oaspec/codegen/context.gleam
+++ b/src/oaspec/codegen/context.gleam
@@ -2,7 +2,7 @@ import oaspec/config.{type Config}
 import oaspec/openapi/spec.{type OpenApiSpec}
 
 /// The version of oaspec used for generated code headers.
-pub const version = "0.3.0"
+pub const version = "0.4.0"
 
 /// Context for code generation, carrying all needed state.
 pub type Context {

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -381,12 +381,23 @@ fn generate_decoder(
           )
           |> se.indent(
             1,
-            "let additional_properties = dict.fold(extra_props, dict.new(), fn(acc, k, v) {",
+            "let additional_properties_result = dict.fold(extra_props, Ok(dict.new()), fn(acc, k, v) {",
           )
-          |> se.indent(2, "case decode.run(v, " <> inner_decoder <> ") {")
-          |> se.indent(3, "Ok(decoded) -> dict.insert(acc, k, decoded)")
-          |> se.indent(3, "Error(_) -> acc")
+          |> se.indent(2, "case acc {")
+          |> se.indent(3, "Ok(decoded_acc) ->")
+          |> se.indent(4, "case decode.run(v, " <> inner_decoder <> ") {")
+          |> se.indent(5, "Ok(decoded) -> Ok(dict.insert(decoded_acc, k, decoded))")
+          |> se.indent(5, "Error(_) -> Error(Nil)")
+          |> se.indent(4, "}")
+          |> se.indent(3, "Error(_) -> Error(Nil)")
           |> se.indent(2, "}")
+          |> se.indent(1, "})")
+          |> se.indent(1, "use additional_properties <- decode.then(case additional_properties_result {")
+          |> se.indent(2, "Ok(decoded) -> decode.success(decoded)")
+          |> se.indent(
+            2,
+            "Error(_) -> decode.failure(dict.new(), \"additionalProperties\")",
+          )
           |> se.indent(1, "})")
         }
         None, True -> {

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -47,6 +47,13 @@ fn generate_decoders(ctx: Context) -> String {
       type_gen.schema_has_optional_fields(schema_ref, ctx)
     })
 
+  // Check if dict module is needed (any schema with typed additionalProperties)
+  let needs_dict =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      type_gen.schema_has_additional_properties(schema_ref, ctx)
+    })
+
   // Check if types module is needed (any non-primitive schema)
   let needs_types =
     list.any(schemas, fn(entry) {
@@ -61,7 +68,10 @@ fn generate_decoders(ctx: Context) -> String {
       }
     })
 
-  let base_imports = ["gleam/dynamic/decode", "gleam/json"]
+  let base_imports = case needs_dict {
+    True -> ["gleam/dict", "gleam/dynamic/decode", "gleam/json"]
+    False -> ["gleam/dynamic/decode", "gleam/json"]
+  }
   let base_imports = case needs_types {
     True -> list.append(base_imports, [ctx.config.package <> "/types"])
     False -> base_imports
@@ -243,7 +253,7 @@ fn generate_decoder(
   let decoder_fn_name = naming.to_snake_case(name) <> "_decoder"
 
   case schema_ref {
-    Inline(ObjectSchema(description:, properties:, required:, nullable:, ..)) -> {
+    Inline(ObjectSchema(description:, properties:, required:, nullable:, additional_properties:, ..)) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb =
         sb
@@ -316,12 +326,32 @@ fn generate_decoder(
           }
         })
 
+      // Decode additional_properties as Dict if typed additionalProperties exists
+      // This decodes all string-keyed values; known property keys are included.
+      let sb = case additional_properties {
+        Some(ap_ref) -> {
+          let inner_decoder = schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
+          sb
+          |> se.indent(
+            1,
+            "use additional_properties <- decode.then(decode.dict(decode.string, " <> inner_decoder <> "))",
+          )
+        }
+        None -> sb
+      }
+
       let param_names =
         list.map(props, fn(entry) {
           let #(prop_name, _) = entry
           let field_name = naming.to_snake_case(prop_name)
           field_name <> ": " <> field_name
         })
+
+      // Add additional_properties to param names if present
+      let param_names = case additional_properties {
+        Some(_) -> list.append(param_names, ["additional_properties: additional_properties"])
+        None -> param_names
+      }
 
       let sb =
         sb
@@ -886,7 +916,17 @@ fn generate_encoders(ctx: Context) -> String {
       }
     })
 
-  let base_imports = ["gleam/json"]
+  // Check if dict/list modules are needed (any schema with typed additionalProperties)
+  let needs_dict =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      type_gen.schema_has_additional_properties(schema_ref, ctx)
+    })
+
+  let base_imports = case needs_dict {
+    True -> ["gleam/dict", "gleam/json", "gleam/list"]
+    False -> ["gleam/json"]
+  }
   let imports = case needs_types {
     True -> list.append(base_imports, [ctx.config.package <> "/types"])
     False -> base_imports
@@ -1010,7 +1050,7 @@ fn generate_encoder(
   let json_fn_name = fn_name <> "_json"
 
   case schema_ref {
-    Inline(ObjectSchema(properties:, required:, ..)) -> {
+    Inline(ObjectSchema(properties:, required:, additional_properties:, ..)) -> {
       // _json version: returns json.Json
       let sb =
         sb
@@ -1021,7 +1061,17 @@ fn generate_encoder(
           <> type_name
           <> ") -> json.Json {",
         )
-        |> se.indent(1, "json.object([")
+
+      // When additional_properties exist, we merge fixed props with dict entries
+      let has_ap = option.is_some(additional_properties)
+      let sb = case has_ap {
+        True ->
+          sb
+          |> se.indent(1, "let base_props = [")
+        False ->
+          sb
+          |> se.indent(1, "json.object([")
+      }
 
       let props = dict.to_list(properties)
       let sb =
@@ -1071,9 +1121,21 @@ fn generate_encoder(
           }
         })
 
+      let sb = case additional_properties {
+        Some(ap_ref) -> {
+          let inner_encoder_fn = schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties", ctx)
+          sb
+          |> se.indent(1, "]")
+          |> se.indent(1, "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, " <> inner_encoder_fn <> "(v)) })")
+          |> se.indent(1, "json.object(list.append(base_props, extra_props))")
+        }
+        None ->
+          sb
+          |> se.indent(1, "])")
+      }
+
       let sb =
         sb
-        |> se.indent(1, "])")
         |> se.line("}")
         |> se.blank_line()
 

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -335,22 +335,43 @@ fn generate_decoder(
           }
         })
 
-      // Decode additional_properties as Dict if typed or untyped additionalProperties exists
-      // This decodes all string-keyed values; known property keys are included.
+      // Decode additional_properties as Dict, then drop known property keys
+      // so only unknown/extra keys remain in additional_properties.
+      let known_keys_expr = case list.is_empty(props) {
+        True -> "[]"
+        False ->
+          "["
+          <> se.join_with(
+            list.map(props, fn(entry) {
+              let #(prop_name, _) = entry
+              "\"" <> prop_name <> "\""
+            }),
+            ", ",
+          )
+          <> "]"
+      }
       let sb = case additional_properties, additional_properties_untyped {
         Some(ap_ref), _ -> {
           let inner_decoder = schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
           sb
           |> se.indent(
             1,
-            "use additional_properties <- decode.then(decode.dict(decode.string, " <> inner_decoder <> "))",
+            "use all_props <- decode.then(decode.dict(decode.string, " <> inner_decoder <> "))",
+          )
+          |> se.indent(
+            1,
+            "let additional_properties = dict.drop(all_props, " <> known_keys_expr <> ")",
           )
         }
         None, True -> {
           sb
           |> se.indent(
             1,
-            "use additional_properties <- decode.then(decode.dict(decode.string, dynamic.dynamic))",
+            "use all_props <- decode.then(decode.dict(decode.string, dynamic.dynamic))",
+          )
+          |> se.indent(
+            1,
+            "let additional_properties = dict.drop(all_props, " <> known_keys_expr <> ")",
           )
         }
         None, False -> sb

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -554,38 +554,14 @@ fn generate_decoder(
     }
 
     Inline(AllOfSchema(description:, schemas:)) -> {
-      // Merge properties from all sub-schemas (same as type generator)
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      let merged_required =
-        list.flat_map(schemas, fn(s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(required:, ..)) -> required
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(required:, ..)) -> required
-                _ -> []
-              }
-            _ -> []
-          }
-        })
+      let merged = type_gen.merge_allof_schemas(schemas, ctx)
       let merged_schema =
         Inline(ObjectSchema(
           description:,
-          properties: merged_props,
-          required: merged_required,
-          additional_properties: None,
-          additional_properties_untyped: False,
+          properties: merged.properties,
+          required: merged.required,
+          additional_properties: merged.additional_properties,
+          additional_properties_untyped: merged.additional_properties_untyped,
           nullable: False,
         ))
       generate_decoder(sb, name, merged_schema, ctx)
@@ -1330,38 +1306,14 @@ fn generate_encoder(
     }
 
     Inline(AllOfSchema(description:, schemas:)) -> {
-      // Merge properties from all sub-schemas (same as type generator)
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      let merged_required =
-        list.flat_map(schemas, fn(s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(required:, ..)) -> required
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(required:, ..)) -> required
-                _ -> []
-              }
-            _ -> []
-          }
-        })
+      let merged = type_gen.merge_allof_schemas(schemas, ctx)
       let merged_schema =
         Inline(ObjectSchema(
           description:,
-          properties: merged_props,
-          required: merged_required,
-          additional_properties: None,
-          additional_properties_untyped: False,
+          properties: merged.properties,
+          required: merged.required,
+          additional_properties: merged.additional_properties,
+          additional_properties_untyped: merged.additional_properties_untyped,
           nullable: False,
         ))
       generate_encoder(sb, name, merged_schema, ctx)

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -47,11 +47,18 @@ fn generate_decoders(ctx: Context) -> String {
       type_gen.schema_has_optional_fields(schema_ref, ctx)
     })
 
-  // Check if dict module is needed (any schema with typed additionalProperties)
+  // Check if dict module is needed (any schema with typed or untyped additionalProperties)
   let needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
       type_gen.schema_has_additional_properties(schema_ref, ctx)
+    })
+
+  // Check if dynamic module is needed (any schema with untyped additionalProperties)
+  let needs_dynamic =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      type_gen.schema_has_untyped_additional_properties(schema_ref, ctx)
     })
 
   // Check if types module is needed (any non-primitive schema)
@@ -68,9 +75,11 @@ fn generate_decoders(ctx: Context) -> String {
       }
     })
 
-  let base_imports = case needs_dict {
-    True -> ["gleam/dict", "gleam/dynamic/decode", "gleam/json"]
-    False -> ["gleam/dynamic/decode", "gleam/json"]
+  let base_imports = case needs_dict, needs_dynamic {
+    True, True -> ["gleam/dict", "gleam/dynamic", "gleam/dynamic/decode", "gleam/json"]
+    True, False -> ["gleam/dict", "gleam/dynamic/decode", "gleam/json"]
+    False, True -> ["gleam/dynamic", "gleam/dynamic/decode", "gleam/json"]
+    False, False -> ["gleam/dynamic/decode", "gleam/json"]
   }
   let base_imports = case needs_types {
     True -> list.append(base_imports, [ctx.config.package <> "/types"])
@@ -253,7 +262,7 @@ fn generate_decoder(
   let decoder_fn_name = naming.to_snake_case(name) <> "_decoder"
 
   case schema_ref {
-    Inline(ObjectSchema(description:, properties:, required:, nullable:, additional_properties:, ..)) -> {
+    Inline(ObjectSchema(description:, properties:, required:, nullable:, additional_properties:, additional_properties_untyped:)) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb =
         sb
@@ -326,10 +335,10 @@ fn generate_decoder(
           }
         })
 
-      // Decode additional_properties as Dict if typed additionalProperties exists
+      // Decode additional_properties as Dict if typed or untyped additionalProperties exists
       // This decodes all string-keyed values; known property keys are included.
-      let sb = case additional_properties {
-        Some(ap_ref) -> {
+      let sb = case additional_properties, additional_properties_untyped {
+        Some(ap_ref), _ -> {
           let inner_decoder = schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
           sb
           |> se.indent(
@@ -337,7 +346,14 @@ fn generate_decoder(
             "use additional_properties <- decode.then(decode.dict(decode.string, " <> inner_decoder <> "))",
           )
         }
-        None -> sb
+        None, True -> {
+          sb
+          |> se.indent(
+            1,
+            "use additional_properties <- decode.then(decode.dict(decode.string, dynamic.dynamic))",
+          )
+        }
+        None, False -> sb
       }
 
       let param_names =
@@ -348,9 +364,10 @@ fn generate_decoder(
         })
 
       // Add additional_properties to param names if present
-      let param_names = case additional_properties {
-        Some(_) -> list.append(param_names, ["additional_properties: additional_properties"])
-        None -> param_names
+      let param_names = case additional_properties, additional_properties_untyped {
+        Some(_), _ -> list.append(param_names, ["additional_properties: additional_properties"])
+        None, True -> list.append(param_names, ["additional_properties: additional_properties"])
+        None, False -> param_names
       }
 
       let sb =
@@ -916,14 +933,17 @@ fn generate_encoders(ctx: Context) -> String {
       }
     })
 
-  // Check if dict/list modules are needed (any schema with typed additionalProperties)
-  let needs_dict =
+  // Check if dict/list modules are needed (only for typed additionalProperties encoding)
+  let needs_typed_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      type_gen.schema_has_additional_properties(schema_ref, ctx)
+      case schema_ref {
+        Inline(ObjectSchema(additional_properties: Some(_), ..)) -> True
+        _ -> False
+      }
     })
 
-  let base_imports = case needs_dict {
+  let base_imports = case needs_typed_dict {
     True -> ["gleam/dict", "gleam/json", "gleam/list"]
     False -> ["gleam/json"]
   }
@@ -1050,7 +1070,7 @@ fn generate_encoder(
   let json_fn_name = fn_name <> "_json"
 
   case schema_ref {
-    Inline(ObjectSchema(properties:, required:, additional_properties:, ..)) -> {
+    Inline(ObjectSchema(properties:, required:, additional_properties:, additional_properties_untyped:, ..)) -> {
       // _json version: returns json.Json
       let sb =
         sb
@@ -1063,7 +1083,7 @@ fn generate_encoder(
         )
 
       // When additional_properties exist, we merge fixed props with dict entries
-      let has_ap = option.is_some(additional_properties)
+      let has_ap = option.is_some(additional_properties) || additional_properties_untyped
       let sb = case has_ap {
         True ->
           sb
@@ -1121,15 +1141,22 @@ fn generate_encoder(
           }
         })
 
-      let sb = case additional_properties {
-        Some(ap_ref) -> {
+      let sb = case additional_properties, additional_properties_untyped {
+        Some(ap_ref), _ -> {
           let inner_encoder_fn = schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties", ctx)
           sb
           |> se.indent(1, "]")
           |> se.indent(1, "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, " <> inner_encoder_fn <> "(v)) })")
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }
-        None ->
+        None, True -> {
+          // Untyped additional_properties (Dynamic) are decode-only;
+          // skip them during encoding as they cannot be reliably re-encoded.
+          sb
+          |> se.indent(1, "]")
+          |> se.indent(1, "json.object(base_props)")
+        }
+        None, False ->
           sb
           |> se.indent(1, "])")
       }

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -76,7 +76,12 @@ fn generate_decoders(ctx: Context) -> String {
     })
 
   let base_imports = case needs_dict, needs_dynamic {
-    True, True -> ["gleam/dict", "gleam/dynamic", "gleam/dynamic/decode", "gleam/json"]
+    True, True -> [
+      "gleam/dict",
+      "gleam/dynamic",
+      "gleam/dynamic/decode",
+      "gleam/json",
+    ]
     True, False -> ["gleam/dict", "gleam/dynamic/decode", "gleam/json"]
     False, True -> ["gleam/dynamic", "gleam/dynamic/decode", "gleam/json"]
     False, False -> ["gleam/dynamic/decode", "gleam/json"]
@@ -262,7 +267,14 @@ fn generate_decoder(
   let decoder_fn_name = naming.to_snake_case(name) <> "_decoder"
 
   case schema_ref {
-    Inline(ObjectSchema(description:, properties:, required:, nullable:, additional_properties:, additional_properties_untyped:)) -> {
+    Inline(ObjectSchema(
+      description:,
+      properties:,
+      required:,
+      nullable:,
+      additional_properties:,
+      additional_properties_untyped:,
+    )) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb =
         sb
@@ -352,15 +364,20 @@ fn generate_decoder(
       }
       let sb = case additional_properties, additional_properties_untyped {
         Some(ap_ref), _ -> {
-          let inner_decoder = schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
+          let inner_decoder =
+            schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
           sb
           |> se.indent(
             1,
-            "use all_props <- decode.then(decode.dict(decode.string, " <> inner_decoder <> "))",
+            "use all_props <- decode.then(decode.dict(decode.string, "
+              <> inner_decoder
+              <> "))",
           )
           |> se.indent(
             1,
-            "let additional_properties = dict.drop(all_props, " <> known_keys_expr <> ")",
+            "let additional_properties = dict.drop(all_props, "
+              <> known_keys_expr
+              <> ")",
           )
         }
         None, True -> {
@@ -371,7 +388,9 @@ fn generate_decoder(
           )
           |> se.indent(
             1,
-            "let additional_properties = dict.drop(all_props, " <> known_keys_expr <> ")",
+            "let additional_properties = dict.drop(all_props, "
+              <> known_keys_expr
+              <> ")",
           )
         }
         None, False -> sb
@@ -385,9 +404,18 @@ fn generate_decoder(
         })
 
       // Add additional_properties to param names if present
-      let param_names = case additional_properties, additional_properties_untyped {
-        Some(_), _ -> list.append(param_names, ["additional_properties: additional_properties"])
-        None, True -> list.append(param_names, ["additional_properties: additional_properties"])
+      let param_names = case
+        additional_properties,
+        additional_properties_untyped
+      {
+        Some(_), _ ->
+          list.append(param_names, [
+            "additional_properties: additional_properties",
+          ])
+        None, True ->
+          list.append(param_names, [
+            "additional_properties: additional_properties",
+          ])
         None, False -> param_names
       }
 
@@ -1091,7 +1119,13 @@ fn generate_encoder(
   let json_fn_name = fn_name <> "_json"
 
   case schema_ref {
-    Inline(ObjectSchema(properties:, required:, additional_properties:, additional_properties_untyped:, ..)) -> {
+    Inline(ObjectSchema(
+      properties:,
+      required:,
+      additional_properties:,
+      additional_properties_untyped:,
+      ..,
+    )) -> {
       // _json version: returns json.Json
       let sb =
         sb
@@ -1104,7 +1138,8 @@ fn generate_encoder(
         )
 
       // When additional_properties exist, we merge fixed props with dict entries
-      let has_ap = option.is_some(additional_properties) || additional_properties_untyped
+      let has_ap =
+        option.is_some(additional_properties) || additional_properties_untyped
       let sb = case has_ap {
         True ->
           sb
@@ -1164,10 +1199,21 @@ fn generate_encoder(
 
       let sb = case additional_properties, additional_properties_untyped {
         Some(ap_ref), _ -> {
-          let inner_encoder_fn = schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties", ctx)
+          let inner_encoder_fn =
+            schema_ref_to_json_encoder_fn(
+              ap_ref,
+              name,
+              "additional_properties",
+              ctx,
+            )
           sb
           |> se.indent(1, "]")
-          |> se.indent(1, "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, " <> inner_encoder_fn <> "(v)) })")
+          |> se.indent(
+            1,
+            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, "
+              <> inner_encoder_fn
+              <> "(v)) })",
+          )
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }
         None, True -> {

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -386,13 +386,19 @@ fn generate_decoder(
           |> se.indent(2, "case acc {")
           |> se.indent(3, "Ok(decoded_acc) ->")
           |> se.indent(4, "case decode.run(v, " <> inner_decoder <> ") {")
-          |> se.indent(5, "Ok(decoded) -> Ok(dict.insert(decoded_acc, k, decoded))")
+          |> se.indent(
+            5,
+            "Ok(decoded) -> Ok(dict.insert(decoded_acc, k, decoded))",
+          )
           |> se.indent(5, "Error(_) -> Error(Nil)")
           |> se.indent(4, "}")
           |> se.indent(3, "Error(_) -> Error(Nil)")
           |> se.indent(2, "}")
           |> se.indent(1, "})")
-          |> se.indent(1, "use additional_properties <- decode.then(case additional_properties_result {")
+          |> se.indent(
+            1,
+            "use additional_properties <- decode.then(case additional_properties_result {",
+          )
           |> se.indent(2, "Ok(decoded) -> decode.success(decoded)")
           |> se.indent(
             2,

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -54,11 +54,12 @@ fn generate_decoders(ctx: Context) -> String {
       type_gen.schema_has_additional_properties(schema_ref, ctx)
     })
 
-  // Check if dynamic module is needed (any schema with untyped additionalProperties)
+  // Check if dynamic module is needed (any schema with additionalProperties —
+  // both typed and untyped use dynamic.dynamic for safe initial dict decode)
   let needs_dynamic =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      type_gen.schema_has_untyped_additional_properties(schema_ref, ctx)
+      type_gen.schema_has_additional_properties(schema_ref, ctx)
     })
 
   // Check if types module is needed (any non-primitive schema)
@@ -362,6 +363,9 @@ fn generate_decoder(
           )
           <> "]"
       }
+      // For additionalProperties, decode the raw dict with dynamic values first
+      // to avoid forcing the value decoder on known properties (which may have
+      // incompatible types). Then drop known keys and decode remaining values.
       let sb = case additional_properties, additional_properties_untyped {
         Some(ap_ref), _ -> {
           let inner_decoder =
@@ -369,16 +373,21 @@ fn generate_decoder(
           sb
           |> se.indent(
             1,
-            "use all_props <- decode.then(decode.dict(decode.string, "
-              <> inner_decoder
-              <> "))",
+            "use all_props <- decode.then(decode.dict(decode.string, dynamic.dynamic))",
           )
           |> se.indent(
             1,
-            "let additional_properties = dict.drop(all_props, "
-              <> known_keys_expr
-              <> ")",
+            "let extra_props = dict.drop(all_props, " <> known_keys_expr <> ")",
           )
+          |> se.indent(
+            1,
+            "let additional_properties = dict.fold(extra_props, dict.new(), fn(acc, k, v) {",
+          )
+          |> se.indent(2, "case decode.run(v, " <> inner_decoder <> ") {")
+          |> se.indent(3, "Ok(decoded) -> dict.insert(acc, k, decoded)")
+          |> se.indent(3, "Error(_) -> acc")
+          |> se.indent(2, "}")
+          |> se.indent(1, "})")
         }
         None, True -> {
           sb

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -1,0 +1,399 @@
+import gleam/dict
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/openapi/resolver
+import oaspec/openapi/schema.{
+  type SchemaObject, type SchemaRef, AllOfSchema, ArraySchema, Inline,
+  IntegerSchema, NumberSchema, ObjectSchema, Reference, StringSchema,
+}
+import oaspec/util/naming
+import oaspec/util/string_extra as se
+
+/// Generate guard/validation functions from OpenAPI schemas that have constraints.
+pub fn generate(ctx: Context) -> List(GeneratedFile) {
+  let content = generate_guards(ctx)
+  case string.contains(content, "pub fn validate_") {
+    True -> [GeneratedFile(path: "guards.gleam", content: content)]
+    False -> []
+  }
+}
+
+/// Generate validation guard functions for schemas with constraints.
+fn generate_guards(ctx: Context) -> String {
+  let schemas = case ctx.spec.components {
+    Some(components) ->
+      list.sort(dict.to_list(components.schemas), fn(a, b) {
+        string.compare(a.0, b.0)
+      })
+    None -> []
+  }
+
+  let sb =
+    se.file_header(context.version)
+    |> se.imports(["gleam/int", "gleam/string"])
+
+  let sb =
+    list.fold(schemas, sb, fn(sb, entry) {
+      let #(name, schema_ref) = entry
+      generate_guards_for_schema(sb, name, schema_ref, ctx)
+    })
+
+  se.to_string(sb)
+}
+
+/// Generate guard functions for a single schema's constrained fields.
+fn generate_guards_for_schema(
+  sb: se.StringBuilder,
+  name: String,
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> se.StringBuilder {
+  case schema_ref {
+    Inline(schema) -> generate_guards_for_schema_object(sb, name, schema, ctx)
+    Reference(ref:) -> {
+      let resolved_name = resolver.ref_to_name(ref)
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema) ->
+          generate_guards_for_schema_object(sb, resolved_name, schema, ctx)
+        _ -> sb
+      }
+    }
+  }
+}
+
+/// Generate guard functions for fields within a schema object.
+fn generate_guards_for_schema_object(
+  sb: se.StringBuilder,
+  name: String,
+  schema: SchemaObject,
+  ctx: Context,
+) -> se.StringBuilder {
+  case schema {
+    ObjectSchema(properties:, ..) -> {
+      let props = dict.to_list(properties)
+      list.fold(props, sb, fn(sb, entry) {
+        let #(prop_name, prop_ref) = entry
+        generate_field_guard(sb, name, prop_name, prop_ref, ctx)
+      })
+    }
+    AllOfSchema(schemas:, ..) -> {
+      let merged_props =
+        list.fold(schemas, dict.new(), fn(acc, s_ref) {
+          case s_ref {
+            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
+            Reference(_) ->
+              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
+                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
+                _ -> acc
+              }
+            _ -> acc
+          }
+        })
+      let props = dict.to_list(merged_props)
+      list.fold(props, sb, fn(sb, entry) {
+        let #(prop_name, prop_ref) = entry
+        generate_field_guard(sb, name, prop_name, prop_ref, ctx)
+      })
+    }
+    // Top-level string/integer constraints (type aliases with constraints)
+    StringSchema(min_length:, max_length:, ..) ->
+      generate_string_guard(sb, name, "", min_length, max_length)
+    IntegerSchema(minimum:, maximum:, ..) ->
+      generate_integer_guard(sb, name, "", minimum, maximum)
+    NumberSchema(minimum:, maximum:, ..) ->
+      generate_float_guard(sb, name, "", minimum, maximum)
+    ArraySchema(min_items:, max_items:, ..) ->
+      generate_list_guard(sb, name, "", min_items, max_items)
+    _ -> sb
+  }
+}
+
+/// Generate a guard for a specific field based on its schema type and constraints.
+fn generate_field_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  prop_ref: SchemaRef,
+  ctx: Context,
+) -> se.StringBuilder {
+  let resolved = case prop_ref {
+    Inline(schema) -> Ok(schema)
+    Reference(_) -> resolver.resolve_schema_ref(prop_ref, ctx.spec)
+  }
+  case resolved {
+    Ok(StringSchema(min_length:, max_length:, ..)) ->
+      generate_string_guard(sb, schema_name, prop_name, min_length, max_length)
+    Ok(IntegerSchema(minimum:, maximum:, ..)) ->
+      generate_integer_guard(sb, schema_name, prop_name, minimum, maximum)
+    Ok(NumberSchema(minimum:, maximum:, ..)) ->
+      generate_float_guard(sb, schema_name, prop_name, minimum, maximum)
+    Ok(ArraySchema(min_items:, max_items:, ..)) ->
+      generate_list_guard(sb, schema_name, prop_name, min_items, max_items)
+    _ -> sb
+  }
+}
+
+/// Generate a string length validation guard.
+fn generate_string_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  min_length: Option(Int),
+  max_length: Option(Int),
+) -> se.StringBuilder {
+  case min_length, max_length {
+    None, None -> sb
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "length")
+      let sb =
+        sb
+        |> se.line(
+          "/// Validate string length for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        )
+      let sb =
+        sb
+        |> se.line(
+          "pub fn " <> fn_name <> "(value: String) -> Result(String, String) {",
+        )
+      let sb =
+        sb |> se.indent(1, "let len = string.length(value)")
+      let sb = case min_length {
+        Some(min) ->
+          sb
+          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> int.to_string(min)
+              <> " characters\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None -> sb
+      }
+      let sb = case max_length {
+        Some(max) -> {
+          // If we already have a min_length guard, we need to chain
+          let sb = case min_length {
+            Some(_) -> {
+              // Replace the last Ok(value) with a nested check
+              // Actually, let's just use a simpler approach with use
+              sb
+            }
+            None -> sb
+          }
+          case min_length {
+            Some(_) ->
+              // Already generated min check, add max as separate function
+              sb
+            None ->
+              sb
+              |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
+              |> se.indent(
+                2,
+                "True -> Error(\"must be at most "
+                  <> int.to_string(max)
+                  <> " characters\")",
+              )
+              |> se.indent(2, "False -> Ok(value)")
+              |> se.indent(1, "}")
+          }
+        }
+        None -> sb
+      }
+      sb
+      |> se.line("}")
+      |> se.blank_line()
+    }
+  }
+}
+
+/// Generate an integer range validation guard.
+fn generate_integer_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  minimum: Option(Int),
+  maximum: Option(Int),
+) -> se.StringBuilder {
+  case minimum, maximum {
+    None, None -> sb
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "range")
+      let sb =
+        sb
+        |> se.line(
+          "/// Validate integer range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        )
+      let sb =
+        sb
+        |> se.line(
+          "pub fn " <> fn_name <> "(value: Int) -> Result(Int, String) {",
+        )
+      let sb = case minimum {
+        Some(min) ->
+          sb
+          |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> int.to_string(min)
+              <> "\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None -> sb
+      }
+      let sb = case maximum, minimum {
+        Some(max), None ->
+          sb
+          |> se.indent(1, "case value > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at most "
+              <> int.to_string(max)
+              <> "\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        _, _ -> sb
+      }
+      sb
+      |> se.line("}")
+      |> se.blank_line()
+    }
+  }
+}
+
+/// Generate a float range validation guard.
+fn generate_float_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  minimum: Option(Float),
+  maximum: Option(Float),
+) -> se.StringBuilder {
+  case minimum, maximum {
+    None, None -> sb
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "range")
+      let sb =
+        sb
+        |> se.line(
+          "/// Validate float range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        )
+      let sb =
+        sb
+        |> se.line(
+          "pub fn "
+          <> fn_name
+          <> "(value: Float) -> Result(Float, String) {",
+        )
+      let sb =
+        sb
+        |> se.indent(1, "// Range validation for float field")
+        |> se.indent(1, "Ok(value)")
+      sb
+      |> se.line("}")
+      |> se.blank_line()
+    }
+  }
+}
+
+/// Generate a list length validation guard.
+fn generate_list_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  min_items: Option(Int),
+  max_items: Option(Int),
+) -> se.StringBuilder {
+  case min_items, max_items {
+    None, None -> sb
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "length")
+      let sb =
+        sb
+        |> se.line(
+          "/// Validate list length for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        )
+      let sb =
+        sb
+        |> se.line(
+          "pub fn "
+          <> fn_name
+          <> "(value: List(a)) -> Result(List(a), String) {",
+        )
+      let sb =
+        sb
+        |> se.indent(1, "let len = list.length(value)")
+      let sb = case min_items {
+        Some(min) ->
+          sb
+          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must have at least "
+              <> int.to_string(min)
+              <> " items\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None -> sb
+      }
+      let sb = case max_items, min_items {
+        Some(max), None ->
+          sb
+          |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must have at most "
+              <> int.to_string(max)
+              <> " items\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        _, _ -> sb
+      }
+      sb
+      |> se.line("}")
+      |> se.blank_line()
+    }
+  }
+}
+
+/// Build the guard function name from schema name, property name, and constraint type.
+fn guard_function_name(
+  schema_name: String,
+  prop_name: String,
+  constraint: String,
+) -> String {
+  let base = naming.to_snake_case(schema_name)
+  case prop_name {
+    "" -> "validate_" <> base <> "_" <> constraint
+    _ -> "validate_" <> base <> "_" <> naming.to_snake_case(prop_name) <> "_" <> constraint
+  }
+}
+
+/// Format a field label for documentation.
+fn field_label(prop_name: String) -> String {
+  case prop_name {
+    "" -> ""
+    _ -> "." <> prop_name
+  }
+}

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -1,4 +1,5 @@
 import gleam/dict
+import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -33,7 +34,7 @@ fn generate_guards(ctx: Context) -> String {
 
   let sb =
     se.file_header(context.version)
-    |> se.imports(["gleam/int", "gleam/string"])
+    |> se.imports(["gleam/float", "gleam/int", "gleam/list", "gleam/string"])
 
   let sb =
     list.fold(schemas, sb, fn(sb, entry) {
@@ -163,8 +164,28 @@ fn generate_string_guard(
         )
       let sb =
         sb |> se.indent(1, "let len = string.length(value)")
-      let sb = case min_length {
-        Some(min) ->
+      let sb = case min_length, max_length {
+        Some(min), Some(max) ->
+          sb
+          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> int.to_string(min)
+              <> " characters\")",
+          )
+          |> se.indent(2, "False ->")
+          |> se.indent(3, "case len > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            4,
+            "True -> Error(\"must be at most "
+              <> int.to_string(max)
+              <> " characters\")",
+          )
+          |> se.indent(4, "False -> Ok(value)")
+          |> se.indent(3, "}")
+          |> se.indent(1, "}")
+        Some(min), None ->
           sb
           |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
           |> se.indent(
@@ -175,37 +196,18 @@ fn generate_string_guard(
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
-        None -> sb
-      }
-      let sb = case max_length {
-        Some(max) -> {
-          // If we already have a min_length guard, we need to chain
-          let sb = case min_length {
-            Some(_) -> {
-              // Replace the last Ok(value) with a nested check
-              // Actually, let's just use a simpler approach with use
-              sb
-            }
-            None -> sb
-          }
-          case min_length {
-            Some(_) ->
-              // Already generated min check, add max as separate function
-              sb
-            None ->
-              sb
-              |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
-              |> se.indent(
-                2,
-                "True -> Error(\"must be at most "
-                  <> int.to_string(max)
-                  <> " characters\")",
-              )
-              |> se.indent(2, "False -> Ok(value)")
-              |> se.indent(1, "}")
-          }
-        }
-        None -> sb
+        None, Some(max) ->
+          sb
+          |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at most "
+              <> int.to_string(max)
+              <> " characters\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None, None -> sb
       }
       sb
       |> se.line("}")
@@ -239,8 +241,28 @@ fn generate_integer_guard(
         |> se.line(
           "pub fn " <> fn_name <> "(value: Int) -> Result(Int, String) {",
         )
-      let sb = case minimum {
-        Some(min) ->
+      let sb = case minimum, maximum {
+        Some(min), Some(max) ->
+          sb
+          |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> int.to_string(min)
+              <> "\")",
+          )
+          |> se.indent(2, "False ->")
+          |> se.indent(3, "case value > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            4,
+            "True -> Error(\"must be at most "
+              <> int.to_string(max)
+              <> "\")",
+          )
+          |> se.indent(4, "False -> Ok(value)")
+          |> se.indent(3, "}")
+          |> se.indent(1, "}")
+        Some(min), None ->
           sb
           |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
           |> se.indent(
@@ -251,10 +273,7 @@ fn generate_integer_guard(
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
-        None -> sb
-      }
-      let sb = case maximum, minimum {
-        Some(max), None ->
+        None, Some(max) ->
           sb
           |> se.indent(1, "case value > " <> int.to_string(max) <> " {")
           |> se.indent(
@@ -265,7 +284,7 @@ fn generate_integer_guard(
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
-        _, _ -> sb
+        None, None -> sb
       }
       sb
       |> se.line("}")
@@ -301,10 +320,63 @@ fn generate_float_guard(
           <> fn_name
           <> "(value: Float) -> Result(Float, String) {",
         )
-      let sb =
-        sb
-        |> se.indent(1, "// Range validation for float field")
-        |> se.indent(1, "Ok(value)")
+      let sb = case minimum, maximum {
+        Some(min), Some(max) ->
+          sb
+          |> se.indent(
+            1,
+            "case value <. " <> float.to_string(min) <> " {",
+          )
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> float.to_string(min)
+              <> "\")",
+          )
+          |> se.indent(2, "False ->")
+          |> se.indent(
+            3,
+            "case value >. " <> float.to_string(max) <> " {",
+          )
+          |> se.indent(
+            4,
+            "True -> Error(\"must be at most "
+              <> float.to_string(max)
+              <> "\")",
+          )
+          |> se.indent(4, "False -> Ok(value)")
+          |> se.indent(3, "}")
+          |> se.indent(1, "}")
+        Some(min), None ->
+          sb
+          |> se.indent(
+            1,
+            "case value <. " <> float.to_string(min) <> " {",
+          )
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at least "
+              <> float.to_string(min)
+              <> "\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None, Some(max) ->
+          sb
+          |> se.indent(
+            1,
+            "case value >. " <> float.to_string(max) <> " {",
+          )
+          |> se.indent(
+            2,
+            "True -> Error(\"must be at most "
+              <> float.to_string(max)
+              <> "\")",
+          )
+          |> se.indent(2, "False -> Ok(value)")
+          |> se.indent(1, "}")
+        None, None -> sb
+      }
       sb
       |> se.line("}")
       |> se.blank_line()
@@ -342,8 +414,28 @@ fn generate_list_guard(
       let sb =
         sb
         |> se.indent(1, "let len = list.length(value)")
-      let sb = case min_items {
-        Some(min) ->
+      let sb = case min_items, max_items {
+        Some(min), Some(max) ->
+          sb
+          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
+          |> se.indent(
+            2,
+            "True -> Error(\"must have at least "
+              <> int.to_string(min)
+              <> " items\")",
+          )
+          |> se.indent(2, "False ->")
+          |> se.indent(3, "case len > " <> int.to_string(max) <> " {")
+          |> se.indent(
+            4,
+            "True -> Error(\"must have at most "
+              <> int.to_string(max)
+              <> " items\")",
+          )
+          |> se.indent(4, "False -> Ok(value)")
+          |> se.indent(3, "}")
+          |> se.indent(1, "}")
+        Some(min), None ->
           sb
           |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
           |> se.indent(
@@ -354,10 +446,7 @@ fn generate_list_guard(
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
-        None -> sb
-      }
-      let sb = case max_items, min_items {
-        Some(max), None ->
+        None, Some(max) ->
           sb
           |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
           |> se.indent(
@@ -368,7 +457,7 @@ fn generate_list_guard(
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
-        _, _ -> sb
+        None, None -> sb
       }
       sb
       |> se.line("}")

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -32,9 +32,24 @@ fn generate_guards(ctx: Context) -> String {
     None -> []
   }
 
+  // Determine which imports are needed based on constraint types present.
+  // Generated guard functions use string/list.length for validation;
+  // constraint values (min/max) are baked as literals at generation time,
+  // so gleam/int and gleam/float are NOT needed in the generated output.
+  let constraint_types = collect_constraint_types(schemas, ctx)
+  let imports = []
+  let imports = case constraint_types.has_string {
+    True -> ["gleam/string", ..imports]
+    False -> imports
+  }
+  let imports = case constraint_types.has_list {
+    True -> ["gleam/list", ..imports]
+    False -> imports
+  }
+
   let sb =
     se.file_header(context.version)
-    |> se.imports(["gleam/float", "gleam/int", "gleam/list", "gleam/string"])
+    |> se.imports(imports)
 
   let sb =
     list.fold(schemas, sb, fn(sb, entry) {
@@ -43,6 +58,68 @@ fn generate_guards(ctx: Context) -> String {
     })
 
   se.to_string(sb)
+}
+
+/// Track which constraint types exist in the schema set.
+type ConstraintTypes {
+  ConstraintTypes(
+    has_string: Bool,
+    has_integer: Bool,
+    has_float: Bool,
+    has_list: Bool,
+  )
+}
+
+/// Scan all schemas to find which constraint types are present.
+fn collect_constraint_types(
+  schemas: List(#(String, SchemaRef)),
+  ctx: Context,
+) -> ConstraintTypes {
+  list.fold(
+    schemas,
+    ConstraintTypes(False, False, False, False),
+    fn(acc, entry) {
+      let #(_name, schema_ref) = entry
+      collect_schema_constraint_types(acc, schema_ref, ctx)
+    },
+  )
+}
+
+/// Collect constraint types from a single schema ref.
+fn collect_schema_constraint_types(
+  acc: ConstraintTypes,
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> ConstraintTypes {
+  let schema = case schema_ref {
+    Inline(s) -> Ok(s)
+    Reference(_) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+  }
+  case schema {
+    Ok(StringSchema(min_length: Some(_), ..))
+    | Ok(StringSchema(max_length: Some(_), ..)) ->
+      ConstraintTypes(..acc, has_string: True)
+    Ok(IntegerSchema(minimum: Some(_), ..))
+    | Ok(IntegerSchema(maximum: Some(_), ..)) ->
+      ConstraintTypes(..acc, has_integer: True)
+    Ok(NumberSchema(minimum: Some(_), ..))
+    | Ok(NumberSchema(maximum: Some(_), ..)) ->
+      ConstraintTypes(..acc, has_float: True)
+    Ok(ArraySchema(min_items: Some(_), ..))
+    | Ok(ArraySchema(max_items: Some(_), ..)) ->
+      ConstraintTypes(..acc, has_list: True)
+    Ok(ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.fold(acc, fn(a, prop) {
+        let #(_, prop_ref) = prop
+        collect_schema_constraint_types(a, prop_ref, ctx)
+      })
+    Ok(AllOfSchema(schemas:, ..)) ->
+      list.fold(schemas, acc, fn(a, s) {
+        collect_schema_constraint_types(a, s, ctx)
+      })
+    _ -> acc
+  }
 }
 
 /// Generate guard functions for a single schema's constrained fields.
@@ -162,8 +239,7 @@ fn generate_string_guard(
         |> se.line(
           "pub fn " <> fn_name <> "(value: String) -> Result(String, String) {",
         )
-      let sb =
-        sb |> se.indent(1, "let len = string.length(value)")
+      let sb = sb |> se.indent(1, "let len = string.length(value)")
       let sb = case min_length, max_length {
         Some(min), Some(max) ->
           sb
@@ -247,17 +323,13 @@ fn generate_integer_guard(
           |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at least "
-              <> int.to_string(min)
-              <> "\")",
+            "True -> Error(\"must be at least " <> int.to_string(min) <> "\")",
           )
           |> se.indent(2, "False ->")
           |> se.indent(3, "case value > " <> int.to_string(max) <> " {")
           |> se.indent(
             4,
-            "True -> Error(\"must be at most "
-              <> int.to_string(max)
-              <> "\")",
+            "True -> Error(\"must be at most " <> int.to_string(max) <> "\")",
           )
           |> se.indent(4, "False -> Ok(value)")
           |> se.indent(3, "}")
@@ -267,9 +339,7 @@ fn generate_integer_guard(
           |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at least "
-              <> int.to_string(min)
-              <> "\")",
+            "True -> Error(\"must be at least " <> int.to_string(min) <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
@@ -278,9 +348,7 @@ fn generate_integer_guard(
           |> se.indent(1, "case value > " <> int.to_string(max) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at most "
-              <> int.to_string(max)
-              <> "\")",
+            "True -> Error(\"must be at most " <> int.to_string(max) <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
@@ -316,62 +384,40 @@ fn generate_float_guard(
       let sb =
         sb
         |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Float) -> Result(Float, String) {",
+          "pub fn " <> fn_name <> "(value: Float) -> Result(Float, String) {",
         )
       let sb = case minimum, maximum {
         Some(min), Some(max) ->
           sb
-          |> se.indent(
-            1,
-            "case value <. " <> float.to_string(min) <> " {",
-          )
+          |> se.indent(1, "case value <. " <> float.to_string(min) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at least "
-              <> float.to_string(min)
-              <> "\")",
+            "True -> Error(\"must be at least " <> float.to_string(min) <> "\")",
           )
           |> se.indent(2, "False ->")
-          |> se.indent(
-            3,
-            "case value >. " <> float.to_string(max) <> " {",
-          )
+          |> se.indent(3, "case value >. " <> float.to_string(max) <> " {")
           |> se.indent(
             4,
-            "True -> Error(\"must be at most "
-              <> float.to_string(max)
-              <> "\")",
+            "True -> Error(\"must be at most " <> float.to_string(max) <> "\")",
           )
           |> se.indent(4, "False -> Ok(value)")
           |> se.indent(3, "}")
           |> se.indent(1, "}")
         Some(min), None ->
           sb
-          |> se.indent(
-            1,
-            "case value <. " <> float.to_string(min) <> " {",
-          )
+          |> se.indent(1, "case value <. " <> float.to_string(min) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at least "
-              <> float.to_string(min)
-              <> "\")",
+            "True -> Error(\"must be at least " <> float.to_string(min) <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
         None, Some(max) ->
           sb
-          |> se.indent(
-            1,
-            "case value >. " <> float.to_string(max) <> " {",
-          )
+          |> se.indent(1, "case value >. " <> float.to_string(max) <> " {")
           |> se.indent(
             2,
-            "True -> Error(\"must be at most "
-              <> float.to_string(max)
-              <> "\")",
+            "True -> Error(\"must be at most " <> float.to_string(max) <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
@@ -475,7 +521,13 @@ fn guard_function_name(
   let base = naming.to_snake_case(schema_name)
   case prop_name {
     "" -> "validate_" <> base <> "_" <> constraint
-    _ -> "validate_" <> base <> "_" <> naming.to_snake_case(prop_name) <> "_" <> constraint
+    _ ->
+      "validate_"
+      <> base
+      <> "_"
+      <> naming.to_snake_case(prop_name)
+      <> "_"
+      <> constraint
   }
 }
 

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -45,9 +45,18 @@ fn generate_types(ctx: Context) -> String {
       schema_has_optional_fields(schema_ref, ctx)
     })
 
-  let imports = case needs_option {
-    True -> ["gleam/option.{type Option}"]
-    False -> []
+  // Check if Dict is needed (any schema with typed additionalProperties)
+  let needs_dict =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      schema_has_additional_properties(schema_ref, ctx)
+    })
+
+  let imports = case needs_option, needs_dict {
+    True, True -> ["gleam/dict.{type Dict}", "gleam/option.{type Option}"]
+    True, False -> ["gleam/option.{type Option}"]
+    False, True -> ["gleam/dict.{type Dict}"]
+    False, False -> []
   }
 
   let sb =
@@ -167,12 +176,13 @@ fn generate_schema_type(
   ctx: Context,
 ) -> se.StringBuilder {
   case schema {
-    ObjectSchema(description:, properties:, required:, ..) -> {
+    ObjectSchema(description:, properties:, required:, additional_properties:, ..) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb = sb |> se.line("pub type " <> type_name <> " {")
       let sb = sb |> se.indent(1, type_name <> "(")
 
       let props = dict.to_list(properties)
+      let has_additional_props = option.is_some(additional_properties)
       let sb =
         list.index_fold(props, sb, fn(sb, entry, idx) {
           let #(prop_name, prop_ref) = entry
@@ -193,12 +203,22 @@ fn generate_schema_type(
             False, True -> field_type
             False, False -> "Option(" <> field_type <> ")"
           }
-          let trailing = case idx == list.length(props) - 1 {
+          let is_last = idx == list.length(props) - 1
+          let trailing = case is_last && !has_additional_props {
             True -> ""
             False -> ","
           }
           sb |> se.indent(2, field_name <> ": " <> final_type <> trailing)
         })
+
+      // Add additional_properties field if typed additionalProperties exists
+      let sb = case additional_properties {
+        Some(ap_ref) -> {
+          let inner_type = schema_ref_to_type(ap_ref, ctx)
+          sb |> se.indent(2, "additional_properties: Dict(String, " <> inner_type <> ")")
+        }
+        None -> sb
+      }
 
       sb
       |> se.indent(1, ")")
@@ -865,6 +885,21 @@ pub fn collect_operations(
       }
     })
   })
+}
+
+/// Check if a schema has typed additionalProperties that would need Dict.
+pub fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(additional_properties: Some(_), ..)) -> True
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
+    Reference(_) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) -> schema_has_additional_properties(Inline(schema_obj), ctx)
+        Error(_) -> False
+      }
+    _ -> False
+  }
 }
 
 /// Check if a schema has any optional or nullable fields that would need Option.

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -692,6 +692,18 @@ fn generate_request_type(
             Some(Inline(IntegerSchema(..))) -> "Int"
             Some(Inline(NumberSchema(..))) -> "Float"
             Some(Inline(BooleanSchema(..))) -> "Bool"
+            Some(Inline(ArraySchema(items:, ..))) -> {
+              let item_type = case items {
+                Inline(StringSchema(..)) -> "String"
+                Inline(IntegerSchema(..)) -> "Int"
+                Inline(NumberSchema(..)) -> "Float"
+                Inline(BooleanSchema(..)) -> "Bool"
+                Reference(ref:) ->
+                  naming.schema_to_type_name(resolver.ref_to_name(ref))
+                _ -> "String"
+              }
+              "List(" <> item_type <> ")"
+            }
             Some(Reference(ref:)) ->
               naming.schema_to_type_name(resolver.ref_to_name(ref))
             _ -> "String"

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -60,10 +60,20 @@ fn generate_types(ctx: Context) -> String {
     })
 
   let imports = case needs_option, needs_dict, needs_dynamic {
-    True, True, True -> ["gleam/dict.{type Dict}", "gleam/dynamic.{type Dynamic}", "gleam/option.{type Option}"]
-    True, True, False -> ["gleam/dict.{type Dict}", "gleam/option.{type Option}"]
+    True, True, True -> [
+      "gleam/dict.{type Dict}",
+      "gleam/dynamic.{type Dynamic}",
+      "gleam/option.{type Option}",
+    ]
+    True, True, False -> [
+      "gleam/dict.{type Dict}",
+      "gleam/option.{type Option}",
+    ]
     True, False, _ -> ["gleam/option.{type Option}"]
-    False, True, True -> ["gleam/dict.{type Dict}", "gleam/dynamic.{type Dynamic}"]
+    False, True, True -> [
+      "gleam/dict.{type Dict}",
+      "gleam/dynamic.{type Dynamic}",
+    ]
     False, True, False -> ["gleam/dict.{type Dict}"]
     False, False, _ -> []
   }
@@ -185,13 +195,21 @@ fn generate_schema_type(
   ctx: Context,
 ) -> se.StringBuilder {
   case schema {
-    ObjectSchema(description:, properties:, required:, additional_properties:, additional_properties_untyped:, ..) -> {
+    ObjectSchema(
+      description:,
+      properties:,
+      required:,
+      additional_properties:,
+      additional_properties_untyped:,
+      ..,
+    ) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb = sb |> se.line("pub type " <> type_name <> " {")
       let sb = sb |> se.indent(1, type_name <> "(")
 
       let props = dict.to_list(properties)
-      let has_additional_props = option.is_some(additional_properties) || additional_properties_untyped
+      let has_additional_props =
+        option.is_some(additional_properties) || additional_properties_untyped
       let sb =
         list.index_fold(props, sb, fn(sb, entry, idx) {
           let #(prop_name, prop_ref) = entry
@@ -225,7 +243,11 @@ fn generate_schema_type(
       let sb = case additional_properties, additional_properties_untyped {
         Some(ap_ref), _ -> {
           let inner_type = schema_ref_to_type(ap_ref, ctx)
-          sb |> se.indent(2, "additional_properties: Dict(String, " <> inner_type <> ")")
+          sb
+          |> se.indent(
+            2,
+            "additional_properties: Dict(String, " <> inner_type <> ")",
+          )
         }
         None, True -> {
           sb |> se.indent(2, "additional_properties: Dict(String, Dynamic)")
@@ -913,7 +935,10 @@ pub fn collect_operations(
 }
 
 /// Check if a schema has typed or untyped additionalProperties that would need Dict.
-pub fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
+pub fn schema_has_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
   case schema_ref {
     Inline(ObjectSchema(additional_properties: Some(_), ..)) -> True
     Inline(ObjectSchema(additional_properties_untyped: True, ..)) -> True
@@ -921,7 +946,8 @@ pub fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> 
       list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
     Reference(_) ->
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) -> schema_has_additional_properties(Inline(schema_obj), ctx)
+        Ok(schema_obj) ->
+          schema_has_additional_properties(Inline(schema_obj), ctx)
         Error(_) -> False
       }
     _ -> False
@@ -929,14 +955,20 @@ pub fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> 
 }
 
 /// Check if a schema has untyped additionalProperties (needs Dynamic import).
-pub fn schema_has_untyped_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
+pub fn schema_has_untyped_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
   case schema_ref {
     Inline(ObjectSchema(additional_properties_untyped: True, ..)) -> True
     Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) { schema_has_untyped_additional_properties(s, ctx) })
+      list.any(schemas, fn(s) {
+        schema_has_untyped_additional_properties(s, ctx)
+      })
     Reference(_) ->
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) -> schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
+        Ok(schema_obj) ->
+          schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
         Error(_) -> False
       }
     _ -> False

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -45,18 +45,27 @@ fn generate_types(ctx: Context) -> String {
       schema_has_optional_fields(schema_ref, ctx)
     })
 
-  // Check if Dict is needed (any schema with typed additionalProperties)
+  // Check if Dict is needed (any schema with typed or untyped additionalProperties)
   let needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
       schema_has_additional_properties(schema_ref, ctx)
     })
 
-  let imports = case needs_option, needs_dict {
-    True, True -> ["gleam/dict.{type Dict}", "gleam/option.{type Option}"]
-    True, False -> ["gleam/option.{type Option}"]
-    False, True -> ["gleam/dict.{type Dict}"]
-    False, False -> []
+  // Check if Dynamic is needed (any schema with untyped additionalProperties)
+  let needs_dynamic =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      schema_has_untyped_additional_properties(schema_ref, ctx)
+    })
+
+  let imports = case needs_option, needs_dict, needs_dynamic {
+    True, True, True -> ["gleam/dict.{type Dict}", "gleam/dynamic.{type Dynamic}", "gleam/option.{type Option}"]
+    True, True, False -> ["gleam/dict.{type Dict}", "gleam/option.{type Option}"]
+    True, False, _ -> ["gleam/option.{type Option}"]
+    False, True, True -> ["gleam/dict.{type Dict}", "gleam/dynamic.{type Dynamic}"]
+    False, True, False -> ["gleam/dict.{type Dict}"]
+    False, False, _ -> []
   }
 
   let sb =
@@ -176,13 +185,13 @@ fn generate_schema_type(
   ctx: Context,
 ) -> se.StringBuilder {
   case schema {
-    ObjectSchema(description:, properties:, required:, additional_properties:, ..) -> {
+    ObjectSchema(description:, properties:, required:, additional_properties:, additional_properties_untyped:, ..) -> {
       let sb = maybe_doc_comment(sb, description)
       let sb = sb |> se.line("pub type " <> type_name <> " {")
       let sb = sb |> se.indent(1, type_name <> "(")
 
       let props = dict.to_list(properties)
-      let has_additional_props = option.is_some(additional_properties)
+      let has_additional_props = option.is_some(additional_properties) || additional_properties_untyped
       let sb =
         list.index_fold(props, sb, fn(sb, entry, idx) {
           let #(prop_name, prop_ref) = entry
@@ -212,12 +221,16 @@ fn generate_schema_type(
         })
 
       // Add additional_properties field if typed additionalProperties exists
-      let sb = case additional_properties {
-        Some(ap_ref) -> {
+      // or untyped additionalProperties: true (uses Dict(String, Dynamic))
+      let sb = case additional_properties, additional_properties_untyped {
+        Some(ap_ref), _ -> {
           let inner_type = schema_ref_to_type(ap_ref, ctx)
           sb |> se.indent(2, "additional_properties: Dict(String, " <> inner_type <> ")")
         }
-        None -> sb
+        None, True -> {
+          sb |> se.indent(2, "additional_properties: Dict(String, Dynamic)")
+        }
+        None, False -> sb
       }
 
       sb
@@ -887,15 +900,31 @@ pub fn collect_operations(
   })
 }
 
-/// Check if a schema has typed additionalProperties that would need Dict.
+/// Check if a schema has typed or untyped additionalProperties that would need Dict.
 pub fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
   case schema_ref {
     Inline(ObjectSchema(additional_properties: Some(_), ..)) -> True
+    Inline(ObjectSchema(additional_properties_untyped: True, ..)) -> True
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
     Reference(_) ->
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
         Ok(schema_obj) -> schema_has_additional_properties(Inline(schema_obj), ctx)
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a schema has untyped additionalProperties (needs Dynamic import).
+pub fn schema_has_untyped_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(additional_properties_untyped: True, ..)) -> True
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_untyped_additional_properties(s, ctx) })
+    Reference(_) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) -> schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
         Error(_) -> False
       }
     _ -> False

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -292,39 +292,15 @@ fn generate_schema_type(
     AllOfSchema(description:, schemas:) -> {
       // Merge all properties into a single object type
       let sb = maybe_doc_comment(sb, description)
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(_) -> {
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            }
-            _ -> acc
-          }
-        })
-      let merged_required =
-        list.flat_map(schemas, fn(s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(required:, ..)) -> required
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(required:, ..)) -> required
-                _ -> []
-              }
-            _ -> []
-          }
-        })
+      let merged = merge_allof_schemas(schemas, ctx)
 
       let merged_schema =
         ObjectSchema(
           description:,
-          properties: merged_props,
-          required: merged_required,
-          additional_properties: None,
-          additional_properties_untyped: False,
+          properties: merged.properties,
+          required: merged.required,
+          additional_properties: merged.additional_properties,
+          additional_properties_untyped: merged.additional_properties_untyped,
           nullable: False,
         )
       generate_schema_type(sb, type_name, raw_name, merged_schema, ctx)
@@ -493,38 +469,14 @@ fn generate_anonymous_type_for_schema(
       }
     }
     AllOfSchema(description:, schemas:) -> {
-      // Merge properties from allOf
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      let merged_required =
-        list.flat_map(schemas, fn(s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(required:, ..)) -> required
-            Reference(_) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(required:, ..)) -> required
-                _ -> []
-              }
-            _ -> []
-          }
-        })
+      let merged = merge_allof_schemas(schemas, ctx)
       let merged_schema =
         ObjectSchema(
           description:,
-          properties: merged_props,
-          required: merged_required,
-          additional_properties: None,
-          additional_properties_untyped: False,
+          properties: merged.properties,
+          required: merged.required,
+          additional_properties: merged.additional_properties,
+          additional_properties_untyped: merged.additional_properties_untyped,
           nullable: False,
         )
       generate_schema_type(sb, type_name, raw_name, merged_schema, ctx)
@@ -870,6 +822,64 @@ fn generate_response_type(
 /// Prefixed with the type name to avoid duplicate constructors across types.
 fn status_code_to_variant(code: String, type_name: String) -> String {
   type_name <> http.status_code_suffix(code)
+}
+
+/// Result of merging allOf sub-schemas.
+pub type MergedAllOf {
+  MergedAllOf(
+    properties: dict.Dict(String, SchemaRef),
+    required: List(String),
+    additional_properties: Option(SchemaRef),
+    additional_properties_untyped: Bool,
+  )
+}
+
+/// Merge allOf sub-schemas: properties, required, and additionalProperties.
+pub fn merge_allof_schemas(
+  schemas: List(SchemaRef),
+  ctx: Context,
+) -> MergedAllOf {
+  list.fold(
+    schemas,
+    MergedAllOf(
+      properties: dict.new(),
+      required: [],
+      additional_properties: None,
+      additional_properties_untyped: False,
+    ),
+    fn(acc, s_ref) {
+      let resolved = case s_ref {
+        Inline(obj) -> Ok(obj)
+        Reference(_) -> resolver.resolve_schema_ref(s_ref, ctx.spec)
+      }
+      case resolved {
+        Ok(ObjectSchema(
+          properties:,
+          required:,
+          additional_properties:,
+          additional_properties_untyped:,
+          ..,
+        )) -> {
+          let merged_ap = case
+            acc.additional_properties,
+            additional_properties
+          {
+            None, ap -> ap
+            existing, _ -> existing
+          }
+          let merged_ap_untyped =
+            acc.additional_properties_untyped || additional_properties_untyped
+          MergedAllOf(
+            properties: dict.merge(acc.properties, properties),
+            required: list.append(acc.required, required),
+            additional_properties: merged_ap,
+            additional_properties_untyped: merged_ap_untyped,
+          )
+        }
+        _ -> acc
+      }
+    },
+  )
 }
 
 /// Collect all operations from the spec with their IDs, paths, and methods.

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -810,17 +810,29 @@ fn generate_response_type(
 
           case content_entries {
             [] -> sb |> se.indent(1, variant_name)
-            [#(_media_type, media_type), ..] ->
-              case media_type.schema {
-                Some(ref) -> {
-                  let suffix =
-                    "Response" <> http.status_code_suffix(status_code)
-                  let inner_type =
-                    schema_ref_to_type_qualified(ref, op_id, suffix, ctx)
-                  sb
-                  |> se.indent(1, variant_name <> "(" <> inner_type <> ")")
-                }
-                None -> sb |> se.indent(1, variant_name)
+            [#(media_type_name, media_type), ..] ->
+              case media_type_name {
+                // text/plain responses always use String type regardless of schema
+                "text/plain" ->
+                  case media_type.schema {
+                    Some(_) ->
+                      sb
+                      |> se.indent(1, variant_name <> "(String)")
+                    None -> sb |> se.indent(1, variant_name)
+                  }
+                // JSON and other content types use schema-derived type
+                _ ->
+                  case media_type.schema {
+                    Some(ref) -> {
+                      let suffix =
+                        "Response" <> http.status_code_suffix(status_code)
+                      let inner_type =
+                        schema_ref_to_type_qualified(ref, op_id, suffix, ctx)
+                      sb
+                      |> se.indent(1, variant_name <> "(" <> inner_type <> ")")
+                    }
+                    None -> sb |> se.indent(1, variant_name)
+                  }
               }
           }
         })

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -61,14 +61,8 @@ fn validate_parameters(
       ]
       _ -> []
     }
-    // Reject array and complex schema parameters
+    // Reject complex schema parameters (array params are supported)
     let schema_errors = case param.schema {
-      Some(Inline(ArraySchema(..))) -> [
-        UnsupportedFeature(
-          path: path,
-          detail: "Array parameters are not yet supported. Use a single-value parameter instead.",
-        ),
-      ]
       Some(Inline(ObjectSchema(..)))
       | Some(Inline(AllOfSchema(..)))
       | Some(Inline(OneOfSchema(..)))

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -4,6 +4,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/set
 import oaspec/codegen/context.{type Context}
 import oaspec/codegen/types as type_gen
+import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   Inline, ObjectSchema, OneOfSchema, Reference,
@@ -40,7 +41,7 @@ fn validate_operations(ctx: Context) -> List(ValidationError) {
   let operations = type_gen.collect_operations(ctx)
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, _path, _method) = op
-    let param_errors = validate_parameters(op_id, operation.parameters)
+    let param_errors = validate_parameters(op_id, operation.parameters, ctx)
     let body_errors = validate_request_body(op_id, operation.request_body)
     let response_errors = validate_responses(op_id, operation.responses)
     list.flatten([param_errors, body_errors, response_errors])
@@ -51,9 +52,11 @@ fn validate_operations(ctx: Context) -> List(ValidationError) {
 fn validate_parameters(
   op_id: String,
   params: List(spec.Parameter),
+  ctx: Context,
 ) -> List(ValidationError) {
   list.flat_map(params, fn(param) {
     let path = op_id <> ".parameters." <> param.name
+    let resolved_schema = resolve_parameter_schema(param.schema, ctx)
     let deep_object_errors = case param.style {
       Some("deepObject") -> [
         UnsupportedFeature(
@@ -63,23 +66,21 @@ fn validate_parameters(
       ]
       _ -> []
     }
-    let complex_schema_errors = case param.in_, param.schema {
-      spec.InPath, _ -> []
-      _, Some(Inline(ObjectSchema(..)))
-      | _, Some(Inline(AllOfSchema(..)))
-      | _, Some(Inline(OneOfSchema(..)))
-      | _, Some(Inline(AnyOfSchema(..)))
-      -> [
+    let complex_schema_errors = case resolved_schema {
+      Some(ObjectSchema(..))
+      | Some(AllOfSchema(..))
+      | Some(OneOfSchema(..))
+      | Some(AnyOfSchema(..)) -> [
         UnsupportedFeature(
           path: path,
-          detail: "Complex schema parameters (object/allOf/oneOf/anyOf) in query/header/cookie are not supported.",
+          detail: "Complex schema parameters (object/allOf/oneOf/anyOf) are not supported.",
         ),
       ]
-      _, _ -> []
+      _ -> []
     }
-    let array_errors = case param.in_, param.schema {
+    let array_errors = case param.in_, resolved_schema {
       spec.InPath, _ -> []
-      _, Some(Inline(ArraySchema(..))) -> [
+      _, Some(ArraySchema(..)) -> [
         UnsupportedFeature(
           path: path,
           detail: "Array parameters in query/header/cookie are not supported.",
@@ -103,6 +104,21 @@ fn validate_parameters(
       required_errors,
     ])
   })
+}
+
+fn resolve_parameter_schema(
+  schema_ref: Option(SchemaRef),
+  ctx: Context,
+) -> Option(SchemaObject) {
+  case schema_ref {
+    Some(Inline(schema_obj)) -> Some(schema_obj)
+    Some(schema_ref) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) -> Some(schema_obj)
+        Error(_) -> None
+      }
+    None -> None
+  }
 }
 
 /// Validate request body for unsupported patterns.

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -9,6 +9,7 @@ import oaspec/openapi/schema.{
   Inline, ObjectSchema, OneOfSchema, Reference,
 }
 import oaspec/openapi/spec
+import oaspec/util/content_type
 
 /// A validation error representing an unsupported OpenAPI feature.
 pub type ValidationError {
@@ -92,9 +93,11 @@ fn validate_request_body(
     None -> []
     Some(rb) -> {
       let content_keys = dict.keys(rb.content)
-      let non_json =
-        list.filter(content_keys, fn(key) { key != "application/json" })
-      let content_type_errors = case non_json {
+      let unsupported =
+        list.filter(content_keys, fn(key) {
+          !content_type.is_supported(content_type.from_string(key))
+        })
+      let content_type_errors = case unsupported {
         [] -> []
         [media_type, ..] -> [
           UnsupportedFeature(
@@ -133,9 +136,11 @@ fn validate_responses(
     list.flat_map(content_entries, fn(ce) {
       let #(media_type_name, media_type) = ce
       let path = op_id <> ".responses." <> status_code
-      let content_type_errors = case media_type_name {
-        "application/json" -> []
-        _ -> [
+      let content_type_errors = case
+        content_type.is_supported(content_type.from_string(media_type_name))
+      {
+        True -> []
+        False -> [
           UnsupportedFeature(
             path: path,
             detail: "Response content type '"

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -50,31 +50,13 @@ fn validate_parameters(
   op_id: String,
   params: List(spec.Parameter),
 ) -> List(ValidationError) {
-  list.flat_map(params, fn(param) {
-    let path = op_id <> ".parameters." <> param.name
-    let style_errors = case param.style {
-      Some("deepObject") -> [
-        UnsupportedFeature(
-          path: path,
-          detail: "style: deepObject is not supported. Gleam cannot express deep object query serialization.",
-        ),
-      ]
-      _ -> []
-    }
-    // Reject complex schema parameters (array params are supported)
-    let schema_errors = case param.schema {
-      Some(Inline(ObjectSchema(..)))
-      | Some(Inline(AllOfSchema(..)))
-      | Some(Inline(OneOfSchema(..)))
-      | Some(Inline(AnyOfSchema(..))) -> [
-        UnsupportedFeature(
-          path: path,
-          detail: "Complex schema parameters (object/allOf/oneOf/anyOf) are not supported.",
-        ),
-      ]
-      _ -> []
-    }
-    list.append(style_errors, schema_errors)
+  list.flat_map(params, fn(_param) {
+    let _path = op_id <> ".parameters."
+    // deepObject style and complex schema parameters (object/allOf/oneOf/anyOf)
+    // are now supported. deepObject params generate flattened key serialization
+    // (e.g. filter[status]=active&filter[type]=dog), and complex schema params
+    // are JSON-serialized in the query string.
+    []
   })
 }
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -197,14 +197,9 @@ fn validate_schema_recursive(
         ]
         False -> []
       }
-      // Check typed additionalProperties (unsupported for now)
+      // Recurse into typed additionalProperties schema
       let typed_ap_errors = case additional_properties {
-        Some(_) -> [
-          UnsupportedFeature(
-            path: path,
-            detail: "Typed additionalProperties is not yet supported.",
-          ),
-        ]
+        Some(ap_ref) -> validate_schema_ref_recursive(path <> ".additionalProperties", ap_ref)
         None -> []
       }
       // Recurse into properties, also catching inline objects

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -7,7 +7,8 @@ import oaspec/codegen/types as type_gen
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
-  Inline, ObjectSchema, OneOfSchema, Reference,
+  BooleanSchema, Inline, IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema,
+  Reference, StringSchema,
 }
 import oaspec/openapi/spec
 import oaspec/util/content_type
@@ -42,7 +43,7 @@ fn validate_operations(ctx: Context) -> List(ValidationError) {
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, _path, _method) = op
     let param_errors = validate_parameters(op_id, operation.parameters, ctx)
-    let body_errors = validate_request_body(op_id, operation.request_body)
+    let body_errors = validate_request_body(op_id, operation.request_body, ctx)
     let response_errors = validate_responses(op_id, operation.responses)
     list.flatten([param_errors, body_errors, response_errors])
   })
@@ -56,7 +57,7 @@ fn validate_parameters(
 ) -> List(ValidationError) {
   list.flat_map(params, fn(param) {
     let path = op_id <> ".parameters." <> param.name
-    let resolved_schema = resolve_parameter_schema(param.schema, ctx)
+    let resolved_schema = resolve_schema_object(param.schema, ctx)
     let deep_object_errors = case param.style {
       Some("deepObject") -> [
         UnsupportedFeature(
@@ -106,7 +107,7 @@ fn validate_parameters(
   })
 }
 
-fn resolve_parameter_schema(
+fn resolve_schema_object(
   schema_ref: Option(SchemaRef),
   ctx: Context,
 ) -> Option(SchemaObject) {
@@ -125,6 +126,7 @@ fn resolve_parameter_schema(
 fn validate_request_body(
   op_id: String,
   request_body: Option(spec.RequestBody),
+  ctx: Context,
 ) -> List(ValidationError) {
   case request_body {
     None -> []
@@ -156,8 +158,61 @@ fn validate_request_body(
             None -> []
           }
         })
-      list.append(content_type_errors, schema_errors)
+      let multipart_field_errors =
+        validate_multipart_request_body_fields(op_id, rb.content, ctx)
+      list.flatten([
+        content_type_errors,
+        schema_errors,
+        multipart_field_errors,
+      ])
     }
+  }
+}
+
+fn validate_multipart_request_body_fields(
+  op_id: String,
+  content: dict.Dict(String, spec.MediaType),
+  ctx: Context,
+) -> List(ValidationError) {
+  case dict.get(content, "multipart/form-data") {
+    Ok(media_type) ->
+      case resolve_schema_object(media_type.schema, ctx) {
+        Some(ObjectSchema(properties:, ..)) ->
+          dict.to_list(properties)
+          |> list.flat_map(fn(entry) {
+            let #(field_name, field_schema) = entry
+            case multipart_field_is_stringifiable(field_schema, ctx) {
+              True -> []
+              False -> [
+                UnsupportedFeature(
+                  path: op_id <> ".requestBody.multipart." <> field_name,
+                  detail: "multipart/form-data fields must be string, integer, number, boolean, binary, or string enums.",
+                ),
+              ]
+            }
+          })
+        Some(_) -> [
+          UnsupportedFeature(
+            path: op_id <> ".requestBody",
+            detail: "multipart/form-data request bodies must use an object schema.",
+          ),
+        ]
+        None -> []
+      }
+    Error(_) -> []
+  }
+}
+
+fn multipart_field_is_stringifiable(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case resolve_schema_object(Some(schema_ref), ctx) {
+    Some(StringSchema(..))
+    | Some(IntegerSchema(..))
+    | Some(NumberSchema(..))
+    | Some(BooleanSchema(..)) -> True
+    _ -> False
   }
 }
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -67,7 +67,8 @@ fn validate_parameters(
       _, Some(Inline(ObjectSchema(..)))
       | _, Some(Inline(AllOfSchema(..)))
       | _, Some(Inline(OneOfSchema(..)))
-      | _, Some(Inline(AnyOfSchema(..))) -> [
+      | _, Some(Inline(AnyOfSchema(..)))
+      -> [
         UnsupportedFeature(
           path: path,
           detail: "Complex schema parameters (object/allOf/oneOf/anyOf) in query/header/cookie are not supported.",
@@ -94,7 +95,12 @@ fn validate_parameters(
       ]
       _, _ -> []
     }
-    list.flatten([deep_object_errors, complex_schema_errors, array_errors, required_errors])
+    list.flatten([
+      deep_object_errors,
+      complex_schema_errors,
+      array_errors,
+      required_errors,
+    ])
   })
 }
 
@@ -212,7 +218,8 @@ fn validate_schema_recursive(
       let _ = additional_properties_untyped
       // Recurse into typed additionalProperties schema
       let typed_ap_errors = case additional_properties {
-        Some(ap_ref) -> validate_schema_ref_recursive(path <> ".additionalProperties", ap_ref)
+        Some(ap_ref) ->
+          validate_schema_ref_recursive(path <> ".additionalProperties", ap_ref)
         None -> []
       }
       // Recurse into properties, also catching inline objects
@@ -257,7 +264,12 @@ fn validate_schema_recursive(
               <> "'",
           )
         })
-      list.flatten([ap_errors, typed_ap_errors, prop_errors, prop_collision_errors])
+      list.flatten([
+        ap_errors,
+        typed_ap_errors,
+        prop_errors,
+        prop_collision_errors,
+      ])
     }
 
     ArraySchema(items:, ..) -> {
@@ -356,9 +368,7 @@ fn validate_name_collisions(ctx: Context) -> List(ValidationError) {
     find_name_collisions(fn_names, fn(dup) {
       UnsupportedFeature(
         path: "paths",
-        detail: "Function name collision after case conversion: '"
-          <> dup
-          <> "'",
+        detail: "Function name collision after case conversion: '" <> dup <> "'",
       )
     })
 
@@ -372,9 +382,7 @@ fn validate_name_collisions(ctx: Context) -> List(ValidationError) {
     find_name_collisions(type_names, fn(dup) {
       UnsupportedFeature(
         path: "paths",
-        detail: "Type name collision after case conversion: '"
-          <> dup
-          <> "'",
+        detail: "Type name collision after case conversion: '" <> dup <> "'",
       )
     })
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -9,7 +9,6 @@ import oaspec/openapi/schema.{
   Inline, ObjectSchema, OneOfSchema, Reference,
 }
 import oaspec/openapi/spec
-import oaspec/util/naming
 
 /// A validation error representing an unsupported OpenAPI feature.
 pub type ValidationError {
@@ -235,26 +234,9 @@ fn validate_schema_recursive(
             validate_schema_ref_recursive(prop_path, prop_ref),
           )
         })
-      // Check property name collisions after snake_case conversion
-      let prop_names =
-        dict.to_list(properties)
-        |> list.map(fn(entry) {
-          let #(prop_name, _) = entry
-          naming.to_snake_case(prop_name)
-        })
-      let prop_collision_errors =
-        find_string_duplicates(prop_names, fn(dup) {
-          UnsupportedFeature(
-            path: path,
-            detail: "Property name collision after snake_case: '" <> dup <> "'",
-          )
-        })
-      list.flatten([
-        ap_errors,
-        typed_ap_errors,
-        prop_errors,
-        prop_collision_errors,
-      ])
+      // Property name collisions after snake_case are auto-resolved
+      // by deduplicate_names during code generation.
+      list.flatten([ap_errors, typed_ap_errors, prop_errors])
     }
 
     ArraySchema(items:, ..) -> {
@@ -285,22 +267,9 @@ fn validate_schema_recursive(
         validate_schema_ref_recursive(path <> ".allOf", s_ref)
       })
 
-    _ -> {
-      // Check enum variant collisions for string enums
-      case schema_obj {
-        schema.StringSchema(enum_values:, ..) if enum_values != [] -> {
-          let variant_names =
-            list.map(enum_values, fn(v) { naming.schema_to_type_name(v) })
-          find_string_duplicates(variant_names, fn(dup) {
-            UnsupportedFeature(
-              path: path,
-              detail: "Enum variant collision after PascalCase: '" <> dup <> "'",
-            )
-          })
-        }
-        _ -> []
-      }
-    }
+    // Enum variant collisions after PascalCase are auto-resolved
+    // by deduplicate_names during code generation.
+    _ -> []
   }
 }
 
@@ -358,51 +327,9 @@ fn validate_name_collisions(ctx: Context) -> List(ValidationError) {
       },
     )
 
-  // Check snake_case function name collisions
-  let fn_name_errors =
-    find_duplicates(
-      operations,
-      fn(op) {
-        let #(op_id, _, _, _) = op
-        naming.operation_to_function_name(op_id)
-      },
-      fn(dup) {
-        UnsupportedFeature(
-          path: "paths",
-          detail: "Function name collision after snake_case conversion: '"
-            <> dup
-            <> "'",
-        )
-      },
-    )
-
-  // Check PascalCase type name collisions for response/request types
-  let type_name_errors =
-    find_duplicates(
-      operations,
-      fn(op) {
-        let #(op_id, _, _, _) = op
-        naming.schema_to_type_name(op_id)
-      },
-      fn(dup) {
-        UnsupportedFeature(
-          path: "paths",
-          detail: "Type name collision after PascalCase conversion: '"
-            <> dup
-            <> "'",
-        )
-      },
-    )
-
-  list.flatten([op_id_errors, fn_name_errors, type_name_errors])
-}
-
-/// Find duplicates in a list of strings.
-fn find_string_duplicates(
-  items: List(String),
-  error_fn: fn(String) -> ValidationError,
-) -> List(ValidationError) {
-  find_duplicates(items, fn(s) { s }, error_fn)
+  // Function/type name collisions after case conversion are auto-resolved
+  // by deduplicate_names during code generation.
+  op_id_errors
 }
 
 /// Find duplicates in a list using a key function, producing errors via an

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -10,6 +10,7 @@ import oaspec/openapi/schema.{
 }
 import oaspec/openapi/spec
 import oaspec/util/content_type
+import oaspec/util/naming
 
 /// A validation error representing an unsupported OpenAPI feature.
 pub type ValidationError {
@@ -50,13 +51,50 @@ fn validate_parameters(
   op_id: String,
   params: List(spec.Parameter),
 ) -> List(ValidationError) {
-  list.flat_map(params, fn(_param) {
-    let _path = op_id <> ".parameters."
-    // deepObject style and complex schema parameters (object/allOf/oneOf/anyOf)
-    // are now supported. deepObject params generate flattened key serialization
-    // (e.g. filter[status]=active&filter[type]=dog), and complex schema params
-    // are JSON-serialized in the query string.
-    []
+  list.flat_map(params, fn(param) {
+    let path = op_id <> ".parameters." <> param.name
+    let deep_object_errors = case param.style {
+      Some("deepObject") -> [
+        UnsupportedFeature(
+          path: path,
+          detail: "Parameter style 'deepObject' is not supported.",
+        ),
+      ]
+      _ -> []
+    }
+    let complex_schema_errors = case param.in_, param.schema {
+      spec.InPath, _ -> []
+      _, Some(Inline(ObjectSchema(..)))
+      | _, Some(Inline(AllOfSchema(..)))
+      | _, Some(Inline(OneOfSchema(..)))
+      | _, Some(Inline(AnyOfSchema(..))) -> [
+        UnsupportedFeature(
+          path: path,
+          detail: "Complex schema parameters (object/allOf/oneOf/anyOf) in query/header/cookie are not supported.",
+        ),
+      ]
+      _, _ -> []
+    }
+    let array_errors = case param.in_, param.schema {
+      spec.InPath, _ -> []
+      _, Some(Inline(ArraySchema(..))) -> [
+        UnsupportedFeature(
+          path: path,
+          detail: "Array parameters in query/header/cookie are not supported.",
+        ),
+      ]
+      _, _ -> []
+    }
+    let required_errors = case param.in_, param.required {
+      spec.InPath, False -> [
+        UnsupportedFeature(
+          path: path,
+          detail: "Path parameters with required: false are not supported.",
+        ),
+      ]
+      _, _ -> []
+    }
+    list.flatten([deep_object_errors, complex_schema_errors, array_errors, required_errors])
   })
 }
 
@@ -203,9 +241,23 @@ fn validate_schema_recursive(
             validate_schema_ref_recursive(prop_path, prop_ref),
           )
         })
-      // Property name collisions after snake_case are auto-resolved
-      // by deduplicate_names during code generation.
-      list.flatten([ap_errors, typed_ap_errors, prop_errors])
+      // Property name collisions after snake_case conversion
+      let prop_names =
+        dict.to_list(properties)
+        |> list.map(fn(entry) {
+          let #(prop_name, _) = entry
+          naming.to_snake_case(prop_name)
+        })
+      let prop_collision_errors =
+        find_name_collisions(prop_names, fn(dup) {
+          UnsupportedFeature(
+            path: path,
+            detail: "Property name collision after snake_case conversion: '"
+              <> dup
+              <> "'",
+          )
+        })
+      list.flatten([ap_errors, typed_ap_errors, prop_errors, prop_collision_errors])
     }
 
     ArraySchema(items:, ..) -> {
@@ -236,8 +288,6 @@ fn validate_schema_recursive(
         validate_schema_ref_recursive(path <> ".allOf", s_ref)
       })
 
-    // Enum variant collisions after PascalCase are auto-resolved
-    // by deduplicate_names during code generation.
     _ -> []
   }
 }
@@ -296,9 +346,39 @@ fn validate_name_collisions(ctx: Context) -> List(ValidationError) {
       },
     )
 
-  // Function/type name collisions after case conversion are auto-resolved
-  // by deduplicate_names during code generation.
-  op_id_errors
+  // Function name collisions after snake_case conversion
+  let fn_names =
+    list.map(operations, fn(op) {
+      let #(op_id, _, _, _) = op
+      naming.operation_to_function_name(op_id)
+    })
+  let fn_collision_errors =
+    find_name_collisions(fn_names, fn(dup) {
+      UnsupportedFeature(
+        path: "paths",
+        detail: "Function name collision after case conversion: '"
+          <> dup
+          <> "'",
+      )
+    })
+
+  // Type name collisions after PascalCase conversion
+  let type_names =
+    list.map(operations, fn(op) {
+      let #(op_id, _, _, _) = op
+      naming.schema_to_type_name(op_id)
+    })
+  let type_collision_errors =
+    find_name_collisions(type_names, fn(dup) {
+      UnsupportedFeature(
+        path: "paths",
+        detail: "Type name collision after case conversion: '"
+          <> dup
+          <> "'",
+      )
+    })
+
+  list.flatten([op_id_errors, fn_collision_errors, type_collision_errors])
 }
 
 /// Find duplicates in a list using a key function, producing errors via an
@@ -318,4 +398,12 @@ fn find_duplicates(
       }
     })
   list.reverse(errors)
+}
+
+/// Find duplicate names in a simple list of strings.
+fn find_name_collisions(
+  names: List(String),
+  error_fn: fn(String) -> ValidationError,
+) -> List(ValidationError) {
+  find_duplicates(names, fn(name) { name }, error_fn)
 }

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -134,7 +134,7 @@ fn validate_request_body(
       let content_keys = dict.keys(rb.content)
       let unsupported =
         list.filter(content_keys, fn(key) {
-          !content_type.is_supported(content_type.from_string(key))
+          !content_type.is_supported_request(content_type.from_string(key))
         })
       let content_type_errors = case unsupported {
         [] -> []
@@ -143,7 +143,7 @@ fn validate_request_body(
             path: op_id <> ".requestBody",
             detail: "Content type '"
               <> media_type
-              <> "' is not supported. Only 'application/json' is supported.",
+              <> "' is not supported. Only 'application/json' and 'multipart/form-data' are supported for request bodies.",
           ),
         ]
       }
@@ -203,10 +203,7 @@ fn validate_multipart_request_body_fields(
   }
 }
 
-fn multipart_field_is_stringifiable(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
+fn multipart_field_is_stringifiable(schema_ref: SchemaRef, ctx: Context) -> Bool {
   case resolve_schema_object(Some(schema_ref), ctx) {
     Some(StringSchema(..))
     | Some(IntegerSchema(..))
@@ -229,7 +226,9 @@ fn validate_responses(
       let #(media_type_name, media_type) = ce
       let path = op_id <> ".responses." <> status_code
       let content_type_errors = case
-        content_type.is_supported(content_type.from_string(media_type_name))
+        content_type.is_supported_response(content_type.from_string(
+          media_type_name,
+        ))
       {
         True -> []
         False -> [
@@ -237,7 +236,7 @@ fn validate_responses(
             path: path,
             detail: "Response content type '"
               <> media_type_name
-              <> "' is not supported. Only 'application/json' is supported.",
+              <> "' is not supported. Only 'application/json' and 'text/plain' are supported.",
           ),
         ]
       }

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -187,16 +187,9 @@ fn validate_schema_recursive(
       additional_properties_untyped:,
       ..,
     ) -> {
-      // Check additionalProperties: true
-      let ap_errors = case additional_properties_untyped {
-        True -> [
-          UnsupportedFeature(
-            path: path,
-            detail: "additionalProperties: true is not supported. Gleam has no untyped map type.",
-          ),
-        ]
-        False -> []
-      }
+      // additionalProperties: true is supported via Dict(String, Dynamic)
+      let ap_errors = []
+      let _ = additional_properties_untyped
       // Recurse into typed additionalProperties schema
       let typed_ap_errors = case additional_properties {
         Some(ap_ref) -> validate_schema_ref_recursive(path <> ".additionalProperties", ap_ref)

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -23,7 +23,8 @@ pub fn validate(ctx: Context) -> List(ValidationError) {
   let op_errors = validate_operations(ctx)
   let schema_errors = validate_component_schemas(ctx)
   let collision_errors = validate_name_collisions(ctx)
-  list.flatten([op_errors, schema_errors, collision_errors])
+  let security_errors = validate_security_schemes(ctx)
+  list.flatten([op_errors, schema_errors, collision_errors, security_errors])
 }
 
 /// Convert a validation error to a human-readable string.
@@ -414,4 +415,35 @@ fn find_name_collisions(
   error_fn: fn(String) -> ValidationError,
 ) -> List(ValidationError) {
   find_duplicates(names, fn(name) { name }, error_fn)
+}
+
+/// Validate security schemes for unsupported types.
+fn validate_security_schemes(ctx: Context) -> List(ValidationError) {
+  let schemes = case ctx.spec.components {
+    Some(components) -> dict.to_list(components.security_schemes)
+    None -> []
+  }
+  list.flat_map(schemes, fn(entry) {
+    let #(name, scheme) = entry
+    case scheme {
+      spec.ApiKeyScheme(..) -> []
+      spec.HttpScheme(scheme: "bearer", ..) -> []
+      spec.HttpScheme(scheme: "basic", ..) -> []
+      spec.HttpScheme(scheme: "digest", ..) -> []
+      spec.HttpScheme(scheme: scheme_name, ..) -> [
+        UnsupportedFeature(
+          path: "components.securitySchemes." <> name,
+          detail: "HTTP security scheme '"
+            <> scheme_name
+            <> "' is not supported. Supported schemes: bearer, basic, digest.",
+        ),
+      ]
+      spec.OAuth2Scheme(..) -> [
+        UnsupportedFeature(
+          path: "components.securitySchemes." <> name,
+          detail: "OAuth2 security scheme is not supported.",
+        ),
+      ]
+    }
+  })
 }

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -3,6 +3,7 @@ import gleam/result
 import oaspec/codegen/client
 import oaspec/codegen/context.{type Context, type GeneratedFile}
 import oaspec/codegen/decoders
+import oaspec/codegen/guards
 import oaspec/codegen/middleware
 import oaspec/codegen/server
 import oaspec/codegen/types
@@ -66,8 +67,9 @@ fn generate_shared(ctx: Context) -> List(GeneratedFile) {
   let type_files = types.generate(ctx)
   let decoder_files = decoders.generate(ctx)
   let middleware_files = middleware.generate(ctx)
+  let guard_files = guards.generate(ctx)
 
-  list.flatten([type_files, decoder_files, middleware_files])
+  list.flatten([type_files, decoder_files, middleware_files, guard_files])
 }
 
 /// Ensure a directory exists, creating it if necessary.

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -1,0 +1,431 @@
+import gleam/dict.{type Dict}
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import oaspec/openapi/schema.{
+  type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
+  Inline, ObjectSchema, OneOfSchema, Reference,
+}
+import oaspec/openapi/spec.{
+  type OpenApiSpec, type PathItem, Components, OpenApiSpec, PathItem,
+}
+import oaspec/util/naming
+
+/// Accumulated state during the hoisting traversal.
+type HoistState {
+  HoistState(
+    /// New schemas to add to components.schemas
+    new_schemas: Dict(String, SchemaRef),
+    /// Set of all existing schema names (original + new) for collision checks
+    existing_names: Dict(String, Nil),
+  )
+}
+
+/// Hoist inline complex schemas into components.schemas, replacing them with $ref.
+/// This is a pre-processing pass that runs after parsing and before validation.
+/// The function is idempotent: running it twice produces the same result.
+pub fn hoist(spec: OpenApiSpec) -> OpenApiSpec {
+  let existing_schemas = case spec.components {
+    Some(components) -> components.schemas
+    None -> dict.new()
+  }
+  let existing_names =
+    dict.keys(existing_schemas)
+    |> list.map(fn(k) { #(k, Nil) })
+    |> dict.from_list()
+
+  let state = HoistState(new_schemas: dict.new(), existing_names: existing_names)
+
+  // 1. Hoist within existing component schemas (nested inline objects)
+  let #(hoisted_component_schemas, state) =
+    hoist_component_schemas(existing_schemas, state)
+
+  // 2. Hoist within all paths/operations
+  let #(hoisted_paths, state) = hoist_paths(spec.paths, state)
+
+  // 3. Merge all new schemas into components
+  let final_schemas = dict.merge(hoisted_component_schemas, state.new_schemas)
+  let components = case spec.components {
+    Some(c) -> Some(Components(..c, schemas: final_schemas))
+    None ->
+      case dict.is_empty(state.new_schemas) {
+        True -> None
+        False ->
+          Some(Components(
+            schemas: final_schemas,
+            parameters: dict.new(),
+            request_bodies: dict.new(),
+            responses: dict.new(),
+            security_schemes: dict.new(),
+          ))
+      }
+  }
+
+  OpenApiSpec(..spec, paths: hoisted_paths, components: components)
+}
+
+/// Determine if a SchemaObject is complex and should be hoisted.
+fn needs_hoisting(schema_obj: SchemaObject) -> Bool {
+  case schema_obj {
+    ObjectSchema(..) -> True
+    AllOfSchema(..) -> True
+    OneOfSchema(..) -> True
+    AnyOfSchema(..) -> True
+    ArraySchema(items: Inline(inner), ..) -> needs_hoisting(inner)
+    _ -> False
+  }
+}
+
+/// Generate a unique schema name, handling collisions by appending 2, 3, etc.
+fn make_unique_name(base_name: String, state: HoistState) -> #(String, HoistState) {
+  case
+    dict.has_key(state.existing_names, base_name)
+    || dict.has_key(state.new_schemas, base_name)
+  {
+    False -> {
+      let state =
+        HoistState(
+          ..state,
+          existing_names: dict.insert(state.existing_names, base_name, Nil),
+        )
+      #(base_name, state)
+    }
+    True -> find_unique_name(base_name, 2, state)
+  }
+}
+
+/// Try incrementing suffixes until a unique name is found.
+fn find_unique_name(
+  base_name: String,
+  suffix: Int,
+  state: HoistState,
+) -> #(String, HoistState) {
+  let candidate = base_name <> int.to_string(suffix)
+  case
+    dict.has_key(state.existing_names, candidate)
+    || dict.has_key(state.new_schemas, candidate)
+  {
+    False -> {
+      let state =
+        HoistState(
+          ..state,
+          existing_names: dict.insert(state.existing_names, candidate, Nil),
+        )
+      #(candidate, state)
+    }
+    True -> find_unique_name(base_name, suffix + 1, state)
+  }
+}
+
+/// Hoist a single SchemaRef if it is inline and complex.
+/// Returns the (possibly replaced) SchemaRef and updated state.
+fn hoist_schema_ref(
+  schema_ref: SchemaRef,
+  name_prefix: String,
+  name_suffix: String,
+  state: HoistState,
+) -> #(SchemaRef, HoistState) {
+  case schema_ref {
+    Reference(_) -> #(schema_ref, state)
+    Inline(schema_obj) -> {
+      case needs_hoisting(schema_obj) {
+        False -> #(schema_ref, state)
+        True -> {
+          // Recursively hoist nested schemas within this object first (depth-first)
+          let base_name =
+            naming.to_pascal_case(name_prefix)
+            <> naming.to_pascal_case(name_suffix)
+          let #(hoisted_obj, state) =
+            hoist_within_schema(schema_obj, base_name, state)
+
+          // Generate unique name and insert into new_schemas
+          let #(unique_name, state) = make_unique_name(base_name, state)
+          let state =
+            HoistState(
+              ..state,
+              new_schemas: dict.insert(
+                state.new_schemas,
+                unique_name,
+                Inline(hoisted_obj),
+              ),
+            )
+
+          let ref = "#/components/schemas/" <> unique_name
+          #(Reference(ref: ref), state)
+        }
+      }
+    }
+  }
+}
+
+/// Recursively hoist within a SchemaObject's children.
+fn hoist_within_schema(
+  schema_obj: SchemaObject,
+  name_prefix: String,
+  state: HoistState,
+) -> #(SchemaObject, HoistState) {
+  case schema_obj {
+    ObjectSchema(
+      description:,
+      properties:,
+      required:,
+      additional_properties:,
+      additional_properties_untyped:,
+      nullable:,
+    ) -> {
+      // Hoist each property
+      let #(new_props, state) =
+        dict.to_list(properties)
+        |> list.fold(#(dict.new(), state), fn(acc, entry) {
+          let #(props_acc, state) = acc
+          let #(prop_name, prop_ref) = entry
+          let #(hoisted_ref, state) =
+            hoist_schema_ref(prop_ref, name_prefix, prop_name, state)
+          #(dict.insert(props_acc, prop_name, hoisted_ref), state)
+        })
+
+      // Hoist additional_properties if present
+      let #(new_ap, state) = case additional_properties {
+        Some(ap_ref) -> {
+          let #(hoisted, state) =
+            hoist_schema_ref(ap_ref, name_prefix, "Value", state)
+          #(Some(hoisted), state)
+        }
+        None -> #(None, state)
+      }
+
+      let result =
+        ObjectSchema(
+          description:,
+          properties: new_props,
+          required:,
+          additional_properties: new_ap,
+          additional_properties_untyped:,
+          nullable:,
+        )
+      #(result, state)
+    }
+
+    ArraySchema(description:, items:, min_items:, max_items:, nullable:) -> {
+      let #(hoisted_items, state) =
+        hoist_schema_ref(items, name_prefix, "Item", state)
+      #(
+        ArraySchema(
+          description:,
+          items: hoisted_items,
+          min_items:,
+          max_items:,
+          nullable:,
+        ),
+        state,
+      )
+    }
+
+    OneOfSchema(description:, schemas:, discriminator:) -> {
+      let #(hoisted_schemas_rev, state) =
+        list.index_fold(schemas, #([], state), fn(acc, s_ref, idx) {
+          let #(schemas_acc, state) = acc
+          let suffix = "Variant" <> int.to_string(idx)
+          let #(hoisted, state) =
+            hoist_schema_ref(s_ref, name_prefix, suffix, state)
+          #([hoisted, ..schemas_acc], state)
+        })
+      #(
+        OneOfSchema(
+          description:,
+          schemas: list.reverse(hoisted_schemas_rev),
+          discriminator:,
+        ),
+        state,
+      )
+    }
+
+    AnyOfSchema(description:, schemas:) -> {
+      let #(hoisted_schemas_rev, state) =
+        list.index_fold(schemas, #([], state), fn(acc, s_ref, idx) {
+          let #(schemas_acc, state) = acc
+          let suffix = "Variant" <> int.to_string(idx)
+          let #(hoisted, state) =
+            hoist_schema_ref(s_ref, name_prefix, suffix, state)
+          #([hoisted, ..schemas_acc], state)
+        })
+      #(
+        AnyOfSchema(description:, schemas: list.reverse(hoisted_schemas_rev)),
+        state,
+      )
+    }
+
+    AllOfSchema(description:, schemas:) -> {
+      let #(hoisted_schemas_rev, state) =
+        list.index_fold(schemas, #([], state), fn(acc, s_ref, idx) {
+          let #(schemas_acc, state) = acc
+          let suffix = "Part" <> int.to_string(idx)
+          let #(hoisted, state) =
+            hoist_schema_ref(s_ref, name_prefix, suffix, state)
+          #([hoisted, ..schemas_acc], state)
+        })
+      #(
+        AllOfSchema(description:, schemas: list.reverse(hoisted_schemas_rev)),
+        state,
+      )
+    }
+
+    _ -> #(schema_obj, state)
+  }
+}
+
+/// Hoist schemas within component schemas.
+fn hoist_component_schemas(
+  schemas: Dict(String, SchemaRef),
+  state: HoistState,
+) -> #(Dict(String, SchemaRef), HoistState) {
+  dict.to_list(schemas)
+  |> list.fold(#(dict.new(), state), fn(acc, entry) {
+    let #(result, state) = acc
+    let #(name, schema_ref) = entry
+    case schema_ref {
+      Inline(schema_obj) -> {
+        let #(hoisted_obj, state) =
+          hoist_within_schema(schema_obj, name, state)
+        #(dict.insert(result, name, Inline(hoisted_obj)), state)
+      }
+      Reference(_) -> #(dict.insert(result, name, schema_ref), state)
+    }
+  })
+}
+
+/// Walk all paths and operations, hoisting inline schemas.
+fn hoist_paths(
+  paths: Dict(String, PathItem),
+  state: HoistState,
+) -> #(Dict(String, PathItem), HoistState) {
+  dict.to_list(paths)
+  |> list.fold(#(dict.new(), state), fn(acc, entry) {
+    let #(result, state) = acc
+    let #(path, path_item) = entry
+    let #(hoisted_item, state) = hoist_path_item(path_item, path, state)
+    #(dict.insert(result, path, hoisted_item), state)
+  })
+}
+
+/// Hoist schemas within a single PathItem.
+fn hoist_path_item(
+  path_item: PathItem,
+  path: String,
+  state: HoistState,
+) -> #(PathItem, HoistState) {
+  let #(get, state) = hoist_maybe_operation(path_item.get, "get", path, state)
+  let #(post, state) = hoist_maybe_operation(path_item.post, "post", path, state)
+  let #(put, state) = hoist_maybe_operation(path_item.put, "put", path, state)
+  let #(delete, state) =
+    hoist_maybe_operation(path_item.delete, "delete", path, state)
+  let #(patch, state) =
+    hoist_maybe_operation(path_item.patch, "patch", path, state)
+
+  let result = PathItem(..path_item, get:, post:, put:, delete:, patch:)
+  #(result, state)
+}
+
+/// Hoist schemas in an optional operation.
+fn hoist_maybe_operation(
+  maybe_op: Option(spec.Operation),
+  method: String,
+  path: String,
+  state: HoistState,
+) -> #(Option(spec.Operation), HoistState) {
+  case maybe_op {
+    None -> #(None, state)
+    Some(operation) -> {
+      let op_id = case operation.operation_id {
+        Some(id) -> id
+        None ->
+          method
+          <> "_"
+          <> string.replace(path, "/", "_")
+          |> string.replace("{", "")
+          |> string.replace("}", "")
+      }
+      let #(hoisted_op, state) = hoist_operation(operation, op_id, state)
+      #(Some(hoisted_op), state)
+    }
+  }
+}
+
+/// Hoist schemas within a single Operation.
+fn hoist_operation(
+  operation: spec.Operation,
+  op_id: String,
+  state: HoistState,
+) -> #(spec.Operation, HoistState) {
+  // Hoist request body schemas
+  let #(request_body, state) = case operation.request_body {
+    None -> #(None, state)
+    Some(rb) -> {
+      let #(hoisted_rb, state) = hoist_request_body(rb, op_id, state)
+      #(Some(hoisted_rb), state)
+    }
+  }
+
+  // Hoist response schemas
+  let #(responses, state) = hoist_responses(operation.responses, op_id, state)
+
+  let result = spec.Operation(..operation, request_body:, responses:)
+  #(result, state)
+}
+
+/// Hoist schemas within a RequestBody.
+fn hoist_request_body(
+  rb: spec.RequestBody,
+  op_id: String,
+  state: HoistState,
+) -> #(spec.RequestBody, HoistState) {
+  let #(new_content, state) =
+    dict.to_list(rb.content)
+    |> list.fold(#(dict.new(), state), fn(acc, entry) {
+      let #(result, state) = acc
+      let #(media_type_name, media_type) = entry
+      case media_type.schema {
+        Some(schema_ref) -> {
+          let #(hoisted, state) =
+            hoist_schema_ref(schema_ref, op_id, "Request", state)
+          let mt = spec.MediaType(schema: Some(hoisted))
+          #(dict.insert(result, media_type_name, mt), state)
+        }
+        None -> #(dict.insert(result, media_type_name, media_type), state)
+      }
+    })
+  #(spec.RequestBody(..rb, content: new_content), state)
+}
+
+/// Hoist schemas within response definitions.
+fn hoist_responses(
+  responses: Dict(String, spec.Response),
+  op_id: String,
+  state: HoistState,
+) -> #(Dict(String, spec.Response), HoistState) {
+  dict.to_list(responses)
+  |> list.fold(#(dict.new(), state), fn(acc, entry) {
+    let #(result, state) = acc
+    let #(status_code, response) = entry
+    let #(new_content, state) =
+      dict.to_list(response.content)
+      |> list.fold(#(dict.new(), state), fn(ct_acc, ct_entry) {
+        let #(ct_result, state) = ct_acc
+        let #(media_type_name, media_type) = ct_entry
+        case media_type.schema {
+          Some(schema_ref) -> {
+            let suffix = "Response" <> naming.to_pascal_case(status_code)
+            let #(hoisted, state) =
+              hoist_schema_ref(schema_ref, op_id, suffix, state)
+            let mt = spec.MediaType(schema: Some(hoisted))
+            #(dict.insert(ct_result, media_type_name, mt), state)
+          }
+          None -> #(dict.insert(ct_result, media_type_name, media_type), state)
+        }
+      })
+    let hoisted_response =
+      spec.Response(..response, content: new_content)
+    #(dict.insert(result, status_code, hoisted_response), state)
+  })
+}

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -17,8 +17,10 @@ type HoistState {
   HoistState(
     /// New schemas to add to components.schemas
     new_schemas: Dict(String, SchemaRef),
-    /// Set of all existing schema names (original + new) for collision checks
+    /// Set of all existing schema names (original + new) for raw collision checks
     existing_names: Dict(String, Nil),
+    /// Set of all generated type names after case normalization
+    existing_type_names: Dict(String, Nil),
   )
 }
 
@@ -34,8 +36,17 @@ pub fn hoist(spec: OpenApiSpec) -> OpenApiSpec {
     dict.keys(existing_schemas)
     |> list.map(fn(k) { #(k, Nil) })
     |> dict.from_list()
+  let existing_type_names =
+    dict.keys(existing_schemas)
+    |> list.map(fn(k) { #(naming.schema_to_type_name(k), Nil) })
+    |> dict.from_list()
 
-  let state = HoistState(new_schemas: dict.new(), existing_names: existing_names)
+  let state =
+    HoistState(
+      new_schemas: dict.new(),
+      existing_names: existing_names,
+      existing_type_names: existing_type_names,
+    )
 
   // 1. Hoist within existing component schemas (nested inline objects)
   let #(hoisted_component_schemas, state) =
@@ -78,16 +89,25 @@ fn needs_hoisting(schema_obj: SchemaObject) -> Bool {
 }
 
 /// Generate a unique schema name, handling collisions by appending 2, 3, etc.
-fn make_unique_name(base_name: String, state: HoistState) -> #(String, HoistState) {
+fn make_unique_name(
+  base_name: String,
+  state: HoistState,
+) -> #(String, HoistState) {
+  let type_name = naming.schema_to_type_name(base_name)
   case
     dict.has_key(state.existing_names, base_name)
-    || dict.has_key(state.new_schemas, base_name)
+    || dict.has_key(state.existing_type_names, type_name)
   {
     False -> {
       let state =
         HoistState(
           ..state,
           existing_names: dict.insert(state.existing_names, base_name, Nil),
+          existing_type_names: dict.insert(
+            state.existing_type_names,
+            type_name,
+            Nil,
+          ),
         )
       #(base_name, state)
     }
@@ -102,15 +122,21 @@ fn find_unique_name(
   state: HoistState,
 ) -> #(String, HoistState) {
   let candidate = base_name <> int.to_string(suffix)
+  let type_name = naming.schema_to_type_name(candidate)
   case
     dict.has_key(state.existing_names, candidate)
-    || dict.has_key(state.new_schemas, candidate)
+    || dict.has_key(state.existing_type_names, type_name)
   {
     False -> {
       let state =
         HoistState(
           ..state,
           existing_names: dict.insert(state.existing_names, candidate, Nil),
+          existing_type_names: dict.insert(
+            state.existing_type_names,
+            type_name,
+            Nil,
+          ),
         )
       #(candidate, state)
     }
@@ -286,8 +312,7 @@ fn hoist_component_schemas(
     let #(name, schema_ref) = entry
     case schema_ref {
       Inline(schema_obj) -> {
-        let #(hoisted_obj, state) =
-          hoist_within_schema(schema_obj, name, state)
+        let #(hoisted_obj, state) = hoist_within_schema(schema_obj, name, state)
         #(dict.insert(result, name, Inline(hoisted_obj)), state)
       }
       Reference(_) -> #(dict.insert(result, name, schema_ref), state)
@@ -316,7 +341,8 @@ fn hoist_path_item(
   state: HoistState,
 ) -> #(PathItem, HoistState) {
   let #(get, state) = hoist_maybe_operation(path_item.get, "get", path, state)
-  let #(post, state) = hoist_maybe_operation(path_item.post, "post", path, state)
+  let #(post, state) =
+    hoist_maybe_operation(path_item.post, "post", path, state)
   let #(put, state) = hoist_maybe_operation(path_item.put, "put", path, state)
   let #(delete, state) =
     hoist_maybe_operation(path_item.delete, "delete", path, state)
@@ -424,8 +450,7 @@ fn hoist_responses(
           None -> #(dict.insert(ct_result, media_type_name, media_type), state)
         }
       })
-    let hoisted_response =
-      spec.Response(..response, content: new_content)
+    let hoisted_response = spec.Response(..response, content: new_content)
     #(dict.insert(result, status_code, hoisted_response), state)
   })
 }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1036,11 +1036,12 @@ fn parse_security_scheme(
         }),
       )
       case in_str {
-        "header" | "query" -> Ok(spec.ApiKeyScheme(name:, in_: in_str))
+        "header" | "query" | "cookie" ->
+          Ok(spec.ApiKeyScheme(name:, in_: in_str))
         _ ->
           Error(InvalidValue(
             path: "securityScheme.apiKey.in",
-            detail: "Only 'header' and 'query' are supported for apiKey. Got: '"
+            detail: "Only 'header', 'query' and 'cookie' are supported for apiKey. Got: '"
               <> in_str
               <> "'",
           ))
@@ -1068,6 +1069,12 @@ fn parse_security_scheme(
               <> "'",
           ))
       }
+    }
+    "oauth2" -> {
+      let description =
+        yay.extract_optional_string(node, "description")
+        |> result.unwrap(None)
+      Ok(spec.OAuth2Scheme(description:))
     }
     _ ->
       Error(InvalidValue(

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1054,21 +1054,10 @@ fn parse_security_scheme(
           MissingField(path: "securityScheme.http", field: "scheme")
         }),
       )
-      case scheme {
-        "bearer" -> {
-          let bearer_format =
-            yay.extract_optional_string(node, "bearerFormat")
-            |> result.unwrap(None)
-          Ok(spec.HttpScheme(scheme:, bearer_format:))
-        }
-        _ ->
-          Error(InvalidValue(
-            path: "securityScheme.http.scheme",
-            detail: "Only 'bearer' is supported for http security scheme. Got: '"
-              <> scheme
-              <> "'",
-          ))
-      }
+      let bearer_format =
+        yay.extract_optional_string(node, "bearerFormat")
+        |> result.unwrap(None)
+      Ok(spec.HttpScheme(scheme:, bearer_format:))
     }
     "oauth2" -> {
       let description =

--- a/src/oaspec/openapi/spec.gleam
+++ b/src/oaspec/openapi/spec.gleam
@@ -39,6 +39,7 @@ pub type Components {
 pub type SecurityScheme {
   ApiKeyScheme(name: String, in_: String)
   HttpScheme(scheme: String, bearer_format: Option(String))
+  OAuth2Scheme(description: Option(String))
 }
 
 /// A single scheme reference within a security requirement (AND element).

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -1,0 +1,38 @@
+/// Supported content types for code generation.
+pub type ContentType {
+  ApplicationJson
+  TextPlain
+  MultipartFormData
+  UnsupportedContentType(String)
+}
+
+/// Parse a content type string into a ContentType.
+pub fn from_string(content_type: String) -> ContentType {
+  case content_type {
+    "application/json" -> ApplicationJson
+    "text/plain" -> TextPlain
+    "multipart/form-data" -> MultipartFormData
+    other -> UnsupportedContentType(other)
+  }
+}
+
+/// Convert a ContentType back to its string representation.
+pub fn to_string(content_type: ContentType) -> String {
+  case content_type {
+    ApplicationJson -> "application/json"
+    TextPlain -> "text/plain"
+    MultipartFormData -> "multipart/form-data"
+    UnsupportedContentType(s) -> s
+  }
+}
+
+/// Check if a content type is currently supported for code generation.
+/// Initially only application/json is supported. As we add features,
+/// we expand this to include text/plain (Phase 1-3) and
+/// multipart/form-data (Phase 2-2).
+pub fn is_supported(content_type: ContentType) -> Bool {
+  case content_type {
+    ApplicationJson -> True
+    _ -> False
+  }
+}

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -33,6 +33,7 @@ pub fn to_string(content_type: ContentType) -> String {
 pub fn is_supported(content_type: ContentType) -> Bool {
   case content_type {
     ApplicationJson -> True
+    TextPlain -> True
     _ -> False
   }
 }

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -34,6 +34,7 @@ pub fn is_supported(content_type: ContentType) -> Bool {
   case content_type {
     ApplicationJson -> True
     TextPlain -> True
+    MultipartFormData -> True
     _ -> False
   }
 }

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -26,15 +26,30 @@ pub fn to_string(content_type: ContentType) -> String {
   }
 }
 
-/// Check if a content type is currently supported for code generation.
-/// Initially only application/json is supported. As we add features,
-/// we expand this to include text/plain (Phase 1-3) and
-/// multipart/form-data (Phase 2-2).
+/// Check if a content type is supported anywhere in code generation.
 pub fn is_supported(content_type: ContentType) -> Bool {
   case content_type {
     ApplicationJson -> True
     TextPlain -> True
     MultipartFormData -> True
+    _ -> False
+  }
+}
+
+/// Check if a content type is supported for request bodies.
+pub fn is_supported_request(content_type: ContentType) -> Bool {
+  case content_type {
+    ApplicationJson -> True
+    MultipartFormData -> True
+    _ -> False
+  }
+}
+
+/// Check if a content type is supported for responses.
+pub fn is_supported_response(content_type: ContentType) -> Bool {
+  case content_type {
+    ApplicationJson -> True
+    TextPlain -> True
     _ -> False
   }
 }

--- a/src/oaspec/util/naming.gleam
+++ b/src/oaspec/util/naming.gleam
@@ -1,3 +1,5 @@
+import gleam/dict
+import gleam/int
 import gleam/list
 import gleam/regexp
 import gleam/string
@@ -102,4 +104,26 @@ fn split_camel_case(input: String) -> List(String) {
 fn insert_underscores_before_caps(input: String) -> String {
   let assert Ok(re) = regexp.from_string("([a-z0-9])([A-Z])")
   regexp.replace(re, input, "\\1_\\2")
+}
+
+/// Deduplicate a list of names by appending _2, _3, etc. to duplicates.
+/// Preserves order. First occurrence keeps original name.
+pub fn deduplicate_names(names: List(String)) -> List(String) {
+  let #(result_rev, _) =
+    list.fold(names, #([], dict.new()), fn(acc, name) {
+      let #(result, counts) = acc
+      case dict.get(counts, name) {
+        Error(_) -> {
+          let counts = dict.insert(counts, name, 1)
+          #([name, ..result], counts)
+        }
+        Ok(count) -> {
+          let new_count = count + 1
+          let unique_name = name <> "_" <> int.to_string(new_count)
+          let counts = dict.insert(counts, name, new_count)
+          #([unique_name, ..result], counts)
+        }
+      }
+    })
+  list.reverse(result_rev)
 }

--- a/test/fixtures/allof_additional_props.yaml
+++ b/test/fixtures/allof_additional_props.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: AllOf AdditionalProps Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtendedItem'
+components:
+  schemas:
+    BaseItem:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+      additionalProperties:
+        type: string
+    ExtendedItem:
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - type: object
+          properties:
+            label:
+              type: string

--- a/test/fixtures/typed_additional_props.yaml
+++ b/test/fixtures/typed_additional_props.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Typed AdditionalProps Test
+  version: 1.0.0
+paths:
+  /config:
+    get:
+      operationId: getConfig
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+components:
+  schemas:
+    Config:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: integer
+      additionalProperties:
+        type: string

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -242,7 +242,7 @@ pub fn parse_global_security_inherited_test() {
   get_public.security |> should.equal(Some([]))
 }
 
-pub fn validate_rejects_array_parameter_test() {
+pub fn validate_accepts_array_parameter_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -267,7 +267,34 @@ paths:
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
   list.any(error_strings, fn(s) { string.contains(s, "Array parameters") })
-  |> should.be_true()
+  |> should.be_false()
+}
+
+pub fn validate_accepts_optional_array_parameter_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: tags
+          in: query
+          required: false
+          schema:
+            type: array
+            items: { type: integer }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  errors |> should.equal([])
 }
 
 pub fn validate_rejects_non_json_response_content_type_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -7,6 +7,7 @@ import gleeunit/should
 import oaspec/codegen/context
 import oaspec/codegen/validate
 import oaspec/config
+import oaspec/openapi/hoist
 import oaspec/openapi/parser
 import oaspec/openapi/resolver
 import oaspec/openapi/schema
@@ -532,4 +533,404 @@ pub fn validate_complex_supported_has_no_errors_test() {
   let ctx = make_ctx("test/fixtures/complex_supported_openapi.yaml")
   let errors = validate.validate(ctx)
   errors |> should.equal([])
+}
+
+// --- Hoist Tests ---
+
+pub fn hoist_inline_object_property_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        address:
+          type: object
+          properties:
+            street: { type: string }
+            city: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // PetAddress should exist in components.schemas
+  dict.has_key(components.schemas, "PetAddress") |> should.be_true()
+
+  // Pet.address should now be a $ref
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "Pet")
+  let assert Ok(schema.Reference(ref: ref)) = dict.get(props, "address")
+  ref |> should.equal("#/components/schemas/PetAddress")
+
+  // PetAddress should have street and city properties
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: addr_props, ..))) =
+    dict.get(components.schemas, "PetAddress")
+  dict.has_key(addr_props, "street") |> should.be_true()
+  dict.has_key(addr_props, "city") |> should.be_true()
+}
+
+pub fn hoist_inline_oneof_variants_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    PetType:
+      oneOf:
+        - type: object
+          properties:
+            bark_volume: { type: integer }
+        - type: object
+          properties:
+            purr_frequency: { type: number }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // The oneOf variants should now be $ref references
+  let assert Ok(schema.Inline(schema.OneOfSchema(schemas: variants, ..))) =
+    dict.get(components.schemas, "PetType")
+  list.each(variants, fn(v) {
+    case v {
+      schema.Reference(_) -> should.be_true(True)
+      schema.Inline(_) -> should.fail()
+    }
+  })
+
+  // Hoisted schemas should exist (naming: PetType0, PetType1 or similar)
+  // At minimum, components.schemas should have more than just PetType
+  dict.size(components.schemas) |> should.equal(3)
+}
+
+pub fn hoist_inline_array_items_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    PetList:
+      type: array
+      items:
+        type: object
+        properties:
+          name: { type: string }
+          age: { type: integer }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // Array items should now be a $ref
+  let assert Ok(schema.Inline(schema.ArraySchema(items: items_ref, ..))) =
+    dict.get(components.schemas, "PetList")
+  let assert schema.Reference(ref: ref) = items_ref
+  string.contains(ref, "#/components/schemas/") |> should.be_true()
+
+  // The extracted schema should exist in components.schemas
+  dict.size(components.schemas) |> should.equal(2)
+}
+
+pub fn hoist_preserves_refs_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name: { type: string }
+        owner:
+          $ref: '#/components/schemas/Owner'
+    Owner:
+      type: object
+      properties:
+        name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // No extra schemas should be added
+  dict.size(components.schemas) |> should.equal(2)
+
+  // The $ref should remain unchanged
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "Pet")
+  let assert Ok(schema.Reference(ref: ref)) = dict.get(props, "owner")
+  ref |> should.equal("#/components/schemas/Owner")
+}
+
+pub fn hoist_preserves_primitives_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name: { type: string }
+        age: { type: integer }
+        active: { type: boolean }
+        score: { type: number }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // No extra schemas should be added for primitives
+  dict.size(components.schemas) |> should.equal(1)
+
+  // Properties should remain inline primitives
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "User")
+  let assert Ok(schema.Inline(schema.StringSchema(..))) =
+    dict.get(props, "name")
+  let assert Ok(schema.Inline(schema.IntegerSchema(..))) =
+    dict.get(props, "age")
+  let assert Ok(schema.Inline(schema.BooleanSchema(..))) =
+    dict.get(props, "active")
+  let assert Ok(schema.Inline(schema.NumberSchema(..))) =
+    dict.get(props, "score")
+}
+
+pub fn hoist_nested_inline_objects_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Company:
+      type: object
+      properties:
+        name: { type: string }
+        headquarters:
+          type: object
+          properties:
+            city: { type: string }
+            coordinates:
+              type: object
+              properties:
+                lat: { type: number }
+                lon: { type: number }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // Both nested levels should be hoisted
+  dict.has_key(components.schemas, "CompanyHeadquarters") |> should.be_true()
+  dict.has_key(components.schemas, "CompanyHeadquartersCoordinates")
+  |> should.be_true()
+
+  // Company.headquarters should be a $ref
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: company_props, ..))) =
+    dict.get(components.schemas, "Company")
+  let assert Ok(schema.Reference(ref: hq_ref)) =
+    dict.get(company_props, "headquarters")
+  hq_ref |> should.equal("#/components/schemas/CompanyHeadquarters")
+
+  // CompanyHeadquarters.coordinates should be a $ref
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: hq_props, ..))) =
+    dict.get(components.schemas, "CompanyHeadquarters")
+  let assert Ok(schema.Reference(ref: coord_ref)) =
+    dict.get(hq_props, "coordinates")
+  coord_ref
+  |> should.equal("#/components/schemas/CompanyHeadquartersCoordinates")
+
+  // CompanyHeadquartersCoordinates should have lat and lon
+  let assert Ok(schema.Inline(schema.ObjectSchema(
+    properties: coord_props,
+    ..,
+  ))) = dict.get(components.schemas, "CompanyHeadquartersCoordinates")
+  dict.has_key(coord_props, "lat") |> should.be_true()
+  dict.has_key(coord_props, "lon") |> should.be_true()
+}
+
+pub fn hoist_request_body_inline_object_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                tag: { type: string }
+      responses:
+        '201': { description: created }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // The inline request body schema should be extracted
+  dict.has_key(components.schemas, "CreatePetRequest")
+  |> should.be_true()
+
+  // The request body should now reference the extracted schema
+  let assert Ok(path_item) = dict.get(hoisted.paths, "/pets")
+  let assert Some(op) = path_item.post
+  let assert Some(req_body) = op.request_body
+  let assert Ok(media_type) = dict.get(req_body.content, "application/json")
+  let assert Some(schema.Reference(ref: ref)) = media_type.schema
+  string.contains(ref, "#/components/schemas/") |> should.be_true()
+}
+
+pub fn hoist_response_inline_object_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: integer }
+                  name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // The inline response schema should be extracted (with status code in name)
+  dict.has_key(components.schemas, "ListPetsResponse200")
+  |> should.be_true()
+
+  // The response should now reference the extracted schema
+  let assert Ok(path_item) = dict.get(hoisted.paths, "/pets")
+  let assert Some(op) = path_item.get
+  let assert Ok(response) = dict.get(op.responses, "200")
+  let assert Ok(media_type) = dict.get(response.content, "application/json")
+  let assert Some(schema.Reference(ref: ref)) = media_type.schema
+  string.contains(ref, "#/components/schemas/") |> should.be_true()
+}
+
+pub fn hoist_idempotent_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name: { type: string }
+        address:
+          type: object
+          properties:
+            street: { type: string }
+            city: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted_once = hoist.hoist(spec)
+  let hoisted_twice = hoist.hoist(hoisted_once)
+
+  // Both hoisted results should have the same schemas
+  let assert Some(components_once) = hoisted_once.components
+  let assert Some(components_twice) = hoisted_twice.components
+  dict.size(components_once.schemas)
+  |> should.equal(dict.size(components_twice.schemas))
+
+  // The schemas should be identical
+  hoisted_once |> should.equal(hoisted_twice)
+}
+
+pub fn hoist_name_collision_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name: { type: string }
+        address:
+          type: object
+          properties:
+            street: { type: string }
+    PetAddress:
+      type: object
+      properties:
+        zip: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  // Original PetAddress should still exist
+  dict.has_key(components.schemas, "PetAddress") |> should.be_true()
+
+  // The hoisted schema should use a suffixed name to avoid collision
+  // There should be 3 schemas: Pet, PetAddress (original), and PetAddress2 (or similar)
+  dict.size(components.schemas) |> should.equal(3)
+
+  // Pet.address should reference the suffixed name, not the original PetAddress
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "Pet")
+  let assert Ok(schema.Reference(ref: ref)) = dict.get(props, "address")
+  // The ref should NOT be the original PetAddress
+  ref |> should.not_equal("#/components/schemas/PetAddress")
+  // It should still be a valid components reference
+  string.contains(ref, "#/components/schemas/") |> should.be_true()
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -11,6 +11,7 @@ import oaspec/openapi/hoist
 import oaspec/openapi/parser
 import oaspec/openapi/resolver
 import oaspec/openapi/schema
+import oaspec/openapi/spec
 import oaspec/util/content_type
 import oaspec/util/naming
 
@@ -452,12 +453,25 @@ fn make_ctx(spec_path: String) -> context.Context {
   context.new(spec, cfg)
 }
 
-pub fn validate_broken_spec_detects_deep_object_test() {
+pub fn validate_accepts_deep_object_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
+  // deepObject style is now supported, so it should NOT appear as a validation error
   list.any(error_strings, fn(s) { string.contains(s, "deepObject") })
-  |> should.be_true()
+  |> should.be_false()
+}
+
+pub fn validate_accepts_complex_schema_parameter_test() {
+  let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  // Complex schema parameters (object/allOf/oneOf/anyOf) are now supported,
+  // so they should NOT appear as validation errors
+  list.any(error_strings, fn(s) {
+    string.contains(s, "Complex schema parameters")
+  })
+  |> should.be_false()
 }
 
 pub fn validate_accepts_multipart_form_data_test() {
@@ -1102,4 +1116,68 @@ pub fn content_type_roundtrip_test() {
   content_type.from_string("image/png")
   |> content_type.to_string()
   |> should.equal("image/png")
+}
+
+pub fn parse_accepts_oauth2_scheme_test() {
+  let yaml =
+    "
+openapi: '3.0.0'
+info: { title: OAuth2 API, version: '1.0' }
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      security:
+        - oauth2Auth: []
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    oauth2Auth:
+      type: oauth2
+      description: OAuth2 authorization code
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes: {}
+"
+  let assert Ok(parsed) = parser.parse_string(yaml)
+  let assert Some(components) = parsed.components
+  let assert Ok(scheme) = dict.get(components.security_schemes, "oauth2Auth")
+  case scheme {
+    spec.OAuth2Scheme(description: Some("OAuth2 authorization code")) ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_accepts_apikey_cookie_test() {
+  let yaml =
+    "
+openapi: '3.0.0'
+info: { title: Cookie API, version: '1.0' }
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      security:
+        - cookieAuth: []
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      name: session_id
+      in: cookie
+"
+  let assert Ok(parsed) = parser.parse_string(yaml)
+  let assert Some(components) = parsed.components
+  let assert Ok(scheme) = dict.get(components.security_schemes, "cookieAuth")
+  case scheme {
+    spec.ApiKeyScheme(name: "session_id", in_: "cookie") ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -297,7 +297,7 @@ paths:
   errors |> should.equal([])
 }
 
-pub fn validate_rejects_non_json_response_content_type_test() {
+pub fn validate_accepts_text_plain_response_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -318,9 +318,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let ctx = make_ctx_from_spec(spec)
   let errors = validate.validate(ctx)
-  let error_strings = list.map(errors, validate.error_to_string)
-  list.any(error_strings, fn(s) { string.contains(s, "text/plain") })
-  |> should.be_true()
+  errors |> should.equal([])
 }
 
 pub fn validate_accepts_property_name_collision_test() {
@@ -1020,7 +1018,7 @@ pub fn content_type_is_supported_test() {
   |> should.be_true()
 
   content_type.is_supported(content_type.TextPlain)
-  |> should.be_false()
+  |> should.be_true()
 
   content_type.is_supported(content_type.MultipartFormData)
   |> should.be_false()

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -11,6 +11,7 @@ import oaspec/openapi/hoist
 import oaspec/openapi/parser
 import oaspec/openapi/resolver
 import oaspec/openapi/schema
+import oaspec/util/content_type
 import oaspec/util/naming
 
 pub fn main() {
@@ -955,4 +956,66 @@ components:
   ref |> should.not_equal("#/components/schemas/PetAddress")
   // It should still be a valid components reference
   string.contains(ref, "#/components/schemas/") |> should.be_true()
+}
+
+// --- ContentType Tests ---
+
+pub fn content_type_from_string_test() {
+  content_type.from_string("application/json")
+  |> should.equal(content_type.ApplicationJson)
+
+  content_type.from_string("text/plain")
+  |> should.equal(content_type.TextPlain)
+
+  content_type.from_string("multipart/form-data")
+  |> should.equal(content_type.MultipartFormData)
+
+  content_type.from_string("application/xml")
+  |> should.equal(content_type.UnsupportedContentType("application/xml"))
+}
+
+pub fn content_type_to_string_test() {
+  content_type.to_string(content_type.ApplicationJson)
+  |> should.equal("application/json")
+
+  content_type.to_string(content_type.TextPlain)
+  |> should.equal("text/plain")
+
+  content_type.to_string(content_type.MultipartFormData)
+  |> should.equal("multipart/form-data")
+
+  content_type.to_string(content_type.UnsupportedContentType("application/xml"))
+  |> should.equal("application/xml")
+}
+
+pub fn content_type_is_supported_test() {
+  content_type.is_supported(content_type.ApplicationJson)
+  |> should.be_true()
+
+  content_type.is_supported(content_type.TextPlain)
+  |> should.be_false()
+
+  content_type.is_supported(content_type.MultipartFormData)
+  |> should.be_false()
+
+  content_type.is_supported(content_type.UnsupportedContentType("application/xml"))
+  |> should.be_false()
+}
+
+pub fn content_type_roundtrip_test() {
+  content_type.from_string("application/json")
+  |> content_type.to_string()
+  |> should.equal("application/json")
+
+  content_type.from_string("text/plain")
+  |> content_type.to_string()
+  |> should.equal("text/plain")
+
+  content_type.from_string("multipart/form-data")
+  |> content_type.to_string()
+  |> should.equal("multipart/form-data")
+
+  content_type.from_string("image/png")
+  |> content_type.to_string()
+  |> should.equal("image/png")
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1400,6 +1400,42 @@ components:
   |> should.be_true()
 }
 
+pub fn typed_additional_props_decoder_rejects_invalid_extra_values_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /config:
+    get:
+      operationId: getConfig
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Config:
+      type: object
+      required: [version]
+      properties:
+        version: { type: integer }
+      additionalProperties:
+        type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let assert [decode_file, ..] = files
+  let content = decode_file.content
+
+  // Invalid extra values must fail decoding rather than being silently dropped.
+  string.contains(content, "Error(_) -> acc")
+  |> should.be_false()
+  string.contains(content, "decode.failure(dict.new(), \"additionalProperties\")")
+  |> should.be_true()
+}
+
 // --- Finding 2: multipart/form-data client must handle optional and $ref fields.
 // Currently body.<field> is concatenated as-is, which breaks for Option(T) and
 // typed $ref fields.

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -571,6 +571,35 @@ pub fn validate_duplicate_operation_id_test() {
   |> should.be_true()
 }
 
+pub fn validate_accepts_typed_additional_properties_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /config:
+    get:
+      operationId: getConfig
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Config:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+      additionalProperties:
+        type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  errors |> should.equal([])
+}
+
 pub fn validate_petstore_has_no_errors_test() {
   let ctx = make_ctx("test/fixtures/petstore.yaml")
   let errors = validate.validate(ctx)

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -506,6 +506,54 @@ pub fn validate_rejects_complex_schema_parameter_test() {
   |> should.be_true()
 }
 
+pub fn validate_rejects_referenced_unsupported_parameter_schemas_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items/{filter}:
+    get:
+      operationId: getItems
+      parameters:
+        - name: filter
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Filter'
+        - name: tags
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/TagList'
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Filter:
+      type: object
+      properties:
+        q: { type: string }
+    TagList:
+      type: array
+      items:
+        type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+
+  list.any(error_strings, fn(s) {
+    string.contains(s, "Complex schema parameters")
+  })
+  |> should.be_true()
+  list.any(error_strings, fn(s) { string.contains(s, "Array parameters") })
+  |> should.be_true()
+}
+
 pub fn validate_accepts_multipart_form_data_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
@@ -1481,6 +1529,52 @@ paths:
   // Optional "description" field must have case/Some/None handling,
   // not raw body.description string concatenation
   string.contains(content, "case body.description")
+  |> should.be_true()
+}
+
+pub fn path_ref_array_parameters_are_stringified_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items/{tags}:
+    get:
+      operationId: getItems
+      parameters:
+        - name: tags
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/TagList'
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    TagList:
+      type: array
+      items:
+        type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx =
+    context.new(
+      spec,
+      config.Config(
+        input: "test.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Client,
+      ),
+    )
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+
+  string.contains(content, "string.join(list.map(tags, fn(x) { x }), \",\")")
   |> should.be_true()
 }
 

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -460,12 +460,12 @@ pub fn validate_broken_spec_detects_deep_object_test() {
   |> should.be_true()
 }
 
-pub fn validate_broken_spec_detects_multipart_test() {
+pub fn validate_accepts_multipart_form_data_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
   list.any(error_strings, fn(s) { string.contains(s, "multipart/form-data") })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 pub fn validate_broken_spec_detects_inline_oneof_test() {
@@ -478,12 +478,14 @@ pub fn validate_broken_spec_detects_inline_oneof_test() {
   |> should.be_true()
 }
 
-pub fn validate_broken_spec_detects_additional_properties_test() {
+pub fn validate_broken_spec_accepts_untyped_additional_properties_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
+  // additionalProperties: true is now supported via Dict(String, Dynamic),
+  // so it should NOT appear as a validation error
   list.any(error_strings, fn(s) { string.contains(s, "additionalProperties") })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 // --- Parser: fail-fast tests ---
@@ -554,11 +556,11 @@ pub fn validate_deep_additional_properties_in_response_test() {
   let ctx = make_ctx("test/fixtures/deep_unsupported.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
-  // additionalProperties: true nested in response object property should be caught
+  // additionalProperties: true is now supported, so no error for it
   list.any(error_strings, fn(s) {
     string.contains(s, "additionalProperties") && string.contains(s, "payload")
   })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 pub fn validate_duplicate_operation_id_test() {
@@ -593,6 +595,34 @@ components:
         name: { type: string }
       additionalProperties:
         type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  errors |> should.equal([])
+}
+
+pub fn validate_accepts_untyped_additional_properties_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      operationId: getData
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Payload:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+      additionalProperties: true
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let ctx = make_ctx_from_spec(spec)
@@ -1050,7 +1080,7 @@ pub fn content_type_is_supported_test() {
   |> should.be_true()
 
   content_type.is_supported(content_type.MultipartFormData)
-  |> should.be_false()
+  |> should.be_true()
 
   content_type.is_supported(content_type.UnsupportedContentType("application/xml"))
   |> should.be_false()

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -359,6 +359,36 @@ paths:
   errors |> should.equal([])
 }
 
+pub fn validate_rejects_text_plain_request_body_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /echo:
+    post:
+      operationId: postEcho
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema: { type: string }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) {
+    string.contains(s, "multipart/form-data")
+    && string.contains(s, "request bodies")
+  })
+  |> should.be_true()
+}
+
 pub fn validate_rejects_property_name_collision_test() {
   let yaml =
     "
@@ -1255,6 +1285,28 @@ pub fn content_type_is_supported_test() {
   |> should.be_false()
 }
 
+pub fn content_type_is_supported_request_test() {
+  content_type.is_supported_request(content_type.ApplicationJson)
+  |> should.be_true()
+
+  content_type.is_supported_request(content_type.MultipartFormData)
+  |> should.be_true()
+
+  content_type.is_supported_request(content_type.TextPlain)
+  |> should.be_false()
+}
+
+pub fn content_type_is_supported_response_test() {
+  content_type.is_supported_response(content_type.ApplicationJson)
+  |> should.be_true()
+
+  content_type.is_supported_response(content_type.TextPlain)
+  |> should.be_true()
+
+  content_type.is_supported_response(content_type.MultipartFormData)
+  |> should.be_false()
+}
+
 pub fn content_type_roundtrip_test() {
   content_type.from_string("application/json")
   |> content_type.to_string()
@@ -1555,7 +1607,10 @@ components:
   // Invalid extra values must fail decoding rather than being silently dropped.
   string.contains(content, "Error(_) -> acc")
   |> should.be_false()
-  string.contains(content, "decode.failure(dict.new(), \"additionalProperties\")")
+  string.contains(
+    content,
+    "decode.failure(dict.new(), \"additionalProperties\")",
+  )
   |> should.be_true()
 }
 
@@ -1794,9 +1849,8 @@ pub fn readme_no_contradictory_multipart_test() {
   let assert Ok(unsupported_start) =
     find_substring_index(content, "### Unsupported")
   let unsupported_section = string.drop_start(content, unsupported_start)
-  // multipart/form-data should NOT appear in the Unsupported section
-  // (it's already in Supported)
-  string.contains(unsupported_section, "multipart/form-data")
+  // multipart/form-data itself should NOT be listed as unsupported
+  string.contains(unsupported_section, "- `multipart/form-data` request bodies")
   |> should.be_false()
 }
 

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -920,10 +920,8 @@ components:
   |> should.equal("#/components/schemas/CompanyHeadquartersCoordinates")
 
   // CompanyHeadquartersCoordinates should have lat and lon
-  let assert Ok(schema.Inline(schema.ObjectSchema(
-    properties: coord_props,
-    ..,
-  ))) = dict.get(components.schemas, "CompanyHeadquartersCoordinates")
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: coord_props, ..))) =
+    dict.get(components.schemas, "CompanyHeadquartersCoordinates")
   dict.has_key(coord_props, "lat") |> should.be_true()
   dict.has_key(coord_props, "lon") |> should.be_true()
 }
@@ -1125,7 +1123,9 @@ pub fn content_type_is_supported_test() {
   content_type.is_supported(content_type.MultipartFormData)
   |> should.be_true()
 
-  content_type.is_supported(content_type.UnsupportedContentType("application/xml"))
+  content_type.is_supported(content_type.UnsupportedContentType(
+    "application/xml",
+  ))
   |> should.be_false()
 }
 
@@ -1205,8 +1205,7 @@ components:
   let assert Some(components) = parsed.components
   let assert Ok(scheme) = dict.get(components.security_schemes, "cookieAuth")
   case scheme {
-    spec.ApiKeyScheme(name: "session_id", in_: "cookie") ->
-      should.be_true(True)
+    spec.ApiKeyScheme(name: "session_id", in_: "cookie") -> should.be_true(True)
     _ -> should.fail()
   }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1174,6 +1174,41 @@ components:
   string.contains(ref, "#/components/schemas/") |> should.be_true()
 }
 
+pub fn hoist_case_normalized_name_collision_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        address:
+          type: object
+          properties:
+            street: { type: string }
+    user_address:
+      type: object
+      properties:
+        zip: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+
+  dict.has_key(components.schemas, "user_address") |> should.be_true()
+  dict.size(components.schemas) |> should.equal(3)
+
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "User")
+  let assert Ok(schema.Reference(ref: ref)) = dict.get(props, "address")
+  ref |> should.not_equal("#/components/schemas/UserAddress")
+}
+
 // --- ContentType Tests ---
 
 pub fn content_type_from_string_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -275,7 +275,7 @@ pub fn parse_global_security_inherited_test() {
   get_public.security |> should.equal(Some([]))
 }
 
-pub fn validate_accepts_array_parameter_test() {
+pub fn validate_rejects_array_parameter_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -300,10 +300,10 @@ paths:
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
   list.any(error_strings, fn(s) { string.contains(s, "Array parameters") })
-  |> should.be_false()
+  |> should.be_true()
 }
 
-pub fn validate_accepts_optional_array_parameter_test() {
+pub fn validate_rejects_optional_array_parameter_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -327,7 +327,9 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let ctx = make_ctx_from_spec(spec)
   let errors = validate.validate(ctx)
-  errors |> should.equal([])
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) { string.contains(s, "Array parameters") })
+  |> should.be_true()
 }
 
 pub fn validate_accepts_text_plain_response_test() {
@@ -354,9 +356,7 @@ paths:
   errors |> should.equal([])
 }
 
-pub fn validate_accepts_property_name_collision_test() {
-  // Property name collisions after snake_case are now auto-resolved
-  // by deduplicate_names during code generation, not validation errors.
+pub fn validate_rejects_property_name_collision_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -385,7 +385,7 @@ components:
   list.any(error_strings, fn(s) {
     string.contains(s, "Property name collision")
   })
-  |> should.be_false()
+  |> should.be_true()
 }
 
 pub fn parse_rejects_optional_path_parameter_test() {
@@ -485,25 +485,22 @@ fn make_ctx(spec_path: String) -> context.Context {
   context.new(spec, cfg)
 }
 
-pub fn validate_accepts_deep_object_test() {
+pub fn validate_rejects_deep_object_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
-  // deepObject style is now supported, so it should NOT appear as a validation error
   list.any(error_strings, fn(s) { string.contains(s, "deepObject") })
-  |> should.be_false()
+  |> should.be_true()
 }
 
-pub fn validate_accepts_complex_schema_parameter_test() {
+pub fn validate_rejects_complex_schema_parameter_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
-  // Complex schema parameters (object/allOf/oneOf/anyOf) are now supported,
-  // so they should NOT appear as validation errors
   list.any(error_strings, fn(s) {
     string.contains(s, "Complex schema parameters")
   })
-  |> should.be_false()
+  |> should.be_true()
 }
 
 pub fn validate_accepts_multipart_form_data_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -4,7 +4,9 @@ import gleam/option.{None, Some}
 import gleam/string
 import gleeunit
 import gleeunit/should
+import oaspec/codegen/client as client_gen
 import oaspec/codegen/context
+import oaspec/codegen/decoders
 import oaspec/codegen/guards
 import oaspec/codegen/types
 import oaspec/codegen/validate
@@ -16,6 +18,7 @@ import oaspec/openapi/schema
 import oaspec/openapi/spec
 import oaspec/util/content_type
 import oaspec/util/naming
+import simplifile
 
 pub fn main() {
   gleeunit.main()
@@ -1348,4 +1351,211 @@ paths:
   let assert Ok(path_item) = dict.get(spec.paths, "/subscribe")
   let assert Some(op) = path_item.post
   op.operation_id |> should.equal(Some("subscribe"))
+}
+
+// =========================================================================
+// Finding reproduction tests
+// =========================================================================
+
+// --- Finding 1: typed additionalProperties decoder must not apply value
+// decoder to known fields. When a schema has additionalProperties: {type: string}
+// but also has a fixed property of type integer, the decoder must not try
+// to decode ALL values as strings (which would fail on the integer field).
+// The fix: use dynamic.dynamic to read the raw dict, then filter + decode.
+pub fn typed_additional_props_decoder_uses_dynamic_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /config:
+    get:
+      operationId: getConfig
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Config:
+      type: object
+      required: [version]
+      properties:
+        version: { type: integer }
+      additionalProperties:
+        type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let assert [decode_file, ..] = files
+  let content = decode_file.content
+  // The decoder must NOT use decode.dict(decode.string, decode.string)
+  // because that would fail on the integer "version" field.
+  // It should use dynamic.dynamic for the initial dict read.
+  string.contains(content, "decode.dict(decode.string, decode.string)")
+  |> should.be_false()
+  // It should decode the dict with dynamic values first
+  string.contains(content, "dynamic.dynamic")
+  |> should.be_true()
+}
+
+// --- Finding 2: multipart/form-data client must handle optional and $ref fields.
+// Currently body.<field> is concatenated as-is, which breaks for Option(T) and
+// typed $ref fields.
+pub fn multipart_optional_field_generates_case_expr_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: uploadFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                description: { type: string }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx =
+    context.new(
+      spec,
+      config.Config(
+        input: "test.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Client,
+      ),
+    )
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  // Optional "description" field must have case/Some/None handling,
+  // not raw body.description string concatenation
+  string.contains(content, "case body.description")
+  |> should.be_true()
+}
+
+// --- Finding 3: unknown HTTP security schemes must produce a validation error
+// or a warning, not be silently ignored at code generation time.
+pub fn unknown_http_security_scheme_rejected_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      operationId: getData
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    myAuth:
+      type: http
+      scheme: hoba
+security:
+  - myAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  // Unknown HTTP scheme "hoba" should be flagged
+  list.any(error_strings, fn(s) {
+    string.contains(s, "hoba") || string.contains(s, "security")
+  })
+  |> should.be_true()
+}
+
+// --- Finding 4: allOf merge must preserve additionalProperties from sub-schemas.
+// Currently, merged ObjectSchema hardcodes additional_properties: None.
+pub fn allof_merge_preserves_additional_properties_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    BaseItem:
+      type: object
+      required: [id]
+      properties:
+        id: { type: integer }
+      additionalProperties:
+        type: string
+    ExtendedItem:
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - type: object
+          properties:
+            label: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = types.generate(ctx)
+  let assert [types_file, ..] = files
+  let content = types_file.content
+  // ExtendedItem must have additional_properties field since BaseItem has it
+  string.contains(content, "pub type ExtendedItem {")
+  |> should.be_true()
+  // Extract the ExtendedItem type block and check it has additional_properties
+  let assert Ok(extended_start) =
+    find_substring_index(content, "pub type ExtendedItem {")
+  let after_extended = string.drop_start(content, extended_start)
+  // The ExtendedItem block itself must contain additional_properties
+  // (not just the BaseItem block above it)
+  let assert Ok(closing_brace) = find_substring_index(after_extended, "\n}\n")
+  let extended_block = string.slice(after_extended, 0, closing_brace + 2)
+  string.contains(extended_block, "additional_properties:")
+  |> should.be_true()
+}
+
+// --- Finding 5: README must not list multipart/form-data in both Supported
+// and Unsupported sections.
+pub fn readme_no_contradictory_multipart_test() {
+  let assert Ok(content) = simplifile.read("README.md")
+  // Find the Unsupported section
+  let assert Ok(unsupported_start) =
+    find_substring_index(content, "### Unsupported")
+  let unsupported_section = string.drop_start(content, unsupported_start)
+  // multipart/form-data should NOT appear in the Unsupported section
+  // (it's already in Supported)
+  string.contains(unsupported_section, "multipart/form-data")
+  |> should.be_false()
+}
+
+fn find_substring_index(haystack: String, needle: String) -> Result(Int, Nil) {
+  case string.contains(haystack, needle) {
+    True -> {
+      let parts = string.split(haystack, needle)
+      case parts {
+        [before, ..] -> Ok(string.length(before))
+        _ -> Error(Nil)
+      }
+    }
+    False -> Error(Nil)
+  }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -5,6 +5,8 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 import oaspec/codegen/context
+import oaspec/codegen/guards
+import oaspec/codegen/types
 import oaspec/codegen/validate
 import oaspec/config
 import oaspec/openapi/hoist
@@ -176,7 +178,7 @@ pub fn parse_secure_api_operation_has_security_test() {
   list.length(sec) |> should.equal(1)
 }
 
-pub fn parse_rejects_basic_auth_test() {
+pub fn parse_accepts_basic_auth_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -190,8 +192,38 @@ components:
       type: http
       scheme: basic
 "
-  let result = parser.parse_string(yaml)
-  should.be_error(result)
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Some(components) = spec.components
+  let assert Ok(scheme) = dict.get(components.security_schemes, "BasicAuth")
+  case scheme {
+    spec.HttpScheme(scheme: "basic", bearer_format: None) ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn parse_accepts_digest_auth_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  securitySchemes:
+    DigestAuth:
+      type: http
+      scheme: digest
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Some(components) = spec.components
+  let assert Ok(scheme) = dict.get(components.security_schemes, "DigestAuth")
+  case scheme {
+    spec.HttpScheme(scheme: "digest", bearer_format: None) ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
 }
 
 pub fn parse_rejects_malformed_security_scopes_test() {
@@ -1180,4 +1212,144 @@ components:
       should.be_true(True)
     _ -> should.fail()
   }
+}
+
+// --- Feature: allOf with primitive sub-schemas (Phase 4-2) ---
+
+pub fn allof_with_primitive_sub_schema_test() {
+  // allOf that mixes object and primitive schemas should not crash.
+  // Primitive sub-schemas are silently ignored; object properties are merged.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    MixedAllOf:
+      allOf:
+        - type: string
+        - type: object
+          required: [name]
+          properties:
+            name: { type: string }
+            age: { type: integer }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+
+  // Should generate types without crashing
+  let files = types.generate(ctx)
+  // Should produce at least one file
+  list.length(files) |> should.not_equal(0)
+
+  // The generated types file should contain the MixedAllOf type
+  // with properties from the object sub-schema
+  let assert [types_file, ..] = files
+  string.contains(types_file.content, "MixedAllOf") |> should.be_true()
+  string.contains(types_file.content, "name: String") |> should.be_true()
+}
+
+// --- Feature: Validation constraints generate guards (Phase 4-3) ---
+
+pub fn validate_constraints_generate_guards_test() {
+  // Schemas with minLength/maxLength/minimum/maximum should produce guard functions.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    User:
+      type: object
+      required: [username, age]
+      properties:
+        username:
+          type: string
+          minLength: 3
+          maxLength: 50
+        age:
+          type: integer
+          minimum: 0
+          maximum: 150
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+
+  // Should generate guard files without crashing
+  let files = guards.generate(ctx)
+  // Should produce at least one file (guards.gleam)
+  list.length(files) |> should.not_equal(0)
+
+  let assert [guard_file] = files
+  guard_file.path |> should.equal("guards.gleam")
+
+  // Should contain validation functions for constrained fields
+  string.contains(guard_file.content, "validate_user_username_length")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_user_age_range")
+  |> should.be_true()
+}
+
+// --- Feature: Callbacks are ignored during parsing (Phase 4-4) ---
+
+pub fn parse_ignores_callbacks_test() {
+  // Operations with a callbacks field should parse without error.
+  // The callbacks field is simply ignored.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Callback Test
+  version: 1.0.0
+paths:
+  /subscribe:
+    post:
+      operationId: subscribe
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                callbackUrl:
+                  type: string
+      callbacks:
+        onEvent:
+          '{$request.body#/callbackUrl}':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        event: { type: string }
+              responses:
+                '200': { description: ok }
+      responses:
+        '201': { description: subscribed }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  spec.info.title |> should.equal("Callback Test")
+  // The operation should have parsed successfully
+  let assert Ok(path_item) = dict.get(spec.paths, "/subscribe")
+  let assert Some(op) = path_item.post
+  op.operation_id |> should.equal(Some("subscribe"))
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -49,6 +49,26 @@ pub fn capitalize_test() {
   |> should.equal("Hello")
 }
 
+pub fn deduplicate_names_no_collision_test() {
+  naming.deduplicate_names(["foo", "bar", "baz"])
+  |> should.equal(["foo", "bar", "baz"])
+}
+
+pub fn deduplicate_names_with_collision_test() {
+  naming.deduplicate_names(["pet_id", "pet_id", "name"])
+  |> should.equal(["pet_id", "pet_id_2", "name"])
+}
+
+pub fn deduplicate_names_triple_collision_test() {
+  naming.deduplicate_names(["x", "x", "x"])
+  |> should.equal(["x", "x_2", "x_3"])
+}
+
+pub fn deduplicate_names_empty_test() {
+  naming.deduplicate_names([])
+  |> should.equal([])
+}
+
 // --- Config Tests ---
 
 pub fn load_config_test() {
@@ -275,7 +295,9 @@ paths:
   |> should.be_true()
 }
 
-pub fn validate_rejects_property_name_collision_test() {
+pub fn validate_accepts_property_name_collision_test() {
+  // Property name collisions after snake_case are now auto-resolved
+  // by deduplicate_names during code generation, not validation errors.
   let yaml =
     "
 openapi: 3.0.3
@@ -304,7 +326,7 @@ components:
   list.any(error_strings, fn(s) {
     string.contains(s, "Property name collision")
   })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 pub fn parse_rejects_optional_path_parameter_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -562,6 +562,46 @@ pub fn validate_accepts_multipart_form_data_test() {
   |> should.be_false()
 }
 
+pub fn validate_rejects_unstringifiable_multipart_fields_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: uploadFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [metadata]
+              properties:
+                metadata:
+                  $ref: '#/components/schemas/Metadata'
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Metadata:
+      type: object
+      properties:
+        title: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) {
+    string.contains(s, "multipart/form-data fields")
+  })
+  |> should.be_true()
+}
+
 pub fn validate_broken_spec_detects_inline_oneof_test() {
   let ctx = make_ctx("test/fixtures/broken_openapi.yaml")
   let errors = validate.validate(ctx)
@@ -1529,6 +1569,54 @@ paths:
   // Optional "description" field must have case/Some/None handling,
   // not raw body.description string concatenation
   string.contains(content, "case body.description")
+  |> should.be_true()
+}
+
+pub fn multipart_ref_scalar_field_is_stringified_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: uploadFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  $ref: '#/components/schemas/UploadId'
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    UploadId:
+      type: integer
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx =
+    context.new(
+      spec,
+      config.Config(
+        input: "test.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Client,
+      ),
+    )
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+
+  string.contains(content, "int.to_string(body.id)")
   |> should.be_true()
 }
 


### PR DESCRIPTION
## Summary
- clarify that complex schema parameters are rejected in path/query/header/cookie locations
- distinguish OAuth2 validation-time rejection from OpenID Connect parse-time rejection
- document the current `allOf` non-object merge behavior more precisely
- clarify that inline complex `additionalProperties` schemas are not handled explicitly

## Testing
- `mise exec -- gleam test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for text/plain responses and multipart/form-data request encoding.
  * Enabled HTTP Basic and Digest authentication schemes alongside API key and bearer authentication.
  * Introduced API key support in cookies with proper append semantics.
  * Added automatic validation guards for string/integer/number constraints and array bounds.
  * Improved additionalProperties handling with typed and untyped variants.
  * Enabled schema hoisting to extract and consolidate inline complex schemas.

* **Bug Fixes**
  * Fixed parameter value percent-encoding for path, query, and cookie parameters.
  * Corrected multipart field handling for optional and referenced schemas.
  * Resolved schema name collision detection after case normalization.

* **Documentation**
  * Updated security scheme and content-type support documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->