### PR TITLE
refactor: extract duplicated schema helpers into shared schema_utils module

### DIFF
--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -13,6 +13,7 @@ import oaspec/codegen/ir.{
   RecordType, TypeAlias, UnionType, VariantWithType,
 }
 import oaspec/codegen/schema_dispatch
+import oaspec/codegen/schema_utils
 import oaspec/openapi/dedup
 import oaspec/openapi/operations
 import oaspec/openapi/resolver
@@ -74,20 +75,20 @@ fn compute_imports(
       let #(_, schema_ref) = entry
       case schema_ref {
         Inline(AnyOfSchema(..)) -> True
-        _ -> schema_has_optional_fields(schema_ref, ctx)
+        _ -> schema_utils.schema_has_optional_fields(schema_ref, ctx)
       }
     })
 
   let needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      schema_has_additional_properties(schema_ref, ctx)
+      schema_utils.schema_has_additional_properties(schema_ref, ctx)
     })
 
   let needs_dynamic =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      schema_has_untyped_additional_properties(schema_ref, ctx)
+      schema_utils.schema_has_untyped_additional_properties(schema_ref, ctx)
     })
 
   case needs_option, needs_dict, needs_dynamic {
@@ -220,7 +221,8 @@ fn schema_type_decls(
               ctx,
             )
           let is_required = list.contains(required, prop_name)
-          let is_already_optional = schema_ref_is_nullable(prop_ref, ctx)
+          let is_already_optional =
+            schema_utils.schema_ref_is_nullable(prop_ref, ctx)
           let final_type = case is_required, is_already_optional {
             True, _ -> field_type
             False, True -> field_type
@@ -366,7 +368,7 @@ fn anonymous_response_type_decls(
             case media_type.schema {
               Some(Inline(schema_obj)) -> {
                 let filtered_schema =
-                  filter_write_only_properties(schema_obj, ctx)
+                  schema_utils.filter_write_only_properties(schema_obj, ctx)
                 anonymous_type_for_schema(
                   op_id,
                   "Response" <> http.status_code_suffix(status_code),
@@ -396,7 +398,8 @@ fn anonymous_request_body_type_decls(
         [#(_media_type, media_type), ..] ->
           case media_type.schema {
             Some(Inline(schema_obj)) -> {
-              let filtered_schema = filter_read_only_properties(schema_obj, ctx)
+              let filtered_schema =
+                schema_utils.filter_read_only_properties(schema_obj, ctx)
               anonymous_type_for_schema(
                 op_id,
                 "RequestBody",
@@ -469,7 +472,7 @@ fn anonymous_type_for_schema(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers (mirrored from types.gleam to avoid import cycle)
+// Helpers
 // ---------------------------------------------------------------------------
 
 fn schema_ref_to_type_with_inline_enum(
@@ -491,171 +494,6 @@ fn schema_ref_to_type(ref: SchemaRef, _ctx: Context) -> String {
   case ref {
     Inline(s) -> schema_dispatch.schema_type(s)
     Reference(name:, ..) -> naming.schema_to_type_name(name)
-  }
-}
-
-fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.is_nullable(s)
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.is_nullable(s)
-        Error(_) -> False
-      }
-  }
-}
-
-fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(properties:, required:, ..)) -> {
-      dict.to_list(properties)
-      |> list.any(fn(entry) {
-        let #(prop_name, prop_ref) = entry
-        !list.contains(required, prop_name)
-        || schema_ref_is_nullable(prop_ref, ctx)
-      })
-    }
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) { schema_has_optional_fields(s, ctx) })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) -> schema_has_optional_fields(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
-}
-
-fn schema_has_additional_properties(schema_ref: SchemaRef, ctx: Context) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(additional_properties: Typed(_), ..)) -> True
-    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) ->
-          schema_has_additional_properties(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
-}
-
-fn schema_has_untyped_additional_properties(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) {
-        schema_has_untyped_additional_properties(s, ctx)
-      })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) ->
-          schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
-}
-
-/// Result of merging allOf sub-schemas.
-fn filter_write_only_properties(
-  schema_obj: SchemaObject,
-  ctx: Context,
-) -> SchemaObject {
-  case schema_obj {
-    ObjectSchema(
-      metadata:,
-      properties:,
-      required:,
-      additional_properties:,
-      min_properties:,
-      max_properties:,
-    ) -> {
-      let filtered_props =
-        dict.filter(properties, fn(_name, prop_ref) {
-          !schema_ref_is_write_only(prop_ref, ctx)
-        })
-      let filtered_required =
-        list.filter(required, fn(name) {
-          case dict.get(filtered_props, name) {
-            Ok(_) -> True
-            Error(_) -> False
-          }
-        })
-      ObjectSchema(
-        metadata:,
-        properties: filtered_props,
-        required: filtered_required,
-        additional_properties:,
-        min_properties:,
-        max_properties:,
-      )
-    }
-    _ -> schema_obj
-  }
-}
-
-fn filter_read_only_properties(
-  schema_obj: SchemaObject,
-  ctx: Context,
-) -> SchemaObject {
-  case schema_obj {
-    ObjectSchema(
-      metadata:,
-      properties:,
-      required:,
-      additional_properties:,
-      min_properties:,
-      max_properties:,
-    ) -> {
-      let filtered_props =
-        dict.filter(properties, fn(_name, prop_ref) {
-          !schema_ref_is_read_only(prop_ref, ctx)
-        })
-      let filtered_required =
-        list.filter(required, fn(name) {
-          case dict.get(filtered_props, name) {
-            Ok(_) -> True
-            Error(_) -> False
-          }
-        })
-      ObjectSchema(
-        metadata:,
-        properties: filtered_props,
-        required: filtered_required,
-        additional_properties:,
-        min_properties:,
-        max_properties:,
-      )
-    }
-    _ -> schema_obj
-  }
-}
-
-fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.get_metadata(s).read_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.get_metadata(s).read_only
-        Error(_) -> False
-      }
-  }
-}
-
-fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.get_metadata(s).write_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.get_metadata(s).write_only
-        Error(_) -> False
-      }
   }
 }
 

