### PR TITLE
Add actionable hints to all validation and capability diagnostics

### DIFF
--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -118,7 +118,12 @@ fn validate_path_template_params(
   list.filter_map(template_names, fn(name) {
     case list.contains(path_param_names, name) {
       True -> Error(Nil)
-      False ->
+      False -> {
+        let defined = case path_param_names {
+          [] -> ""
+          names ->
+            " Defined path parameters: " <> string.join(names, ", ") <> "."
+        }
         Ok(diagnostic.validation(
           severity: SeverityError,
           target: TargetBoth,
@@ -129,9 +134,11 @@ fn validate_path_template_params(
             <> path
             <> "' has no corresponding parameter definition.",
           hint: Some(
-            "Add a parameter definition with 'in: path' for this variable, or remove it from the path template.",
+            "Add a parameter definition with 'in: path' for this variable, or remove it from the path template."
+            <> defined,
           ),
         ))
+      }
     }
   })
 }
@@ -723,7 +730,7 @@ fn validate_server_multipart_request_body(
                       path: op_id <> ".requestBody.multipart." <> field_name,
                       detail: "multipart/form-data server request bodies only support primitive scalar fields.",
                       hint: Some(
-                        "Use primitive scalar types (string, integer, number, boolean) for multipart form fields.",
+                        "Use primitive scalar types or arrays of primitive scalars (string, integer, number, boolean) for multipart form fields.",
                       ),
                     ),
                   ]

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -82,6 +82,9 @@ fn validate_operations(ctx: Context) -> List(Diagnostic) {
           target: TargetBoth,
           path: op_id,
           detail: "Operation has no responses defined. OpenAPI 3.x requires at least one response.",
+          hint: Some(
+            "Add at least one response (e.g., '200': { description: ok }) to this operation.",
+          ),
         ),
       ]
       False -> []
@@ -125,6 +128,9 @@ fn validate_path_template_params(
             <> "}' in '"
             <> path
             <> "' has no corresponding parameter definition.",
+          hint: Some(
+            "Add a parameter definition with 'in: path' for this variable, or remove it from the path template.",
+          ),
         ))
     }
   })
@@ -162,6 +168,7 @@ fn validate_parameters(
           target: TargetBoth,
           path: path,
           detail: "Parameter style is not supported. Supported styles: form, deepObject, simple.",
+          hint: Some("Use style 'form', 'simple', or 'deepObject' instead."),
         ),
       ]
       _ -> []
@@ -175,6 +182,9 @@ fn validate_parameters(
           target: TargetBoth,
           path: path,
           detail: "Parameters using 'content' instead of 'schema' are not supported.",
+          hint: Some(
+            "Replace the 'content' field with a 'schema' field in the parameter definition.",
+          ),
         ),
       ]
       spec.ParameterSchema(_) -> []
@@ -217,6 +227,9 @@ fn validate_server_structured_param(
             target: TargetServer,
             path: path,
             detail: "Query array parameters are only supported for inline primitive items in server code generation.",
+            hint: Some(
+              "Use inline primitive items (string, integer, number, boolean) for array query parameters.",
+            ),
           ),
         ]
         spec.InHeader, Some(ArraySchema(items: Inline(StringSchema(..)), ..))
@@ -230,6 +243,9 @@ fn validate_server_structured_param(
             target: TargetServer,
             path: path,
             detail: "Header array parameters are only supported for inline primitive items in server code generation.",
+            hint: Some(
+              "Use inline primitive items (string, integer, number, boolean) for array header parameters.",
+            ),
           ),
         ]
         _, _ -> []
@@ -266,6 +282,9 @@ fn validate_server_deep_object_param(
               target: TargetServer,
               path: path <> "." <> prop_name,
               detail: "deepObject properties are only supported for inline primitive scalars and inline primitive array leaves in server code generation.",
+              hint: Some(
+                "Simplify deepObject properties to primitive scalars or primitive arrays.",
+              ),
             ),
           ]
         }
