### PR TITLE
refactor: unify allOf property merging to use canonical allof_merge module

### DIFF
--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -2,6 +2,7 @@ import gleam/dict
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
+import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
@@ -236,21 +237,10 @@ fn generate_inline_enum_decoders(
 ) -> se.StringBuilder {
   let props = case schema_ref {
     Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
-    Inline(AllOfSchema(schemas:, ..)) -> {
-      let merged =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(..) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      ir_build.sorted_entries(merged)
-    }
+    Inline(AllOfSchema(schemas:, ..)) ->
+      ir_build.sorted_entries(
+        allof_merge.merge_allof_schemas(schemas, ctx).properties,
+      )
     _ -> []
   }
   list.fold(props, sb, fn(sb, entry) {
@@ -1264,21 +1254,10 @@ fn generate_inline_enum_encoders(
 ) -> se.StringBuilder {
   let props = case schema_ref {
     Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
-    Inline(AllOfSchema(schemas:, ..)) -> {
-      let merged =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(..) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      ir_build.sorted_entries(merged)
-    }
+    Inline(AllOfSchema(schemas:, ..)) ->
+      ir_build.sorted_entries(
+        allof_merge.merge_allof_schemas(schemas, ctx).properties,
+      )
     _ -> []
   }
   list.fold(props, sb, fn(sb, entry) {

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -4,6 +4,7 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
+import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/types as type_gen
@@ -240,19 +241,10 @@ fn generate_guards_for_schema_object(
       })
     }
     AllOfSchema(schemas:, ..) -> {
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(..) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      let props = ir_build.sorted_entries(merged_props)
+      let props =
+        ir_build.sorted_entries(
+          allof_merge.merge_allof_schemas(schemas, ctx).properties,
+        )
       list.fold(props, sb, fn(sb, entry) {
         let #(prop_name, prop_ref) = entry
         generate_field_guard(sb, name, prop_name, prop_ref, ctx)
@@ -1166,7 +1158,7 @@ fn collect_guard_calls(
       list.append(prop_calls, size_calls)
     }
     Ok(AllOfSchema(schemas:, ..)) -> {
-      let merged = merge_allof_props_and_required(schemas, ctx)
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
       ir_build.sorted_entries(merged.properties)
       |> list.flat_map(fn(entry) {
         let #(prop_name, prop_ref) = entry
@@ -1390,38 +1382,4 @@ fn collect_field_guard_calls(
     }
     _ -> []
   }
-}
-
-/// Merge properties and required lists from allOf sub-schemas.
-type MergedProps {
-  MergedProps(properties: dict.Dict(String, SchemaRef), required: List(String))
-}
-
-fn merge_allof_props_and_required(
-  schemas: List(SchemaRef),
-  ctx: Context,
-) -> MergedProps {
-  list.fold(
-    schemas,
-    MergedProps(properties: dict.new(), required: []),
-    fn(acc, s_ref) {
-      case s_ref {
-        Inline(ObjectSchema(properties:, required:, ..)) ->
-          MergedProps(
-            properties: dict.merge(acc.properties, properties),
-            required: list.append(acc.required, required),
-          )
-        Reference(..) ->
-          case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-            Ok(ObjectSchema(properties:, required:, ..)) ->
-              MergedProps(
-                properties: dict.merge(acc.properties, properties),
-                required: list.append(acc.required, required),
-              )
-            _ -> acc
-          }
-        _ -> acc
-      }
-    },
-  )
 }

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -16,7 +16,6 @@ import oaspec/codegen/schema_dispatch
 import oaspec/codegen/schema_utils
 import oaspec/openapi/dedup
 import oaspec/openapi/operations
-import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, Forbidden, Inline,
   ObjectSchema, OneOfSchema, Reference, StringSchema, Typed, Untyped,
@@ -124,19 +123,8 @@ fn inline_enums_for_schema(
     Inline(ObjectSchema(properties:, ..)) ->
       inline_enums_from_properties(parent_name, properties, ctx)
     Inline(AllOfSchema(schemas:, ..)) -> {
-      let merged_props =
-        list.fold(schemas, dict.new(), fn(acc, s_ref) {
-          case s_ref {
-            Inline(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-            Reference(..) ->
-              case resolver.resolve_schema_ref(s_ref, ctx.spec) {
-                Ok(ObjectSchema(properties:, ..)) -> dict.merge(acc, properties)
-                _ -> acc
-              }
-            _ -> acc
-          }
-        })
-      inline_enums_from_properties(parent_name, merged_props, ctx)
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
+      inline_enums_from_properties(parent_name, merged.properties, ctx)
     }
     _ -> []
   }


### PR DESCRIPTION
## Summary
- Replace 4 ad-hoc allOf property merging implementations with calls to the canonical `allof_merge.merge_allof_schemas()`
- Remove ~75 lines of duplicated merge logic across 3 files

## Changes
- **`src/oaspec/codegen/guards.gleam`** — Remove the duplicated `MergedProps` type and `merge_allof_props_and_required()` function. Replace both the inline `list.fold` for property merging and the `merge_allof_props_and_required` call with `allof_merge.merge_allof_schemas()`
- **`src/oaspec/codegen/decoders.gleam`** — Replace 2 identical inline `list.fold` blocks (in `generate_inline_enum_decoders` and `generate_inline_enum_encoders`) with `allof_merge.merge_allof_schemas().properties`
- **`src/oaspec/codegen/ir_build.gleam`** — Replace inline `list.fold` in `inline_enum_decls` with `allof_merge.merge_allof_schemas()`. Remove now-unused `resolver` import

## Design Decisions
- The canonical `merge_allof_schemas` also handles `additional_properties` and non-object sub-schemas (synthetic "value" fields), which the ad-hoc versions did not. This gives more complete behavior at no additional cost since callers only access `.properties` and `.required`
- No new API added to `allof_merge` — existing public function is sufficient

Closes #58