### PR TITLE
Replace todo with panic in generated handler stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pub fn create_pet(config: ClientConfig, body: types.CreatePetRequest)
 pub fn list_pets(req: request_types.ListPetsRequest)
   -> response_types.ListPetsResponse {
   let _ = req
-  todo
+  panic as "unimplemented: list_pets"
 }
 ```
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -36,11 +36,11 @@ info "Code generation done."
 # -------------------------------------------------------
 # Step 2: Overwrite handlers with real implementation
 # -------------------------------------------------------
-info "Writing handler implementations (replacing todo stubs)..."
+info "Writing handler implementations (replacing panic stubs)..."
 
 cat > "$SCRIPT_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
 // Hand-written handler implementations for integration testing.
-// These replace the generated todo stubs.
+// These replace the generated panic stubs.
 
 import api/request_types
 import api/response_types

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -212,13 +212,12 @@ Describe 'oaspec generate'
 
     # --- Server handlers ---
 
-    It 'generates handler stubs with TODO markers'
+    It 'generates handler stubs with panic placeholders'
       The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'pub fn list_pets'
       The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'pub fn create_pet'
       The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'pub fn get_pet'
       The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'pub fn delete_pet'
-      The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include '// TODO: Implement'
-      The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'todo'
+      The contents of file "$TEST_OUTPUT_DIR/api/handlers.gleam" should include 'panic as "unimplemented:'
     End
 
     It 'handler signatures reference request and response types'

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -106,8 +106,7 @@ fn generate_handler(
   }
 
   sb
-  |> se.indent(1, "// TODO: Implement " <> fn_name)
-  |> se.indent(1, "todo")
+  |> se.indent(1, "panic as \"unimplemented: " <> fn_name <> "\"")
   |> se.line("}")
   |> se.blank_line()
 }
@@ -136,8 +135,7 @@ fn generate_callback_handlers(
       )
       |> se.doc_comment("URL: " <> url_expression)
       |> se.line("pub fn " <> fn_name <> "() -> String {")
-      |> se.indent(1, "// TODO: Implement callback " <> callback_name)
-      |> se.indent(1, "todo")
+      |> se.indent(1, "panic as \"unimplemented: " <> fn_name <> "\"")
       |> se.line("}")
       |> se.blank_line()
     })

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2952,6 +2952,45 @@ security:
   }
 }
 
+// --- Handler stubs use panic instead of todo ---
+pub fn server_handler_stubs_use_panic_not_todo_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(handler_file) =
+    list.find(files, fn(f) { string.contains(f.path, "handlers") })
+  let content = handler_file.content
+
+  // Handler stubs must use panic, not todo
+  string.contains(content, "panic as \"unimplemented: get_items\"")
+  |> should.be_true()
+
+  // Must NOT contain bare todo keyword
+  string.contains(content, "  todo\n")
+  |> should.be_false()
+}
+
 // --- Server router must call handlers, not return hardcoded "OK" ---
 pub fn server_router_calls_handlers_test() {
   let yaml =


### PR DESCRIPTION
## Summary
- Generated handler stubs previously used the bare `todo` keyword, which triggers warnings under `--warnings-as-errors` and prevents fresh server output from building without manual edits.
- Replaced with `panic as "unimplemented: <function_name>"` so generated code compiles out of the box and provides meaningful error messages at runtime.
- Updated README example, shellspec tests, and integration test comments to match.

Closes #20

## Test plan
- [x] New unit test `server_handler_stubs_use_panic_not_todo_test` verifies `panic as "unimplemented: ..."` is generated and bare `todo` is absent
- [x] Updated shellspec test to check for `panic as "unimplemented:"` instead of `// TODO: Implement` and `todo`
- [x] All 369 gleam tests pass
- [x] All 51 shellspec examples pass (previously 1 failure)
- [x] All integration tests pass
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server handler implementation examples to use panic-based placeholders for unimplemented handlers with clearer error messages.

* **Refactor**
  * Generated server handler stubs now emit explicit panic statements with function names instead of todo placeholders.

* **Tests**
  * Added test coverage to validate panic-based handler stub generation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->