### PR TITLE
Add --check and --fail-on-warnings flags to generate command

### DIFF
--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -433,3 +433,49 @@ Describe 'oaspec validate'
     End
   End
 End
+
+# ===================================================================
+# generate --check tests
+# ===================================================================
+
+Describe 'oaspec generate --check'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'when output matches'
+    It 'passes when generated code matches existing files'
+      clean_test_output
+      # First generate normally
+      generate --config=test/fixtures/oaspec.yaml >/dev/null 2>&1
+      # Then check — should pass
+      When run generate --config=test/fixtures/oaspec.yaml --check=true
+      The status should be success
+      The output should include 'check passed'
+    End
+  End
+
+  Describe 'when output does not exist'
+    It 'fails when output files do not exist'
+      clean_test_output
+      When run generate --config=test/fixtures/oaspec.yaml --check=true
+      The status should be failure
+      The output should include 'out of date'
+    End
+  End
+End
+
+# ===================================================================
+# generate --fail-on-warnings tests
+# ===================================================================
+
+Describe 'oaspec generate --fail-on-warnings'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'with a clean spec'
+    It 'succeeds when there are no warnings'
+      clean_test_output
+      When run generate --config=test/fixtures/oaspec.yaml --fail-on-warnings=true
+      The status should be success
+      The output should include 'Successfully generated'
+    End
+  End
+End

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -446,7 +446,7 @@ Describe 'oaspec generate --check'
     Before 'setup'
 
     It 'passes when generated code matches existing files'
-      When run generate --config=test/fixtures/oaspec.yaml --check=true
+      When run generate --config=test/fixtures/oaspec.yaml --check
       The status should be success
       The output should include 'check passed'
     End
@@ -456,7 +456,7 @@ Describe 'oaspec generate --check'
     Before 'clean_test_output'
 
     It 'fails when output files do not exist'
-      When run generate --config=test/fixtures/oaspec.yaml --check=true
+      When run generate --config=test/fixtures/oaspec.yaml --check
       The status should be failure
       The output should include 'out of date'
     End
@@ -473,9 +473,19 @@ Describe 'oaspec generate --fail-on-warnings'
   Describe 'with a clean spec'
     It 'succeeds when there are no warnings'
       clean_test_output
-      When run generate --config=test/fixtures/oaspec.yaml --fail-on-warnings=true
+      When run generate --config=test/fixtures/oaspec.yaml --fail-on-warnings
       The status should be success
       The output should include 'Successfully generated'
+    End
+  End
+
+  Describe 'with a spec that has warnings'
+    It 'fails when warnings are present'
+      clean_test_output
+      When run generate --config=test/fixtures/oaspec-with-warnings.yaml --fail-on-warnings
+      The status should be failure
+      The output should include 'Warnings:'
+      The output should include '--fail-on-warnings is set'
     End
   End
 End

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -442,11 +442,10 @@ Describe 'oaspec generate --check'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   Describe 'when output matches'
+    setup() { clean_test_output; generate --config=test/fixtures/oaspec.yaml >/dev/null 2>&1 || true; }
+    Before 'setup'
+
     It 'passes when generated code matches existing files'
-      clean_test_output
-      # First generate normally
-      generate --config=test/fixtures/oaspec.yaml >/dev/null 2>&1
-      # Then check — should pass
       When run generate --config=test/fixtures/oaspec.yaml --check=true
       The status should be success
       The output should include 'check passed'
@@ -454,8 +453,9 @@ Describe 'oaspec generate --check'
   End
 
   Describe 'when output does not exist'
+    Before 'clean_test_output'
+
     It 'fails when output files do not exist'
-      clean_test_output
       When run generate --config=test/fixtures/oaspec.yaml --check=true
       The status should be failure
       The output should include 'out of date'

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -2,7 +2,9 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/order
 import gleam/result
+import gleam/string
 import glint
 import oaspec/codegen/context
 import oaspec/codegen/writer
@@ -46,6 +48,22 @@ fn generate_command() -> glint.Command(Nil) {
       |> glint.flag_help("Output directory override"),
     )
 
