### PR TITLE
fix: resolve regex recompilation and quadratic list operations

### DIFF
--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -157,9 +157,9 @@ fn inline_enums_from_properties(
           <> naming.schema_to_type_name(prop_name)
         let deduped_variants = dedup.dedup_enum_variants(enum_values)
         let variants =
-          list.index_map(enum_values, fn(value, idx) {
-            let variant_suffix =
-              list_at_or(deduped_variants, idx, naming.to_pascal_case(value))
+          list.zip(enum_values, deduped_variants)
+          |> list.map(fn(pair) {
+            let #(_, variant_suffix) = pair
             naming.schema_to_type_name(type_name) <> variant_suffix
           })
         Ok(Declaration(
@@ -209,10 +209,10 @@ fn schema_type_decls(
         dedup.dedup_property_names(list.map(props, fn(e) { e.0 }))
 
       let fields =
-        list.index_map(props, fn(entry, idx) {
+        list.zip(props, deduped_names)
+        |> list.map(fn(pair) {
+          let #(entry, field_name) = pair
           let #(prop_name, prop_ref) = entry
-          let field_name =
-            list_at_or(deduped_names, idx, naming.to_snake_case(prop_name))
           let field_type =
             schema_ref_to_type_with_inline_enum(
               prop_ref,
@@ -264,9 +264,9 @@ fn schema_type_decls(
     StringSchema(metadata:, enum_values:, ..) if enum_values != [] -> {
       let deduped_variants = dedup.dedup_enum_variants(enum_values)
       let variants =
-        list.index_map(enum_values, fn(value, idx) {
-          let variant_suffix =
-            list_at_or(deduped_variants, idx, naming.to_pascal_case(value))
+        list.zip(enum_values, deduped_variants)
+        |> list.map(fn(pair) {
+          let #(_, variant_suffix) = pair
           naming.schema_to_type_name(type_name) <> variant_suffix
         })
       [
@@ -494,14 +494,6 @@ fn schema_ref_to_type(ref: SchemaRef, _ctx: Context) -> String {
   case ref {
     Inline(s) -> schema_dispatch.schema_type(s)
     Reference(name:, ..) -> naming.schema_to_type_name(name)
-  }
-}
-
-fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
-  case lst, idx {
-    [], _ -> default
-    [head, ..], 0 -> head
-    [_, ..rest], n -> list_at_or(rest, n - 1, default)
   }
 }
 

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -236,6 +236,7 @@ fn generate_request_type(
       let sb = sb |> se.line("pub type " <> type_name <> " {")
       let sb = sb |> se.indent(1, type_name <> "(")
 
+      let param_count = list.length(params)
       let sb =
         list.index_fold(params, sb, fn(sb, ref_p, idx) {
           case ref_p {
@@ -265,7 +266,7 @@ fn generate_request_type(
                 True -> field_type
                 False -> "Option(" <> field_type <> ")"
               }
-              let has_more = idx < list.length(params) - 1
+              let has_more = idx < param_count - 1
               let has_body = option.is_some(operation.request_body)
               let trailing = case has_more || has_body {
                 True -> ","

--- a/src/oaspec/util/naming.gleam
+++ b/src/oaspec/util/naming.gleam
@@ -1,14 +1,34 @@
 import gleam/dict
 import gleam/int
 import gleam/list
-import gleam/regexp
+import gleam/regexp.{type Regexp}
 import gleam/string
+
+/// Pre-compiled regexes used by naming functions.
+/// Compiled once per public function call instead of on every internal call.
+type Regexes {
+  Regexes(
+    word_separator: Regexp,
+    camel_case: Regexp,
+    underscore_before_caps: Regexp,
+  )
+}
+
+fn compile_regexes() -> Regexes {
+  let assert Ok(word_separator) = regexp.from_string("[_\\-\\s./]+")
+  let assert Ok(camel_case) =
+    regexp.from_string("([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)")
+  let assert Ok(underscore_before_caps) =
+    regexp.from_string("([a-z0-9])([A-Z])")
+  Regexes(word_separator:, camel_case:, underscore_before_caps:)
+}
 
 /// Convert a string to PascalCase for Gleam type names.
 /// Examples: "pet_store" -> "PetStore", "get-user" -> "GetUser"
 pub fn to_pascal_case(input: String) -> String {
+  let re = compile_regexes()
   input
-  |> split_words
+  |> split_words(re)
   |> list.map(capitalize)
   |> string.join("")
 }
@@ -17,10 +37,11 @@ pub fn to_pascal_case(input: String) -> String {
 /// Examples: "PetStore" -> "pet_store", "getUserById" -> "get_user_by_id"
 /// Gleam keywords are suffixed with _ to avoid syntax errors.
 pub fn to_snake_case(input: String) -> String {
+  let re = compile_regexes()
   let result =
     input
-    |> insert_underscores_before_caps
-    |> split_words
+    |> insert_underscores_before_caps(re)
+    |> split_words(re)
     |> list.map(string.lowercase)
     |> string.join("_")
   escape_keyword(result)
@@ -77,19 +98,16 @@ pub fn capitalize(input: String) -> String {
 }
 
 /// Split a string into words by common separators.
-fn split_words(input: String) -> List(String) {
-  let assert Ok(re) = regexp.from_string("[_\\-\\s./]+")
-  let parts = regexp.split(re, input)
+fn split_words(input: String, re: Regexes) -> List(String) {
+  let parts = regexp.split(re.word_separator, input)
   parts
-  |> list.flat_map(split_camel_case)
+  |> list.flat_map(split_camel_case(_, re))
   |> list.filter(fn(s) { s != "" })
 }
 
 /// Split camelCase/PascalCase into separate words.
-fn split_camel_case(input: String) -> List(String) {
-  let assert Ok(re) =
-    regexp.from_string("([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)")
-  let matches = regexp.scan(re, input)
+fn split_camel_case(input: String, re: Regexes) -> List(String) {
+  let matches = regexp.scan(re.camel_case, input)
   case matches {
     [] -> [input]
     _ ->
@@ -101,9 +119,8 @@ fn split_camel_case(input: String) -> List(String) {
 }
 
 /// Insert underscores before capital letters in camelCase strings.
-fn insert_underscores_before_caps(input: String) -> String {
-  let assert Ok(re) = regexp.from_string("([a-z0-9])([A-Z])")
-  regexp.replace(re, input, "\\1_\\2")
+fn insert_underscores_before_caps(input: String, re: Regexes) -> String {
+  regexp.replace(re.underscore_before_caps, input, "\\1_\\2")
 }
 
 /// Deduplicate a list of names by appending _2, _3, etc. to duplicates.


### PR DESCRIPTION
## Summary
- Fix three performance issues that compound on large OpenAPI specs
- Eliminate repeated regex compilation in naming functions
- Replace O(n²) algorithms with O(n) alternatives in codegen

## Changes
- **`src/oaspec/util/naming.gleam`** — Introduce a `Regexes` record type to hold pre-compiled regexes. `to_pascal_case` and `to_snake_case` compile all 3 regexes once and pass them to internal helpers (`split_words`, `split_camel_case`, `insert_underscores_before_caps`)
- **`src/oaspec/codegen/types.gleam`** — Pre-compute `list.length(params)` before `list.index_fold` to avoid O(n²) recomputation
- **`src/oaspec/codegen/ir_build.gleam`** — Replace `list_at_or` + `list.index_map` (O(n²)) with `list.zip` (O(n)) at 3 call sites for enum variant and field name mapping. Remove the now-unused `list_at_or` helper

## Design Decisions
- Gleam lacks module-level constants for opaque types like `Regexp`, so regexes are compiled once per public entry-point call and threaded through as a parameter. This is the idiomatic Gleam approach
- Public API of `naming.gleam` is unchanged — the `Regexes` type is private

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined implementation of code generation and naming utilities for improved efficiency in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->