### PR TITLE
Add validate subcommand for spec-only validation

### DIFF
--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -390,3 +390,46 @@ Describe 'oaspec generate'
     End
   End
 End
+
+# ===================================================================
+# Validate subcommand tests
+# ===================================================================
+
+Describe 'oaspec validate'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'CLI help'
+    It 'shows usage when called with --help'
+      When run validate_spec --help
+      The status should be success
+      The output should include 'validate'
+      The output should include 'config'
+    End
+  End
+
+  Describe 'successful validation'
+    It 'validates a valid spec without generating files'
+      clean_test_output
+      When run validate_spec --config=test/fixtures/oaspec.yaml
+      The status should be success
+      The output should include 'Validation passed'
+      The output should not include 'Generated'
+      The output should not include 'Successfully generated'
+    End
+
+    It 'does not write any files'
+      clean_test_output
+      When run validate_spec --config=test/fixtures/oaspec.yaml
+      The status should be success
+      The output should not include 'Generated:'
+    End
+  End
+
+  Describe 'error handling'
+    It 'exits with error when config file does not exist'
+      When run validate_spec --config=nonexistent.yaml
+      The status should be failure
+      The output should include 'Error'
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -24,6 +24,11 @@ generate() {
   cd "$PROJECT_ROOT" && gleam run -- generate "$@" 2>&1
 }
 
