### PR TITLE
v0.6.1: Port OSS test fixtures and fix parser for real-world specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-09
+
+### Added
+
+- OSS test fixtures from libopenapi (MIT) and oapi-codegen (Apache 2.0) covering real-world specs: burgershop, all-the-components, petstore v3, circular refs, nullable combinations, recursive allOf, allOf with additionalProperties, bearer auth, multi-content types, cookies, name conflicts, illegal enum names
+
+### Fixed
+
+- Parser now skips `x-` vendor extension keys in paths and responses maps instead of trying to parse them as paths/status codes
+- Parser accepts `openapi` version field as YAML float (e.g. `openapi: 3.0` parsed as number instead of string)
+- Operation `responses` field is now optional at parse time (webhook operations often omit it); validation can catch missing responses separately
+
 ## [0.6.0] - 2026-04-09
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "oaspec"
-version = "0.6.0"
+version = "0.6.1"
 target = "erlang"
 description = "Generate Gleam code from OpenAPI 3.x specifications"
 licences = ["MIT"]

--- a/src/oaspec/codegen/context.gleam
+++ b/src/oaspec/codegen/context.gleam
@@ -2,7 +2,7 @@ import oaspec/config.{type Config}
 import oaspec/openapi/spec.{type OpenApiSpec}
 
 /// The version of oaspec used for generated code headers.
-pub const version = "0.6.0"
+pub const version = "0.6.1"
 
 /// Context for code generation, carrying all needed state.
 pub type Context {

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1,4 +1,6 @@
 import gleam/dict.{type Dict}
+import gleam/float
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -61,8 +63,18 @@ pub fn parse_string(content: String) -> Result(OpenApiSpec, ParseError) {
 
 /// Parse the root OpenAPI object.
 fn parse_root(node: yay.Node) -> Result(OpenApiSpec, ParseError) {
+  // openapi field may be a string ("3.0.3") or a YAML number (3.0 parsed as float)
   use openapi <- result.try(
     yay.extract_string(node, "openapi")
+    |> result.lazy_or(fn() {
+      yay.extract_float(node, "openapi")
+      |> result.map(fn(f) {
+        case f == int.to_float(float.truncate(f)) {
+          True -> int.to_string(float.truncate(f)) <> ".0"
+          False -> float.to_string(f)
+        }
+      })
+    })
     |> result.map_error(fn(_) { MissingField(path: "", field: "openapi") }),
   )
 
@@ -187,19 +199,23 @@ fn parse_paths(
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(path) -> {
-            // Check for $ref first — resolve from components.pathItems
-            use path_item <- result.try(
-              case
-                yay.extract_optional_string(value_node, "$ref")
-                |> result.unwrap(None)
-              {
-                Some(ref_str) -> resolve_path_item_ref(ref_str, components)
-                None -> parse_path_item(value_node, path, components)
-              },
-            )
-            Ok(dict.insert(acc, path, path_item))
-          }
+          yay.NodeStr(path) ->
+            case string.starts_with(path, "x-") {
+              True -> Ok(acc)
+              False -> {
+                // Check for $ref first — resolve from components.pathItems
+                use path_item <- result.try(
+                  case
+                    yay.extract_optional_string(value_node, "$ref")
+                    |> result.unwrap(None)
+                  {
+                    Some(ref_str) -> resolve_path_item_ref(ref_str, components)
+                    None -> parse_path_item(value_node, path, components)
+                  },
+                )
+                Ok(dict.insert(acc, path, path_item))
+              }
+            }
           _ -> Ok(acc)
         }
       })
@@ -421,16 +437,15 @@ fn parse_optional_request_body(
   }
 }
 
-/// Parse responses, requiring the field to be present.
+/// Parse responses, treating the field as optional.
+/// OpenAPI 3.x requires responses on operations, but webhook operations
+/// in the wild often omit them. Validation can catch missing responses.
 fn parse_responses_required(
   node: yay.Node,
   context: String,
   components: Option(Components),
 ) -> Result(dict.Dict(String, Response), ParseError) {
-  case yay.select_sugar(from: node, selector: "responses") {
-    Ok(_) -> parse_responses(node, context, components)
-    Error(_) -> Error(MissingField(path: context, field: "responses"))
-  }
+  parse_responses(node, context, components)
 }
 
 /// Parse parameters list from a node.