--- a/src/oaspec/codegen/schema_utils.gleam
+++ b/src/oaspec/codegen/schema_utils.gleam
@@ -1,0 +1,188 @@
+/// Shared schema analysis utilities used by types.gleam and ir_build.gleam.
+/// Extracted to break the import-cycle that previously forced ir_build.gleam
+/// to mirror these helpers from types.gleam.
+import gleam/dict
+import gleam/list
+import oaspec/codegen/context.{type Context}
+import oaspec/openapi/resolver
+import oaspec/openapi/schema.{
+  type SchemaObject, type SchemaRef, AllOfSchema, Inline, ObjectSchema,
+  Reference, Typed, Untyped,
+}
+
+/// Check if a schema has typed or untyped additionalProperties that would need Dict.
+pub fn schema_has_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(additional_properties: Typed(_), ..)) -> True
+    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
+    Reference(..) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) ->
+          schema_has_additional_properties(Inline(schema_obj), ctx)
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a schema has untyped additionalProperties (needs Dynamic import).
+pub fn schema_has_untyped_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) {
+        schema_has_untyped_additional_properties(s, ctx)
+      })
+    Reference(..) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) ->
+          schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a schema has any optional or nullable fields that would need Option.
+pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(properties:, required:, ..)) -> {
+      dict.to_list(properties)
+      |> list.any(fn(entry) {
+        let #(prop_name, prop_ref) = entry
+        !list.contains(required, prop_name)
+        || schema_ref_is_nullable(prop_ref, ctx)
+      })
+    }
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_optional_fields(s, ctx) })
+    Reference(..) ->
+      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+        Ok(schema_obj) -> schema_has_optional_fields(Inline(schema_obj), ctx)
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a SchemaRef is nullable, resolving $ref if needed.
+pub fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
+  case ref {
+    Inline(s) -> schema.is_nullable(s)
+    Reference(..) ->
+      case resolver.resolve_schema_ref(ref, ctx.spec) {
+        Ok(s) -> schema.is_nullable(s)
+        Error(_) -> False
+      }
+  }
+}
+
+/// Check if a SchemaRef has readOnly metadata, resolving $ref if needed.
+pub fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
+  case ref {
+    Inline(s) -> schema.get_metadata(s).read_only
+    Reference(..) ->
+      case resolver.resolve_schema_ref(ref, ctx.spec) {
+        Ok(s) -> schema.get_metadata(s).read_only
+        Error(_) -> False
+      }
+  }
+}
+
+/// Check if a SchemaRef has writeOnly metadata, resolving $ref if needed.
+pub fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
+  case ref {
+    Inline(s) -> schema.get_metadata(s).write_only
+    Reference(..) ->
+      case resolver.resolve_schema_ref(ref, ctx.spec) {
+        Ok(s) -> schema.get_metadata(s).write_only
+        Error(_) -> False
+      }
+  }
+}
+
+/// Filter readOnly properties from an ObjectSchema for request body context.
+/// Returns a new schema with readOnly properties removed.
+pub fn filter_read_only_properties(
+  schema_obj: SchemaObject,
+  ctx: Context,
+) -> SchemaObject {
+  case schema_obj {
+    ObjectSchema(
+      metadata:,
+      properties:,
+      required:,
+      additional_properties:,
+      min_properties:,
+      max_properties:,
+    ) -> {
+      let filtered_props =
+        dict.filter(properties, fn(_name, prop_ref) {
+          !schema_ref_is_read_only(prop_ref, ctx)
+        })
+      let filtered_required =
+        list.filter(required, fn(name) {
+          case dict.get(filtered_props, name) {
+            Ok(_) -> True
+            Error(_) -> False
+          }
+        })
+      ObjectSchema(
+        metadata:,
+        properties: filtered_props,
+        required: filtered_required,
+        additional_properties:,
+        min_properties:,
+        max_properties:,
+      )
+    }
+    _ -> schema_obj
+  }
+}
+
+/// Filter writeOnly properties from an ObjectSchema for response body context.
+/// Returns a new schema with writeOnly properties removed.
+pub fn filter_write_only_properties(
+  schema_obj: SchemaObject,
+  ctx: Context,
+) -> SchemaObject {
+  case schema_obj {
+    ObjectSchema(
+      metadata:,
+      properties:,
+      required:,
+      additional_properties:,
+      min_properties:,
+      max_properties:,
+    ) -> {
+      let filtered_props =
+        dict.filter(properties, fn(_name, prop_ref) {
+          !schema_ref_is_write_only(prop_ref, ctx)
+        })
+      let filtered_required =
+        list.filter(required, fn(name) {
+          case dict.get(filtered_props, name) {
+            Ok(_) -> True
+            Error(_) -> False
+          }
+        })
+      ObjectSchema(
+        metadata:,
+        properties: filtered_props,
+        required: filtered_required,
+        additional_properties:,
+        min_properties:,
+        max_properties:,
+      )
+    }
+    _ -> schema_obj
+  }
+}

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -6,12 +6,12 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/ir_render
 import oaspec/codegen/schema_dispatch