+    use check <- glint.flag(
+      glint.string_flag("check")
+      |> glint.flag_default("")
+      |> glint.flag_help(
+        "Check that generated code matches existing files without writing (pass --check=true)",
+      ),
+    )
+
+    use fail_on_warnings <- glint.flag(
+      glint.string_flag("fail-on-warnings")
+      |> glint.flag_default("")
+      |> glint.flag_help(
+        "Treat warnings as errors (pass --fail-on-warnings=true)",
+      ),
+    )
+
     glint.command_help(
       "Generate Gleam code from an OpenAPI specification",
       fn() {
@@ -59,8 +77,24 @@ fn generate_command() -> glint.Command(Nil) {
             "" -> None
             s -> Some(s)
           }
+          let check_mode = case check(flags) |> result.unwrap("") {
+            "true" -> True
+            _ -> False
+          }
+          let fail_on_warnings_mode = case
+            fail_on_warnings(flags) |> result.unwrap("")
+          {
+            "true" -> True
+            _ -> False
+          }
 
-          run_generate(config_path, mode_opt, output_opt)
+          run_generate(
+            config_path,
+            mode_opt,
+            output_opt,
+            check_mode,
+            fail_on_warnings_mode,
+          )
         })
       },
     )
@@ -169,6 +203,8 @@ fn run_generate(
   config_path: String,
   mode_opt: Option(String),
   output_opt: Option(String),
+  check_mode: Bool,
+  fail_on_warnings: Bool,
 ) -> Nil {
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
@@ -196,6 +232,7 @@ fn run_generate(
             }
             Ok(summary) -> {
               io.println("Spec loaded: " <> summary.spec_title)
+              let has_warnings = summary.warnings != []
               case summary.warnings {
                 [] -> Nil
                 warnings -> {
@@ -205,29 +242,79 @@ fn run_generate(
                   })
                 }
               }
-              io.println("Generating code...")
-              case
-                writer.write_all(summary.files, cfg, fn(path) {
-                  io.println("  Generated: " <> path)
-                })
-              {
-                Ok(written) -> {
+              case fail_on_warnings && has_warnings {
+                True -> {
                   io.println("")
                   io.println(
-                    "Successfully generated "
-                    <> int.to_string(list.length(written))
-                    <> " files",
+                    "Error: warnings present and --fail-on-warnings is set.",
                   )
-                }
-                Error(e) -> {
-                  io.println("Error: " <> writer.error_to_string(e))
                   halt(1)
+                }
+                False -> Nil
+              }
+              case check_mode {
+                True -> run_check(summary.files, cfg)
+                False -> {
+                  io.println("Generating code...")
+                  case
+                    writer.write_all(summary.files, cfg, fn(path) {
+                      io.println("  Generated: " <> path)
+                    })
+                  {
+                    Ok(written) -> {
+                      io.println("")
+                      io.println(
+                        "Successfully generated "
+                        <> int.to_string(list.length(written))
+                        <> " files",
+                      )
+                    }
+                    Error(e) -> {
+                      io.println("Error: " <> writer.error_to_string(e))
+                      halt(1)
+                    }
+                  }
                 }
               }
             }
           }
         }
       }
+    }
+  }
+}
+
+/// Check that generated code matches existing files on disk.
+/// Exits 0 if all files match, exits 1 if any differ or are missing.
+fn run_check(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
+  io.println("Checking generated code against existing files...")
+  let diffs =
+    writer.resolve_paths(files, cfg)
+    |> list.filter_map(fn(entry) {
+      let #(path, content) = entry
+      case simplifile.read(path) {
+        Error(_) -> Ok(path <> " (missing)")
+        Ok(existing) ->
+          case string.compare(existing, content) {
+            order.Eq -> Error(Nil)
+            _ -> Ok(path <> " (differs)")
+          }
+      }
+    })
+  case diffs {
+    [] -> {
+      io.println("")
+      io.println("All files up to date, check passed.")
+    }
+    _ -> {
+      io.println("")
+      list.each(diffs, fn(d) { io.println("  " <> d) })
+      io.println(
+        "\n"
+        <> int.to_string(list.length(diffs))
+        <> " file(s) out of date. Run 'oaspec generate' to update.",
+      )
+      halt(1)
     }
   }
 }

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -285,12 +285,15 @@ fn run_generate(
 }
 
 /// Check that generated code matches existing files on disk.
