### PR TITLE
Port 14 more OSS test fixtures and improve parser error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generate Gleam code from OpenAPI 3.x specifications with strict codegen for a la
 - Parameter support (deepObject, array, complex schema parameters)
 - Content type support (JSON, form-urlencoded, multipart, XML, octet-stream, text/plain)
 - OpenAPI descriptions as doc comments
-- Thoroughly tested: 273+ unit tests, ShellSpec CLI tests, integration compile tests, and 26 real-world OpenAPI spec fixtures
+- Thoroughly tested: 293+ unit tests, ShellSpec CLI tests, integration compile tests, and 40 real-world OpenAPI spec fixtures
 
 ## Install
 

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1348,9 +1348,24 @@ pub fn parse_error_to_string(error: ParseError) -> String {
   case error {
     FileError(detail:) -> detail
     YamlError(detail:) -> detail
-    MissingField(path:, field:) -> "Missing field '" <> field <> "' at " <> path
-    InvalidValue(path:, detail:) ->
-      "Invalid value at " <> path <> ": " <> detail
+    MissingField(path:, field:) -> {
+      let location = case path {
+        "" -> "root"
+        p -> p
+      }
+      "Missing required field '"
+      <> field
+      <> "' at "
+      <> location
+      <> ". Check your OpenAPI spec structure."
+    }
+    InvalidValue(path:, detail:) -> {
+      let location = case path {
+        "" -> "root"
+        p -> p
+      }
+      "Invalid value at " <> location <> ": " <> detail
+    }
   }
 }
 

--- a/test/fixtures/oss_oapi_codegen_head_digit_of_httpheader.yaml
+++ b/test/fixtures/oss_oapi_codegen_head_digit_of_httpheader.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.2
+info:
+  title: Head Digit Header Test
+  version: "0.0.1"
+paths:
+  /foo:
+    get:
+      responses:
+        200:
+          $ref: "#/components/responses/200"
+components:
+  responses:
+    "200":
+      description: OK
+      headers:
+        "000-foo":
+          schema:
+            type: string

--- a/test/fixtures/oss_oapi_codegen_head_digit_of_operation_id.yaml
+++ b/test/fixtures/oss_oapi_codegen_head_digit_of_operation_id.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.2
+info:
+  title: Head Digit OperationId Test
+  version: "0.0.1"
+paths:
+  /3gpp/foo:
+    get:
+      operationId: 3GPPFoo
+      responses:
+        '200':
+          description: ok

--- a/test/fixtures/oss_oapi_codegen_issue_1087.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_1087.yaml
@@ -1,0 +1,109 @@
+openapi: 3.0.3
+info:
+  title: test
+  description: "The API for Test"
+  version: 2.0.0
+servers:
+  - url: http://localhost:8000
+tags:
+  - name: Tag
+    description: Foo Bar
+paths:
+  /api/my/path:
+    get:
+      tags:
+        - Tag
+      summary: list things
+      description: my list of things
+      operationId: getThings
+      responses:
+        200:
+          $ref: "#/components/responses/ThingResponse"
+        304:
+          $ref: "#/components/responses/304"
+        401:
+          $ref: "./deps/my-deps.json#/components/responses/401"
+        403:
+          $ref: "./deps/my-deps.json#/components/responses/403"
+        404:
+          $ref: "#/components/responses/404"
+        500:
+          $ref: "./deps/my-deps.json#/components/responses/DefaultError"
+components:
+  securitySchemes:
+    bearerAuthWebhook:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: The JWT access token.
+  responses:
+    Empty:
+      description: No content
+    ThingResponse:
+      description: List of Things
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ThingList"
+    304:
+      description: Response when client should use cached results
+      headers:
+        Cache-Control:
+          description: defines TTL of resource in seconds, indicates that the response can be stored in caches, and indicates that the response can be stored only in a private cache
+          example: "max-age: 86400, must-revalidate, private"
+          schema:
+            type: string
+        ETag:
+          description: "indicate the current version of the resource"
+          schema:
+            type: string
+    404:
+      description: Not Found. Resource could not be found
+      content:
+        application/json:
+          schema:
+            $ref: "./deps/my-deps.json#/components/schemas/Error"
+          example:
+            code: 404
+            domain: "Foo"
+            message: "Not Found. Subscription could not be found"
+            reason: "Not_Found"
+    409:
+      description: Conflict. Resource already exists
+      content:
+        application/json:
+          schema:
+            $ref: "./deps/my-deps.json#/components/schemas/Error"
+          example:
+            code: 404
+            domain: "Webhook"
+            message: "Conflict. Resource already exists"
+            reason: "Conflict"
+    410:
+      description: Gone. Record no longer available
+      content:
+        application/json:
+          schema:
+            $ref: "./deps/my-deps.json#/components/schemas/Error"
+          example:
+            code: 403
+            domain: ""
+            message: "Gone"
+            reason: "Already deleted"
+  schemas:
+    Thing:
+      type: object
+      properties:
+        name:
+          type: string
+          description: just a name
+      required: [ name]
+    ThingList:
+      type: object
+      description: Object containing list of Things
+      properties:
+        keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/Thing"
+      required: [ keys ]

