### PR TITLE
Sort all dict.to_list calls in codegen for deterministic output

### DIFF
--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -6,6 +6,7 @@ import oaspec/codegen/client_request
 import oaspec/codegen/client_response
 import oaspec/codegen/client_security
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/ir_build
 import oaspec/openapi/operations
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{Inline, Reference}
@@ -319,7 +320,7 @@ fn generate_client(ctx: Context) -> String {
 
   // Collect security schemes
   let security_schemes = case ctx.spec.components {
-    Some(components) -> dict.to_list(components.security_schemes)
+    Some(components) -> ir_build.sorted_entries(components.security_schemes)
     _ -> []
   }
 
@@ -430,7 +431,7 @@ fn generate_default_base_url(
 ) -> se.StringBuilder {
   case ctx.spec.servers {
     [first_server, ..] -> {
-      let variables = dict.to_list(first_server.variables)
+      let variables = ir_build.sorted_entries(first_server.variables)
       let resolved_url =
         substitute_server_variables(first_server.url, variables)
       let defaults_doc = case variables {
@@ -490,7 +491,7 @@ fn generate_client_function(
   // Add doc comment listing supported content types for multi-content request bodies
   let sb = case operation.request_body {
     Some(Value(rb)) -> {
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = ir_build.sorted_entries(rb.content)
       case content_entries {
         [_, _, ..] -> {
           let ct_names =
@@ -699,7 +700,7 @@ fn generate_client_function(
         False -> 2
       }
       let _ = indent_offset
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = ir_build.sorted_entries(rb.content)
       let sb = case content_entries {
         // Multiple content types: accept pre-serialized String body
         // with a content_type parameter
@@ -886,7 +887,7 @@ fn generate_client_function(
             <> naming.schema_to_type_name(op_id)
             <> "Response"
             <> http.status_code_suffix(status_code)
-          let content_entries = dict.to_list(response.content)
+          let content_entries = ir_build.sorted_entries(response.content)
           case content_entries {
             [] ->
               sb

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -1,8 +1,8 @@
-import gleam/dict
 import gleam/list
 import gleam/option.{Some}
 import gleam/string
 import oaspec/codegen/context.{type Context}
+import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{Inline, Reference}
@@ -40,7 +40,7 @@ pub fn build_param_list(
         True -> body_type
         False -> "Option(" <> body_type <> ")"
       }
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = ir_build.sorted_entries(rb.content)
       case content_entries {
         // Multi-content: add content_type param before body
         [_, _, ..] -> [", content_type: String", ", body: " <> wrapped_type]
@@ -138,7 +138,7 @@ pub fn to_str_for_optional_value(
 
 /// Get the Gleam type for a request body parameter.
 pub fn get_body_type(rb: spec.RequestBody(Resolved), op_id: String) -> String {
-  let content_entries = dict.to_list(rb.content)
+  let content_entries = ir_build.sorted_entries(rb.content)
   case content_entries {
     // Multiple content types: use pre-serialized String
     [_, _, ..] -> "String"
@@ -164,7 +164,7 @@ pub fn get_body_encode_expr(
   op_id: String,
   _ctx: Context,
 ) -> String {
-  let content_entries = dict.to_list(rb.content)
+  let content_entries = ir_build.sorted_entries(rb.content)
   case content_entries {
     [#(_, media_type), ..] ->
       case media_type.schema {
@@ -198,18 +198,18 @@ pub fn generate_multipart_body(
   ctx: Context,
 ) -> se.StringBuilder {
   let boundary = "----oaspec-boundary"
-  let content_entries = dict.to_list(rb.content)
+  let content_entries = ir_build.sorted_entries(rb.content)
   let #(properties, required_fields) = case content_entries {
     [#(_, media_type), ..] ->
       case media_type.schema {
         Some(Inline(schema.ObjectSchema(properties:, required:, ..))) -> #(
-          dict.to_list(properties),
+          ir_build.sorted_entries(properties),
           required,
         )
         Some(Reference(..) as schema_ref) ->
           case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
-              #(dict.to_list(properties), required)
+              #(ir_build.sorted_entries(properties), required)
             }
             _ -> #([], [])
           }
@@ -354,7 +354,7 @@ pub fn generate_form_nested_object(
   }
   let sub_props = case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> #(
-      dict.to_list(properties),
+      ir_build.sorted_entries(properties),
       required,
     )
     _ -> #([], [])
@@ -492,7 +492,7 @@ pub fn generate_form_bracket_fields(
   }
   case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
-      let props = dict.to_list(properties)
+      let props = ir_build.sorted_entries(properties)
       list.fold(props, sb, fn(sb, entry) {
         let #(prop_name, prop_ref) = entry
         let prop_field = naming.to_snake_case(prop_name)
@@ -584,18 +584,18 @@ pub fn generate_form_urlencoded_body(
   _op_id: String,
   ctx: Context,
 ) -> se.StringBuilder {
-  let content_entries = dict.to_list(rb.content)
+  let content_entries = ir_build.sorted_entries(rb.content)
   let #(properties, required_fields) = case content_entries {
     [#(_, media_type), ..] ->
       case media_type.schema {
         Some(Inline(schema.ObjectSchema(properties:, required:, ..))) -> #(
-          dict.to_list(properties),
+          ir_build.sorted_entries(properties),
           required,
         )
         Some(Reference(..) as schema_ref) ->
           case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
-              #(dict.to_list(properties), required)
+              #(ir_build.sorted_entries(properties), required)
             }
             _ -> #([], [])
           }
@@ -853,13 +853,13 @@ pub fn generate_deep_object_query_param(
     ParameterSchema(Reference(..) as schema_ref) ->
       case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
         Ok(schema.ObjectSchema(properties:, required:, ..)) -> #(
-          dict.to_list(properties),
+          ir_build.sorted_entries(properties),
           required,
         )
         _ -> #([], [])
       }
     ParameterSchema(Inline(schema.ObjectSchema(properties:, required:, ..))) -> #(
-      dict.to_list(properties),
+      ir_build.sorted_entries(properties),
       required,
     )
     _ -> #([], [])

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -147,12 +147,12 @@ fn generate_anonymous_response_decoders(
   operation: spec.Operation(Resolved),
   ctx: Context,
 ) -> se.StringBuilder {
-  let responses = dict.to_list(operation.responses)
+  let responses = http.sort_response_entries(dict.to_list(operation.responses))
   list.fold(responses, sb, fn(sb, entry) {
     let #(status_code, ref_or_response) = entry
     case ref_or_response {
       Value(response) -> {
-        let content_entries = dict.to_list(response.content)
+        let content_entries = ir_build.sorted_entries(response.content)
         case content_entries {
           [#(_, media_type), ..] ->
             case media_type.schema {
@@ -188,7 +188,7 @@ fn generate_anonymous_request_body_decoder(
 ) -> se.StringBuilder {
   case operation.request_body {
     Some(Value(rb)) -> {
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = ir_build.sorted_entries(rb.content)
       case content_entries {
         [#(_, media_type), ..] ->
           case media_type.schema {
@@ -235,7 +235,7 @@ fn generate_inline_enum_decoders(
   ctx: Context,
 ) -> se.StringBuilder {
   let props = case schema_ref {
-    Inline(ObjectSchema(properties:, ..)) -> dict.to_list(properties)
+    Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
     Inline(AllOfSchema(schemas:, ..)) -> {
       let merged =
         list.fold(schemas, dict.new(), fn(acc, s_ref) {
@@ -249,7 +249,7 @@ fn generate_inline_enum_decoders(
             _ -> acc
           }
         })
-      dict.to_list(merged)
+      ir_build.sorted_entries(merged)
     }
     _ -> []
   }
@@ -297,7 +297,7 @@ fn generate_decoder(
           <> ") {",
         )
 
-      let props = dict.to_list(properties)
+      let props = ir_build.sorted_entries(properties)
       let deduped_names =
         dedup.dedup_property_names(list.map(props, fn(e) { e.0 }))
       let sb =
@@ -1263,7 +1263,7 @@ fn generate_inline_enum_encoders(
   ctx: Context,
 ) -> se.StringBuilder {
   let props = case schema_ref {
-    Inline(ObjectSchema(properties:, ..)) -> dict.to_list(properties)
+    Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
     Inline(AllOfSchema(schemas:, ..)) -> {
       let merged =
         list.fold(schemas, dict.new(), fn(acc, s_ref) {
@@ -1277,7 +1277,7 @@ fn generate_inline_enum_encoders(
             _ -> acc
           }
         })
-      dict.to_list(merged)
+      ir_build.sorted_entries(merged)
     }
     _ -> []
   }
@@ -1317,7 +1317,7 @@ fn generate_anonymous_request_body_encoder(
 ) -> se.StringBuilder {
   case operation.request_body {
     Some(Value(rb)) -> {
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = ir_build.sorted_entries(rb.content)
       case content_entries {
         [#(_, media_type), ..] ->
           case media_type.schema {
@@ -1377,7 +1377,7 @@ fn generate_encoder(
       }
 
       // Filter out readOnly properties -- they should not be sent to the server
-      let all_props = dict.to_list(properties)
+      let all_props = ir_build.sorted_entries(properties)
       let all_deduped_names =
         dedup.dedup_property_names(list.map(all_props, fn(e) { e.0 }))
       // Build list of (prop_name, prop_ref, field_name) with readOnly filtered out

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -233,7 +233,7 @@ fn generate_guards_for_schema_object(
           min_properties,
           max_properties,
         )
-      let props = dict.to_list(properties)
+      let props = ir_build.sorted_entries(properties)
       list.fold(props, sb, fn(sb, entry) {
         let #(prop_name, prop_ref) = entry
         generate_field_guard(sb, name, prop_name, prop_ref, ctx)
@@ -252,7 +252,7 @@ fn generate_guards_for_schema_object(
             _ -> acc
           }
         })
-      let props = dict.to_list(merged_props)
+      let props = ir_build.sorted_entries(merged_props)
       list.fold(props, sb, fn(sb, entry) {
         let #(prop_name, prop_ref) = entry
         generate_field_guard(sb, name, prop_name, prop_ref, ctx)
@@ -1151,7 +1151,7 @@ fn collect_guard_calls(
       ..,
     )) -> {
       let prop_calls =
-        dict.to_list(properties)
+        ir_build.sorted_entries(properties)
         |> list.flat_map(fn(entry) {
           let #(prop_name, prop_ref) = entry
           let is_required = list.contains(required, prop_name)
@@ -1167,7 +1167,7 @@ fn collect_guard_calls(
     }
     Ok(AllOfSchema(schemas:, ..)) -> {
       let merged = merge_allof_props_and_required(schemas, ctx)
-      dict.to_list(merged.properties)
+      ir_build.sorted_entries(merged.properties)
       |> list.flat_map(fn(entry) {
         let #(prop_name, prop_ref) = entry
         let is_required = list.contains(merged.required, prop_name)

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -146,7 +146,7 @@ fn inline_enums_from_properties(
   properties: dict.Dict(String, SchemaRef),
   _ctx: Context,
 ) -> List(Declaration) {
-  let entries = dict.to_list(properties)
+  let entries = sorted_entries(properties)
   list.filter_map(entries, fn(entry) {
     let #(prop_name, prop_ref) = entry
     case prop_ref {
@@ -203,7 +203,7 @@ fn schema_type_decls(
 ) -> List(Declaration) {
   case schema {
     ObjectSchema(metadata:, properties:, required:, additional_properties:, ..) -> {
-      let props = dict.to_list(properties)
+      let props = sorted_entries(properties)
       let deduped_names =
         dedup.dedup_property_names(list.map(props, fn(e) { e.0 }))
 
@@ -355,12 +355,12 @@ fn anonymous_response_type_decls(
   operation: spec.Operation(Resolved),
   ctx: Context,
 ) -> List(Declaration) {
-  let responses = dict.to_list(operation.responses)
+  let responses = http.sort_response_entries(dict.to_list(operation.responses))
   list.flat_map(responses, fn(entry) {
     let #(status_code, ref_or) = entry
     case ref_or {
       Value(response) -> {
-        let content_entries = dict.to_list(response.content)
+        let content_entries = sorted_entries(response.content)
         case content_entries {
           [#(_media_type, media_type), ..] ->
             case media_type.schema {
@@ -391,7 +391,7 @@ fn anonymous_request_body_type_decls(
 ) -> List(Declaration) {
   case operation.request_body {
     Some(Value(rb)) -> {
-      let content_entries = dict.to_list(rb.content)
+      let content_entries = sorted_entries(rb.content)
       case content_entries {
         [#(_media_type, media_type), ..] ->
           case media_type.schema {
@@ -665,6 +665,13 @@ fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
     [head, ..], 0 -> head
     [_, ..rest], n -> list_at_or(rest, n - 1, default)
   }
+}
+
+/// Sort dict entries by key for deterministic output ordering.
+/// Gleam Dict does not guarantee iteration order, so all codegen paths
+/// that produce output from dict entries must sort first.
+pub fn sorted_entries(d: dict.Dict(String, v)) -> List(#(String, v)) {
+  dict.to_list(d) |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
 }
 
 /// Check if a schema ref is marked as internal (allOf helper type).

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/ir_build
 import oaspec/codegen/server_request_decode as decode_helpers
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{Inline, Reference}
@@ -117,10 +118,10 @@ fn generate_callback_handlers(
   op_id: String,
   operation: spec.Operation(Resolved),
 ) -> se.StringBuilder {
-  let callbacks = dict.to_list(operation.callbacks)
+  let callbacks = ir_build.sorted_entries(operation.callbacks)
   list.fold(callbacks, sb, fn(sb, entry) {
     let #(callback_name, callback) = entry
-    let callback_entries = dict.to_list(callback.entries)
+    let callback_entries = ir_build.sorted_entries(callback.entries)
     list.fold(callback_entries, sb, fn(sb, cb_entry) {
       let #(url_expression, _path_item) = cb_entry
       let fn_name =

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context}
+import oaspec/codegen/ir_build
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type AdditionalProperties, type SchemaRef, Forbidden, Inline, ObjectSchema,
@@ -327,7 +328,7 @@ fn deep_object_properties(
     _ -> #(dict.new(), [])
   }
   let #(properties, required_fields) = details
-  dict.to_list(properties)
+  ir_build.sorted_entries(properties)
   |> list.map(fn(entry) {
     let #(prop_name, prop_ref) = entry
     DeepObjectProperty(
@@ -502,7 +503,7 @@ pub fn object_properties_from_schema_ref(
     _ -> #(dict.new(), [])
   }
   let #(properties, required_fields) = details
-  dict.to_list(properties)
+  ir_build.sorted_entries(properties)
   |> list.map(fn(entry) {
     let #(prop_name, prop_ref) = entry
     DeepObjectProperty(

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -367,7 +367,7 @@ fn generate_response_type(
   ctx: Context,
 ) -> se.StringBuilder {
   let type_name = naming.schema_to_type_name(op_id) <> "Response"
-  let responses = dict.to_list(operation.responses)
+  let responses = http.sort_response_entries(dict.to_list(operation.responses))
 
   case list.is_empty(responses) {
     True -> sb
@@ -380,7 +380,7 @@ fn generate_response_type(
           case ref_or {
             Value(response) -> {
               let variant_name = status_code_to_variant(status_code, type_name)
-              let content_entries = dict.to_list(response.content)
+              let content_entries = ir_build.sorted_entries(response.content)
 
               case content_entries {
                 [] -> sb |> se.indent(1, variant_name)
@@ -640,7 +640,7 @@ fn extract_request_body_type(
   op_id: String,
   ctx: Context,
 ) -> String {
-  let content_entries = dict.to_list(rb.content)
+  let content_entries = ir_build.sorted_entries(rb.content)
   case content_entries {
     [#(_media_type, media_type), ..] ->
       case media_type.schema {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1689,6 +1689,112 @@ components:
   string.contains(content, "admin_user_part") |> should.be_false()
 }
 
+// --- Feature: Deterministic output ordering (idempotency) ---
+
+pub fn generation_is_idempotent_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        '400': { description: bad request }
+        '500': { description: internal error }
+components:
+  schemas:
+    User:
+      type: object
+      required: [id]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        email: { type: string }
+        age: { type: integer }
+        score: { type: number }
+        active: { type: boolean }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx1 = make_ctx_from_spec(spec)
+
+  // Generate types twice and compare
+  let files1 = types.generate(ctx1)
+  let assert Ok(spec2) = parser.parse_string(yaml)
+  let spec2 = hoist.hoist(spec2)
+  let ctx2 = make_ctx_from_spec(spec2)
+  let files2 = types.generate(ctx2)
+
+  // Types output must be identical across runs
+  let assert [t1, ..] = files1
+  let assert [t2, ..] = files2
+  t1.content |> should.equal(t2.content)
+
+  // Decoders output must be identical across runs
+  let dec1 = decoders.generate(ctx1)
+  let dec2 = decoders.generate(ctx2)
+  let assert [d1, ..] = dec1
+  let assert [d2, ..] = dec2
+  d1.content |> should.equal(d2.content)
+}
+
+pub fn generated_type_fields_are_alphabetically_ordered_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Widget:
+      type: object
+      required: [id]
+      properties:
+        zebra: { type: string }
+        alpha: { type: string }
+        middle: { type: integer }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = types.generate(ctx)
+  let assert [types_file, ..] = files
+  let content = types_file.content
+
+  // Fields must appear in sorted order, not dict iteration order
+  let assert Ok(alpha_pos) = string_index(content, "alpha:")
+  let assert Ok(middle_pos) = string_index(content, "middle:")
+  let assert Ok(zebra_pos) = string_index(content, "zebra:")
+  { alpha_pos < middle_pos } |> should.be_true()
+  { middle_pos < zebra_pos } |> should.be_true()
+}
+
+fn string_index(haystack: String, needle: String) -> Result(Int, Nil) {
+  case string.split(haystack, needle) {
+    [before, ..] if before != haystack -> Ok(string.length(before))
+    _ -> Error(Nil)
+  }
+}
+
 // --- Feature: Validation constraints generate guards (Phase 4-3) ---
 
 pub fn validate_constraints_generate_guards_test() {


### PR DESCRIPTION
## Summary
- Gleam `Dict` does not guarantee iteration order. Many codegen paths iterated over dict entries (properties, responses, content types, callbacks, security schemes, server variables) without sorting, which could produce non-deterministic output across runs or OTP versions.
- Added a `sorted_entries()` helper in `ir_build` and applied it to all 27 output-affecting `dict.to_list` call sites across 8 codegen modules.
- Response entries use the existing `http.sort_response_entries()`.

Closes #47

## Changes

| Module | Changes |
|--------|---------|
| `ir_build.gleam` | Added `sorted_entries()` helper; sorted properties, responses, content entries |
| `decoders.gleam` | Sorted properties, responses, content entries in decoder and encoder generation |
| `client.gleam` | Sorted security schemes, server variables, content entries |
| `client_request.gleam` | Sorted properties in multipart, form-urlencoded, deep object, bracket form encoding |
| `guards.gleam` | Sorted properties in guard generation and guard call collection |
| `server.gleam` | Sorted callback entries and callback sub-entries |
| `server_request_decode.gleam` | Sorted properties in deep object parameter decoding |
| `types.gleam` | Sorted response entries and content entries in response/request type generation |

## Test plan
- [x] New `generation_is_idempotent_test` verifies types and decoders produce identical output across runs
- [x] New `generated_type_fields_are_alphabetically_ordered_test` verifies field ordering is stable
- [x] All 374 gleam tests pass
- [x] All 51 shellspec examples pass
- [x] All integration tests pass
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic code generation to ensure identical output from the same OpenAPI specification across runs.
  * Generated client and server code now uses consistent alphabetical ordering for object properties and content entries.

* **Tests**
  * Added tests to verify code generation idempotence and alphabetical field ordering in generated types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->