@@ -817,10 +832,14 @@ fn parse_responses(
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(status_code) -> {
-            use resp <- result.try(parse_response(value_node, components))
-            Ok(dict.insert(acc, status_code, resp))
-          }
+          yay.NodeStr(status_code) ->
+            case string.starts_with(status_code, "x-") {
+              True -> Ok(acc)
+              False -> {
+                use resp <- result.try(parse_response(value_node, components))
+                Ok(dict.insert(acc, status_code, resp))
+              }
+            }
           yay.NodeInt(code) -> {
             use resp <- result.try(parse_response(value_node, components))
             let code_str = string.inspect(code)

--- a/test/fixtures/oss_libopenapi_all_components.yaml
+++ b/test/fixtures/oss_libopenapi_all_components.yaml
@@ -1,0 +1,385 @@
+jsonSchemaDialect: https://pb33f.io/api"
+externalDocs:
+  description: Find out more
+  url: https://quobix.com/
+x-hack: code
+openapi: 3.1.1
+info:
+  title: Burger Shop
+  description: |
+    The best burger API at quobix. You can find the testiest burgers on the world
+  termsOfService: https://quobix.com
+  contact:
+    name: quobix
+  license:
+    name: Quobix
+  version: "1.2"
+tags:
+  - name: "pizza"
+    description: pizza!
+    externalDocs:
+      description: "Find out more"
+      url: "https://quobix.com/"
+  - name: "Dressing"
+    description: "Variety of dressings: cheese, veggie, oil and a lot more"
+    externalDocs:
+      description: "Find out more information about our products)"
+      url: "https://quobix.com/"
+servers:
+  - url: https://quobix.com/api
+  - url: https://pb33f.com/api
+security:
+  - api_key: []
+paths:
+  /burgers:
+    servers:
+      - url: https://somwhere.quobix.com/api
+      - url: https://pb33f.io/api
+    post:
+      operationId: createBurger
+      tags:
+        - "Meat"
+      summary:  Create a new burger
+      description: A new burger for our menu, yummy yum yum.
+      requestBody:
+        description: Give us the new burger!
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Burger'
+            examples:
+              pbjBurger:
+                summary: A horrible, nutty, sticky mess.
+                value:
+                  name: Peanut And Jelly
+                  numPatties: 3
+              cakeBurger:
+                summary: A sickly, sweet, atrocity
+                value:
+                  name: Chocolate Cake Burger
+                  numPatties: 5
+      responses:
+        "200":
+          description: A tasty burger for you to eat.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Burger'
+              examples:
+                quarterPounder:
+                  summary: A juicy two handler sammich
+                  value:
+                    name: Quarter Pounder with Cheese
+                    numPatties: 1
+                filetOFish:
+                  summary: A tasty treat from the sea
+                  value:
+                    name: Filet-O-Fish
+                    numPatties: 1
+          links:
+            LocateBurger:
+              operationId: locateBurger
+              parameters:
+                burgerId: '$response.body#/id'
+              description: Go and get a tasty burger
+            AnotherLocateBurger:
+              operationId: locateBurger
+              parameters:
+                burgerId: '$response.body#/id'
+              description: Go and get a another really tasty burger
+        "500":
+          description: Unexpected error creating a new burger. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: oh my goodness
+                  value:
+                    message: something went terribly wrong my friend, no new burger for you.
+        "422":
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: invalid request
+                  value:
+                    message: unable to accept this request, looks bad, missing something.
+  /burgers/{burgerId}:
+    get:
+      servers:
+        - url: https://nowhere.quobix.com/api
+        - url: https://pb33f.net/api
+      operationId: locateBurger
+      tags:
+        - "Meat"
+      summary: Search a burger by ID - returns the burger with that identifier
+      description: Look up a tasty burger take it and enjoy it
+      parameters:
+        - in: path
+          name: burgerId
+          schema:
+            type: string
+          example: big-mac
+          description: the name of the burger. use this to order your food
+          required: true
+      responses:
+        "200":
+          description: A tasty burger for you to eat. Wide variety of products to choose from
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Burger'
+              examples:
+                quarterPounder:
+                  summary: A juicy two handler sammich
+                  value:
+                    name: Quarter Pounder with Cheese
+                    numPatties: 1
+                filetOFish:
+                  summary: A tasty treat from the sea
+                  value:
+                    name: Filet-O-Fish
+                    numPatties: 1
+          links:
+            ListBurgerDressings:
+              operationId: listBurgerDressings
+              parameters:
+                dressingId: 'something here'
+              description: 'Try the ketchup!'
+        "404":
+          description: Cannot find your burger. Sorry. We may have sold out of this type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                notFound:
+                  $ref: '#/components/examples/notFound'
+        "500":
+          description: Unexpected error. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: oh my stars
+                  value:
+                    message: something went terribly wrong my friend, burger location crashed!
+  /burgers/{burgerId}/dressings:
+    get:
+      operationId: listBurgerDressings
+      tags:
+        - "Dressing"
+      summary:  Get a list of all dressings available
+      description: Same as the summary, look up a tasty burger, by its ID - the burger identifier
+      parameters:
+        - in: path
+          name: burgerId
+          schema:
+            type: string
+          example: big-mac
+          description: the name of the our fantastic burger. You can pick a name from our menu
+          required: true
+      callbacks:
+        myCallback:
+          $ref: '#/components/callbacks/myCallback'
+      responses:
+        "200":
+          links:
+            getBurger:
+              $ref: '#/components/links/getBurger'
+          description: an array of
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Dressing'
+        "404":
+          description: Cannot find your burger in which to list dressings. Sorry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Unexpected error listing dressings for burger. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /dressings/{dressingId}:
+    get:
+      operationId: getDressing
+      tags:
+        - "Dressing"
+      summary:  Get a specific dressing - you can choose the dressing from our menu
+      description: Same as the summary, get a dressing, by its ID
+      parameters:
+        - in: path
+          name: dressingId
+          schema:
+            type: string
+          example: cheese
+          description: This is the unique identifier for the dressing items.
+          required: true
+      responses:
+        "404":
+          description: Cannot find your dressing, sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Unexpected error getting a dressing. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /dressings:
+    get:
+      operationId: getAllDressings
+      tags:
+        - "Dressing"
+      summary:  Get all dressings available in our store
+      description: Get all dressings and choose from them
+      responses:
+        "200":
+          $ref: '#/components/responses/dressingResponse'
+        "500":
+          description: Unexpected error. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  responses:
+    dressingResponse:
+      description: an array of dressings
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Dressing'
+  callbacks:
+    myCallback:
+      '{$request.query.queryUrl}':
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/Fries'
+          responses:
+            '200':
+              description: callback successfully processed
+  links:
+    burger:
+      operationId: getBurger
+      parameters:
+        burgerId: $request.path.id
+  headers:
+    MyHeader:
+      description: a header
+  examples:
+    notFound:
+      summary: burger missing
+      value:
+        message: can't find a burger with that ID, we may have sold out my friend.
+  schemas:
+    Error:
+      type: object
+      description: Error defining what went wrong when providing a specification. The message should help indicate the issue clearly.
+      properties:
+        message:
+          type: string
+          description: returns the error message if something wrong happens
+          example: No such burger as 'Big-Whopper'
+    Burger:
+      type: object
+      description: The tastiest food on the planet you would love to eat everyday
+      required:
+        - name
+        - numPatties
+      properties:
+        name:
+          type: string
+          description: The name of your tasty burger - burger names are listed in our menus
+          example: Big Mac
+        numPatties:
+          type: integer
+          description: The number of burger patties used
+          example: 2
+        numTomatoes:
+          type: integer
+          description: how many slices of orange goodness would you like?
+          example: 1
+    Fries:
+      type: object
+      description: golden slices of happy fun joy
+      required:
+        - potatoShape
+        - favoriteDressings
+        - favoriteDrink
+      properties:
+        seasoning:
+          type: array
+          description: herbs and spices for your golden joy
+          items:
+            type: string
+            description: type of herb or spice used to liven up the yummy
+            example: salt
+        potatoShape:
+          type: string
+          description: what type of potato shape? wedges? shoestring?
+          example: Crispy Shoestring
+        favoriteDressings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Dressing'
+        favoriteBurger:
+          $ref: '#/components/schemas/Burger'
+        favoriteDrink:
+          $ref: '#/components/schemas/Drink'
+    Dressing:
+      type: object
+      description: This is the object that contains the information about the content of the dressing
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of your dressing you can pick up from the menu
+          example: Cheese
+    Drink:
+      type: object
+      description: a frosty cold beverage can be coke or sprite
+      required:
+        - size
+        - drinkType
+      properties:
+        ice:
+          type: boolean
+        drinkType:
+          description: select from coke or sprite
+          enum:
+            - coke
+            - sprite
+        size:
+          type: string
+          description: what size man? S/M/L
+          example: M
+webhooks:
+  bHook:
+    get:
+      description: coffee in the morning
+  aHook:
+    get:
+      description: jazz in the evening

--- a/test/fixtures/oss_libopenapi_burgershop.yaml
+++ b/test/fixtures/oss_libopenapi_burgershop.yaml
@@ -1,0 +1,553 @@
+openapi: 3.1.0
+info:
+  title: Burger Shop
+  description: |
+    The best burger API at princess beef. You can find the testiest burgers in the world
+  termsOfService: https://pb33f.io
+  contact:
+    name: pb33f
+    email: buckaroo@pb33f.io
+    url: https://pb33f.io
+  license:
+    name: pb33f
+    url: https://pb33f.io/made-up
+  version: "1.2"
+security:
+  - OAuthScheme:
+      - read:burgers
+      - write:burgers
+tags:
+  - name: "Burgers"
+    description: "All kinds of yummy burgers."
+    externalDocs:
+      description: "Find out more"
+      url: "https://pb33f.io"
+    x-internal-ting: somethingSpecial
+    x-internal-tong: 1
+    x-internal-tang: 1.2
+    x-internal-tung: true
+    x-internal-arr:
+      - one
+      - two
+    x-internal-arrmap:
+      - what: now
+      - why: that
+    x-something-else:
+      ok:
+        - what: now?
+  - name: "Dressing"
+    description: "Variety of dressings: cheese, veggie, oil and a lot more"
+    externalDocs:
+      description: "Find out more information about our products)"
+      url: "https://pb33f.io"
+servers:
+  - url: "{scheme}://api.pb33f.io"
+    description: "this is our main API server, for all fun API things."
+    variables:
+      scheme:
+        enum: [https, wss]
+        default: https
+        description: this is a server variable for the scheme
+  - url: "https://{domain}.{host}.com"
+    description: "this is our second API server, for all fun API things."
+    variables:
+      domain:
+        default: "api"
+        description: the default API domain is 'api'
+      host:
+        default: "pb33f.io"
+        description: the default host for this API is 'pb33f.io'
+paths:
+  x-milky-milk: milky
+  /burgers:
+    x-burger-meta: meaty
+    post:
+      operationId: createBurger
+      tags:
+        - "Burgers"
+      summary:  Create a new burger
+      description: A new burger for our menu, yummy yum yum.
+      requestBody:
+        $ref: '#/components/requestBodies/BurgerRequest'
+      responses:
+        "200":
+          headers:
+            UseOil:
+              $ref: '#/components/headers/UseOil'
+          description: A tasty burger for you to eat.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Burger'
+              examples:
+                quarterPounder:
+                  $ref: '#/components/examples/QuarterPounder'
+                filetOFish:
+                  summary: a cripsy fish sammich filled with ocean goodness.
+                  value:
+                    name: Filet-O-Fish
+                    numPatties: 1
+          links:
+            LocateBurger:
+              $ref: '#/components/links/LocateBurger'
+            AnotherLocateBurger:
+              $ref: '#/components/links/AnotherLocateBurger'
+        "500":
+          description: Unexpected error creating a new burger. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: oh my goodness
+                  value:
+                    message: something went terribly wrong my friend, no new burger for you.
+        "422":
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: invalid request
+                  value:
+                    message: unable to accept this request, looks bad, missing something.
+      security:
+        - OAuthScheme:
+          - read:burgers
+          - write:burgers
+      servers:
+        - url: https://pb33f.io
+          description: this is an alternative server for this operation.
+  /burgers/{burgerId}:
+    get:
+      callbacks:
+        burgerCallback:
+          $ref: '#/components/callbacks/BurgerCallback'
+      operationId: locateBurger
+      tags:
+        - "Burgers"
+      summary: Search a burger by ID - returns the burger with that identifier
+      description: Look up a tasty burger take it and enjoy it
+      parameters:
+        - $ref: '#/components/parameters/BurgerId'
+        - $ref: '#/components/parameters/BurgerHeader'
+      responses:
+        "200":
+          description: A tasty burger for you to eat. Wide variety of products to choose from
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Burger'
+              examples:
+                quarterPounder:
+                  $ref: '#/components/examples/QuarterPounder'
+                filetOFish:
+                  summary: A tasty treat from the sea
+                  value:
+                    name: Filet-O-Fish
+                    numPatties: 1
+          links:
+            ListBurgerDressings:
+              operationId: listBurgerDressings
+              parameters:
+                dressingId: 'something here'
+              description: 'Try the ketchup!'
+        "404":
+          description: Cannot find your burger. Sorry. We may have sold out of this type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                notFound:
+                  summary: burger missing
+                  value:
+                    message: can't find a burger with that ID, we may have sold out my friend.
+        "500":
+          description: Unexpected error. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                unexpectedError:
+                  summary: oh my stars
+                  value:
+                    message: something went terribly wrong my friend, burger location crashed!
+  /burgers/{burgerId}/dressings:
+    get:
+      operationId: listBurgerDressings
+      tags:
+        - "Dressing"
+      summary:  Get a list of all dressings available
+      description: Same as the summary, look up a tasty burger, by its ID - the burger identifier
+      parameters:
+        - in: path
+          name: burgerId
+          schema:
+            type: string
+          example: big-mac
+          description: the name of the our fantastic burger. You can pick a name from our menu
+          required: true
+      responses:
+        "200":
+          $ref: '#/components/responses/DressingResponse'
+        "404":
+          description: Cannot find your burger in which to list dressings. Sorry
+          content:
+            application/json:
+              x-nice: rice
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: There is no burger here
+        "500":
+          description: Unexpected error listing dressings for burger. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: computer says no dressings for this burger.
+  /dressings/{dressingId}:
+    x-winter-coat: warm
+    get:
+      operationId: getDressing
+      tags:
+        - "Dressing"
+      summary:  Get a specific dressing - you can choose the dressing from our menu
+      description: Same as the summary, get a dressing, by its ID
+      x-runny-nose: runny.
+      parameters:
+        - in: path
+          name: dressingId
+          schema:
+            x-hot-cross-buns: bunny
+            type: string
+          example: cheese
+          description: This is the unique identifier for the dressing items.
+          required: true
+      responses:
+        x-toasty-roasty: hot
+        "200":
+          description: a dressing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dressing'
+              example:
+                name: Butter Sauce
+        "404":
+          description: Cannot find your dressing, sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: No such dressing as 'Pizza'
+        "500":
+          description: Unexpected error getting a dressing. Sorry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: failed looking up dressing by ID, our server borked.
+  /dressings:
+    get:
+      operationId: getAllDressings
+      tags:
+        - "Dressing"
+      summary:  Get all dressings available in our store
+      description: Get all dressings and choose from them
+      responses:
+        "200":
+          description: an array of dressings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Dressing'
+              example:
+                - name: Burger Sauce
+        "418":
+          description: I am a teapot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: It's teapot time.
+        "500":
+          description: Something went wrong with getting dressings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "failed looking up all dressings, something went wrong."
+components:
+  callbacks:
+    BurgerCallback:
+      x-break-everything: please
+      "{$request.query.queryUrl}":
+        post:
+          requestBody:
+            description: Callback payload
+            content:
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: callback successfully processes
+  links:
+    LocateBurger:
+      operationId: locateBurger
+      parameters:
+        burgerId: '$response.body#/id'
+      description: Go and get a tasty burger
+    AnotherLocateBurger:
+      operationId: locateBurger
+      parameters:
+        burgerId: '$response.body#/id'
+      description: Go and get another really tasty burger
+      server:
+        url: https://pb33f.io
+  headers:
+    UseOil:
+      description: this is a header example for UseOil
+      schema:
+        type: string
+  requestBodies:
+    BurgerRequest:
+      description: Give us the new burger!
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Burger'
+          examples:
+            pbjBurger:
+              summary: A horrible, nutty, sticky mess.
+              value:
+                name: Peanut And Jelly
+                numPatties: 3
+            cakeBurger:
+              summary: A sickly, sweet, atrocity
+              value:
+                name: Chocolate Cake Burger
+                numPatties: 5
+  examples:
+    QuarterPounder:
+      summary: A juicy two hander sammich
+      value:
+        name: Quarter Pounder with Cheese
+        numPatties: 1
+  responses:
+    DressingResponse:
+      description: all the dressings for a burger.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Dressing'
+          example:
+            - name: Thousand Island
+  securitySchemes:
+    APIKeyScheme:
+      type: apiKey
+      description: an apiKey security scheme
+      name: apiKeyScheme
+      in: query
+    JWTScheme:
+      type: http
+      description: an JWT security scheme
+      name: aJWTThing
+      scheme: bearer
+      bearerFormat: JWT
+    OAuthScheme:
+      type: oauth2
+      description: an oAuth security scheme
+      name: oAuthy
+      flows:
+        implicit:
+          authorizationUrl: https://pb33f.io/oauth
+          scopes:
+            write:burgers: modify and add new burgers
+            read:burgers: read all burgers
+        authorizationCode:
+          authorizationUrl: https://pb33f.io/oauth
+          tokenUrl: https://api.pb33f.io/oauth/token
+          scopes:
+            write:burgers: modify burgers and stuff
+            read:burgers: read all the burgers
+  parameters:
+    BurgerHeader:
+      in: header
+      name: burgerHeader
+      schema:
+        properties:
+          burgerTheme:
+            type: string
+            description: something about a theme goes in here?
+          burgerTime:
+            type: number
+            description: number of burgers ordered so far this year.
+      example: big-mac
+      description: the name of the burger. use this to order your food
+      required: true
+      content:
+        application/json:
+          example: somethingNice
+          encoding:
+            burgerTheme:
+              contentType: text/plain
+              headers:
+                someHeader:
+                  description: this is a header
+                  schema:
+                    type: string
+          schema:
+            type: object
+            required: [burgerTheme, burgerTime]
+            properties:
+              burgerTheme:
+                type: string
+                description: something about a theme?
+              burgerTime:
+                type: number
+                description: number of burgers ordered this year.
+    BurgerId:
+      in: path
+      name: burgerId
+      schema:
+        type: string
+      example: big-mac
+      description: the name of the burger. use this to order your tasty burger
+      required: true
+  schemas:
+    Error:
+      type: object
+      description: Error defining what went wrong when providing a specification. The message should help indicate the issue clearly.
+      properties:
+        message:
+          type: string
+          description: returns the error message if something wrong happens
+          example: No such burger as 'Big-Whopper'
+    Burger:
+      type: object
+      description: The tastiest food on the planet you would love to eat everyday
+      required:
+        - name
+        - numPatties
+      properties:
+        name:
+          type: string
+          description: The name of your tasty burger - burger names are listed in our menus
+          example: Big Mac
+        numPatties:
+          type: integer
+          description: The number of burger patties used
+          example: 2
+        numTomatoes:
+          type: integer
+          description: how many slices of orange goodness would you like?
+          example: 1
+        fries:
+          $ref: '#/components/schemas/Fries'
+    Fries:
+      type: object
+      description: golden slices of happy fun joy
+      required:
+        - potatoShape
+        - favoriteDrink
+      properties:
+        seasoning:
+          type: array
+          description: herbs and spices for your golden joy
+          items:
+            type: string
+            description: type of herb or spice used to liven up the yummy
+            example: salt
+        potatoShape:
+          type: string
+          description: what type of potato shape? wedges? shoestring?
+          example: Crispy Shoestring
+        favoriteDrink:
+          $ref: '#/components/schemas/Drink'
+    Dressing:
+      type: object
+      description: This is the object that contains the information about the content of the dressing
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of your dressing you can pick up from the menu
+          example: Cheese
+      additionalProperties:
+        type: object
+        description: something in here.
+    Drink:
+      type: object
+      description: a frosty cold beverage can be coke or sprite
+      required:
+        - size
+        - drinkType
+      properties:
+        ice:
+          type: boolean
+        drinkType:
+          type: string
+          description: select from coke or sprite
+          enum:
+            - coke
+        size:
+          type: string
+          description: what size man? S/M/L
+          example: M
+      additionalProperties: true
+      discriminator:
+        propertyName: drinkType
+        mapping:
+          drink: some value
+    SomePayload:
+      type: object
+      description: some kind of payload for something.
+      xml:
+        name: is html programming? yes.
+      externalDocs:
+        url: https://pb33f.io/docs
+      oneOf:
+        - $ref: '#/components/schemas/Drink'
+      anyOf:
+        - $ref: '#/components/schemas/Drink'
+      allOf:
+        - $ref: '#/components/schemas/Drink'
+      not:
+        type: string
+      items:
+        $ref: '#/components/schemas/Drink'
+  x-screaming-baby: loud
+x-something-something: darkside
+externalDocs:
+  description: "Find out more information about our products and services"
+  url: "https://pb33f.io"
+jsonSchemaDialect: https://pb33f.io/schema
+webhooks:
+  someHook:
+    post:
+      requestBody:
+        description: Information about a new burger
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Burger"
+      responses:
+        "200":
+          description: the hook is good! you have a new burger.

--- a/test/fixtures/oss_libopenapi_circular.yaml
+++ b/test/fixtures/oss_libopenapi_circular.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0
+paths:
+  /burgers:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Nine'
+components:
+  schemas:
+    One:
+      description: "test one"
+      properties:
+        things:
+          "$ref": "#/components/schemas/Two"
+      required:
+        - things
+    Two:
+      description: "test two"
+      properties:
+        testThing:
+          "$ref": "#/components/schemas/One"
+        oneOf:
+          - "$ref": "#/components/schemas/Three"
+        allOf:
+          - "$ref": "#/components/schemas/Three"
+        anyOf:
+          - "$ref": "#/components/schemas/Three"
+      required:
+        - testThing
+        - anyOf
+    Three:
+      description: "test three"
+      properties:
+        tester:
+          "$ref": "#/components/schemas/Four"
+        bester:
+          "$ref": "#/components/schemas/Seven"
+        yester:
+          "$ref": "#/components/schemas/Seven"
+      required:
+        - tester
+        - bester
+        - yester
+    Four:
+      description: "test four"
+      properties:
+        lemons:
+          "$ref": "#/components/schemas/Nine"
+      required:
+        - lemons
+    Five:
+      properties:
+        rice:
+          "$ref": "#/components/schemas/Six"
+      required:
+        - rice
+    Six:
+      properties:
+        mints:
+          "$ref": "#/components/schemas/Nine"
+      required:
+        - mints
+    Seven:
+      properties:
+        wow:
+          "$ref": "#/components/schemas/Three"
+      required:
+        - wow
+    Nine:
+      description: done.
+    Ten:
+      properties:
+        yeah:
+          "$ref": "#/components/schemas/Ten"
+      required:
+        - yeah

--- a/test/fixtures/oss_libopenapi_petstorev3.json
+++ b/test/fixtures/oss_libopenapi_petstorev3.json
@@ -1,0 +1,1225 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.11"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name of pet that needs to be updated",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status of pet that needs to be updated",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "query",
+            "description": "Additional Metadata",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "Creates list of users with given input array",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Update an existent user in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64",
+            "example": 198772
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32",
+            "example": 7
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "example": "approved",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean"
+          }
+        },
+        "xml": {
+          "name": "order"
+        }
+      },
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 100000
+          },
+          "username": {
+            "type": "string",
+            "example": "fehguy"
+          },
+          "address": {
+            "type": "array",
+            "xml": {
+              "name": "addresses",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          }
+        },
+        "xml": {
+          "name": "customer"
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "example": "437 Lytton"
+          },
+          "city": {
+            "type": "string",
+            "example": "Palo Alto"
+          },
+          "state": {
+            "type": "string",
+            "example": "CA"
+          },
+          "zip": {
+            "type": "string",
+            "example": "94301"
+          }
+        },
+        "xml": {
+          "name": "address"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "Dogs"
+          }
+        },
+        "xml": {
+          "name": "category"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "username": {
+            "type": "string",
+            "example": "theUser"
+          },
+          "firstName": {
+            "type": "string",
+            "example": "John"
+          },
+          "lastName": {
+            "type": "string",
+            "example": "James"
+          },
+          "email": {
+            "type": "string",
+            "example": "john@email.com"
+          },
+          "password": {
+            "type": "string",
+            "example": "12345"
+          },
+          "phone": {
+            "type": "string",
+            "example": "12345"
+          },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "format": "int32",
+            "example": 1
+          }
+        },
+        "xml": {
+          "name": "user"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "tag"
+        }
+      },
+      "Pet": {
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "pet"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "##default"
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/test/fixtures/oss_oapi_codegen_allof_additional.yaml
+++ b/test/fixtures/oss_oapi_codegen_allof_additional.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: test schema
+  version: "1.0.0"
+
+paths:
+
+components:
+  schemas:
+    Person:
+      allOf:
+        # common fields
+        - type: object
+          additionalProperties: true
+          required:
+            - metadata
+          properties:
+            metadata:
+              type: string
+        # person specific fields
+        - type: object
+          additionalProperties: true
+          properties:
+            name:
+              type: string
+            age:
+              type: number

--- a/test/fixtures/oss_oapi_codegen_cookies.yaml
+++ b/test/fixtures/oss_oapi_codegen_cookies.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.1"
+info:
+  version: 1.0.0
+  title: Cookie parameters
+paths:
+  /cookies:
+    get:
+      operationId: cookieParams
+      parameters:
+        - name: authId
+          description: Cookie parameter
+          in: cookie
+          required: false
+          schema:
+            type: string
+        - name: serverId
+          description: Another cookie parameter
+          in: cookie
+          required: false
+          schema:
+            type: string
+      responses:
+        204:
+          description: no content

--- a/test/fixtures/oss_oapi_codegen_illegal_enums.yaml
+++ b/test/fixtures/oss_oapi_codegen_illegal_enums.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.2
+
+info:
+  title: ...
+  version: 0.0.0
+
+paths:
+  /foo:
+    get:
+      responses:
+        200:
+          description: ...
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Bar'
+
+components:
+  schemas:
+    Bar:
+      type: string
+      enum:
+        - ''
+        - Foo
+        - Bar
+        - Foo Bar
+        - Foo-Bar
+        - 1Foo
+        - Bar  # A swagger validator would catch this duplicate value
+        - ' Foo'
+        - ' Foo '
+        - _Foo_
+        - "1"

--- a/test/fixtures/oss_oapi_codegen_multi_content.yaml
+++ b/test/fixtures/oss_oapi_codegen_multi_content.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.1
+info:
+  title: api
+  version: "0.1.0"
+paths:
+  /whatever:
+    post:
+      operationId: CreateWhatever
+      requestBody:
+        content:
+          application/json-patch+json:
+            schema:
+              $ref: "#/components/schemas/Whatever"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Whatever"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/Whatever"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/Whatever"
+      responses:
+        201:
+          description: Whatever created
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Whatever"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Whatever"
+            text/json:
+              schema:
+                $ref: "#/components/schemas/Whatever"
+components:
+  schemas:
+    Whatever:
+      type: object
+      properties:
+        someProperty:
+          type: string

--- a/test/fixtures/oss_oapi_codegen_name_conflicts.yaml
+++ b/test/fixtures/oss_oapi_codegen_name_conflicts.yaml
@@ -1,0 +1,607 @@
+openapi: 3.0.1
+
+info:
+  title: "Comprehensive name collision resolution test"
+  description: |
+    Exercises all documented name collision patterns across issues and PRs:
+    #200, #254, #255, #292, #407, #899, #1357, #1450, #1474, #1713, #1881, #2097, #2213
+    Also covers oapi-codegen-exp#14 (inline response object with $ref properties).
+    Patterns K/L/M cover x-go-name preservation during collision resolution (PR #2213 review).
+  version: 0.0.0
+
+paths:
+  # Pattern A: Cross-section collision (issues #200, #254, #407, #1881, PR #292)
+  # "Bar" appears in schemas, parameters, requestBodies, responses, and headers.
+  /foo:
+    post:
+      operationId: postFoo
+      parameters:
+        - $ref: '#/components/parameters/Bar'
+      requestBody:
+        $ref: '#/components/requestBodies/Bar'
+      responses:
+        200:
+          $ref: '#/components/responses/Bar'
+
+  # Pattern B: Schema vs client wrapper (issues #1474, #1713, #1450)
+  # Schema "CreateItemResponse" collides with createItem wrapper.
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateItemResponse'
+
+    # Pattern C: Schema alias vs client wrapper (issue #1357)
+    # Schema "ListItemsResponse" (string alias) collides with listItems wrapper.
+    get:
+      operationId: listItems
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListItemsResponse'
+
+  # Pattern D: Operation name = schema response name (issue #255)
+  # Schema "QueryResponse" collides with query wrapper.
+  /query:
+    post:
+      operationId: query
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                q:
+                  type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResponse'
+
+  # Pattern E: Schema matches op+Response (issues #2097, #899)
+  # Schema "GetStatusResponse" collides with getStatus wrapper.
+  /status:
+    get:
+      operationId: getStatus
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetStatusResponse'
+
+  # Pattern F: x-go-type-name extension + cross-section collision
+  # Schema "Qux" has x-go-type-name and collides with response "Qux".
+  /qux:
+    get:
+      operationId: getQux
+      responses:
+        '200':
+          $ref: '#/components/responses/Qux'
+    post:
+      operationId: postQux
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Qux'
+      responses:
+        '200':
+          description: OK
+
+  # Pattern G: x-go-type extension + cross-section collision
+  # Schema "Zap" has x-go-type and collides with response "Zap".
+  /zap:
+    get:
+      operationId: getZap
+      responses:
+        '200':
+          $ref: '#/components/responses/Zap'
+    post:
+      operationId: postZap
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Zap'
+      responses:
+        '200':
+          description: OK
+
+  # Pattern H: Multiple JSON content types in requestBody (PR #2213)
+  # "Order" appears in schemas and requestBodies. The requestBody has 3 content
+  # types that all contain "json" and collapse to the same "JSON" short name:
+  #   application/json, application/merge-patch+json, application/json-patch+json
+  # This triggers an infinite oscillation between context suffix and content type
+  # suffix strategies unless the numeric fallback can break the cycle.
+  /orders:
+    post:
+      operationId: createOrder
+      requestBody:
+        $ref: '#/components/requestBodies/Order'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+
+  # Pattern I: Inline response object with $ref properties to x-go-type schemas
+  # (oapi-codegen-exp#14). The response has an inline object with properties that
+  # $ref component schemas carrying x-go-type. Each property ref should use the
+  # component schema's type alias, not produce duplicate type declarations.
+  /entities:
+    get:
+      operationId: listEntities
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Widget'
+                  metadata:
+                    $ref: '#/components/schemas/Metadata'
+
+  # Pattern J: Duplicate inline oneOf members across response content types
+  # A PATCH operation returns multiple JSON content types
+  # (application/json, application/json-patch+json, application/json-patch-query+json,
+  # application/merge-patch+json). The json-patch and json-patch-query variants
+  # share an identical oneOf schema with inline (non-$ref) members. The codegen
+  # must not emit duplicate type declarations for those inline members.
+  #
+  # Additionally, the requestBody shares the same name as a component schema
+  # ("Resource_MVO") where the requestBody content schemas $ref the component
+  # schema, and one content type $refs a different schema.
+  /resources/{id}:
+    patch:
+      operationId: patchResource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: '#/components/requestBodies/Resource_MVO'
+      responses:
+        '200':
+          $ref: '#/components/responses/200Resource_Patch'
+
+  # Pattern K: x-go-name on schema — resolver must preserve user-specified names
+  # Schema "Renamer" has x-go-name: "SpecialName". Response "Renamer" also exists.
+  # The resolver should use "SpecialName" for the schema (pinned by x-go-name)
+  # and "Renamer" for the response (no collision since the schema is "SpecialName").
+  # Covers: PR #2213 review finding (x-go-name not respected by resolver)
+  /renamed-schema:
+    get:
+      operationId: getRenamedSchema
+      responses:
+        '200':
+          $ref: '#/components/responses/Renamer'
+    post:
+      operationId: postRenamedSchema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Renamer'
+      responses:
+        '200':
+          description: OK
+
+  # Pattern L: x-go-name on response — resolver must preserve user-specified names
+  # Response "Outcome" has x-go-name: "OutcomeResult". Schema "Outcome" also exists.
+  # The resolver should use "OutcomeResult" for the response (pinned by x-go-name)
+  # and "Outcome" for the schema (no collision since the response is "OutcomeResult").
+  # Covers: PR #2213 review finding (x-go-name not respected by resolver)
+  /outcome:
+    get:
+      operationId: getOutcome
+      responses:
+        '200':
+          $ref: '#/components/responses/Outcome'
+    post:
+      operationId: postOutcome
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Outcome'
+      responses:
+        '200':
+          description: OK
+
+  # Pattern M: x-go-name on requestBody — resolver must preserve user-specified names
+  # RequestBody "Payload" has x-go-name: "PayloadBody". Schema "Payload" also exists.
+  # The resolver should use "PayloadBody" for the requestBody (pinned by x-go-name)
+  # and "Payload" for the schema (no collision since the requestBody is "PayloadBody").
+  # Covers: PR #2213 review finding (x-go-name not respected by resolver)
+  /payload:
+    post:
+      operationId: sendPayload
+      requestBody:
+        $ref: '#/components/requestBodies/Payload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payload'
+
+  # Cross-section: requestBody vs schema (issues #254, #407)
+  # "Pet" appears in both schemas and requestBodies.
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+
+components:
+  schemas:
+    Bar:
+      type: object
+      properties:
+        value:
+          type: string
+
+    Bar2:
+      type: object
+      properties:
+        value:
+          type: number
+
+    CreateItemResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+    ListItemsResponse:
+      type: string
+
+    QueryResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: string
+
+    GetStatusResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        timestamp:
+          type: string
+
+    # Pattern H: Schema "Order" collides with requestBody "Order" which has
+    # 3 content types that all map to the "JSON" short name.
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        product:
+          type: string
+
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+
+    # Pattern I: schemas with x-go-type used as $ref targets in inline response properties.
+    # (oapi-codegen-exp#14)
+    Widget:
+      type: object
+      x-go-type: string
+      properties:
+        id:
+          type: string
+
+    Metadata:
+      type: object
+      x-go-type: string
+      properties:
+        total:
+          type: integer
+
+    # Pattern J: schema "Resource_MVO" collides with requestBody "Resource_MVO".
+    # The requestBody's content schemas $ref the component schema, plus one
+    # content type $refs a different schema (JsonPatch). The response for the
+    # PATCH operation has multiple JSON content types, two of which share an
+    # identical oneOf schema with inline members.
+    Resource_MVO:
+      type: object
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+
+    JsonPatch:
+      type: array
+      items:
+        type: object
+        properties:
+          op:
+            type: string
+          path:
+            type: string
+
+    # Pattern K: x-go-name on schema — should be pinned as "SpecialName"
+    Renamer:
+      x-go-name: SpecialName
+      type: object
+      properties:
+        label:
+          type: string
+
+    # Pattern L: schema "Outcome" (no x-go-name — keeps bare name)
+    Outcome:
+      type: object
+      properties:
+        value:
+          type: string
+
+    # Pattern M: schema "Payload" (no x-go-name — keeps bare name)
+    Payload:
+      type: object
+      properties:
+        content:
+          type: string
+
+    # Pattern F: x-go-type-name extension + cross-section collision
+    # Schema "Qux" has x-go-type-name: CustomQux and collides with response "Qux".
+    Qux:
+      type: object
+      x-go-type-name: CustomQux
+      properties:
+        label:
+          type: string
+
+    # Pattern G: x-go-type extension + cross-section collision
+    # Schema "Zap" has x-go-type: string and collides with response "Zap".
+    Zap:
+      type: object
+      x-go-type: string
+      properties:
+        unused:
+          type: string
+
+  parameters:
+    Bar:
+      name: bar
+      in: query
+      schema:
+        type: string
+
+  requestBodies:
+    Bar:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              value:
+                type: integer
+
+    # Pattern H: requestBody "Order" with 3 content types that all contain "json"
+    # and collapse to the same "JSON" suffix via contentTypeSuffix().
+    Order:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              product:
+                type: string
+        application/merge-patch+json:
+          schema:
+            type: object
+            properties:
+              product:
+                type: string
+        application/json-patch+json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                op:
+                  type: string
+                path:
+                  type: string
+                value:
+                  type: string
+
+    Pet:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              species:
+                type: string
+
+    # Pattern M: requestBody "Payload" has x-go-name — should be pinned as "PayloadBody"
+    Payload:
+      x-go-name: PayloadBody
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: string
+
+    # Pattern J: requestBody "Resource_MVO" shares name with schema "Resource_MVO".
+    # Content schemas $ref the component schema, except json-patch which $refs JsonPatch.
+    Resource_MVO:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resource_MVO'
+        application/merge-patch+json:
+          schema:
+            $ref: '#/components/schemas/Resource_MVO'
+        application/json-patch+json:
+          schema:
+            $ref: '#/components/schemas/JsonPatch'
+
+  headers:
+    Bar:
+      schema:
+        type: boolean
+
+  responses:
+    Bar:
+      description: Bar response
+      headers:
+        X-Bar:
+          $ref: '#/components/headers/Bar'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              value1:
+                $ref: '#/components/schemas/Bar'
+              value2:
+                $ref: '#/components/schemas/Bar2'
+
+    # Pattern K: response "Renamer" — no x-go-name, should keep bare name "Renamer"
+    # because the schema collision is avoided by the schema's x-go-name: SpecialName.
+    Renamer:
+      description: A Renamer response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: string
+
+    # Pattern L: response "Outcome" has x-go-name — should be pinned as "OutcomeResult"
+    Outcome:
+      x-go-name: OutcomeResult
+      description: An Outcome response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: string
+
+    Qux:
+      description: A Qux response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: string
+
+    Zap:
+      description: A Zap response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: string
+
+    # Pattern J: response with multiple JSON content types where json-patch
+    # and json-patch-query variants share an identical oneOf schema with
+    # inline (non-$ref) members. The codegen must not emit duplicate type
+    # declarations for those inline members.
+    200Resource_Patch:
+      description: Patch success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resource'
+        application/merge-patch+json:
+          schema:
+            $ref: '#/components/schemas/Resource'
+        application/json-patch+json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/Resource'
+              - type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+              - type: string
+                nullable: true
+        application/json-patch-query+json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/Resource'
+              - type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+              - type: string
+                nullable: true

--- a/test/fixtures/oss_oapi_codegen_nullable.yaml
+++ b/test/fixtures/oss_oapi_codegen_nullable.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.1
+info:
+  version: '0.0.1'
+  title: example
+  description: |
+    Make sure that nullable types are generated properly
+paths:
+  /example:
+    patch:
+      operationId: examplePatch
+      requestBody:
+        description: The patch body
+        required: true
+        content:
+          application/json:
+            example:
+              name: Example Patch
+            schema:
+              $ref: "#/components/schemas/PatchRequest"
+      responses:
+        '200':
+          description: "OK"
+
+components:
+  schemas:
+    PatchRequest:
+      type: object
+      description: A request to patch an existing user object.
+      required:
+        - simple_required_nullable
+        - complex_required_nullable
+      properties:
+        simple_required_nullable:
+          # required and nullable
+          $ref: "#/components/schemas/simple_required_nullable"
+        simple_optional_nullable:
+          # optional and nullable
+          $ref: "#/components/schemas/simple_optional_nullable"
+        simple_optional_non_nullable:
+          # optional and non-nullable
+          $ref: "#/components/schemas/simple_optional_non_nullable"
+        complex_required_nullable:
+          # required and nullable
+          $ref: "#/components/schemas/complex_required_nullable"
+        complex_optional_nullable:
+          # optional and nullable
+          $ref: "#/components/schemas/complex_optional_nullable"
+      additionalProperties: false
+
+    simple_required_nullable:
+      type: integer
+      nullable: true
+      description: Simple required and nullable
+
+    simple_optional_nullable:
+      type: integer
+      nullable: true
+      description: Simple optional and nullable
+
+    simple_optional_non_nullable:
+      type: string
+      description: Simple optional and non nullable
+
+    complex_required_nullable:
+      type: object
+      nullable: true
+      description: Complex required and nullable
+      properties:
+        name:
+          description: Optional and non nullable
+          type: string
+
+    complex_optional_nullable:
+      type: object
+      description: Complex, optional and nullable
+      properties:
+        alias_name:
+          description: Optional and nullable
+          type: string
+          nullable: true
+        name:
+          description: Optional and non nullable
+          type: string
+      nullable: true

--- a/test/fixtures/oss_oapi_codegen_recursive_allof.yaml
+++ b/test/fixtures/oss_oapi_codegen_recursive_allof.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.2
+info:
+  version: '0.0.1'
+  title: example
+  description: |
+    Make sure that recursive $ref in allOf are handled properly
+paths:
+  /example:
+    get:
+      operationId: exampleGet
+      responses:
+        '200':
+          description: "OK"
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/RecursiveObject'
+
+components:
+  schemas:
+    RecursiveObject:
+      allOf:
+        - $ref: "#/components/schemas/NonRecursiveObject"
+        - $ref: "#/components/schemas/RecursiveObject"
+        - properties:
+            FieldInRecursive::
+              type: string
+
+    NonRecursiveObject:
+      properties:
+        FieldInNonRecursive:
+          type: string

--- a/test/fixtures/oss_oapi_codegen_security.yaml
+++ b/test/fixtures/oss_oapi_codegen_security.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.1"
+info:
+  title: Security Test
+  version: "1.0.0"
+components:
+  securitySchemes:
+    bearerAuth:
+      scheme: bearer
+      type: http
+paths:
+  /auth-check:
+    get:
+      operationId: authCheck
+      security:
+        - bearerAuth: []
+      responses:
+        200:
+          description: good
+  /test:
+    get:
+      operationId: test
+      responses:
+        200:
+          description: good

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -669,10 +669,13 @@ pub fn validate_broken_spec_accepts_untyped_additional_properties_test() {
 
 // --- Parser: fail-fast tests ---
 
-pub fn parse_missing_responses_fails_test() {
-  let result = parser.parse_file("test/fixtures/missing_responses.yaml")
-  should.be_error(result)
-  let assert Error(parser.MissingField(path: _, field: "responses")) = result
+pub fn parse_missing_responses_succeeds_with_empty_dict_test() {
+  // Missing responses field is now parsed as empty dict (not a parse error).
+  // Validation catches missing responses separately.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/missing_responses.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
 }
 
 pub fn parse_invalid_param_location_fails_test() {
@@ -7401,4 +7404,108 @@ components:
   |> should.be_true()
   string.contains(content, "dict.size")
   |> should.be_true()
+}
+
+// --- OSS fixture tests ---
+// Test fixtures ported from open source projects under MIT / Apache 2.0 licenses.
+// libopenapi: MIT License, Copyright (c) 2022-2025 Princess Beef Heavy Industries
+// oapi-codegen: Apache License 2.0, Copyright deepmap/oapi-codegen contributors
+
+pub fn oss_libopenapi_all_components_parses_test() {
+  // all-the-components.yaml has webhooks without responses field.
+  // OpenAPI spec requires responses on operations, but webhooks in the wild
+  // often omit them. Parser should handle this gracefully.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_all_components.yaml")
+  spec.info.title |> should.equal("Burger Shop")
+  let ops = dict.to_list(spec.paths)
+  list.length(ops) |> should.not_equal(0)
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_libopenapi_all_components_validates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_all_components.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let blocking = validate.errors_only(errors)
+  list.length(blocking) |> should.equal(0)
+}
+
+pub fn oss_libopenapi_all_components_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_all_components.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) -> {
+      let blocking = validate.errors_only(errors)
+      list.length(blocking) |> should.equal(0)
+    }
+  }
+}
+
+pub fn oss_libopenapi_burgershop_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_burgershop.yaml")
+  spec.info.title |> should.equal("Burger Shop")
+  spec.info.version |> should.equal("1.2")
+  // Has webhooks
+  dict.size(spec.webhooks) |> should.not_equal(0)
+  // Has security
+  list.length(spec.security) |> should.not_equal(0)
+}
+
+pub fn oss_libopenapi_burgershop_schemas_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_burgershop.yaml")
+  let assert Some(components) = spec.components
+  // Has expected schemas
+  let schema_names = dict.keys(components.schemas)
+  list.contains(schema_names, "Burger") |> should.be_true()
+  list.contains(schema_names, "Error") |> should.be_true()
+  list.contains(schema_names, "Fries") |> should.be_true()
+  list.contains(schema_names, "Dressing") |> should.be_true()
+  list.contains(schema_names, "Drink") |> should.be_true()
+}
+
+pub fn oss_libopenapi_petstorev3_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_libopenapi_petstorev3.json")
+  spec.info.title |> should.equal("Swagger Petstore - OpenAPI 3.0")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_libopenapi_circular_rejects_missing_info_test() {
+  // circular-tests.yaml has no info field, which is required by OpenAPI 3.x.
+  // Parser should reject this with a clear error.
+  let result = parser.parse_file("test/fixtures/oss_libopenapi_circular.yaml")
+  case result {
+    Error(_) -> Nil
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn oss_oapi_codegen_cookies_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_cookies.yaml")
+  spec.info.title |> should.not_equal("")
+}
+
+pub fn oss_oapi_codegen_name_conflicts_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_name_conflicts.yaml")
+  let assert Some(components) = spec.components
+  // Should have many schemas (name conflict resolution tests many similar names)
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_illegal_enums_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_illegal_enums.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -7509,3 +7509,82 @@ pub fn oss_oapi_codegen_illegal_enums_parses_test() {
   let assert Some(components) = spec.components
   dict.size(components.schemas) |> should.not_equal(0)
 }
+
+pub fn oss_oapi_codegen_nullable_parses_test() {
+  // Tests all combinations of required/optional + nullable/non-nullable
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_nullable.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_nullable_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_nullable.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) -> {
+      let blocking = validate.errors_only(errors)
+      list.length(blocking) |> should.equal(0)
+    }
+  }
+}
+
+pub fn oss_oapi_codegen_recursive_allof_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_recursive_allof.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_allof_additional_parses_test() {
+  // allOf with additionalProperties: true
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_allof_additional.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_allof_additional_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_allof_additional.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) -> {
+      let blocking = validate.errors_only(errors)
+      list.length(blocking) |> should.equal(0)
+    }
+  }
+}
+
+pub fn oss_oapi_codegen_security_parses_test() {
+  // Bearer token authentication
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_security.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.security_schemes) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_multi_content_parses_test() {
+  // Multiple content types in requestBody and responses
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_multi_content.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_multi_content_rejects_unsupported_types_test() {
+  // This spec has text/json and application/*+json which are unsupported.
+  // Validation should catch them.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_multi_content.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let blocking = validate.errors_only(errors)
+  // Should have blocking errors for unsupported content types
+  list.length(blocking) |> should.not_equal(0)
+}


### PR DESCRIPTION
## Summary

- Port 12 test fixtures from open source OpenAPI tooling projects (libopenapi MIT, oapi-codegen Apache 2.0)
- Fix 3 parser bugs discovered by running real-world specs through oaspec

## Test fixtures added

From **libopenapi** (MIT License):
- `burgershop.openapi.yaml` — comprehensive spec with callbacks, security, response headers/links, vendor extensions
- `all-the-components.yaml` — exercises all OpenAPI component types
- `petstorev3.json` — standard petstore in JSON format
- `circular-tests.yaml` — circular schema references (validates parser rejects incomplete specs)

From **oapi-codegen** (Apache 2.0 License):
- `cookies` — cookie parameter handling
- `name_conflicts` — schema name collision resolution
- `illegal_enum_names` — edge cases in enum variant naming
- `nullable` — all required/optional + nullable/non-nullable combinations
- `recursive_allof` — recursive allOf with self-references
- `allof_additional` — allOf with additionalProperties: true
- `security` — bearer token authentication
- `multi_content` — multiple request/response content types

## Parser fixes

- **x-extension keys**: skip `x-` vendor extension keys in paths and responses maps (was failing on `x-toasty-roasty` in responses)
- **YAML float version**: accept `openapi: 3.0` where YAML parses the number as float instead of string
- **Optional responses**: make operation `responses` optional at parse time (webhooks often omit them)

## Test plan

- [x] `gleam test` — 248 passed, no failures
- [x] `gleam format --check src/ test/` — pass
- [x] ShellSpec — 51 examples, 0 failures
- [x] Integration tests — all pass
- [x] `just all` — pass
- [x] No Co-Author trailers in any commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.6.1

* **Bug Fixes**
  * Parser now correctly skips vendor extension keys (prefixed with `x-`) in paths and responses rather than treating them as standard entries.
  * OpenAPI version field now accepts YAML float values in addition to string format.
  * Operation-level `responses` field is now treated as optional during parsing.

* **Tests**
  * Expanded test coverage with comprehensive fixture tests for OpenAPI specification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->