--- a/test/fixtures/oss_oapi_codegen_issue_1397.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_1397.yaml
@@ -1,0 +1,52 @@
+openapi: "3.0.1"
+components:
+  schemas:
+    Test:
+      type: object
+      properties:
+        field1:
+          description: A array of enum values
+          items:
+            enum:
+            - option1
+            - option2
+            type: string
+          maxItems: 5
+          minItems: 0
+          type: array
+        field2:
+          description: A nested object with allocated name
+          properties:
+            field1:
+              type: boolean
+            field2:
+              type: string
+          required:
+          - field1
+          - field2
+          type: object
+          x-go-type-name: MyTestRequestNestedField
+        field3:
+          description: A nested object without allocated name
+          properties:
+            field1:
+              type: boolean
+            field2:
+              type: string
+          required:
+          - field1
+          - field2
+          type: object
+      x-go-type-name: MyTestRequest
+paths:
+  /test:
+    get:
+      operationId: test
+      requestBody:
+        content:
+          application/test+json:
+            schema:
+              $ref: "#/components/schemas/Test"
+      responses:
+        204:
+          description: good

--- a/test/fixtures/oss_oapi_codegen_issue_1914.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_1914.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+paths:
+  /pet:
+    post:
+      description: Ensure that the `text/plain` format correctly handles coercing a UUID type to a string.
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: uuid
+  /pet/1234:
+    post:
+      description: Ensure that the `text/plain` format correctly handles coercing a numerical type to a string.
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: number

--- a/test/fixtures/oss_oapi_codegen_issue_1963.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_1963.yaml
@@ -1,0 +1,105 @@
+openapi: 3.0.3
+info:
+  title: issue-1963
+  version: 1.0.0
+paths:
+  /json:
+    post:
+      operationId: JsonEndpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Request"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+  /text:
+    post:
+      operationId: TextEndpoint
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+  /formdata:
+    post:
+      operationId: FormdataEndpoint
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/Request"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: "#/components/schemas/Response"
+  /multipart:
+    post:
+      operationId: MultipartEndpoint
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                field:
+                  type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            multipart/form-data:
+              schema:
+                type: object
+                properties:
+                  field:
+                    type: string
+  /binary:
+    post:
+      operationId: BinaryEndpoint
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+components:
+  schemas:
+    Request:
+      type: object
+      properties:
+        value:
+          type: string
+    Response:
+      type: object
+      properties:
+        value:
+          type: string

--- a/test/fixtures/oss_oapi_codegen_issue_2113.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_2113.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.4"
+info:
+  title: API
+  version: "0.0.1"
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        "400":
+          $ref: "./common/spec.yaml#/components/responses/StandardError"
+        default:
+          $ref: "./common/spec.yaml#/components/responses/StandardError"