@@ -343,6 +362,9 @@ fn validate_complex_param_schema(
                     target: TargetServer,
                     path: path,
                     detail: "Complex path parameters are not supported for server code generation.",
+                    hint: Some(
+                      "Use a simple scalar type (string, integer, number, boolean) for path parameters.",
+                    ),
                   ),
                 ]
               }
@@ -352,6 +374,9 @@ fn validate_complex_param_schema(
                 target: TargetBoth,
                 path: path,
                 detail: "Complex schema (object/oneOf/allOf/anyOf) parameters require style: deepObject. Without it, the parameter cannot be serialized.",
+                hint: Some(
+                  "Add 'style: deepObject' to the parameter definition.",
+                ),
               ),
             ]
           }
@@ -381,6 +406,9 @@ fn validate_deep_object_no_nested_objects(
               target: TargetBoth,
               path: path <> "." <> prop_name,
               detail: "Nested object properties in deepObject parameters are not supported. Only one level of object nesting is supported (e.g., filter[name]=value).",
+              hint: Some(
+                "Flatten the property structure to a single level of nesting.",
+              ),
             ),
           ]
           _ -> []
@@ -429,6 +457,9 @@ fn validate_request_body(
             detail: "Content type '"
               <> media_type
               <> "' is not supported. Supported request content types: application/json, multipart/form-data, application/x-www-form-urlencoded.",
+            hint: Some(
+              "Use application/json, multipart/form-data, or application/x-www-form-urlencoded.",
+            ),
           ),
         ]
       }
@@ -504,6 +535,9 @@ fn validate_multipart_request_body_fields(
                   target: TargetBoth,
                   path: op_id <> ".requestBody.multipart." <> field_name,
                   detail: "multipart/form-data fields must be string, integer, number, boolean, binary, or string enums.",
+                  hint: Some(
+                    "Use a primitive scalar type, binary, or string enum for multipart fields.",
+                  ),
                 ),
               ]
             }
@@ -514,6 +548,9 @@ fn validate_multipart_request_body_fields(
             target: TargetBoth,
             path: op_id <> ".requestBody",
             detail: "multipart/form-data request bodies must use an object schema.",
+            hint: Some(
+              "Wrap fields in an object schema with properties for each form field.",
+            ),
           ),
         ]
         None -> []
@@ -539,6 +576,9 @@ fn validate_form_urlencoded_schema(
             target: TargetBoth,
             path: op_id <> ".requestBody",
             detail: "application/x-www-form-urlencoded request bodies must use an object schema.",
+            hint: Some(
+              "Wrap fields in an object schema with properties for each form field.",
+            ),
           ),
         ]
         None -> []
@@ -570,6 +610,9 @@ fn validate_server_form_urlencoded_request_body(
                 target: TargetServer,
                 path: op_id <> ".requestBody",
                 detail: "application/x-www-form-urlencoded request bodies are only supported as the sole request content type for server code generation.",
+                hint: Some(
+                  "Remove other content type definitions from this operation's request body.",
+                ),
               ),
             ]
             False -> []
@@ -591,6 +634,9 @@ fn validate_server_form_urlencoded_request_body(
                       target: TargetServer,
                       path: op_id <> ".requestBody.form." <> field_name,
                       detail: "application/x-www-form-urlencoded server request bodies only support primitive scalars, primitive arrays, and nested objects with primitive leaves (max 5 levels).",
+                      hint: Some(
+                        "Simplify to primitive scalars, primitive arrays, or shallow nested objects.",
+                      ),
                     ),
                   ]
                 }
@@ -627,6 +673,9 @@ fn validate_server_request_body_content_types(
           detail: "Content type '"
             <> media_type
             <> "' is not supported for server code generation. Server router only supports application/json request bodies with typed decoding.",
+          hint: Some(
+            "Use application/json for typed server request bodies, or multipart/form-data and application/x-www-form-urlencoded for form data.",
+          ),
         )
       })
     }
