### PR TITLE
refactor: reduce deep nesting in cli.gleam and extract shared pipeline in generate.gleam

### DIFF
--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -201,87 +201,50 @@ fn run_generate(
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
 
-  case load_config(config_path, mode_opt, output_opt) {
-    Error(msg) -> {
-      io.println("Error: " <> msg)
+  use cfg <- require(load_config(config_path, mode_opt, output_opt), fn(msg) {
+    "Error: " <> msg
+  })
+
+  io.println("Parsing OpenAPI spec: " <> cfg.input)
+  use spec <- require(parser.parse_file(cfg.input), fn(e) {
+    "Error: " <> parser.parse_error_to_string(e)
+  })
+
+  use summary <- require(generate.generate(spec, cfg), format_generate_error)
+
+  io.println("Spec loaded: " <> summary.spec_title)
+  print_warnings(summary.warnings)
+  case fail_on_warnings && summary.warnings != [] {
+    True -> {
+      io.println("")
+      io.println("Error: warnings present and --fail-on-warnings is set.")
       halt(1)
     }
-    Ok(cfg) -> {
-      io.println("Parsing OpenAPI spec: " <> cfg.input)
-      case parser.parse_file(cfg.input) {
-        Error(e) -> {
-          io.println("Error: " <> parser.parse_error_to_string(e))
-          halt(1)
-        }
-        Ok(spec) -> {
-          case generate.generate(spec, cfg) {
-            Error(generate.ValidationErrors(errors:)) -> {
-              io.println("Error: OpenAPI spec contains unsupported features:")
-              list.each(errors, fn(e) {
-                io.println("  - " <> diagnostic.to_string(e))
-              })
-              halt(1)
-            }
-            Ok(summary) -> {
-              io.println("Spec loaded: " <> summary.spec_title)
-              let has_warnings = summary.warnings != []
-              case summary.warnings {
-                [] -> Nil
-                warnings -> {
-                  io.println("Warnings:")
-                  list.each(warnings, fn(w) {
-                    io.println("  - " <> diagnostic.to_string(w))
-                  })
-                }
-              }
-              case fail_on_warnings && has_warnings {
-                True -> {
-                  io.println("")
-                  io.println(
-                    "Error: warnings present and --fail-on-warnings is set.",
-                  )
-                  halt(1)
-                }
-                False -> Nil
-              }
-              case check_mode {
-                True -> run_check(summary.files, cfg)
-                False -> {
-                  io.println("Generating code...")
-                  case
-                    writer.write_all(summary.files, cfg, fn(path) {
-                      io.println("  Generated: " <> path)
-                    })
-                  {
-                    Ok(written) -> {
-                      let output_dirs = writer.output_dirs(cfg)
-                      case formatter.format_files(output_dirs) {
-                        Ok(Nil) -> io.println("  Formatted generated code")
-                        Error(e) -> {
-                          io.println("Error: " <> formatter.error_to_string(e))
-                          halt(1)
-                        }
-                      }
-                      io.println("")
-                      io.println(
-                        "Successfully generated "
-                        <> int.to_string(list.length(written))
-                        <> " files",
-                      )
-                    }
-                    Error(e) -> {
-                      io.println("Error: " <> writer.error_to_string(e))
-                      halt(1)
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    False -> Nil
   }
+  case check_mode {
+    True -> run_check(summary.files, cfg)
+    False -> write_files(summary.files, cfg)
+  }
+}
+
+/// Write generated files to disk, format them, and print summary.
+fn write_files(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
+  io.println("Generating code...")
+  use written <- require(
+    writer.write_all(files, cfg, fn(path) {
+      io.println("  Generated: " <> path)
+    }),
+    fn(e) { "Error: " <> writer.error_to_string(e) },
+  )
+  use _ <- require(formatter.format_files(writer.output_dirs(cfg)), fn(e) {
+    "Error: " <> formatter.error_to_string(e)
+  })
+  io.println("  Formatted generated code")
+  io.println("")
+  io.println(
+    "Successfully generated " <> int.to_string(list.length(written)) <> " files",
+  )
 }
 
 /// Check that generated code matches existing files on disk.
@@ -412,46 +375,24 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
 
-  case load_config(config_path, mode_opt, None) {
-    Error(msg) -> {
-      io.println("Error: " <> msg)
-      halt(1)
-    }
-    Ok(cfg) -> {
-      io.println("Parsing OpenAPI spec: " <> cfg.input)
-      case parser.parse_file(cfg.input) {
-        Error(e) -> {
-          io.println("Error: " <> parser.parse_error_to_string(e))
-          halt(1)
-        }
-        Ok(spec) -> {
-          case generate.validate_only(spec, cfg) {
-            Error(generate.ValidationErrors(errors:)) -> {
-              io.println("Error: OpenAPI spec contains unsupported features:")
-              list.each(errors, fn(e) {
-                io.println("  - " <> diagnostic.to_string(e))
-              })
-              halt(1)
-            }
-            Ok(summary) -> {
-              io.println("Spec loaded: " <> summary.spec_title)
-              case summary.warnings {
-                [] -> Nil
-                warnings -> {
-                  io.println("Warnings:")
-                  list.each(warnings, fn(w) {
-                    io.println("  - " <> diagnostic.to_string(w))
-                  })
-                }
-              }
-              io.println("")
-              io.println("Validation passed.")
-            }
-          }
-        }
-      }
-    }
-  }
+  use cfg <- require(load_config(config_path, mode_opt, None), fn(msg) {
+    "Error: " <> msg
+  })
+
+  io.println("Parsing OpenAPI spec: " <> cfg.input)
+  use spec <- require(parser.parse_file(cfg.input), fn(e) {
+    "Error: " <> parser.parse_error_to_string(e)
+  })
+
+  use summary <- require(
+    generate.validate_only(spec, cfg),
+    format_generate_error,
+  )
+
+  io.println("Spec loaded: " <> summary.spec_title)
+  print_warnings(summary.warnings)
+  io.println("")
+  io.println("Validation passed.")
 }
 
 /// Pure config loading and validation pipeline.
@@ -478,6 +419,47 @@ fn load_config(
   config.validate_output_package_match(cfg)
   |> result.map(fn(_) { cfg })
   |> result.map_error(config.error_to_string)
+}
+
+/// Unwrap a Result or print the error message and exit.
+/// Designed for use with `use value <- require(result, to_message)`.
+fn require(
+  result: Result(a, b),
+  to_message: fn(b) -> String,
+  continue: fn(a) -> Nil,
+) -> Nil {
+  case result {
+    Ok(value) -> continue(value)
+    Error(err) -> {
+      io.println(to_message(err))
+      halt(1)
+    }
+  }
+}
+
+/// Format a GenerateError into a printable error message.
+fn format_generate_error(err: generate.GenerateError) -> String {
+  case err {
+    generate.ValidationErrors(errors:) ->
+      "Error: OpenAPI spec contains unsupported features:\n"
+      <> string.join(
+        list.map(errors, fn(e) { "  - " <> diagnostic.to_string(e) }),
+        "\n",
+      )
+  }
+}
+
+/// Print warnings if any exist.
+fn print_warnings(warnings: List(diagnostic.Diagnostic)) -> Nil {
+  case warnings {
+    [] -> Nil
+    _ -> {
+      io.println("Warnings:")
+      list.each(warnings, fn(w) {
+        io.println("  - " <> diagnostic.to_string(w))
+      })
+    }
+  }
 }
 
 /// Exit the process with a status code.

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -36,13 +36,18 @@ pub type GenerateError {
   ValidationErrors(errors: List(Diagnostic))
 }
 
-/// Pure generation pipeline: parse → normalize → resolve → capability_check → hoist → dedup → validate → codegen.
-/// Takes an already-parsed spec and config; returns generated files or errors.
-/// Does not perform IO — callers handle writing files and printing output.
-pub fn generate(
+/// Intermediate result from the shared pipeline.
+/// Contains the validated context and accumulated warnings.
+type PreparedContext {
+  PreparedContext(ctx: Context, spec_title: String, warnings: List(Diagnostic))
+}
+
+/// Shared pipeline: normalize → resolve → capability_check → hoist → dedup → validate.
+/// Returns a validated context with accumulated warnings, or errors.
+fn prepare_context(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
-) -> Result(GenerationSummary, GenerateError) {
+) -> Result(PreparedContext, GenerateError) {
   let spec_title = spec.info.title <> " v" <> spec.info.version
 
   // Normalize OAS 3.1 patterns to 3.0-compatible form
@@ -85,19 +90,30 @@ pub fn generate(
     |> validate.filter_by_mode(cfg.mode)
   let blocking_errors = validate.errors_only(validation_issues)
   let validation_warnings = validate.warnings_only(validation_issues)
-  case list.is_empty(blocking_errors) {
+  use _ <- result.try(case list.is_empty(blocking_errors) {
     False -> Error(ValidationErrors(errors: blocking_errors))
-    True -> {
-      let files = generate_all_files(ctx)
-      let warnings =
-        list.flatten([
-          capability_warnings,
-          preserved_warnings,
-          validation_warnings,
-        ])
-      Ok(GenerationSummary(files:, spec_title:, warnings:))
-    }
-  }
+    True -> Ok(Nil)
+  })
+
+  let warnings =
+    list.flatten([capability_warnings, preserved_warnings, validation_warnings])
+  Ok(PreparedContext(ctx:, spec_title:, warnings:))
+}
+
+/// Pure generation pipeline: parse → normalize → resolve → capability_check → hoist → dedup → validate → codegen.
+/// Takes an already-parsed spec and config; returns generated files or errors.
+/// Does not perform IO — callers handle writing files and printing output.
+pub fn generate(
+  spec: OpenApiSpec(Unresolved),
+  cfg: Config,
+) -> Result(GenerationSummary, GenerateError) {
+  use prepared <- result.try(prepare_context(spec, cfg))
+  let files = generate_all_files(prepared.ctx)
+  Ok(GenerationSummary(
+    files:,
+    spec_title: prepared.spec_title,
+    warnings: prepared.warnings,
+  ))
 }
 
 /// Validation-only pipeline: parse → normalize → resolve → capability_check → hoist → dedup → validate.
@@ -106,50 +122,11 @@ pub fn validate_only(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
 ) -> Result(ValidationSummary, GenerateError) {
-  let spec_title = spec.info.title <> " v" <> spec.info.version
-
-  let spec = normalize.normalize(spec)
-
-  use spec <- result.try(
-    resolve.resolve(spec)
-    |> result.map_error(fn(errors) { ValidationErrors(errors:) }),
-  )
-
-  let capability_issues =
-    capability_check.check(spec)
-    |> validate.filter_by_mode(cfg.mode)
-  let capability_errors = validate.errors_only(capability_issues)
-  let capability_warnings = validate.warnings_only(capability_issues)
-  use _ <- result.try(case list.is_empty(capability_errors) {
-    False -> Error(ValidationErrors(errors: capability_errors))
-    True -> Ok(Nil)
-  })
-
-  let spec = hoist.hoist(spec)
-  let spec = dedup.dedup(spec)
-  let ctx = context.new(spec, cfg)
-
-  let preserved_warnings =
-    capability_check.check_preserved(ctx)
-    |> diagnostic.filter_by_mode(cfg.mode)
-
-  let validation_issues =
-    validate.validate(ctx)
-    |> validate.filter_by_mode(cfg.mode)
-  let blocking_errors = validate.errors_only(validation_issues)
-  let validation_warnings = validate.warnings_only(validation_issues)
-  case list.is_empty(blocking_errors) {
-    False -> Error(ValidationErrors(errors: blocking_errors))
-    True -> {
-      let warnings =
-        list.flatten([
-          capability_warnings,
-          preserved_warnings,
-          validation_warnings,
-        ])
-      Ok(ValidationSummary(spec_title:, warnings:))
-    }
-  }
+  use prepared <- result.try(prepare_context(spec, cfg))
+  Ok(ValidationSummary(
+    spec_title: prepared.spec_title,
+    warnings: prepared.warnings,
+  ))
 }
 
 /// Pure file generation: produce all GeneratedFile values without any IO.


### PR DESCRIPTION
## Summary
- Extract shared validation pipeline into `prepare_context()` in generate.gleam to eliminate duplication
- Flatten deeply nested case expressions in cli.gleam using idiomatic Gleam `use` bindings

## Changes
- **`src/oaspec/generate.gleam`** — Extract the shared pipeline (normalize → resolve → capability_check → hoist → dedup → validate) into a private `prepare_context()` function with a `PreparedContext` type. Both `generate()` and `validate_only()` now delegate to this shared function, eliminating ~50 lines of duplication
- **`src/oaspec/cli.gleam`** — Introduce a `require()` helper that unwraps a `Result` or prints the error and exits. Refactor `run_generate` (6+ nesting levels → flat) and `run_validate` (4 nesting levels → flat) using `use value <- require(...)`. Extract `write_files()`, `print_warnings()`, and `format_generate_error()` helpers

## Design Decisions
- `require()` uses callback style (`fn(a) -> Nil`) compatible with Gleam's `use` syntax, since `halt()` returns `Nil` and cannot be used in `let` bindings that expect a different type
- `PreparedContext` is a private type — the public API of `generate.gleam` is unchanged
- Error message formatting for `GenerateError` is centralized in `format_generate_error()` to avoid duplication between `run_generate` and `run_validate`

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified initialization logic between code generation and validation processes to reduce code duplication throughout the codebase.
  * Enhanced error handling and control flow in command execution to provide more consistent error reporting and feedback.
  * Centralized error message formatting and warning output mechanisms to ensure consistent user-facing behavior across all CLI commands and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->