--- a/test/fixtures/oss_oapi_codegen_issue_2232.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_2232.yaml
@@ -1,0 +1,46 @@
+openapi: "3.0.3"
+info:
+  title: test
+  version: 1.0.0
+paths:
+  /v1/endpoint:
+    get:
+      operationId: GetEndpoint
+      parameters:
+        - name: env_param_level
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - dev
+              - live
+          x-oapi-codegen-extra-tags:
+            validate: "required,oneof=dev live"
+        - name: env_schema_level
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - dev
+              - live
+            x-oapi-codegen-extra-tags:
+              validate: "required,oneof=dev live"
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            x-oapi-codegen-extra-tags:
+              validate: "min=0,max=100"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string

--- a/test/fixtures/oss_oapi_codegen_issue_2238.yaml
+++ b/test/fixtures/oss_oapi_codegen_issue_2238.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Issue 2238
+paths:
+  /test:
+    get:
+      parameters:
+        - name: X-Tags
+          in: header
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+        - name: tags
+          in: cookie
+          schema:
+            type: array
+            items:
+              type: string
+          required: false

--- a/test/fixtures/oss_openapi_gen_issue_11897.yaml
+++ b/test/fixtures/oss_openapi_gen_issue_11897.yaml
@@ -1,0 +1,130 @@
+openapi: 3.0.1
+info:
+  title: metadata-svc
+  description: Metadata Service
+  contact:
+    name: Test Svc
+    email: xyz@xyz.com
+  version: 3.1.2
+servers:
+- url: https://localhost:8080/
+tags:
+- name: metadata
+  description: APIs to get metadata.
+paths:
+  /v1/array-of-string:
+    get:
+      tags:
+      - metadata
+      summary: Get groups.
+      description: Get the list of groups for this example.
+      operationId: getWithArrayOfString
+      responses:
+        200:
+          description: List of groups.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /v1/array-of-objects:
+    get:
+      tags:
+      - metadata
+      summary: Get groups.
+      description: Get the list of groups for this example.
+      operationId: getWithArrayOfObjects
+      responses:
+        200:
+          description: List of groups.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TestResponse'
+  /v1/set-of-strings:
+    get:
+      tags:
+      - metadata
+      summary: Get groups.
+      description: Get the set of strings for this example.
+      operationId: getWithSetOfStrings
+      responses:
+        200:
+          description: Set of strings.
+          content:
+            application/json:
+              schema:
+                type: array
+                uniqueItems: true
+                items:
+                  type: string
+  /v1/set-of-objects:
+    get:
+      tags:
+        - metadata
+      summary: Get groups.
+      description: Get the set of groups for this example.
+      operationId: getWithSetOfObjects
+      responses:
+        200:
+          description: Set of groups.
+          content:
+            application/json:
+              schema:
+                type: array
+                uniqueItems: true
+                items:
+                  $ref: '#/components/schemas/TestResponse'
+  /v1/map-of-strings:
+    get:
+      tags:
+      - metadata
+      summary: Get groups.
+      description: Get the map of strings for this example.
+      operationId: getWithMapOfStrings
+      responses:
+        200:
+          description: Map of strings.
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+  /v1/map-of-objects:
+    get:
+      tags:
+        - metadata
+      summary: Get groups.
+      description: Get the map of groups for this example.
+      operationId: getWithMapOfObjects
+      responses:
+        200:
+          description: Map of groups.
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  $ref: '#/components/schemas/TestResponse'
+                type: object
+components:
+  schemas:
+    TestResponse:
+      title: TestResponse
+      required:
+      - enabled
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Default value is false.
+          example: false
+      description: Object
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      name: Authorization
+      in: header

