### PR TITLE
Strict validation fixes: component aliases, malformed objects, error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 357 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 94 OSS-derived fixtures (130 total)
+- Backed by 362 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 94 OSS-derived fixtures (135 total)
 
 ## Why oaspec
 
@@ -173,8 +173,9 @@ These are the most important limitations today:
 
 - The following JSON Schema 2020-12 keywords are detected and rejected at parse time: `const`, `$defs`, `prefixItems`, `if`/`then`/`else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`
 - OpenAPI 3.1 multi-type unions such as `type: [string, integer]` should be modeled with `oneOf` instead
+- The `mutualTLS` security scheme type (OpenAPI 3.1) is not supported
 - `xml` annotations are not used for code generation
-- Some fields are parsed and preserved but not yet used by codegen, including `webhooks`, `externalDocs`, top-level `tags`, parameter examples, media examples and encoding, response headers and links, operation-level servers, and component headers/examples/links
+- Some fields are parsed and preserved but not yet used by codegen (warnings are emitted): `webhooks`, `externalDocs`, top-level `tags`, parameter examples, media examples and encoding, response headers and links, operation-level servers, and component headers/examples/links
 
 ## Development
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -638,7 +638,7 @@ fn validate_server_request_body_content_types(
           path: op_id <> ".requestBody",
           detail: "Content type '"
             <> media_type
-            <> "' is not supported for server code generation. Server router only supports application/json request bodies with typed decoding.",
+            <> "' is not supported for server code generation. Supported: application/json, application/x-www-form-urlencoded, multipart/form-data.",
         )
       })
     }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -88,8 +88,8 @@ fn parse_root(node: yay.Node) -> Result(OpenApiSpec, ParseError) {
   use servers <- result.try(parse_servers(node))
   use security <- result.try(parse_security_requirements(node, ""))
   use webhooks <- result.try(parse_webhooks(node, components))
-  let tags = parse_tags(node)
-  let external_docs = parse_optional_external_docs(node)
+  use tags <- result.try(parse_tags(node))
+  use external_docs <- result.try(parse_optional_external_docs(node))
   let json_schema_dialect =
     yay.extract_optional_string(node, "jsonSchemaDialect")
     |> result.unwrap(None)
@@ -152,7 +152,7 @@ fn parse_info(root: yay.Node) -> Result(Info, ParseError) {
     |> result.unwrap(None)
 
   let contact = parse_optional_contact(info_node)
-  let license = parse_optional_license(info_node)
+  use license <- result.try(parse_optional_license(info_node))
 
   Ok(Info(
     title:,
@@ -184,7 +184,7 @@ fn parse_server(node: yay.Node) -> Result(Server, ParseError) {
     yay.extract_optional_string(node, "description")
     |> result.unwrap(None)
 
-  let variables = parse_server_variables(node)
+  use variables <- result.try(parse_server_variables(node))
 
   Ok(Server(url:, description:, variables:))
 }
@@ -403,7 +403,7 @@ fn parse_operation(
 
   use callbacks <- result.try(parse_callbacks(node, context, components))
   use op_servers <- result.try(parse_servers(node))
-  let external_docs = parse_optional_external_docs(node)
+  use external_docs <- result.try(parse_optional_external_docs(node))
 
   Ok(Operation(
     operation_id:,
@@ -2027,35 +2027,47 @@ fn parse_optional_contact(info_node: yay.Node) -> Option(Contact) {
 }
 
 /// Parse optional license from an info node.
-fn parse_optional_license(info_node: yay.Node) -> Option(License) {
+/// If `license` is present, `name` is required per OpenAPI 3.x.
+fn parse_optional_license(
+  info_node: yay.Node,
+) -> Result(Option(License), ParseError) {
   case yay.select_sugar(from: info_node, selector: "license") {
     Ok(license_node) -> {
-      case yay.extract_string(license_node, "name") {
-        Ok(name) -> {
-          let url =
-            yay.extract_optional_string(license_node, "url")
-            |> result.unwrap(None)
-          Some(License(name:, url:))
-        }
-        _ -> None
-      }
+      use name <- result.try(
+        yay.extract_string(license_node, "name")
+        |> result.map_error(fn(_) {
+          MissingField(path: "info.license", field: "name")
+        }),
+      )
+      let url =
+        yay.extract_optional_string(license_node, "url")
+        |> result.unwrap(None)
+      Ok(Some(License(name:, url:)))
     }
-    _ -> None
+    _ -> Ok(None)
   }
 }
 
 /// Parse server variables from a server node.
-fn parse_server_variables(node: yay.Node) -> Dict(String, ServerVariable) {
+/// `default` is required per OpenAPI 3.x for each server variable.
+fn parse_server_variables(
+  node: yay.Node,
+) -> Result(Dict(String, ServerVariable), ParseError) {
   case yay.select_sugar(from: node, selector: "variables") {
     Ok(yay.NodeMap(entries)) ->
-      list.fold(entries, dict.new(), fn(acc, entry) {
+      list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
           yay.NodeStr(var_name) -> {
-            let default =
-              yay.extract_optional_string(value_node, "default")
-              |> result.unwrap(None)
-              |> option.unwrap("")
+            use default <- result.try(
+              yay.extract_string(value_node, "default")
+              |> result.map_error(fn(_) {
+                MissingField(
+                  path: "servers.variables." <> var_name,
+                  field: "default",
+                )
+              }),
+            )
             let enum_values = case yay.extract_string_list(value_node, "enum") {
               Ok(values) -> values
               _ -> []
@@ -2063,54 +2075,59 @@ fn parse_server_variables(node: yay.Node) -> Dict(String, ServerVariable) {
             let description =
               yay.extract_optional_string(value_node, "description")
               |> result.unwrap(None)
-            dict.insert(
+            Ok(dict.insert(
               acc,
               var_name,
               ServerVariable(default:, enum_values:, description:),
-            )
+            ))
           }
-          _ -> acc
+          _ -> Ok(acc)
         }
       })
-    _ -> dict.new()
+    _ -> Ok(dict.new())
   }
 }
 
 /// Parse optional external docs from a node.
-fn parse_optional_external_docs(node: yay.Node) -> Option(ExternalDoc) {
+/// If `externalDocs` is present, `url` is required per OpenAPI 3.x.
+fn parse_optional_external_docs(
+  node: yay.Node,
+) -> Result(Option(ExternalDoc), ParseError) {
   case yay.select_sugar(from: node, selector: "externalDocs") {
     Ok(doc_node) -> {
-      case yay.extract_string(doc_node, "url") {
-        Ok(url) -> {
-          let description =
-            yay.extract_optional_string(doc_node, "description")
-            |> result.unwrap(None)
-          Some(ExternalDoc(url:, description:))
-        }
-        _ -> None
-      }
+      use url <- result.try(
+        yay.extract_string(doc_node, "url")
+        |> result.map_error(fn(_) {
+          MissingField(path: "externalDocs", field: "url")
+        }),
+      )
+      let description =
+        yay.extract_optional_string(doc_node, "description")
+        |> result.unwrap(None)
+      Ok(Some(ExternalDoc(url:, description:)))
     }
-    _ -> None
+    _ -> Ok(None)
   }
 }
 
 /// Parse tags array from root.
-fn parse_tags(node: yay.Node) -> List(Tag) {
+fn parse_tags(node: yay.Node) -> Result(List(Tag), ParseError) {
   case yay.select_sugar(from: node, selector: "tags") {
     Ok(yay.NodeSeq(items)) ->
-      list.filter_map(items, fn(tag_node) {
-        case yay.extract_string(tag_node, "name") {
-          Ok(name) -> {
-            let description =
-              yay.extract_optional_string(tag_node, "description")
-              |> result.unwrap(None)
-            let external_docs = parse_optional_external_docs(tag_node)
-            Ok(Tag(name:, description:, external_docs:))
-          }
-          _ -> Error(Nil)
-        }
+      list.try_map(items, fn(tag_node) {
+        use name <- result.try(
+          yay.extract_string(tag_node, "name")
+          |> result.map_error(fn(_) {
+            MissingField(path: "tags", field: "name")
+          }),
+        )
+        let description =
+          yay.extract_optional_string(tag_node, "description")
+          |> result.unwrap(None)
+        use external_docs <- result.try(parse_optional_external_docs(tag_node))
+        Ok(Tag(name:, description:, external_docs:))
       })
-    _ -> []
+    _ -> Ok([])
   }
 }
 

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -985,26 +985,54 @@ fn parse_schemas_map(
 }
 
 /// Parse the parameters map from components.
+/// Uses two passes: first parse concrete entries, then resolve $ref aliases.
 fn parse_parameters_map(
   components_node: yay.Node,
 ) -> Result(Dict(String, Parameter), ParseError) {
   case yay.select_sugar(from: components_node, selector: "parameters") {
     Ok(yay.NodeMap(entries)) -> {
-      list.try_fold(entries, dict.new(), fn(acc, entry) {
+      // Pass 1: parse concrete (non-$ref) entries
+      use concrete <- result.try(
+        list.try_fold(entries, dict.new(), fn(acc, entry) {
+          let #(key_node, value_node) = entry
+          case key_node {
+            yay.NodeStr(name) ->
+              case yay.extract_optional_string(value_node, "$ref") {
+                Ok(Some(_)) -> Ok(acc)
+                _ -> {
+                  use param <- result.try(parse_parameter(value_node, None))
+                  Ok(dict.insert(acc, name, param))
+                }
+              }
+            _ -> Ok(acc)
+          }
+        }),
+      )
+      // Pass 2: resolve $ref aliases against concrete entries
+      list.try_fold(entries, concrete, fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(name) -> {
-            // Skip $ref aliases at component definition level —
-            // they reference sibling entries and cannot be resolved during
-            // component parsing (components are not yet fully built).
+          yay.NodeStr(name) ->
             case yay.extract_optional_string(value_node, "$ref") {
-              Ok(Some(_)) -> Ok(acc)
-              _ -> {
-                use param <- result.try(parse_parameter(value_node, None))
-                Ok(dict.insert(acc, name, param))
+              Ok(Some(ref_str)) -> {
+                use ref_name <- result.try(validate_ref_prefix(
+                  ref_str,
+                  "#/components/parameters/",
+                  "components.parameters." <> name,
+                ))
+                case dict.get(acc, ref_name) {
+                  Ok(target) -> Ok(dict.insert(acc, name, target))
+                  Error(_) ->
+                    Error(InvalidValue(
+                      path: "components.parameters." <> name,
+                      detail: "Component alias references '"
+                        <> ref_str
+                        <> "' which is not defined.",
+                    ))
+                }
               }
+              _ -> Ok(acc)
             }
-          }
           _ -> Ok(acc)
         }
       })
@@ -1014,27 +1042,55 @@ fn parse_parameters_map(
 }
 
 /// Parse the requestBodies map from components.
+/// Uses two passes: first parse concrete entries, then resolve $ref aliases.
 fn parse_request_bodies_map(
   components_node: yay.Node,
 ) -> Result(Dict(String, RequestBody), ParseError) {
   case yay.select_sugar(from: components_node, selector: "requestBodies") {
     Ok(yay.NodeMap(entries)) -> {
-      list.try_fold(entries, dict.new(), fn(acc, entry) {
+      use concrete <- result.try(
+        list.try_fold(entries, dict.new(), fn(acc, entry) {
+          let #(key_node, value_node) = entry
+          case key_node {
+            yay.NodeStr(name) ->
+              case yay.extract_optional_string(value_node, "$ref") {
+                Ok(Some(_)) -> Ok(acc)
+                _ -> {
+                  use rb <- result.try(parse_request_body(
+                    value_node,
+                    "components.requestBodies." <> name,
+                  ))
+                  Ok(dict.insert(acc, name, rb))
+                }
+              }
+            _ -> Ok(acc)
+          }
+        }),
+      )
+      list.try_fold(entries, concrete, fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(name) -> {
-            // Skip $ref aliases at component definition level
+          yay.NodeStr(name) ->
             case yay.extract_optional_string(value_node, "$ref") {
-              Ok(Some(_)) -> Ok(acc)
-              _ -> {
-                use rb <- result.try(parse_request_body(
-                  value_node,
+              Ok(Some(ref_str)) -> {
+                use ref_name <- result.try(validate_ref_prefix(
+                  ref_str,
+                  "#/components/requestBodies/",
                   "components.requestBodies." <> name,
                 ))
-                Ok(dict.insert(acc, name, rb))
+                case dict.get(acc, ref_name) {
+                  Ok(target) -> Ok(dict.insert(acc, name, target))
+                  Error(_) ->
+                    Error(InvalidValue(
+                      path: "components.requestBodies." <> name,
+                      detail: "Component alias references '"
+                        <> ref_str
+                        <> "' which is not defined.",
+                    ))
+                }
               }
+              _ -> Ok(acc)
             }
-          }
           _ -> Ok(acc)
         }
       })
@@ -1044,24 +1100,52 @@ fn parse_request_bodies_map(
 }
 
 /// Parse the responses map from components.
+/// Uses two passes: first parse concrete entries, then resolve $ref aliases.
 fn parse_responses_map(
   components_node: yay.Node,
 ) -> Result(Dict(String, Response), ParseError) {
   case yay.select_sugar(from: components_node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
-      list.try_fold(entries, dict.new(), fn(acc, entry) {
+      use concrete <- result.try(
+        list.try_fold(entries, dict.new(), fn(acc, entry) {
+          let #(key_node, value_node) = entry
+          case key_node {
+            yay.NodeStr(name) ->
+              case yay.extract_optional_string(value_node, "$ref") {
+                Ok(Some(_)) -> Ok(acc)
+                _ -> {
+                  use resp <- result.try(parse_response(value_node, None))
+                  Ok(dict.insert(acc, name, resp))
+                }
+              }
+            _ -> Ok(acc)
+          }
+        }),
+      )
+      list.try_fold(entries, concrete, fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(name) -> {
-            // Skip $ref aliases at component definition level
+          yay.NodeStr(name) ->
             case yay.extract_optional_string(value_node, "$ref") {
-              Ok(Some(_)) -> Ok(acc)
-              _ -> {
-                use resp <- result.try(parse_response(value_node, None))
-                Ok(dict.insert(acc, name, resp))
+              Ok(Some(ref_str)) -> {
+                use ref_name <- result.try(validate_ref_prefix(
+                  ref_str,
+                  "#/components/responses/",
+                  "components.responses." <> name,
+                ))
+                case dict.get(acc, ref_name) {
+                  Ok(target) -> Ok(dict.insert(acc, name, target))
+                  Error(_) ->
+                    Error(InvalidValue(
+                      path: "components.responses." <> name,
+                      detail: "Component alias references '"
+                        <> ref_str
+                        <> "' which is not defined.",
+                    ))
+                }
               }
+              _ -> Ok(acc)
             }
-          }
           _ -> Ok(acc)
         }
       })
@@ -1504,19 +1588,46 @@ fn parse_security_schemes_map(
 ) -> Result(Dict(String, spec.SecurityScheme), ParseError) {
   case yay.select_sugar(from: components_node, selector: "securitySchemes") {
     Ok(yay.NodeMap(entries)) -> {
-      list.try_fold(entries, dict.new(), fn(acc, entry) {
+      use concrete <- result.try(
+        list.try_fold(entries, dict.new(), fn(acc, entry) {
+          let #(key_node, value_node) = entry
+          case key_node {
+            yay.NodeStr(name) ->
+              case yay.extract_optional_string(value_node, "$ref") {
+                Ok(Some(_)) -> Ok(acc)
+                _ -> {
+                  use scheme <- result.try(parse_security_scheme(value_node))
+                  Ok(dict.insert(acc, name, scheme))
+                }
+              }
+            _ -> Ok(acc)
+          }
+        }),
+      )
+      list.try_fold(entries, concrete, fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(name) -> {
-            // Skip $ref aliases at component definition level
+          yay.NodeStr(name) ->
             case yay.extract_optional_string(value_node, "$ref") {
-              Ok(Some(_)) -> Ok(acc)
-              _ -> {
-                use scheme <- result.try(parse_security_scheme(value_node))
-                Ok(dict.insert(acc, name, scheme))
+              Ok(Some(ref_str)) -> {
+                use ref_name <- result.try(validate_ref_prefix(
+                  ref_str,
+                  "#/components/securitySchemes/",
+                  "components.securitySchemes." <> name,
+                ))
+                case dict.get(acc, ref_name) {
+                  Ok(target) -> Ok(dict.insert(acc, name, target))
+                  Error(_) ->
+                    Error(InvalidValue(
+                      path: "components.securitySchemes." <> name,
+                      detail: "Component alias references '"
+                        <> ref_str
+                        <> "' which is not defined.",
+                    ))
+                }
               }
+              _ -> Ok(acc)
             }
-          }
           _ -> Ok(acc)
         }
       })
@@ -1526,22 +1637,56 @@ fn parse_security_schemes_map(
 }
 
 /// Parse the pathItems map from components.
+/// Uses two passes: first parse concrete entries, then resolve $ref aliases.
 fn parse_path_items_map(
   components_node: yay.Node,
 ) -> Result(Dict(String, PathItem), ParseError) {
   case yay.select_sugar(from: components_node, selector: "pathItems") {
     Ok(yay.NodeMap(entries)) -> {
-      list.try_fold(entries, dict.new(), fn(acc, entry) {
+      use concrete <- result.try(
+        list.try_fold(entries, dict.new(), fn(acc, entry) {
+          let #(key_node, value_node) = entry
+          case key_node {
+            yay.NodeStr(name) ->
+              case yay.extract_optional_string(value_node, "$ref") {
+                Ok(Some(_)) -> Ok(acc)
+                _ -> {
+                  use path_item <- result.try(parse_path_item(
+                    value_node,
+                    "components.pathItems." <> name,
+                    None,
+                  ))
+                  Ok(dict.insert(acc, name, path_item))
+                }
+              }
+            _ -> Ok(acc)
+          }
+        }),
+      )
+      list.try_fold(entries, concrete, fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
-          yay.NodeStr(name) -> {
-            use path_item <- result.try(parse_path_item(
-              value_node,
-              "components.pathItems." <> name,
-              None,
-            ))
-            Ok(dict.insert(acc, name, path_item))
-          }
+          yay.NodeStr(name) ->
+            case yay.extract_optional_string(value_node, "$ref") {
+              Ok(Some(ref_str)) -> {
+                use ref_name <- result.try(validate_ref_prefix(
+                  ref_str,
+                  "#/components/pathItems/",
+                  "components.pathItems." <> name,
+                ))
+                case dict.get(acc, ref_name) {
+                  Ok(target) -> Ok(dict.insert(acc, name, target))
+                  Error(_) ->
+                    Error(InvalidValue(
+                      path: "components.pathItems." <> name,
+                      detail: "Component alias references '"
+                        <> ref_str
+                        <> "' which is not defined.",
+                    ))
+                }
+              }
+              _ -> Ok(acc)
+            }
           _ -> Ok(acc)
         }
       })

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1240,7 +1240,7 @@ pub fn parse_schema_object(
           use discriminator <- result.try(
             case yay.select_sugar(from: node, selector: "discriminator") {
               Ok(_) -> {
-                use d <- result.try(parse_discriminator(node))
+                use d <- result.try(parse_discriminator(node, path))
                 Ok(Some(d))
               }
               Error(_) -> Ok(None)
@@ -1257,7 +1257,7 @@ pub fn parse_schema_object(
               use discriminator <- result.try(
                 case yay.select_sugar(from: node, selector: "discriminator") {
                   Ok(_) -> {
-                    use d <- result.try(parse_discriminator(node))
+                    use d <- result.try(parse_discriminator(node, path))
                     Ok(Some(d))
                   }
                   Error(_) -> Ok(None)
@@ -1531,18 +1531,21 @@ fn parse_properties(
 }
 
 /// Parse discriminator from a node.
-fn parse_discriminator(node: yay.Node) -> Result(Discriminator, ParseError) {
+fn parse_discriminator(
+  node: yay.Node,
+  path: String,
+) -> Result(Discriminator, ParseError) {
   use disc_node <- result.try(
     yay.select_sugar(from: node, selector: "discriminator")
     |> result.map_error(fn(_) {
-      MissingField(path: "schema", field: "discriminator")
+      MissingField(path: path, field: "discriminator")
     }),
   )
 
   use property_name <- result.try(
     yay.extract_string(disc_node, "propertyName")
     |> result.map_error(fn(_) {
-      MissingField(path: "discriminator", field: "propertyName")
+      MissingField(path: path <> ".discriminator", field: "propertyName")
     }),
   )
 

--- a/test/fixtures/component_param_alias.yaml
+++ b/test/fixtures/component_param_alias.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.0"
+info:
+  title: Component Parameter Alias Test
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: getTest
+      parameters:
+        - $ref: "#/components/parameters/AliasedLimit"
+      responses:
+        "200":
+          description: OK
+components:
+  parameters:
+    BaseLimit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+    AliasedLimit:
+      $ref: "#/components/parameters/BaseLimit"

--- a/test/fixtures/component_response_alias.yaml
+++ b/test/fixtures/component_response_alias.yaml
@@ -1,0 +1,17 @@
+openapi: "3.0.0"
+info:
+  title: Component Response Alias Test
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: getTest
+      responses:
+        "200":
+          $ref: "#/components/responses/AliasedOk"
+components:
+  responses:
+    BaseOk:
+      description: Success
+    AliasedOk:
+      $ref: "#/components/responses/BaseOk"

--- a/test/fixtures/malformed_external_docs_no_url.yaml
+++ b/test/fixtures/malformed_external_docs_no_url.yaml
@@ -1,0 +1,7 @@
+openapi: "3.0.0"
+info:
+  title: Malformed ExternalDocs Test
+  version: 1.0.0
+externalDocs:
+  description: Some docs without url
+paths: {}

--- a/test/fixtures/malformed_license_no_name.yaml
+++ b/test/fixtures/malformed_license_no_name.yaml
@@ -1,0 +1,7 @@
+openapi: "3.0.0"
+info:
+  title: Malformed License Test
+  version: 1.0.0
+  license:
+    url: https://example.com
+paths: {}

--- a/test/fixtures/malformed_server_var_no_default.yaml
+++ b/test/fixtures/malformed_server_var_no_default.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.0"
+info:
+  title: Malformed Server Variable Test
+  version: 1.0.0
+servers:
+  - url: https://{env}.example.com
+    variables:
+      env:
+        enum:
+          - staging
+          - production
+        description: Environment name
+paths: {}

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -8859,3 +8859,36 @@ pub fn unknown_param_style_rejects_test() {
     _ -> should.fail()
   }
 }
+
+// ---------------------------------------------------------------------------
+// Strict parsing of malformed optional objects
+// ---------------------------------------------------------------------------
+
+/// License without required 'name' should be rejected.
+pub fn malformed_license_no_name_rejects_test() {
+  let result = parser.parse_file("test/fixtures/malformed_license_no_name.yaml")
+  case result {
+    Error(parser.MissingField(_, "name")) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+/// ExternalDocs without required 'url' should be rejected.
+pub fn malformed_external_docs_no_url_rejects_test() {
+  let result =
+    parser.parse_file("test/fixtures/malformed_external_docs_no_url.yaml")
+  case result {
+    Error(parser.MissingField(_, "url")) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+/// Server variable without required 'default' should be rejected.
+pub fn malformed_server_var_no_default_rejects_test() {
+  let result =
+    parser.parse_file("test/fixtures/malformed_server_var_no_default.yaml")
+  case result {
+    Error(parser.MissingField(_, "default")) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -8784,6 +8784,30 @@ pub fn schema_no_type_with_properties_parses_test() {
 }
 
 // ---------------------------------------------------------------------------
+// Component $ref alias resolution
+// ---------------------------------------------------------------------------
+
+/// Component parameter $ref alias should resolve to the target entry.
+pub fn component_param_alias_resolves_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/component_param_alias.yaml")
+  let assert Some(components) = spec.components
+  // Both BaseLimit and AliasedLimit should be present
+  dict.size(components.parameters) |> should.equal(2)
+  let assert Ok(aliased) = dict.get(components.parameters, "AliasedLimit")
+  aliased.name |> should.equal("limit")
+}
+
+/// Component response $ref alias should resolve to the target entry.
+pub fn component_response_alias_resolves_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/component_response_alias.yaml")
+  let assert Some(components) = spec.components
+  // Both BaseOk and AliasedOk should be present
+  dict.size(components.responses) |> should.equal(2)
+}
+
+// ---------------------------------------------------------------------------
 // $ref prefix validation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Resolve component-level `$ref` aliases** in all 5 component maps (parameters, requestBodies, responses, securitySchemes, pathItems) using a two-pass approach instead of silently dropping them
- **Reject malformed optional objects** (license without `name`, externalDocs without `url`, server variable without `default`) instead of silently normalizing them
- **Add path context to discriminator errors** (e.g. `components.schemas.Pet.discriminator` instead of `discriminator`)
- **Fix README** test count (362), add `mutualTLS` to Current Boundaries, clarify parsed-but-unused warnings
- **Fix stale error message** about server request body content types to list all three supported types

## Test plan

- [x] `just all` passes (362 unit tests, 51 ShellSpec, 40 integration)
- [x] Component `$ref` aliases resolve correctly (new test: `component_param_alias_resolves_test`, `component_response_alias_resolves_test`)
- [x] Malformed license/externalDocs/server variables rejected (3 new tests)
- [x] README test counts and boundaries match implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error messages for unsupported request body content types to accurately reflect supported formats.

* **Improvements**
  * Enhanced parser validation to reject missing required fields in license objects, external documentation, and server variables.
  * Fixed component reference alias resolution to properly trace to target definitions.

* **Documentation**
  * Updated test fixture counts and clarified that certain unsupported OpenAPI features now emit warnings during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->