+# Helper: run oaspec validate command
+validate_spec() {
+  cd "$PROJECT_ROOT" && gleam run -- validate "$@" 2>&1
+}
+
 # Helper: clean test output
 clean_test_output() {
   rm -rf "$TEST_OUTPUT_DIR" "$TEST_OUTPUT_DIR_CLIENT"

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -19,6 +19,7 @@ pub fn app() -> glint.Glint(Nil) {
   |> glint.global_help("Generate Gleam code from OpenAPI 3.x specifications")
   |> glint.pretty_help(glint.default_pretty_help())
   |> glint.add(at: ["generate"], do: generate_command())
+  |> glint.add(at: ["validate"], do: validate_command())
   |> glint.add(at: ["init"], do: init_command())
 }
 
@@ -60,6 +61,40 @@ fn generate_command() -> glint.Command(Nil) {
           }
 
           run_generate(config_path, mode_opt, output_opt)
+        })
+      },
+    )
+  }
+}
+
+/// The validate command definition.
+fn validate_command() -> glint.Command(Nil) {
+  {
+    use config_path <- glint.flag(
+      glint.string_flag("config")
+      |> glint.flag_default("./oaspec.yaml")
+      |> glint.flag_help("Path to config file"),
+    )
+
+    use mode <- glint.flag(
+      glint.string_flag("mode")
+      |> glint.flag_default("")
+      |> glint.flag_help(
+        "Generation mode: server, client, or both (overrides config)",
+      ),
+    )
+
+    glint.command_help(
+      "Validate an OpenAPI specification without generating code",
+      fn() {
+        glint.command(fn(_named_args, _args, flags) {
+          let config_path = config_path(flags) |> result.unwrap("./oaspec.yaml")
+          let mode_opt = case mode(flags) |> result.unwrap("") {
+            "" -> None
+            s -> Some(s)
+          }
+
+          run_validate(config_path, mode_opt)
         })
       },
     )
@@ -189,6 +224,53 @@ fn run_generate(
                   halt(1)
                 }
               }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Execute the validation-only pipeline.
+fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
+  io.println("oaspec v" <> context.version)
+  io.println("Loading config from: " <> config_path)
+
+  case load_config(config_path, mode_opt, None) {
+    Error(msg) -> {
+      io.println("Error: " <> msg)
+      halt(1)
+    }
+    Ok(cfg) -> {
+      io.println("Parsing OpenAPI spec: " <> cfg.input)
+      case parser.parse_file(cfg.input) {
+        Error(e) -> {
+          io.println("Error: " <> parser.parse_error_to_string(e))
+          halt(1)
+        }
+        Ok(spec) -> {
+          case generate.validate_only(spec, cfg) {
+            Error(generate.ValidationErrors(errors:)) -> {
+              io.println("Error: OpenAPI spec contains unsupported features:")
+              list.each(errors, fn(e) {
+                io.println("  - " <> diagnostic.to_string(e))
+              })
+              halt(1)
+            }
+            Ok(summary) -> {
+              io.println("Spec loaded: " <> summary.spec_title)
+              case summary.warnings {
+                [] -> Nil
+                warnings -> {
+                  io.println("Warnings:")
+                  list.each(warnings, fn(w) {
+                    io.println("  - " <> diagnostic.to_string(w))
+                  })
+                }
+              }
+              io.println("")
+              io.println("Validation passed.")
             }
           }
         }

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -26,6 +26,11 @@ pub type GenerationSummary {
   )
 }
 
+/// Result of a successful validation-only run.
+pub type ValidationSummary {
+  ValidationSummary(spec_title: String, warnings: List(Diagnostic))
+}
+
 /// Errors from the pure generation pipeline.
 pub type GenerateError {
   ValidationErrors(errors: List(Diagnostic))
@@ -91,6 +96,58 @@ pub fn generate(
           validation_warnings,
         ])
       Ok(GenerationSummary(files:, spec_title:, warnings:))
+    }
+  }
+}
+
+/// Validation-only pipeline: parse → normalize → resolve → capability_check → hoist → dedup → validate.
+/// Runs the same checks as generate() but skips code generation and file writing.
+pub fn validate_only(
+  spec: OpenApiSpec(Unresolved),
+  cfg: Config,
+) -> Result(ValidationSummary, GenerateError) {
+  let spec_title = spec.info.title <> " v" <> spec.info.version
+
+  let spec = normalize.normalize(spec)
+
+  use spec <- result.try(
+    resolve.resolve(spec)
+    |> result.map_error(fn(errors) { ValidationErrors(errors:) }),
+  )
+
+  let capability_issues =
+    capability_check.check(spec)
+    |> validate.filter_by_mode(cfg.mode)
+  let capability_errors = validate.errors_only(capability_issues)
+  let capability_warnings = validate.warnings_only(capability_issues)
+  use _ <- result.try(case list.is_empty(capability_errors) {
+    False -> Error(ValidationErrors(errors: capability_errors))
+    True -> Ok(Nil)
+  })
+
+  let spec = hoist.hoist(spec)
+  let spec = dedup.dedup(spec)
+  let ctx = context.new(spec, cfg)
+
+  let preserved_warnings =
+    capability_check.check_preserved(ctx)
+    |> diagnostic.filter_by_mode(cfg.mode)
+
+  let validation_issues =
+    validate.validate(ctx)
+    |> validate.filter_by_mode(cfg.mode)
+  let blocking_errors = validate.errors_only(validation_issues)
+  let validation_warnings = validate.warnings_only(validation_issues)
+  case list.is_empty(blocking_errors) {
+    False -> Error(ValidationErrors(errors: blocking_errors))
+    True -> {
+      let warnings =
+        list.flatten([
+          capability_warnings,
+          preserved_warnings,
+          validation_warnings,
+        ])
+      Ok(ValidationSummary(spec_title:, warnings:))
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added `oaspec validate` subcommand that runs the full validation pipeline (parse → normalize → resolve → capability check → hoist → dedup → validate) but skips code generation and file writing.
- Useful for CI pipelines and local development: check spec compatibility without creating output files.
- Accepts `--config` and `--mode` flags, matching the `generate` command interface.
- Exits 0 with "Validation passed" on success, or exits 1 with diagnostic messages on failure.

Closes #42

## Changes
- `generate.gleam`: Added `validate_only()` function and `ValidationSummary` type
- `cli.gleam`: Added `validate` subcommand with `--config` and `--mode` flags, and `run_validate` handler
- `spec_helper.sh`: Added `validate_spec` helper
- `generate_spec.sh`: Added 4 ShellSpec tests for the validate subcommand

## Test plan
- [x] `oaspec validate --help` shows usage with config and mode flags
- [x] `oaspec validate --config=test/fixtures/oaspec.yaml` outputs "Validation passed" without generating files
- [x] `oaspec validate --config=nonexistent.yaml` exits with error
- [x] All 374 gleam tests pass
- [x] All 55 shellspec examples pass (4 new)
- [x] All integration tests pass
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `validate` subcommand to check OpenAPI specifications for compatibility issues without generating code
* Supports `--config` flag to specify a custom configuration file

## Tests
* Added test suite for the new validate subcommand

<!-- end of auto-generated comment: release notes by coderabbit.ai -->