--- a/test/fixtures/oss_openapi_gen_issue_14731.yaml
+++ b/test/fixtures/oss_openapi_gen_issue_14731.yaml
@@ -1,0 +1,109 @@
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: 'FooService'
+paths:
+  /parentWithMapping:
+    put:
+      tags:
+        - pet
+      summary: put parent
+      operationId: putParentWithMapping
+      requestBody:
+        description: The updated account definition to save.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParentWithMapping'
+      responses:
+        '200':
+          $ref: '#/components/responses/ParentWithMapping'
+  /parentWithoutMapping:
+    put:
+      tags:
+        - pet
+      summary: put parent
+      operationId: putParentWithoutMapping
+      requestBody:
+        description: The updated account definition to save.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParentWithoutMapping'
+      responses:
+        '200':
+          $ref: '#/components/responses/ParentWithoutMapping'
+components:
+  schemas:
+    ParentWithMapping:
+      type: object
+      description: Defines an account by name.
+      properties:
+        childType:
+          $ref: '#/components/schemas/ChildType'
+      required:
+        - type
+      discriminator:
+        propertyName: childType
+        mapping:
+          child_a: '#/components/schemas/ChildWithMappingA'
+          child_b: '#/components/schemas/ChildWithMappingB'
+
+    ChildWithMappingA:
+      allOf:
+        - $ref: "#/components/schemas/ParentWithMapping"
+        - type: object
+          properties:
+            nameA:
+              type: string
+    ChildWithMappingB:
+      allOf:
+        - $ref: "#/components/schemas/ParentWithMapping"
+        - type: object
+          properties:
+            nameB:
+              type: string
+    ChildType:
+      type: string
+      x-extensible-enum:
+        - child_a
+        - child_b
+    ParentWithoutMapping:
+      type: object
+      description: Defines an account by name.
+      properties:
+        childType:
+          $ref: '#/components/schemas/ChildType'
+      required:
+        - type
+      discriminator:
+        propertyName: childType
+    ChildWithoutMappingA:
+      allOf:
+        - $ref: "#/components/schemas/ParentWithoutMapping"
+        - type: object
+          properties:
+            nameA:
+              type: string
+    ChildWithoutMappingB:
+      allOf:
+        - $ref: "#/components/schemas/ParentWithoutMapping"
+        - type: object
+          properties:
+            nameB:
+              type: string
+  responses:
+    ParentWithMapping:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ParentWithMapping'
+    ParentWithoutMapping:
+      description: The saved account definition.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ParentWithoutMapping'

--- a/test/fixtures/oss_openapi_gen_issue_1666.yaml
+++ b/test/fixtures/oss_openapi_gen_issue_1666.yaml
@@ -1,0 +1,83 @@
+openapi: "3.0.3"
+info:
+  title: issue #1666
+  version: 1.0.0
+tags:
+  - name: test1
+  - name: test2
+  - name: test3
+  - name: test4
+paths:
+  "/not-required":
+    post:
+      operationId: notRequired
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestRequest'
+      responses:
+        '200':
+          description: success
+      tags:
+        - test1
+  "/required":
+    post:
+      operationId: required
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestRequest'
+      responses:
+        '200':
+          description: success
+      tags:
+        - test2
+  "/with-path-param/{param1}":
+    post:
+      operationId: withPathParam
+      parameters:
+      - name: param1
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestRequest'
+      responses:
+        '200':
+          description: success
+      tags:
+        - test3
+  "/with-path-param-required/{param1}":
+    post:
+      operationId: withPathParamRequired
+      parameters:
+      - name: param1
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestRequest'
+      responses:
+        '200':
+          description: success
+      tags:
+        - test4
+components:
+  schemas:
+    TestRequest:
+      type: object
+      properties:
+        key1:
+          type: string