+import oaspec/codegen/schema_utils
 import oaspec/openapi/operations
-import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   BooleanSchema, Inline, IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema,
-  Reference, StringSchema, Typed, Untyped,
+  Reference, StringSchema,
 }
 import oaspec/openapi/spec.{type Resolved, Value}
 import oaspec/util/http
@@ -462,19 +462,7 @@ pub fn schema_has_additional_properties(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(additional_properties: Typed(_), ..)) -> True
-    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) ->
-          schema_has_additional_properties(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
+  schema_utils.schema_has_additional_properties(schema_ref, ctx)
 }
 
 /// Check if a schema has untyped additionalProperties (needs Dynamic import).
@@ -482,80 +470,22 @@ pub fn schema_has_untyped_additional_properties(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(additional_properties: Untyped, ..)) -> True
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) {
-        schema_has_untyped_additional_properties(s, ctx)
-      })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) ->
-          schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
+  schema_utils.schema_has_untyped_additional_properties(schema_ref, ctx)
 }
 
 /// Check if a schema has any optional or nullable fields that would need Option.
 pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
-  case schema_ref {
-    Inline(ObjectSchema(properties:, required:, ..)) -> {
-      let has_optional =
-        dict.to_list(properties)
-        |> list.any(fn(entry) {
-          let #(prop_name, prop_ref) = entry
-          !list.contains(required, prop_name)
-          || schema_ref_is_nullable(prop_ref, ctx)
-        })
-      has_optional
-    }
-    Inline(AllOfSchema(schemas:, ..)) ->
-      list.any(schemas, fn(s) { schema_has_optional_fields(s, ctx) })
-    Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
-        Ok(schema_obj) -> schema_has_optional_fields(Inline(schema_obj), ctx)
-        Error(_) -> False
-      }
-    _ -> False
-  }
-}
-
-/// Check if a SchemaRef is nullable, resolving $ref if needed.
-fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.is_nullable(s)
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.is_nullable(s)
-        Error(_) -> False
-      }
-  }
+  schema_utils.schema_has_optional_fields(schema_ref, ctx)
 }
 
 /// Check if a SchemaRef has readOnly metadata, resolving $ref if needed.
 pub fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.get_metadata(s).read_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.get_metadata(s).read_only