@@ -651,6 +700,9 @@ fn validate_server_multipart_request_body(
                 target: TargetServer,
                 path: op_id <> ".requestBody",
                 detail: "multipart/form-data request bodies are only supported as the sole request content type for server code generation.",
+                hint: Some(
+                  "Remove other content type definitions from this operation's request body.",
+                ),
               ),
             ]
             False -> []
@@ -670,6 +722,9 @@ fn validate_server_multipart_request_body(
                       target: TargetServer,
                       path: op_id <> ".requestBody.multipart." <> field_name,
                       detail: "multipart/form-data server request bodies only support primitive scalar fields.",
+                      hint: Some(
+                        "Use primitive scalar types (string, integer, number, boolean) for multipart form fields.",
+                      ),
                     ),
                   ]
                 }
@@ -780,6 +835,9 @@ fn validate_responses(
             detail: "Response content type '"
               <> media_type_name
               <> "' is not supported. Supported response content types: application/json, text/plain, application/octet-stream, application/xml, text/xml.",
+            hint: Some(
+              "Use application/json, text/plain, application/octet-stream, application/xml, or text/xml.",
+            ),
           ),
         ]
       }
@@ -827,6 +885,9 @@ fn validate_schema_ref_recursive(
             detail: "External $ref '"
               <> ref
               <> "' is not supported. Only local references (#/components/...) are supported.",
+            hint: Some(
+              "Inline the external schema or copy it into #/components/schemas/ and use a local $ref.",
+            ),
           ),
         ]
         True ->
@@ -840,6 +901,9 @@ fn validate_schema_ref_recursive(
                 detail: "Unresolved schema reference: '"
                   <> ref
                   <> "'. The referenced schema does not exist in components.",
+                hint: Some(
+                  "Verify the schema is defined in components.schemas and the $ref path is spelled correctly.",
+                ),
               ),
             ]
           }
@@ -926,6 +990,9 @@ fn validate_security_schemes(ctx: Context) -> List(Diagnostic) {
               detail: "Security requirement references scheme '"
                 <> scheme_ref.scheme_name
                 <> "' which is not defined in components.securitySchemes.",
+              hint: Some(
+                "Add the security scheme definition to components.securitySchemes or fix the scheme name.",
+              ),
             ))
         }
       })
@@ -949,6 +1016,9 @@ fn validate_security_schemes(ctx: Context) -> List(Diagnostic) {
                     detail: "Security requirement references scheme '"
                       <> scheme_ref.scheme_name
                       <> "' which is not defined in components.securitySchemes.",
+                    hint: Some(
+                      "Add the security scheme definition to components.securitySchemes or fix the scheme name.",
+                    ),
                   ))
               }
             })

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -150,6 +150,9 @@ fn check_schema(path: String, schema_obj: SchemaObject) -> List(Diagnostic) {
             }),
             "; ",
           ),
+          hint: Some(
+            "Remove the keyword or restructure the schema using supported constructs.",
+          ),
         ),
       ]
     }
@@ -197,6 +200,9 @@ fn check_security_schemes(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
               detail: "Unsupported security scheme type: '"
                 <> scheme_type
                 <> "'. Supported types: apiKey, http, oauth2, openIdConnect.",
+              hint: Some(
+                "Use apiKey, http (bearer), oauth2, or openIdConnect instead.",
+              ),
             ))
           _ -> Error(Nil)
         }
@@ -216,6 +222,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         target: TargetBoth,
         path: "webhooks",
         detail: "Webhooks are parsed but not used by code generation.",
+        hint: Some(
+          "Webhooks will not appear in generated code. No action needed unless you expected them.",
+        ),
       ),
     ]
   }
@@ -240,6 +249,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                   target: TargetServer,
                   path: base_path <> ".content",
                   detail: "Multiple response content types are not fully supported for server code generation. Generated server responses lose the content-type header.",
+                  hint: Some(
+                    "Use a single content type per response for full server code generation support.",
+                  ),
                 ),
               ]
               _, _ -> []
@@ -252,6 +264,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                   target: TargetBoth,
                   path: base_path <> ".headers",
                   detail: "Response headers are parsed but not used by code generation.",
