### PR TITLE
fix: use to_short_string for CLI diagnostic output by default

### DIFF
--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -443,7 +443,7 @@ fn format_generate_error(err: generate.GenerateError) -> String {
     generate.ValidationErrors(errors:) ->
       "Error: OpenAPI spec contains unsupported features:\n"
       <> string.join(
-        list.map(errors, fn(e) { "  - " <> diagnostic.to_string(e) }),
+        list.map(errors, fn(e) { "  - " <> diagnostic.to_short_string(e) }),
         "\n",
       )
   }
@@ -456,7 +456,7 @@ fn print_warnings(warnings: List(diagnostic.Diagnostic)) -> Nil {
     _ -> {
       io.println("Warnings:")
       list.each(warnings, fn(w) {
-        io.println("  - " <> diagnostic.to_string(w))
+        io.println("  - " <> diagnostic.to_short_string(w))
       })
     }
   }


### PR DESCRIPTION
## Summary
- Switch CLI diagnostic display to the user-friendly short format

## Changes
- **`src/oaspec/cli.gleam`** — Replace `diagnostic.to_string` with `diagnostic.to_short_string` in both `format_generate_error` and `print_warnings`, removing the `[Phase]` prefix from CLI output

Before:
```
  - [CapabilityCheck] Error at components.schemas.Foo: $defs not supported
```

After:
```
  - Error at components.schemas.Foo: $defs not supported
```

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined CLI diagnostic output for validation errors and warnings, displaying abbreviated messages for clearer, more concise feedback during generate and validate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->