-        Error(_) -> False
-      }
-  }
+  schema_utils.schema_ref_is_read_only(ref, ctx)
 }
 
 /// Check if a SchemaRef has writeOnly metadata, resolving $ref if needed.
 pub fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(s) -> schema.get_metadata(s).write_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
-        Ok(s) -> schema.get_metadata(s).write_only
-        Error(_) -> False
-      }
-  }
+  schema_utils.schema_ref_is_write_only(ref, ctx)
 }
 
 /// Filter readOnly properties from an ObjectSchema for request body context.
@@ -564,37 +494,7 @@ pub fn filter_read_only_properties(
   schema_obj: SchemaObject,
   ctx: Context,
 ) -> SchemaObject {
-  case schema_obj {
-    ObjectSchema(
-      metadata:,
-      properties:,
-      required:,
-      additional_properties:,
-      min_properties:,
-      max_properties:,
-    ) -> {
-      let filtered_props =
-        dict.filter(properties, fn(_name, prop_ref) {
-          !schema_ref_is_read_only(prop_ref, ctx)
-        })
-      let filtered_required =
-        list.filter(required, fn(name) {
-          case dict.get(filtered_props, name) {
-            Ok(_) -> True
-            Error(_) -> False
-          }
-        })
-      ObjectSchema(
-        metadata:,
-        properties: filtered_props,
-        required: filtered_required,
-        additional_properties:,
-        min_properties:,
-        max_properties:,
-      )
-    }
-    _ -> schema_obj
-  }
+  schema_utils.filter_read_only_properties(schema_obj, ctx)
 }
 
 /// Filter writeOnly properties from an ObjectSchema for response body context.
@@ -603,37 +503,7 @@ pub fn filter_write_only_properties(
   schema_obj: SchemaObject,
   ctx: Context,
 ) -> SchemaObject {
-  case schema_obj {
-    ObjectSchema(
-      metadata:,
-      properties:,
-      required:,
-      additional_properties:,
-      min_properties:,
-      max_properties:,
-    ) -> {
-      let filtered_props =
-        dict.filter(properties, fn(_name, prop_ref) {
-          !schema_ref_is_write_only(prop_ref, ctx)
-        })
-      let filtered_required =
-        list.filter(required, fn(name) {
-          case dict.get(filtered_props, name) {
-            Ok(_) -> True
-            Error(_) -> False
-          }
-        })
-      ObjectSchema(
-        metadata:,
-        properties: filtered_props,
-        required: filtered_required,
-        additional_properties:,
-        min_properties:,
-        max_properties:,
-      )
-    }
-    _ -> schema_obj
-  }
+  schema_utils.filter_write_only_properties(schema_obj, ctx)
 }
 
 /// Extract the Gleam type for a request body from its content media types.


### PR DESCRIPTION
## Summary
- Extract 8 duplicated schema helper functions from `types.gleam` and `ir_build.gleam` into a new shared `codegen/schema_utils.gleam` module
- Eliminate the "mirrored from types.gleam to avoid import cycle" workaround in `ir_build.gleam`
- Net reduction of ~100 lines of duplicated code

## Changes
- **New file: `src/oaspec/codegen/schema_utils.gleam`** — Contains the 8 shared helper functions: `schema_has_optional_fields`, `schema_has_additional_properties`, `schema_has_untyped_additional_properties`, `schema_ref_is_nullable`, `schema_ref_is_read_only`, `schema_ref_is_write_only`, `filter_read_only_properties`, `filter_write_only_properties`
- **`src/oaspec/codegen/types.gleam`** — Public functions now delegate to `schema_utils`, preserving the existing public API for downstream callers (`decoders.gleam`, `guards.gleam`)
- **`src/oaspec/codegen/ir_build.gleam`** — Removed 8 private mirrored functions and replaced internal calls with `schema_utils.*` calls

## Design Decisions
- `types.gleam` retains thin delegation wrappers to maintain backward compatibility for modules that import via `type_gen.*`
- `schema_ref_is_nullable` is now public in `schema_utils` (was private in both original files) since it is needed by `schema_has_optional_fields`
- No import cycle risk: `schema_utils` only depends on `context`, `resolver`, and `schema` modules

Closes #53