### PR TITLE
Exclude allOf PartN helper types from generated public API

### DIFF
--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/types as type_gen
 import oaspec/openapi/dedup
@@ -101,6 +102,7 @@ fn generate_decoders(ctx: Context) -> String {
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
       })
+      |> list.filter(fn(entry) { !ir_build.is_internal_schema(entry.1) })
     None -> []
   }
 
@@ -1141,6 +1143,7 @@ fn generate_encoders(ctx: Context) -> String {
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
       })
+      |> list.filter(fn(entry) { !ir_build.is_internal_schema(entry.1) })
     None -> []
   }
 

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -5,6 +5,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/ir_build
 import oaspec/codegen/types as type_gen
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
@@ -36,6 +37,7 @@ fn generate_guards(ctx: Context) -> String {
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
       })
+      |> list.filter(fn(entry) { !ir_build.is_internal_schema(entry.1) })
     None -> []
   }
 

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -31,6 +31,7 @@ pub fn build_types_module(ctx: Context) -> Module {
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
       })
+      |> list.filter(fn(entry) { !is_internal_schema(entry.1) })
     None -> []
   }
 
@@ -663,5 +664,13 @@ fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
     [], _ -> default
     [head, ..], 0 -> head
     [_, ..rest], n -> list_at_or(rest, n - 1, default)
+  }
+}
+
+/// Check if a schema ref is marked as internal (allOf helper type).
+pub fn is_internal_schema(schema_ref: schema.SchemaRef) -> Bool {
+  case schema_ref {
+    Inline(obj) -> schema.get_metadata(obj).internal
+    _ -> False
   }
 }

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -310,6 +310,24 @@ fn hoist_within_schema(
           let suffix = "Part" <> int.to_string(idx)
           let #(hoisted, state) =
             hoist_schema_ref(s_ref, name_prefix, suffix, state)
+          // Mark hoisted allOf parts as internal so they don't appear
+          // in the public generated API (types, decoders, encoders).
+          let state = case hoisted {
+            Reference(name:, ..) ->
+              case dict.get(state.new_schemas, name) {
+                Ok(Inline(obj)) ->
+                  HoistState(
+                    ..state,
+                    new_schemas: dict.insert(
+                      state.new_schemas,
+                      name,
+                      Inline(schema.set_internal(obj)),
+                    ),
+                  )
+                _ -> state
+              }
+            _ -> state
+          }
           #([hoisted, ..schemas_acc], state)
         })
       #(

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1062,6 +1062,7 @@ pub fn parse_schema_object(
       const_value:,
       raw_type: None,
       unsupported_keywords:,
+      internal: False,
     )
 
   // Check for composition keywords first

--- a/src/oaspec/openapi/schema.gleam
+++ b/src/oaspec/openapi/schema.gleam
@@ -20,6 +20,7 @@ pub type SchemaMetadata {
     const_value: Option(JsonValue),
     raw_type: Option(List(String)),
     unsupported_keywords: List(String),
+    internal: Bool,
   )
 }
 
@@ -37,6 +38,7 @@ pub fn default_metadata() -> SchemaMetadata {
     const_value: option.None,
     raw_type: option.None,
     unsupported_keywords: [],
+    internal: False,
   )
 }
 
