### PR TITLE
Skip default_base_url generation when no servers are defined

### DIFF
--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -464,14 +464,7 @@ fn generate_default_base_url(
       |> se.line("}")
       |> se.blank_line()
     }
-    [] -> {
-      sb
-      |> se.doc_comment("Build the base URL from server template variables.")
-      |> se.line("pub fn default_base_url() -> String {")
-      |> se.indent(1, "\"\"")
-      |> se.line("}")
-      |> se.blank_line()
-    }
+    [] -> sb
   }
 }
 

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -5474,12 +5474,9 @@ paths:
   let assert [client_file] = files
   let content = client_file.content
 
-  string.contains(content, "pub fn default_base_url() -> String {")
-  |> should.be_true()
-
-  // With no servers, should return empty string
-  string.contains(content, "  \"\"")
-  |> should.be_true()
+  // With no servers, default_base_url should not be generated
+  string.contains(content, "default_base_url")
+  |> should.be_false()
 }
 
 // --- Feature: Guards for exclusiveMinimum, exclusiveMaximum, multipleOf ---


### PR DESCRIPTION
## Summary
- When an OpenAPI spec has no top-level `servers`, the generator previously emitted `default_base_url()` returning an empty string `""`. This was a silent footgun that could produce invalid HTTP requests.
- Now the function is simply not generated, giving users a compile-time error that guides them to supply an explicit base URL.

Closes #34

## Test plan
- [x] Updated `server_empty_default_base_url_test` to assert `default_base_url` is absent when no servers exist
- [x] Existing tests for servers with/without variables still pass
- [x] `just all` passes (gleam test, shellspec, all integration tests, format check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code generation has been optimized to eliminate unnecessary function generation: the `default_base_url` function is no longer emitted when OpenAPI specifications define no servers. This produces more concise generated client code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->