--- a/test/fixtures/oss_openapi_gen_issue_18516.yaml
+++ b/test/fixtures/oss_openapi_gen_issue_18516.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.3
+info:
+  title: test
+  description: Test API
+  version: 1.0.1
+
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SomeObject"
+
+components:
+  schemas:
+    SomeObject:
+      type: object
+      required: 
+        - ids
+        - users
+        - user
+        - role
+        - custom
+      properties:
+        ids:
+          type: array
+          nullable: true
+          items:
+            type: integer
+        users:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+        user:
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+        role:
+          type: string
+          nullable: true
+          enum:
+            - admin
+            - tenant
+        custom:
+          $ref: "#/components/schemas/customEnum"
+    customEnum:
+      type: string
+      nullable: true
+      enum:
+        - custom
+        

--- a/test/fixtures/oss_openapi_gen_recursion_bug_4650.yaml
+++ b/test/fixtures/oss_openapi_gen_recursion_bug_4650.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.1
+info:
+  title: Test
+  version: v1
+paths:
+  /api/v1/filters:
+    get:
+      responses:
+        '200':
+          description: default response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Filter'
+components:
+  schemas:
+    AndFilter:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Filter'
+        - type: object
+          properties:
+            operator:
+              type: string
+              default: and
+              enum:
+                - and
+                - or
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/Filter'
+    Filter:
+      type: object
+      properties:
+        operator:
+          type: string
+          enum:
+            - and
+            - or
+      example:
+        operator: eq
+        field: name
+        value: john
+      discriminator:
+        propertyName: operator
+        mapping:
+          and: '#/components/schemas/AndFilter'
+          or: '#/components/schemas/OrFilter'
+      oneOf:
+        - $ref: '#/components/schemas/AndFilter'
+        - $ref: '#/components/schemas/OrFilter'
+    OrFilter:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Filter'
+        - type: object
+          properties:
+            operator:
+              type: string
+              default: or
+              enum:
+                - and
+                - or

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -7987,3 +7987,76 @@ pub fn oss_oapi_codegen_head_digit_operation_id_parses_test() {
   let paths = dict.to_list(spec.paths)
   list.length(paths) |> should.not_equal(0)
 }
+
+// --- OSS fixture batch: openapi-generator bug specs (Apache 2.0) ---
+
+pub fn oss_openapi_gen_issue_11897_array_of_string_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_11897.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_openapi_gen_issue_11897_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_11897.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) ->
+      list.length(validate.errors_only(errors)) |> should.equal(0)
+  }
+}
+
+pub fn oss_openapi_gen_issue_14731_discriminator_mapping_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_14731.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_openapi_gen_issue_1666_optional_body_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_1666.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_openapi_gen_issue_1666_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_1666.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) ->
+      list.length(validate.errors_only(errors)) |> should.equal(0)
+  }
+}
+
+pub fn oss_openapi_gen_recursion_bug_4650_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_recursion_bug_4650.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.not_equal(0)
+}
+
+pub fn oss_openapi_gen_issue_18516_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_18516.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_openapi_gen_issue_18516_generates_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_openapi_gen_issue_18516.yaml")
+  let ctx = make_ctx_from_spec(spec)
+  let result = generate.generate(spec, ctx.config)
+  case result {
+    Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
+    Error(generate.ValidationErrors(errors:)) ->
+      list.length(validate.errors_only(errors)) |> should.equal(0)
+  }
+}

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -7853,3 +7853,137 @@ pub fn oss_kiota_multi_security_generates_test() {
     }
   }
 }