@@ -169,5 +171,87 @@ pub fn get_metadata(schema: SchemaObject) -> SchemaMetadata {
     AllOfSchema(metadata:, ..) -> metadata
     OneOfSchema(metadata:, ..) -> metadata
     AnyOfSchema(metadata:, ..) -> metadata
+  }
+}
+
+/// Mark a schema as internal (not part of the public generated API).
+pub fn set_internal(schema: SchemaObject) -> SchemaObject {
+  let meta = get_metadata(schema)
+  let meta = SchemaMetadata(..meta, internal: True)
+  set_metadata(schema, meta)
+}
+
+/// Replace the metadata on a schema object.
+fn set_metadata(schema: SchemaObject, meta: SchemaMetadata) -> SchemaObject {
+  case schema {
+    StringSchema(format:, enum_values:, min_length:, max_length:, pattern:, ..) ->
+      StringSchema(
+        metadata: meta,
+        format:,
+        enum_values:,
+        min_length:,
+        max_length:,
+        pattern:,
+      )
+    IntegerSchema(
+      format:,
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      IntegerSchema(
+        metadata: meta,
+        format:,
+        minimum:,
+        maximum:,
+        exclusive_minimum:,
+        exclusive_maximum:,
+        multiple_of:,
+      )
+    NumberSchema(
+      format:,
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      NumberSchema(
+        metadata: meta,
+        format:,
+        minimum:,
+        maximum:,
+        exclusive_minimum:,
+        exclusive_maximum:,
+        multiple_of:,
+      )
+    BooleanSchema(..) -> BooleanSchema(metadata: meta)
+    ArraySchema(items:, min_items:, max_items:, unique_items:, ..) ->
+      ArraySchema(metadata: meta, items:, min_items:, max_items:, unique_items:)
+    ObjectSchema(
+      properties:,
+      required:,
+      additional_properties:,
+      min_properties:,
+      max_properties:,
+      ..,
+    ) ->
+      ObjectSchema(
+        metadata: meta,
+        properties:,
+        required:,
+        additional_properties:,
+        min_properties:,
+        max_properties:,
+      )
+    AllOfSchema(schemas:, ..) -> AllOfSchema(metadata: meta, schemas:)
+    OneOfSchema(schemas:, discriminator:, ..) ->
+      OneOfSchema(metadata: meta, schemas:, discriminator:)
+    AnyOfSchema(schemas:, discriminator:, ..) ->
+      AnyOfSchema(metadata: meta, schemas:, discriminator:)
   }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1549,6 +1549,146 @@ components:
   string.contains(types_file.content, "name: String") |> should.be_true()
 }
 
+// --- Feature: allOf PartN helper types must not appear in public generated API ---
+
+pub fn allof_part_types_not_in_generated_types_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+    AdminUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            permissions:
+              type: array
+              items: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = types.generate(ctx)
+  let assert [types_file, ..] = files
+  let content = types_file.content
+
+  // The merged AdminUser type should be present
+  string.contains(content, "pub type AdminUser {") |> should.be_true()
+
+  // PartN helper types must NOT appear in generated types
+  string.contains(content, "AdminUserPart") |> should.be_false()
+}
+
+pub fn allof_part_types_not_in_generated_decoders_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+    AdminUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            permissions:
+              type: array
+              items: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+
+  // Find decode file
+  let assert Ok(decode_file) =
+    list.find(files, fn(f) { string.contains(f.path, "decode") })
+  let content = decode_file.content
+
+  // The merged AdminUser decoder should be present
+  string.contains(content, "admin_user_decoder") |> should.be_true()
+
+  // PartN helper decoders must NOT appear
+  string.contains(content, "admin_user_part") |> should.be_false()
+}
+
+pub fn allof_part_types_not_in_generated_encoders_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+    AdminUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            permissions:
+              type: array
+              items: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+
+  // Find encode file
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { string.contains(f.path, "encode") })
+  let content = encode_file.content
+
+  // The merged AdminUser encoder should be present
+  string.contains(content, "encode_admin_user") |> should.be_true()
+
+  // PartN helper encoders must NOT appear
+  string.contains(content, "admin_user_part") |> should.be_false()
+}
+
 // --- Feature: Validation constraints generate guards (Phase 4-3) ---
 
 pub fn validate_constraints_generate_guards_test() {


### PR DESCRIPTION
## Summary
- allOf hoisting creates intermediate `PartN` types (e.g. `AdminUserPart1`, `RegularUserPart1`, `PostSearchRequestPart1`) as internal generator artifacts. These leaked into generated `types.gleam`, `decode.gleam`, and `encode.gleam`, cluttering the public API with names that end users should never need to reference.
- Added an `internal` flag to `SchemaMetadata`, set during allOf hoisting, and filtered out during type/decoder/encoder/guard generation.
- The merged parent types (e.g. `AdminUser`) already contain all fields and work independently of the `PartN` helpers.

Closes #21

## Changes
- `schema.gleam`: Added `internal: Bool` field to `SchemaMetadata`, plus `set_internal`/`set_metadata` helpers
- `hoist.gleam`: Mark allOf PartN schemas as `internal: True` after hoisting
- `ir_build.gleam`: Filter internal schemas from types generation, expose `is_internal_schema` helper
- `decoders.gleam`: Filter internal schemas from decoder and encoder generation
- `guards.gleam`: Filter internal schemas from guard generation
- `parser.gleam`: Include `internal: False` in initial metadata construction

## Test plan
- [x] New test `allof_part_types_not_in_generated_types_test` - verifies PartN types absent from types.gleam
- [x] New test `allof_part_types_not_in_generated_decoders_test` - verifies PartN decoders absent
- [x] New test `allof_part_types_not_in_generated_encoders_test` - verifies PartN encoders absent
- [x] All 372 gleam tests pass
- [x] All 51 shellspec examples pass
- [x] All integration tests pass (including complex spec with allOf)
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved code generation filtering to exclude internal schemas from generated modules, resulting in cleaner generated code when using schema composition patterns.

* **Tests**
  * Added tests verifying internal schema filtering behavior in generated types, decoders, and encoders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->