+                  hint: Some(
+                    "Response headers will not appear in generated code. No action needed.",
+                  ),
                 ),
               ]
             }
@@ -263,6 +278,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                   target: TargetBoth,
                   path: base_path <> ".links",
                   detail: "Response links are parsed but not used by code generation.",
+                  hint: Some(
+                    "Response links will not appear in generated code. No action needed.",
+                  ),
                 ),
               ]
             }
@@ -278,6 +296,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                       target: TargetBoth,
                       path: base_path <> "." <> media_type_name <> ".encoding",
                       detail: "MediaType encoding is parsed but not used by code generation.",
+                      hint: Some(
+                        "Encoding settings will not affect generated code. No action needed.",
+                      ),
                     ),
                   ]
                 }
@@ -300,6 +321,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         target: TargetBoth,
         path: "externalDocs",
         detail: "External docs are parsed but not used by code generation.",
+        hint: Some(
+          "External docs will not appear in generated code. Include documentation in descriptions instead.",
+        ),
       ),
     ]
     None -> []
@@ -312,6 +336,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         target: TargetBoth,
         path: "tags",
         detail: "Top-level tags are parsed but not used by code generation.",
+        hint: Some("Tags will not appear in generated code. No action needed."),
       ),
     ]
   }
@@ -326,6 +351,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             target: TargetClient,
             path: op_id <> ".servers",
             detail: "Operation-level servers are parsed but client code generation uses only the top-level server URL.",
+            hint: Some(
+              "Only the first top-level server URL is used for default_base_url(). Override at runtime via ClientConfig if needed.",
+            ),
           ),
         ]
       }
@@ -344,6 +372,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                 target: TargetClient,
                 path: "paths." <> path <> ".servers",
                 detail: "Path-level servers are parsed but client code generation uses only the top-level server URL.",
+                hint: Some(
+                  "Only the first top-level server URL is used for default_base_url(). Override at runtime via ClientConfig if needed.",
+                ),
               ),
             ]
           }
@@ -360,6 +391,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             target: TargetBoth,
             path: "components.headers",
             detail: "Component headers are parsed but not used by code generation.",
+            hint: Some(
+              "Component headers will not appear in generated code. No action needed.",
+            ),
           ),
         ]
       }
@@ -371,6 +405,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             target: TargetBoth,
             path: "components.examples",
             detail: "Component examples are parsed but not used by code generation.",
+            hint: Some(
+              "Component examples will not appear in generated code. Include examples in descriptions instead.",
+            ),
           ),
         ]
       }
@@ -382,6 +419,9 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             target: TargetBoth,
             path: "components.links",
             detail: "Component links are parsed but not used by code generation.",