+
+// --- Parser error message quality tests ---
+
+pub fn parse_error_missing_info_has_actionable_message_test() {
+  let result =
+    parser.parse_string(
+      "
+openapi: 3.0.3
+paths: {}
+",
+    )
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "info") |> should.be_true()
+  string.contains(msg, "root") |> should.be_true()
+}
+
+pub fn parse_error_missing_version_has_path_test() {
+  let result =
+    parser.parse_string(
+      "
+openapi: 3.0.3
+info:
+  title: Test
+paths: {}
+",
+    )
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "version") |> should.be_true()
+  string.contains(msg, "info") |> should.be_true()
+}
+
+pub fn parse_error_missing_param_name_has_path_test() {
+  let result =
+    parser.parse_string(
+      "
+openapi: 3.0.3
+info:
+  title: Test
+  version: '1.0'
+paths:
+  /x:
+    get:
+      operationId: getX
+      parameters:
+        - in: query
+          schema:
+            type: string
+      responses:
+        '200': { description: ok }
+",
+    )
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "name") |> should.be_true()
+  string.contains(msg, "parameter") |> should.be_true()
+}
+
+// --- OSS fixture batch: more oapi-codegen regression specs ---
+
+pub fn oss_oapi_codegen_issue_1087_rejects_unresolved_ref_test() {
+  // Has external $ref and numeric response key (304) as component ref
+  let result =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1087.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  // Should mention the unresolved reference
+  string.contains(msg, "response") |> should.be_true()
+}
+
+pub fn oss_oapi_codegen_issue_1963_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1963.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_issue_2232_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_2232.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_issue_2238_header_array_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_2238.yaml")
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_issue_2113_rejects_external_ref_test() {
+  // Has external $ref (./common/spec.yaml#/...) which is not supported
+  let result =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_2113.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "response") |> should.be_true()
+}
+
+pub fn oss_oapi_codegen_issue_1397_rejects_missing_info_test() {
+  let result =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1397.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "info") |> should.be_true()
+}
+
+pub fn oss_oapi_codegen_issue_1914_rejects_missing_info_test() {
+  let result =
+    parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1914.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "info") |> should.be_true()
+}
+
+pub fn oss_oapi_codegen_head_digit_httpheader_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file(
+      "test/fixtures/oss_oapi_codegen_head_digit_of_httpheader.yaml",
+    )
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}
+
+pub fn oss_oapi_codegen_head_digit_operation_id_parses_test() {
+  let assert Ok(spec) =
+    parser.parse_file(
+      "test/fixtures/oss_oapi_codegen_head_digit_of_operation_id.yaml",
+    )
+  let paths = dict.to_list(spec.paths)
+  list.length(paths) |> should.not_equal(0)
+}


### PR DESCRIPTION
## Summary

- Port 14 additional test fixtures (9 from oapi-codegen, 5 from openapi-generator), bringing total to 40 OSS fixtures
- Improve parser error messages to be more actionable for users

## Parser error message improvements

- `MissingField` errors now show `root` instead of empty string for top-level fields
- All `MissingField` errors include hint: "Check your OpenAPI spec structure."
- Empty paths in `InvalidValue` errors also replaced with `root`

Before: `Missing field 'info' at `
After: `Missing required field 'info' at root. Check your OpenAPI spec structure.`

## Test fixtures added

**oapi-codegen** (Apache 2.0) — 9 specs:
- issue-1087: numeric response ref key + external ref (correctly rejected)
- issue-1963: multiple content types in requestBody
- issue-2232: parameter-level validation
- issue-2238: header array parameters
- issue-2113: external $ref (correctly rejected)
- issue-1397: missing info field (correctly rejected with clear message)
- issue-1914: missing info field (correctly rejected with clear message)
- head-digit-of-httpheader: digit-prefixed header names
- head-digit-of-operation-id: digit-prefixed operationId (3GPPFoo)

**openapi-generator** (Apache 2.0) — 5 specs:
- issue_11897: array-of-string responses with tags and servers
- issue_14731: discriminator mapping with oneOf inheritance
- issue_1666: optional request body with multiple operations
- recursion-bug-4650: recursive Filter schema with self-reference
- issue_18516: diverse schema types in responses

## Test plan

- [x] `gleam test` — 293 passed, no failures
- [x] `gleam format --check src/ test/` — pass
- [x] No Co-Author trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for missing or invalid fields during OpenAPI spec parsing, providing clearer guidance on spec structure issues.

* **Tests**
  * Expanded test coverage from 273+ to 293+ unit tests and added 14 new real-world OpenAPI spec fixtures (from 26 to 40 total).
  * Enhanced parser error message validation and fixture-based regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->