-/// Exits 0 if all files match, exits 1 if any differ or are missing.
+/// Exits 0 if all files match, exits 1 if any differ, missing, or orphaned.
 fn run_check(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
   io.println("Checking generated code against existing files...")
+  let resolved = writer.resolve_paths(files, cfg)
+  let expected_paths = list.map(resolved, fn(entry) { entry.0 })
+
+  // Check for missing or differing files
   let diffs =
-    writer.resolve_paths(files, cfg)
-    |> list.filter_map(fn(entry) {
+    list.filter_map(resolved, fn(entry) {
       let #(path, content) = entry
       case simplifile.read(path) {
         Error(_) -> Ok(path <> " (missing)")
@@ -301,17 +304,41 @@ fn run_check(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
           }
       }
     })
-  case diffs {
+
+  // Check for orphaned files in output directories
+  let output_dirs = writer.output_dirs(cfg)
+  let orphans =
+    list.flat_map(output_dirs, fn(dir) {
+      case simplifile.read_directory(dir) {
+        Error(_) -> []
+        Ok(entries) ->
+          list.filter_map(entries, fn(name) {
+            case string.ends_with(name, ".gleam") {
+              False -> Error(Nil)
+              True -> {
+                let full_path = dir <> "/" <> name
+                case list.contains(expected_paths, full_path) {
+                  True -> Error(Nil)
+                  False -> Ok(full_path <> " (orphaned)")
+                }
+              }
+            }
+          })
+      }
+    })
+
+  let all_issues = list.append(diffs, orphans)
+  case all_issues {
     [] -> {
       io.println("")
       io.println("All files up to date, check passed.")
     }
     _ -> {
       io.println("")
-      list.each(diffs, fn(d) { io.println("  " <> d) })
+      list.each(all_issues, fn(d) { io.println("  " <> d) })
       io.println(
         "\n"
-        <> int.to_string(list.length(diffs))
+        <> int.to_string(list.length(all_issues))
         <> " file(s) out of date. Run 'oaspec generate' to update.",
       )
       halt(1)

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -49,19 +49,17 @@ fn generate_command() -> glint.Command(Nil) {
     )
 
     use check <- glint.flag(
-      glint.string_flag("check")
-      |> glint.flag_default("")
+      glint.bool_flag("check")
+      |> glint.flag_default(False)
       |> glint.flag_help(
-        "Check that generated code matches existing files without writing (pass --check=true)",
+        "Check that generated code matches existing files without writing",
       ),
     )
 
     use fail_on_warnings <- glint.flag(
-      glint.string_flag("fail-on-warnings")
-      |> glint.flag_default("")
-      |> glint.flag_help(
-        "Treat warnings as errors (pass --fail-on-warnings=true)",
-      ),
+      glint.bool_flag("fail-on-warnings")
+      |> glint.flag_default(False)
+      |> glint.flag_help("Treat warnings as errors"),
     )
 
     glint.command_help(
@@ -77,16 +75,9 @@ fn generate_command() -> glint.Command(Nil) {
             "" -> None
             s -> Some(s)
           }
-          let check_mode = case check(flags) |> result.unwrap("") {
-            "true" -> True
-            _ -> False
-          }
-          let fail_on_warnings_mode = case
-            fail_on_warnings(flags) |> result.unwrap("")
-          {
-            "true" -> True
-            _ -> False
-          }
+          let check_mode = check(flags) |> result.unwrap(False)
+          let fail_on_warnings_mode =
+            fail_on_warnings(flags) |> result.unwrap(False)
 
           run_generate(
             config_path,

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -91,6 +91,41 @@ fn write_files(
   })
 }
 
+/// Resolve generated files to their full output paths and content.
+/// Used by --check to compare against existing files without writing.
+pub fn resolve_paths(
+  files: List(GeneratedFile),
+  cfg: config.Config,
+) -> List(#(String, String)) {
+  let shared_files =
+    list.filter(files, fn(f) { f.target == context.SharedTarget })
+  let server_files =
+    list.filter(files, fn(f) { f.target == context.ServerTarget })
+  let client_files =
+    list.filter(files, fn(f) { f.target == context.ClientTarget })
+
+  let server_path = cfg.output_server
+  let client_path = cfg.output_client
+
+  let server_entries = case cfg.mode {
+    Server | Both ->
+      list.map(list.append(shared_files, server_files), fn(f) {
+        #(server_path <> "/" <> f.path, f.content)
+      })
+    Client -> []
+  }
+
+  let client_entries = case cfg.mode {
+    Client | Both ->
+      list.map(list.append(shared_files, client_files), fn(f) {
+        #(client_path <> "/" <> f.path, f.content)
+      })
+    Server -> []
+  }
+
+  list.append(server_entries, client_entries)
+}
+
 /// Convert a write error to a human-readable string.
 pub fn error_to_string(error: WriteError) -> String {
   case error {

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -126,6 +126,15 @@ pub fn resolve_paths(
   list.append(server_entries, client_entries)
 }
 
+/// Return the output directories that would be written to for the given config.
+pub fn output_dirs(cfg: config.Config) -> List(String) {
+  case cfg.mode {
+    Server -> [cfg.output_server]
+    Client -> [cfg.output_client]
+    Both -> [cfg.output_server, cfg.output_client]
+  }
+}
+
 /// Convert a write error to a human-readable string.
 pub fn error_to_string(error: WriteError) -> String {
   case error {

--- a/test/fixtures/oaspec-with-warnings.yaml
+++ b/test/fixtures/oaspec-with-warnings.yaml
@@ -1,0 +1,5 @@
+input: test/fixtures/spec-with-warnings.yaml
+output:
+  server: ./test_output/api
+  client: ./test_output_client/api
+package: api

--- a/test/fixtures/spec-with-warnings.yaml
+++ b/test/fixtures/spec-with-warnings.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: Warnings Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+webhooks:
+  onNewItem:
+    post:
+      operationId: onNewItemHook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: ok


### PR DESCRIPTION
## Summary
Add two CI-oriented flags to `oaspec generate`:

- **`--check=true`**: Run the full generation pipeline but compare output against existing files instead of writing. Exits 0 if all files match, exits 1 with a list of missing or differing files. Useful for CI to detect stale generated code.
- **`--fail-on-warnings=true`**: Treat validation warnings as errors and exit 1 if any are present. Useful for enforcing strict spec compliance.

Also adds `writer.resolve_paths()` to compute file output paths without writing, supporting the `--check` workflow.

Closes #32

## Usage
```bash
# CI: verify generated code is up to date
oaspec generate --config=oaspec.yaml --check=true

# CI: fail if spec has any warnings
oaspec generate --config=oaspec.yaml --fail-on-warnings=true

# Both together
oaspec generate --config=oaspec.yaml --check=true --fail-on-warnings=true
```

## Changes
- `cli.gleam`: Added `--check` and `--fail-on-warnings` flags to generate command, `run_check()` function for file comparison
- `writer.gleam`: Added `resolve_paths()` to compute output file paths and content without writing to disk
- `generate_spec.sh`: Added 3 ShellSpec tests for `--check` (match, missing files) and `--fail-on-warnings` (clean spec)

## Test plan
- [x] `--check=true` passes when generated files match existing output
- [x] `--check=true` fails with file list when output is missing
- [x] `--fail-on-warnings=true` succeeds on a spec with no warnings
- [x] All 376 gleam tests pass
- [x] All 58 shellspec examples pass (3 new)
- [x] All integration tests pass
- [x] `just all` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --check to verify generated output: reports "up to date" when files match or lists missing/differing/orphaned files and fails when mismatches exist.
  * Added --fail-on-warnings to treat generation warnings as errors, causing the command to fail if warnings are present.

* **Tests**
  * Added integration tests validating --check and --fail-on-warnings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->