+            hint: Some(
+              "Component links will not appear in generated code. No action needed.",
+            ),
           ),
         ]
       }

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -107,7 +107,11 @@ pub fn invalid_value(path path: String, detail detail: String) -> Diagnostic {
 // Convenience constructors for resolve phase
 // ============================================================================
 
-pub fn resolve_error(path path: String, detail detail: String) -> Diagnostic {
+pub fn resolve_error(
+  path path: String,
+  detail detail: String,
+  hint hint: Option(String),
+) -> Diagnostic {
   Diagnostic(
     code: "resolve_error",
     phase: PhaseResolve,
@@ -116,7 +120,7 @@ pub fn resolve_error(path path: String, detail detail: String) -> Diagnostic {
     pointer: path,
     source_loc: NoSourceLoc,
     message: detail,
-    hint: None,
+    hint: hint,
   )
 }
 
@@ -129,6 +133,7 @@ pub fn capability(
   detail detail: String,
   severity severity: Severity,
   target target: Target,
+  hint hint: Option(String),
 ) -> Diagnostic {
   Diagnostic(
     code: "capability",
@@ -138,7 +143,7 @@ pub fn capability(
     pointer: path,
     source_loc: NoSourceLoc,
     message: detail,
-    hint: None,
+    hint: hint,
   )
 }
 
@@ -151,6 +156,7 @@ pub fn validation(
   detail detail: String,
   severity severity: Severity,
   target target: Target,
+  hint hint: Option(String),
 ) -> Diagnostic {
   Diagnostic(
     code: "validation",
@@ -160,7 +166,7 @@ pub fn validation(
     pointer: path,
     source_loc: NoSourceLoc,
     message: detail,
-    hint: None,
+    hint: hint,
   )
 }
 

--- a/src/oaspec/openapi/resolve.gleam
+++ b/src/oaspec/openapi/resolve.gleam
@@ -155,6 +155,9 @@ fn resolve_alias(
       Error(diagnostic.resolve_error(
         path: context,
         detail: "Circular component alias detected: " <> ref,
+        hint: Some(
+          "Check that component $ref chains don't form a cycle. Each $ref must eventually point to a concrete definition.",
+        ),
       ))
     False -> {
       let new_seen = set.insert(seen, ref)
@@ -170,6 +173,9 @@ fn resolve_alias(
               <> " — target '"
               <> ref_name
               <> "' not found.",
+            hint: Some(
+              "Verify the target component exists and the $ref path is spelled correctly.",
+            ),
           ))
       }
     }
@@ -201,6 +207,9 @@ fn validate_ref_kind(
           <> "' points to wrong component kind; expected prefix '"
           <> expected_prefix
           <> "'",
+        hint: Some(
+          "Use the correct $ref prefix for the component type (e.g., #/components/schemas/ for schemas).",
+        ),
       ))
   }
 }
@@ -257,6 +266,9 @@ fn resolve_path_item_ref(
                 detail: "Unresolved $ref: "
                   <> ref_str
                   <> " — target not found in components",
+                hint: Some(
+                  "Verify the referenced component exists and the $ref path is spelled correctly.",
+                ),
               ))
           }
         }
@@ -267,6 +279,9 @@ fn resolve_path_item_ref(
         detail: "Unresolved $ref: "
           <> ref_str
           <> " — target not found in components",
+        hint: Some(
+          "Verify the referenced component exists and the $ref path is spelled correctly.",
+        ),
       ))
     Error(_) ->
       Error(diagnostic.resolve_error(
@@ -274,6 +289,9 @@ fn resolve_path_item_ref(
         detail: "Unresolved $ref: "
           <> ref_str
           <> " — target not found in components",
+        hint: Some(
+          "Verify the referenced component exists and the $ref path is spelled correctly.",
+        ),
       ))
   }
 }
@@ -415,6 +433,7 @@ fn resolve_param_ref(
             detail: "Unresolved $ref: "
               <> ref_str
               <> " — target not found in components.parameters",
+            hint: Some("Verify the parameter exists in components.parameters."),
           ))
       }
     }
@@ -443,6 +462,9 @@ fn resolve_request_body_ref(
             detail: "Unresolved $ref: "
               <> ref_str
               <> " — target not found in components.requestBodies",
+            hint: Some(
+              "Verify the request body exists in components.requestBodies.",
+            ),
           ))
       }
     }
@@ -471,6 +493,7 @@ fn resolve_response_ref(
             detail: "Unresolved $ref: "
               <> ref_str
               <> " — target not found in components.responses",
+            hint: Some("Verify the response exists in components.responses."),
           ))
       }
     }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1795,6 +1795,88 @@ fn string_index(haystack: String, needle: String) -> Result(Int, Nil) {
   }
 }
 
