### PR TITLE
refactor: replace raw String status codes with type-safe HttpStatusCode enum

### DIFF
--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -355,7 +355,7 @@ Describe 'oaspec generate'
     # Inline object in response
 
     It 'generates anonymous type for inline response object'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchResponse200 {'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type PostSearchResponseOk {'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'results: Option(List(User))'
       The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'total: Option(Int)'
     End
@@ -363,9 +363,9 @@ Describe 'oaspec generate'
     # oneOf with $ref in response
 
     It 'generates oneOf type with $ref variants'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type GetUserResponse200 {'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponse200AdminUser(AdminUser)'
-      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponse200RegularUser(RegularUser)'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'pub type GetUserResponseOk {'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponseOkAdminUser(AdminUser)'
+      The contents of file "$TEST_OUTPUT_DIR/api/types.gleam" should include 'GetUserResponseOkRegularUser(RegularUser)'
     End
 
     # allOf merged requestBody
@@ -379,8 +379,8 @@ Describe 'oaspec generate'
     # Response types reference anonymous types
 
     It 'response types reference anonymous types correctly'
-      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'PostSearchResponseOk(types.PostSearchResponse200)'
-      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'GetUserResponseOk(types.GetUserResponse200)'
+      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'PostSearchResponseOk(types.PostSearchResponseOk)'
+      The contents of file "$TEST_OUTPUT_DIR/api/response_types.gleam" should include 'GetUserResponseOk(types.GetUserResponseOk)'
     End
 
     # Request types reference merged allOf type

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -927,7 +927,7 @@ fn generate_client_function(
   let has_default =
     list.any(responses, fn(entry) {
       let #(code, _) = entry
-      code == "default"
+      code == http.DefaultStatus
     })
   let sb = case has_default {
     True -> sb

--- a/src/oaspec/codegen/client_response.gleam
+++ b/src/oaspec/codegen/client_response.gleam
@@ -10,7 +10,7 @@ import oaspec/util/string_extra as se
 /// Generate response handling for a single content type.
 pub fn generate_single_content_response(
   sb: se.StringBuilder,
-  status_code: String,
+  status_code: http.HttpStatusCode,
   variant_name: String,
   media_type_name: String,
   media_type: spec.MediaType,
@@ -76,7 +76,7 @@ pub fn generate_single_content_response(
 /// all branches return resp.body directly.
 pub fn generate_multi_content_response(
   sb: se.StringBuilder,
-  status_code: String,
+  status_code: http.HttpStatusCode,
   variant_name: String,
   _content_entries: List(#(String, spec.MediaType)),
   _op_id: String,
@@ -97,7 +97,7 @@ pub fn generate_multi_content_response(
 pub fn get_response_decode_expr(
   schema_ref: schema.SchemaRef,
   op_id: String,
-  status_code: String,
+  status_code: http.HttpStatusCode,
   _ctx: Context,
 ) -> String {
   case schema_ref {

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -437,7 +437,10 @@ fn generate_response_type(
 
 /// Convert an HTTP status code to a Gleam variant name.
 /// Prefixed with the type name to avoid duplicate constructors across types.
-fn status_code_to_variant(code: String, type_name: String) -> String {
+fn status_code_to_variant(
+  code: http.HttpStatusCode,
+  type_name: String,
+) -> String {
   type_name <> http.status_code_suffix(code)
 }
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -17,6 +17,7 @@ import oaspec/openapi/schema.{
 }
 import oaspec/openapi/spec.{type Resolved}
 import oaspec/util/content_type
+import oaspec/util/http
 
 /// Validate the parsed spec for unsupported patterns.
 /// Returns a list of errors; empty list means validation passed.
@@ -66,8 +67,8 @@ fn validate_operations(ctx: Context) -> List(Diagnostic) {
     let resolved_responses =
       dict.to_list(operation.responses)
       |> list.map(fn(entry) {
-        let #(code, ref_or) = entry
-        #(code, spec.unwrap_ref(ref_or))
+        let #(status_code, ref_or) = entry
+        #(status_code, spec.unwrap_ref(ref_or))
       })
       |> dict.from_list
     let path_errors =
@@ -818,7 +819,7 @@ fn multipart_field_is_stringifiable(schema_ref: SchemaRef, ctx: Context) -> Bool
 /// Validate response schemas and content types.
 fn validate_responses(
   op_id: String,
-  responses: dict.Dict(String, spec.Response(Resolved)),
+  responses: dict.Dict(http.HttpStatusCode, spec.Response(Resolved)),
   ctx: Context,
 ) -> List(Diagnostic) {
   let entries = dict.to_list(responses)
@@ -827,7 +828,8 @@ fn validate_responses(
     let content_entries = dict.to_list(response.content)
     list.flat_map(content_entries, fn(ce) {
       let #(media_type_name, media_type) = ce
-      let path = op_id <> ".responses." <> status_code
+      let path =
+        op_id <> ".responses." <> http.status_code_to_string(status_code)
       let content_type_errors = case
         content_type.is_supported_response(content_type.from_string(
           media_type_name,

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -16,6 +16,7 @@ import oaspec/openapi/schema.{
   Inline, ObjectSchema, OneOfSchema, Reference, Typed,
 }
 import oaspec/openapi/spec.{type OpenApiSpec, type Resolved, Value}
+import oaspec/util/http
 
 /// Run capability checks on a resolved spec.
 /// Returns errors for unsupported features and warnings for parsed-but-unused features.
@@ -106,7 +107,11 @@ fn check_operation_schemas(
             case mt.schema {
               Some(sr) ->
                 check_schema_ref(
-                  base_path <> ".responses." <> code <> "." <> ct,
+                  base_path
+                    <> ".responses."
+                    <> http.status_code_to_string(code)
+                    <> "."
+                    <> ct,
                   sr,
                 )
               None -> []
@@ -237,7 +242,8 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         let #(status_code, ref_or) = entry
         case ref_or {
           Value(response) -> {
-            let base_path = op_id <> ".responses." <> status_code
+            let base_path =
+              op_id <> ".responses." <> http.status_code_to_string(status_code)
             let multi_content_warnings = case
               ctx.config.mode,
               list.length(dict.to_list(response.content))

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -11,6 +11,7 @@ import oaspec/openapi/spec.{
   type OpenApiSpec, type PathItem, type RefOr, Components, OpenApiSpec, PathItem,
   Ref, Value,
 }
+import oaspec/util/http
 import oaspec/util/naming
 
 /// Accumulated state during the hoisting traversal.
@@ -523,10 +524,10 @@ fn hoist_request_body(
 
 /// Hoist schemas within response definitions.
 fn hoist_responses(
-  responses: Dict(String, RefOr(spec.Response(stage))),
+  responses: Dict(http.HttpStatusCode, RefOr(spec.Response(stage))),
   op_id: String,
   state: HoistState,
-) -> #(Dict(String, RefOr(spec.Response(stage))), HoistState) {
+) -> #(Dict(http.HttpStatusCode, RefOr(spec.Response(stage))), HoistState) {
   dict.to_list(responses)
   |> list.fold(#(dict.new(), state), fn(acc, entry) {
     let #(result, state) = acc
@@ -541,7 +542,7 @@ fn hoist_responses(
             let #(media_type_name, media_type) = ct_entry
             case media_type.schema {
               Some(schema_ref) -> {
-                let suffix = "Response" <> naming.to_pascal_case(status_code)
+                let suffix = "Response" <> http.status_code_suffix(status_code)
                 let #(hoisted, state) =
                   hoist_schema_ref(schema_ref, op_id, suffix, state)
                 let mt = spec.MediaType(..media_type, schema: Some(hoisted))

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -23,6 +23,7 @@ import oaspec/openapi/spec.{
   SecurityRequirement, Server, ServerVariable, Tag, Trace, Value,
 }
 import oaspec/openapi/value
+import oaspec/util/http
 import simplifile
 import yay
 
@@ -473,7 +474,10 @@ fn parse_responses_required(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
-) -> Result(dict.Dict(String, RefOr(Response(Unresolved))), Diagnostic) {
+) -> Result(
+  dict.Dict(http.HttpStatusCode, RefOr(Response(Unresolved))),
+  Diagnostic,
+) {
   parse_responses(node, context, components)
 }
 
@@ -801,7 +805,7 @@ fn parse_responses(
   node: yay.Node,
   _context: String,
   components: Option(Components(Unresolved)),
-) -> Result(Dict(String, RefOr(Response(Unresolved))), Diagnostic) {
+) -> Result(Dict(http.HttpStatusCode, RefOr(Response(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
       list.try_fold(entries, dict.new(), fn(acc, entry) {
@@ -810,15 +814,21 @@ fn parse_responses(
           yay.NodeStr(status_code) ->
             case string.starts_with(status_code, "x-") {
               True -> Ok(acc)
-              False -> {
-                use resp <- result.try(parse_response(value_node, components))
-                Ok(dict.insert(acc, status_code, resp))
-              }
+              False ->
+                case http.parse_status_code(status_code) {
+                  Ok(code) -> {
+                    use resp <- result.try(parse_response(
+                      value_node,
+                      components,
+                    ))
+                    Ok(dict.insert(acc, code, resp))
+                  }
+                  Error(_) -> Ok(acc)
+                }
             }
           yay.NodeInt(code) -> {
             use resp <- result.try(parse_response(value_node, components))
-            let code_str = string.inspect(code)
-            Ok(dict.insert(acc, code_str, resp))
+            Ok(dict.insert(acc, http.Status(code), resp))
           }
           _ -> Ok(acc)
         }

--- a/src/oaspec/openapi/resolve.gleam
+++ b/src/oaspec/openapi/resolve.gleam
@@ -513,9 +513,9 @@ fn option_try(
 
 /// Map over dict values with a fallible function, collecting first error.
 fn try_map_values(
-  d: Dict(String, a),
-  f: fn(String, a) -> Result(a, List(Diagnostic)),
-) -> Result(Dict(String, a), List(Diagnostic)) {
+  d: Dict(k, a),
+  f: fn(k, a) -> Result(a, List(Diagnostic)),
+) -> Result(Dict(k, a), List(Diagnostic)) {
   dict.to_list(d)
   |> list.try_fold(dict.new(), fn(acc, entry) {
     let #(key, value) = entry

--- a/src/oaspec/openapi/spec.gleam
+++ b/src/oaspec/openapi/spec.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/option.{type Option}
 import oaspec/openapi/schema.{type SchemaRef}
 import oaspec/openapi/value.{type JsonValue}
+import oaspec/util/http
 
 // ============================================================================
 // Stage and RefOr: core of the stage-typed AST
@@ -217,7 +218,7 @@ pub type Operation(stage) {
     tags: List(String),
     parameters: List(RefOr(Parameter(stage))),
     request_body: Option(RefOr(RequestBody(stage))),
-    responses: Dict(String, RefOr(Response(stage))),
+    responses: Dict(http.HttpStatusCode, RefOr(Response(stage))),
     deprecated: Bool,
     security: Option(List(SecurityRequirement)),
     callbacks: Dict(String, Callback(stage)),

--- a/src/oaspec/util/http.gleam
+++ b/src/oaspec/util/http.gleam
@@ -1,82 +1,110 @@
 import gleam/int
 import gleam/list
 
-/// Shared HTTP status code utilities for code generation.
-/// Get a human-readable suffix for a given HTTP status code.
-/// Used to build anonymous type names like "ListPetsResponseOk".
-pub fn status_code_suffix(code: String) -> String {
+/// Type-safe HTTP status code representation.
+/// Replaces raw String status codes throughout the codebase.
+pub type HttpStatusCode {
+  /// An exact HTTP status code, e.g. 200, 404, 500.
+  Status(Int)
+  /// A wildcard range, e.g. 2XX is StatusRange(2), 4XX is StatusRange(4).
+  StatusRange(Int)
+  /// The OpenAPI "default" catch-all response.
+  DefaultStatus
+}
+
+/// Parse a raw status code string from an OpenAPI spec into an HttpStatusCode.
+/// Returns Error(Nil) for unrecognisable strings.
+pub fn parse_status_code(code: String) -> Result(HttpStatusCode, Nil) {
   case code {
-    "200" -> "Ok"
-    "201" -> "Created"
-    "204" -> "NoContent"
-    "400" -> "BadRequest"
-    "401" -> "Unauthorized"
-    "403" -> "Forbidden"
-    "404" -> "NotFound"
-    "409" -> "Conflict"
-    "422" -> "UnprocessableEntity"
-    "500" -> "InternalServerError"
-    "default" -> "Default"
-    "1XX" | "1xx" -> "Status1xx"
-    "2XX" | "2xx" -> "Status2xx"
-    "3XX" | "3xx" -> "Status3xx"
-    "4XX" | "4xx" -> "Status4xx"
-    "5XX" | "5xx" -> "Status5xx"
-    other -> "Status" <> other
+    "default" -> Ok(DefaultStatus)
+    "1XX" | "1xx" -> Ok(StatusRange(1))
+    "2XX" | "2xx" -> Ok(StatusRange(2))
+    "3XX" | "3xx" -> Ok(StatusRange(3))
+    "4XX" | "4xx" -> Ok(StatusRange(4))
+    "5XX" | "5xx" -> Ok(StatusRange(5))
+    _ ->
+      case int.parse(code) {
+        Ok(n) -> Ok(Status(n))
+        Error(_) -> Error(Nil)
+      }
   }
 }
 
-/// Convert a status code string to a valid Gleam case pattern.
-/// Exact codes become integer literals, range codes become guard expressions,
-/// and "default" becomes "_" (catch-all).
-pub fn status_code_to_int_pattern(code: String) -> String {
+/// Convert an HttpStatusCode back to its canonical string form.
+pub fn status_code_to_string(code: HttpStatusCode) -> String {
   case code {
-    "default" -> "_"
-    "1XX" | "1xx" -> "status if status >= 100 && status <= 199"
-    "2XX" | "2xx" -> "status if status >= 200 && status <= 299"
-    "3XX" | "3xx" -> "status if status >= 300 && status <= 399"
-    "4XX" | "4xx" -> "status if status >= 400 && status <= 499"
-    "5XX" | "5xx" -> "status if status >= 500 && status <= 599"
-    _ -> code
+    Status(n) -> int.to_string(n)
+    StatusRange(n) -> int.to_string(n) <> "XX"
+    DefaultStatus -> "default"
+  }
+}
+
+/// Shared HTTP status code utilities for code generation.
+/// Get a human-readable suffix for a given HTTP status code.
+/// Used to build anonymous type names like "ListPetsResponseOk".
+pub fn status_code_suffix(code: HttpStatusCode) -> String {
+  case code {
+    Status(200) -> "Ok"
+    Status(201) -> "Created"
+    Status(204) -> "NoContent"
+    Status(400) -> "BadRequest"
+    Status(401) -> "Unauthorized"
+    Status(403) -> "Forbidden"
+    Status(404) -> "NotFound"
+    Status(409) -> "Conflict"
+    Status(422) -> "UnprocessableEntity"
+    Status(500) -> "InternalServerError"
+    Status(n) -> "Status" <> int.to_string(n)
+    StatusRange(1) -> "Status1xx"
+    StatusRange(2) -> "Status2xx"
+    StatusRange(3) -> "Status3xx"
+    StatusRange(4) -> "Status4xx"
+    StatusRange(5) -> "Status5xx"
+    StatusRange(n) -> "Status" <> int.to_string(n) <> "xx"
+    DefaultStatus -> "Default"
+  }
+}
+
+/// Convert an HttpStatusCode to a valid Gleam case pattern.
+/// Exact codes become integer literals, range codes become guard expressions,
+/// and DefaultStatus becomes "_" (catch-all).
+pub fn status_code_to_int_pattern(code: HttpStatusCode) -> String {
+  case code {
+    DefaultStatus -> "_"
+    StatusRange(n) -> {
+      let low = int.to_string(n * 100)
+      let high = int.to_string(n * 100 + 99)
+      "status if status >= " <> low <> " && status <= " <> high
+    }
+    Status(n) -> int.to_string(n)
   }
 }
 
 /// Sort response entries so that exact codes come before ranges,
 /// and ranges come before the default catch-all. This ensures
 /// correct pattern matching order in generated case expressions.
-pub fn sort_response_entries(entries: List(#(String, a))) -> List(#(String, a)) {
+pub fn sort_response_entries(
+  entries: List(#(HttpStatusCode, a)),
+) -> List(#(HttpStatusCode, a)) {
   list.sort(entries, fn(a, b) {
     int.compare(status_sort_priority(a.0), status_sort_priority(b.0))
   })
 }
 
-/// Convert a status code string to an integer string for use in ServerResponse.
-/// Range codes and "default" map to a representative status code.
-pub fn status_code_to_int(code: String) -> String {
+/// Convert an HttpStatusCode to an integer string for use in ServerResponse.
+/// Range codes and DefaultStatus map to a representative status code.
+pub fn status_code_to_int(code: HttpStatusCode) -> String {
   case code {
-    "default" -> "500"
-    "1XX" | "1xx" -> "100"
-    "2XX" | "2xx" -> "200"
-    "3XX" | "3xx" -> "300"
-    "4XX" | "4xx" -> "400"
-    "5XX" | "5xx" -> "500"
-    _ -> code
+    DefaultStatus -> "500"
+    StatusRange(n) -> int.to_string(n * 100)
+    Status(n) -> int.to_string(n)
   }
 }
 
-fn status_sort_priority(code: String) -> Int {
+fn status_sort_priority(code: HttpStatusCode) -> Int {
   case code {
-    "default" -> 9999
-    "1XX" | "1xx" -> 1100
-    "2XX" | "2xx" -> 1200
-    "3XX" | "3xx" -> 1300
-    "4XX" | "4xx" -> 1400
-    "5XX" | "5xx" -> 1500
-    _ -> {
-      case int.parse(code) {
-        Ok(n) -> n
-        Error(_) -> 9998
-      }
-    }
+    DefaultStatus -> 9999
+    StatusRange(n) -> n * 100 + 1000
+    Status(n) -> n
   }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1196,13 +1196,13 @@ paths:
   let assert Some(components) = hoisted.components
 
   // The inline response schema should be extracted (with status code in name)
-  dict.has_key(components.schemas, "ListPetsResponse200")
+  dict.has_key(components.schemas, "ListPetsResponseOk")
   |> should.be_true()
 
   // The response should now reference the extracted schema
   let assert Ok(spec.Value(path_item)) = dict.get(hoisted.paths, "/pets")
   let assert Some(op) = path_item.get
-  let assert Ok(spec.Value(response)) = dict.get(op.responses, "200")
+  let assert Ok(spec.Value(response)) = dict.get(op.responses, http.Status(200))
   let assert Ok(media_type) = dict.get(response.content, "application/json")
   let assert Some(schema.Reference(ref: ref, ..)) = media_type.schema
   string.contains(ref, "#/components/schemas/") |> should.be_true()
@@ -3658,24 +3658,24 @@ paths:
 /// status_code_to_int_pattern must not pass through range codes like "2XX".
 pub fn status_code_range_pattern_test() {
   // Range codes must produce valid Gleam patterns, not raw "2XX"
-  http.status_code_to_int_pattern("2XX")
+  http.status_code_to_int_pattern(http.StatusRange(2))
   |> should.not_equal("2XX")
 
   // Exact codes still work
-  http.status_code_to_int_pattern("200")
+  http.status_code_to_int_pattern(http.Status(200))
   |> should.equal("200")
 
   // Default is wildcard
-  http.status_code_to_int_pattern("default")
+  http.status_code_to_int_pattern(http.DefaultStatus)
   |> should.equal("_")
 }
 
 /// status_code_suffix must handle range codes.
 pub fn status_code_suffix_range_test() {
-  http.status_code_suffix("2XX")
+  http.status_code_suffix(http.StatusRange(2))
   |> should.equal("Status2xx")
 
-  http.status_code_suffix("4XX")
+  http.status_code_suffix(http.StatusRange(4))
   |> should.equal("Status4xx")
 }
 
@@ -5116,7 +5116,7 @@ paths:
   let assert Ok(parsed) = parser.parse_string(yaml)
   let assert Ok(spec.Value(pi)) = dict.get(parsed.paths, "/items")
   let assert Some(op) = pi.get
-  let assert Ok(spec.Value(resp)) = dict.get(op.responses, "200")
+  let assert Ok(spec.Value(resp)) = dict.get(op.responses, http.Status(200))
   let assert Ok(header) = dict.get(resp.headers, "X-Rate-Limit")
   header.description |> should.equal(Some("Rate limit"))
   header.required |> should.be_true()
@@ -9677,7 +9677,7 @@ pub fn parse_empty_response_body_test() {
   spec.info.title |> should.equal("Empty Response Body API")
   let assert Ok(spec.Value(path_item)) = dict.get(spec.paths, "/items")
   let assert Some(op) = path_item.post
-  let assert Ok(_) = dict.get(op.responses, "201")
+  let assert Ok(_) = dict.get(op.responses, http.Status(201))
 }
 
 pub fn parse_enum_edge_cases_test() {
@@ -9743,7 +9743,7 @@ pub fn parse_default_response_only_test() {
   spec.info.title |> should.equal("Default Response Only API")
   let assert Ok(spec.Value(path_item)) = dict.get(spec.paths, "/proxy")
   let assert Some(op) = path_item.get
-  let assert Ok(_) = dict.get(op.responses, "default")
+  let assert Ok(_) = dict.get(op.responses, http.DefaultStatus)
 }
 
 pub fn parse_abbreviation_identifiers_test() {


### PR DESCRIPTION
## Summary
- Define `HttpStatusCode` algebraic data type with `Status(Int)`, `StatusRange(Int)`, and `DefaultStatus` variants in `util/http.gleam`
- Parse raw status code strings into `HttpStatusCode` during the OpenAPI parsing phase, eliminating stringly-typed status code handling
- Migrate `Operation.responses` dict key from `String` to `HttpStatusCode` across the entire codebase

## Changes
- **util/http.gleam**: Add `HttpStatusCode` type, `parse_status_code`, and `status_code_to_string` functions; refactor all existing functions (`status_code_suffix`, `status_code_to_int_pattern`, `status_code_to_int`, `sort_response_entries`) to accept `HttpStatusCode` instead of `String`
- **spec.gleam**: Change `Operation.responses` key type to `HttpStatusCode` (leave `Components.responses` as `String` since those keys are component names)
- **parser.gleam**: Convert status code strings/ints to `HttpStatusCode` at parse time
- **Pipeline modules** (resolve, normalize, hoist, capability_check): Update to work with `HttpStatusCode` keys
- **Codegen modules** (client, client_response, types, server, decoders, ir_build, validate): Update function signatures and call sites
- **resolve.gleam**: Generalize `try_map_values` key type from `String` to generic `k`

## Design Decisions
- `Components.responses` retains `Dict(String, ...)` because its keys are named component references (e.g. "NotFound"), not HTTP status codes
- `StatusRange(Int)` stores only the prefix digit (e.g. `StatusRange(2)` for `2XX`) to keep the type simple
- Invalid status code strings in the parser are silently skipped, consistent with the existing lenient parsing approach for unknown key types

## Limitations
- Hoisted schema names change from numeric-based (e.g. `ListPetsResponse200`) to suffix-based (e.g. `ListPetsResponseOk`), which is a breaking change for previously generated code

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Response status handling unified into a typed HTTP-status model, improving consistency and influencing generated response type names/sorting.
* **User-facing impact**
  * Generated response type names and pattern handling now use semantic status representations (e.g., "Ok" for 2xx) instead of raw numeric/default strings.
* **Tests**
  * Updated integration and unit expectations to match the new status-code representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->