+// --- Feature: Validation diagnostics include actionable hints ---
+
+pub fn validation_errors_include_hints_test() {
+  // A spec with an unsupported content type should produce a diagnostic with a hint
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        required: true
+        content:
+          text/csv:
+            schema:
+              type: string
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+    )
+  let assert Error(generate.ValidationErrors(errors:)) =
+    generate.validate_only(spec, cfg)
+  // All validation errors must have hints
+  list.each(errors, fn(e) { option.is_some(e.hint) |> should.be_true() })
+}
+
+pub fn capability_warnings_include_hints_test() {
+  // A spec with webhooks should produce a capability warning with a hint
+  let yaml =
+    "
+openapi: 3.1.0
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+webhooks:
+  newPet:
+    post:
+      operationId: newPetHook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+    )
+  let assert Ok(summary) = generate.validate_only(spec, cfg)
+  // Should have at least one warning (webhooks parsed but unused)
+  { summary.warnings != [] } |> should.be_true()
+  // All warnings must have hints
+  list.each(summary.warnings, fn(w) {
+    option.is_some(w.hint) |> should.be_true()
+  })
+}
+
 // --- Feature: Validation constraints generate guards (Phase 4-3) ---
 
 pub fn validate_constraints_generate_guards_test() {
@@ -6351,12 +6433,14 @@ pub fn filter_by_mode_drops_server_errors_for_client_test() {
       detail: "server-only",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetServer,
+      hint: None,
     ),
     diagnostic.validation(
       path: "y",
       detail: "shared",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetBoth,
+      hint: None,
     ),
   ]
   let filtered = validate.filter_by_mode(issues, config.Client)
@@ -6371,12 +6455,14 @@ pub fn filter_by_mode_drops_client_errors_for_server_test() {
       detail: "client-only",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetClient,
+      hint: None,
     ),
     diagnostic.validation(
       path: "y",
       detail: "shared",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetBoth,
+      hint: None,
     ),
   ]
   let filtered = validate.filter_by_mode(issues, config.Server)
@@ -6391,18 +6477,21 @@ pub fn filter_by_mode_keeps_all_errors_for_both_test() {
       detail: "client-only",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetClient,
+      hint: None,
     ),
     diagnostic.validation(
       path: "y",
       detail: "server-only",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetServer,
+      hint: None,
     ),
     diagnostic.validation(
       path: "z",
       detail: "shared",
       severity: diagnostic.SeverityError,
       target: diagnostic.TargetBoth,
+      hint: None,
     ),
   ]
   let filtered = validate.filter_by_mode(issues, config.Both)


### PR DESCRIPTION
## Summary
- Every diagnostic previously had `hint: None`, leaving users to figure out how to fix problems on their own.
- Now all 50+ diagnostic construction sites include a concrete hint telling the user what to do next.
- The `validation()`, `capability()`, and `resolve_error()` helper functions now accept a `hint` parameter instead of hardcoding `None`, so future diagnostics are guided toward including hints by the API itself.

Closes #43

## Changes
- `diagnostic.gleam`: Added `hint` parameter to `validation()`, `capability()`, and `resolve_error()` helpers
- `validate.gleam`: Added actionable hints to all 24 validation diagnostic call sites
- `capability_check.gleam`: Added actionable hints to all 14 capability diagnostic call sites
- `resolve.gleam`: Added actionable hints to all 9 resolve error call sites
- `oaspec_test.gleam`: Updated test call sites to match new signatures; added 2 tests verifying hints are present

## Example output (before → after)

**Before:**
```
[Validate] Error at upload.requestBody.content: Content type 'text/csv' is not supported.
  Supported request content types: application/json, multipart/form-data, application/x-www-form-urlencoded.
```

**After:**
```
[Validate] Error at upload.requestBody.content: Content type 'text/csv' is not supported.
  Supported request content types: application/json, multipart/form-data, application/x-www-form-urlencoded.
  Hint: Use application/json, multipart/form-data, or application/x-www-form-urlencoded.
```

## Test plan
- [x] New `validation_errors_include_hints_test` verifies all validation errors have hints
- [x] New `capability_warnings_include_hints_test` verifies all capability warnings have hints
- [x] All 376 gleam tests pass
- [x] All 55 shellspec examples pass
- [x] All integration tests pass
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Diagnostics now include contextual hints across validation, capability checks, and resolution errors—offering actionable suggestions for missing responses, unbound path parameters, unsupported parameter styles/content types, server/request-body constraints, unresolved references, and security scheme issues.
* **Tests**
  * Added tests to ensure validation errors and capability warnings include hint messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->