### PR TITLE
refactor: extract shared import-needs analysis from codegen modules

### DIFF
--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -6,6 +6,7 @@ import oaspec/codegen/client_request
 import oaspec/codegen/client_response
 import oaspec/codegen/client_security
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
 import oaspec/openapi/operations
 import oaspec/openapi/resolver
@@ -186,46 +187,10 @@ fn generate_client(ctx: Context) -> String {
 
   // Check which modules are actually needed
   let needs_typed_schemas =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      // Need types/encode when $ref body or $ref params exist
-      let has_ref_body = case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(ce) {
-            let #(_, mt) = ce
-            case mt.schema {
-              Some(Reference(..)) -> True
-              Some(Inline(schema.ObjectSchema(..))) -> True
-              Some(Inline(schema.AllOfSchema(..))) -> True
-              _ -> False
-            }
-          })
-        _ -> False
-      }
-      let has_ref_params =
-        list.any(operation.parameters, fn(ref_p) {
-          case ref_p {
-            Value(p) ->
-              case p.payload {
-                ParameterSchema(Reference(..)) -> True
-                _ -> False
-              }
-            _ -> False
-          }
-        })
-      has_ref_body || has_ref_params
-    })
+    import_analysis.operations_need_typed_schemas(operations)
 
   let needs_option =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> !p.required
-          _ -> False
-        }
-      })
-    })
+    import_analysis.operations_have_optional_params(operations)
     || {
       let security_schemes = case ctx.spec.components {
         Some(c) -> dict.to_list(c.security_schemes)

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -22,8 +22,9 @@ import oaspec/util/string_extra as se
 
 /// Generate decoder and encoder modules.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let decode_content = generate_decoders(ctx)
-  let encode_content = generate_encoders(ctx)
+  let operations = operations.collect_operations(ctx)
+  let decode_content = generate_decoders(ctx, operations)
+  let encode_content = generate_encoders(ctx, operations)
 
   [
     GeneratedFile(
@@ -44,7 +45,10 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 // ===================================================================
 
 /// Generate JSON decoders for all component schemas and anonymous types.
-fn generate_decoders(ctx: Context) -> String {
+fn generate_decoders(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   let schemas = case ctx.spec.components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
@@ -122,7 +126,7 @@ fn generate_decoders(ctx: Context) -> String {
     })
 
   // Generate decoders for anonymous inline schemas from operations
-  let sb = generate_anonymous_decoders(sb, ctx)
+  let sb = generate_anonymous_decoders(sb, ctx, operations)
 
   se.to_string(sb)
 }
@@ -131,8 +135,8 @@ fn generate_decoders(ctx: Context) -> String {
 fn generate_anonymous_decoders(
   sb: se.StringBuilder,
   ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> se.StringBuilder {
-  let operations = operations.collect_operations(ctx)
   list.fold(operations, sb, fn(sb, op) {
     let #(op_id, operation, _path, _method) = op
     let sb = generate_anonymous_response_decoders(sb, op_id, operation, ctx)
@@ -1139,7 +1143,10 @@ fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
 // ===================================================================
 
 /// Generate JSON encoders for all component schemas and anonymous types.
-fn generate_encoders(ctx: Context) -> String {
+fn generate_encoders(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   let schemas = case ctx.spec.components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
@@ -1219,7 +1226,7 @@ fn generate_encoders(ctx: Context) -> String {
     })
 
   // Generate encoders for anonymous inline schemas from operations
-  let sb = generate_anonymous_encoders(sb, ctx)
+  let sb = generate_anonymous_encoders(sb, ctx, operations)
 
   // Generate encode_dynamic helper if needed for untyped additionalProperties
   let sb = case needs_dynamic {
@@ -1290,8 +1297,8 @@ fn generate_inline_enum_encoders(
 fn generate_anonymous_encoders(
   sb: se.StringBuilder,
   ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> se.StringBuilder {
-  let operations = operations.collect_operations(ctx)
   list.fold(operations, sb, fn(sb, op) {
     let #(op_id, operation, _path, _method) = op
     // Only requestBody inline schemas need encoders (for client body encoding)

--- a/src/oaspec/codegen/import_analysis.gleam
+++ b/src/oaspec/codegen/import_analysis.gleam
@@ -1,0 +1,71 @@
+import gleam/dict
+import gleam/list
+import gleam/option.{Some}
+import oaspec/openapi/schema.{AllOfSchema, Inline, ObjectSchema, Reference}
+import oaspec/openapi/spec.{
+  type HttpMethod, type Operation, type Resolved, ParameterSchema, Value,
+}
+
+/// Check if any operation has parameters with Reference schemas,
+/// or request body content with Reference/ObjectSchema/AllOfSchema.
+/// This determines whether the generated module needs to import the types module.
+pub fn operations_need_typed_schemas(
+  operations: List(#(String, Operation(Resolved), String, HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    let has_ref_body = case operation.request_body {
+      Some(Value(rb)) ->
+        list.any(dict.to_list(rb.content), fn(ce) {
+          let #(_, mt) = ce
+          case mt.schema {
+            Some(Reference(..)) -> True
+            Some(Inline(ObjectSchema(..))) -> True
+            Some(Inline(AllOfSchema(..))) -> True
+            _ -> False
+          }
+        })
+      _ -> False
+    }
+    let has_ref_params =
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            case p.payload {
+              ParameterSchema(Reference(..)) -> True
+              _ -> False
+            }
+          _ -> False
+        }
+      })
+    has_ref_body || has_ref_params
+  })
+}
+
+/// Check if any operation has optional (non-required) parameters.
+pub fn operations_have_optional_params(
+  operations: List(#(String, Operation(Resolved), String, HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(operation.parameters, fn(ref_p) {
+      case ref_p {
+        Value(p) -> !p.required
+        _ -> False
+      }
+    })
+  })
+}
+
+/// Check if any operation has an optional (non-required) request body.
+pub fn operations_have_optional_body(
+  operations: List(#(String, Operation(Resolved), String, HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    case operation.request_body {
+      Some(Value(rb)) -> !rb.required
+      _ -> False
+    }
+  })
+}

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
 import oaspec/codegen/server_request_decode as decode_helpers
 import oaspec/openapi/operations
@@ -14,8 +15,9 @@ import oaspec/util/string_extra as se
 
 /// Generate server stub files.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let handlers_content = generate_handlers(ctx)
-  let router_content = generate_router(ctx)
+  let operations = operations.collect_operations(ctx)
+  let handlers_content = generate_handlers(ctx, operations)
+  let router_content = generate_router(ctx, operations)
 
   [
     GeneratedFile(
@@ -32,15 +34,16 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 }
 
 /// Generate handler stubs for all operations.
-fn generate_handlers(ctx: Context) -> String {
+fn generate_handlers(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   let sb =
     se.file_header(context.version)
     |> se.imports([
       ctx.config.package <> "/request_types",
       ctx.config.package <> "/response_types",
     ])
-
-  let operations = operations.collect_operations(ctx)
 
   let sb =
     list.fold(operations, sb, fn(sb, op) {
@@ -159,8 +162,10 @@ fn url_expression_to_suffix(url_expression: String) -> String {
 }
 
 /// Generate a router module that dispatches requests.
-fn generate_router(ctx: Context) -> String {
-  let operations = operations.collect_operations(ctx)
+fn generate_router(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   let has_deep_object =
     list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
@@ -319,15 +324,10 @@ fn generate_router(ctx: Context) -> String {
   let needs_uri_import = needs_cookie_lookup || has_form_urlencoded_body
 
   let needs_option =
-    list.any(operations, fn(op) {
+    import_analysis.operations_have_optional_params(operations)
+    || import_analysis.operations_have_optional_body(operations)
+    || list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
-      let has_optional_params =
-        list.any(operation.parameters, fn(ref_p) {
-          case ref_p {
-            Value(p) -> !p.required
-            _ -> False
-          }
-        })
       let has_optional_deep_object_fields =
         list.any(operation.parameters, fn(ref_p) {
           case ref_p {
@@ -346,15 +346,9 @@ fn generate_router(ctx: Context) -> String {
           decode_helpers.multipart_body_has_optional_fields(rb, ctx)
         _ -> False
       }
-      let has_optional_body = case operation.request_body {
-        Some(Value(rb)) -> !rb.required
-        _ -> False
-      }
-      has_optional_params
-      || has_optional_deep_object_fields
+      has_optional_deep_object_fields
       || has_optional_form_urlencoded_fields
       || has_optional_multipart_fields
-      || has_optional_body
     })
 
   let needs_json =

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{None, Some}
 import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
 import oaspec/codegen/ir_render
 import oaspec/codegen/schema_dispatch
@@ -20,9 +21,10 @@ import oaspec/util/string_extra as se
 
 /// Generate type definitions from OpenAPI schemas.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
+  let operations = operations.collect_operations(ctx)
   let types_content = generate_types(ctx)
-  let request_types_content = generate_request_types(ctx)
-  let response_types_content = generate_response_types(ctx)
+  let request_types_content = generate_request_types(ctx, operations)
+  let response_types_content = generate_response_types(ctx, operations)
 
   [
     GeneratedFile(
@@ -142,57 +144,17 @@ pub fn schema_to_gleam_type(schema: SchemaObject, _ctx: Context) -> String {
 }
 
 /// Generate request types for all operations.
-fn generate_request_types(ctx: Context) -> String {
-  let operations = operations.collect_operations(ctx)
-
+fn generate_request_types(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   // Only import Option if any operation has optional parameters or optional body
   let needs_option =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      let has_optional_params =
-        list.any(operation.parameters, fn(ref_p) {
-          case ref_p {
-            Value(p) -> !p.required
-            _ -> False
-          }
-        })
-      let has_optional_body = case operation.request_body {
-        Some(Value(rb)) -> !rb.required
-        _ -> False
-      }
-      has_optional_params || has_optional_body
-    })
+    import_analysis.operations_have_optional_params(operations)
+    || import_analysis.operations_have_optional_body(operations)
 
   // Check if types module is needed ($ref params or non-primitive body)
-  let needs_types =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      let has_ref_params =
-        list.any(operation.parameters, fn(ref_p) {
-          case ref_p {
-            Value(p) ->
-              case p.payload {
-                spec.ParameterSchema(Reference(..)) -> True
-                _ -> False
-              }
-            _ -> False
-          }
-        })
-      let has_typed_body = case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(ce) {
-            let #(_, mt) = ce
-            case mt.schema {
-              Some(Reference(..)) -> True
-              Some(Inline(schema.ObjectSchema(..))) -> True
-              Some(Inline(schema.AllOfSchema(..))) -> True
-              _ -> False
-            }
-          })
-        _ -> False
-      }
-      has_ref_params || has_typed_body
-    })
+  let needs_types = import_analysis.operations_need_typed_schemas(operations)
 
   let base_imports = case needs_types {
     True -> [ctx.config.package <> "/types"]
@@ -340,8 +302,10 @@ fn responses_need_types_import(
 }
 
 /// Generate response types for all operations.
-fn generate_response_types(ctx: Context) -> String {
-  let operations = operations.collect_operations(ctx)
+fn generate_response_types(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> String {
   let needs_types = responses_need_types_import(operations, ctx)
   let imports = case needs_types {
     True -> [ctx.config.package <> "/types"]

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -24,9 +24,10 @@ import oaspec/util/http
 /// Name collisions and duplicate operationIds are handled by the dedup pass
 /// before validation, so they are no longer checked here.
 pub fn validate(ctx: Context) -> List(Diagnostic) {
-  let op_errors = validate_operations(ctx)
+  let operations = operations.collect_operations(ctx)
+  let op_errors = validate_operations(ctx, operations)
   let schema_errors = validate_component_schemas(ctx)
-  let security_errors = validate_security_schemes(ctx)
+  let security_errors = validate_security_schemes(ctx, operations)
   list.flatten([op_errors, schema_errors, security_errors])
 }
 
@@ -54,8 +55,10 @@ pub fn error_to_string(error: Diagnostic) -> String {
 }
 
 /// Validate all operations for unsupported patterns.
-fn validate_operations(ctx: Context) -> List(Diagnostic) {
-  let operations = operations.collect_operations(ctx)
+fn validate_operations(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> List(Diagnostic) {
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, path, _method) = op
     // All refs are guaranteed to be resolved by this point
@@ -980,7 +983,10 @@ fn validate_schema_recursive(
 
 /// Validate that all security scheme references in global and operation-level
 /// security requirements point to schemes defined in components.securitySchemes.
-fn validate_security_schemes(ctx: Context) -> List(Diagnostic) {
+fn validate_security_schemes(
+  ctx: Context,
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> List(Diagnostic) {
   let scheme_names = case ctx.spec.components {
     Some(components) -> dict.keys(components.security_schemes)
     None -> []
@@ -1007,7 +1013,6 @@ fn validate_security_schemes(ctx: Context) -> List(Diagnostic) {
       })
     })
 
-  let operations = operations.collect_operations(ctx)
   let operation_errors =
     list.flat_map(operations, fn(op) {
       let #(op_id, operation, _path, _method) = op

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -9,6 +9,7 @@ import oaspec/codegen/client as client_gen
 import oaspec/codegen/context
 import oaspec/codegen/decoders
 import oaspec/codegen/guards
+import oaspec/codegen/import_analysis
 import oaspec/codegen/ir
 import oaspec/codegen/ir_render
 import oaspec/codegen/schema_dispatch
@@ -11136,4 +11137,303 @@ pub fn error_to_string_file_write_error_test() {
     detail: "disk full",
   ))
   |> should.equal("Failed to write file /tmp/out/types.gleam: disk full")
+}
+
+// ===================================================================
+// import_analysis tests
+// ===================================================================
+
+fn make_operation(
+  parameters: List(spec.RefOr(spec.Parameter(spec.Resolved))),
+  request_body: option.Option(spec.RefOr(spec.RequestBody(spec.Resolved))),
+) -> #(String, spec.Operation(spec.Resolved), String, spec.HttpMethod) {
+  #(
+    "testOp",
+    spec.Operation(
+      operation_id: Some("testOp"),
+      summary: None,
+      description: None,
+      tags: [],
+      parameters: parameters,
+      request_body: request_body,
+      responses: dict.new(),
+      deprecated: False,
+      security: None,
+      callbacks: dict.new(),
+      servers: [],
+      external_docs: None,
+    ),
+    "/test",
+    spec.Get,
+  )
+}
+
+fn make_param(
+  name: String,
+  required: Bool,
+  payload: spec.ParameterPayload,
+) -> spec.Parameter(spec.Resolved) {
+  spec.Parameter(
+    name: name,
+    in_: spec.InQuery,
+    description: None,
+    required: required,
+    payload: payload,
+    style: None,
+    explode: None,
+    deprecated: False,
+    allow_reserved: False,
+    examples: dict.new(),
+  )
+}
+
+pub fn import_analysis_empty_operations_test() {
+  import_analysis.operations_need_typed_schemas([])
+  |> should.equal(False)
+  import_analysis.operations_have_optional_params([])
+  |> should.equal(False)
+  import_analysis.operations_have_optional_body([])
+  |> should.equal(False)
+}
+
+pub fn import_analysis_operations_need_typed_schemas_with_ref_param_test() {
+  let param =
+    make_param(
+      "id",
+      True,
+      spec.ParameterSchema(schema.Reference(
+        ref: "#/components/schemas/UserId",
+        name: "UserId",
+      )),
+    )
+  let op = make_operation([spec.Value(param)], None)
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(True)
+}
+
+pub fn import_analysis_operations_need_typed_schemas_with_inline_param_test() {
+  let param =
+    make_param(
+      "name",
+      True,
+      spec.ParameterSchema(
+        schema.Inline(schema.StringSchema(
+          metadata: schema.default_metadata(),
+          format: None,
+          enum_values: [],
+          min_length: None,
+          max_length: None,
+          pattern: None,
+        )),
+      ),
+    )
+  let op = make_operation([spec.Value(param)], None)
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(False)
+}
+
+pub fn import_analysis_operations_need_typed_schemas_with_ref_body_test() {
+  let rb =
+    spec.RequestBody(
+      description: None,
+      content: dict.from_list([
+        #(
+          "application/json",
+          spec.MediaType(
+            schema: Some(schema.Reference(
+              ref: "#/components/schemas/User",
+              name: "User",
+            )),
+            example: None,
+            examples: dict.new(),
+            encoding: dict.new(),
+          ),
+        ),
+      ]),
+      required: True,
+    )
+  let op = make_operation([], Some(spec.Value(rb)))
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(True)
+}
+
+pub fn import_analysis_operations_have_optional_params_test() {
+  let required_param =
+    make_param(
+      "id",
+      True,
+      spec.ParameterSchema(
+        schema.Inline(schema.StringSchema(
+          metadata: schema.default_metadata(),
+          format: None,
+          enum_values: [],
+          min_length: None,
+          max_length: None,
+          pattern: None,
+        )),
+      ),
+    )
+  let optional_param =
+    make_param(
+      "filter",
+      False,
+      spec.ParameterSchema(
+        schema.Inline(schema.StringSchema(
+          metadata: schema.default_metadata(),
+          format: None,
+          enum_values: [],
+          min_length: None,
+          max_length: None,
+          pattern: None,
+        )),
+      ),
+    )
+
+  // Only required params
+  let op1 = make_operation([spec.Value(required_param)], None)
+  import_analysis.operations_have_optional_params([op1])
+  |> should.equal(False)
+
+  // Has optional param
+  let op2 = make_operation([spec.Value(optional_param)], None)
+  import_analysis.operations_have_optional_params([op2])
+  |> should.equal(True)
+}
+
+pub fn import_analysis_operations_have_optional_body_test() {
+  let required_body =
+    spec.RequestBody(description: None, content: dict.new(), required: True)
+  let optional_body =
+    spec.RequestBody(description: None, content: dict.new(), required: False)
+
+  // Required body
+  let op1 = make_operation([], Some(spec.Value(required_body)))
+  import_analysis.operations_have_optional_body([op1])
+  |> should.equal(False)
+
+  // Optional body
+  let op2 = make_operation([], Some(spec.Value(optional_body)))
+  import_analysis.operations_have_optional_body([op2])
+  |> should.equal(True)
+
+  // No body
+  let op3 = make_operation([], None)
+  import_analysis.operations_have_optional_body([op3])
+  |> should.equal(False)
+}
+
+pub fn import_analysis_operations_need_typed_schemas_with_object_body_test() {
+  let rb =
+    spec.RequestBody(
+      description: None,
+      content: dict.from_list([
+        #(
+          "application/json",
+          spec.MediaType(
+            schema: Some(
+              schema.Inline(schema.ObjectSchema(
+                metadata: schema.default_metadata(),
+                properties: dict.new(),
+                required: [],
+                additional_properties: schema.Forbidden,
+                min_properties: None,
+                max_properties: None,
+              )),
+            ),
+            example: None,
+            examples: dict.new(),
+            encoding: dict.new(),
+          ),
+        ),
+      ]),
+      required: True,
+    )
+  let op = make_operation([], Some(spec.Value(rb)))
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(True)
+}
+
+pub fn import_analysis_operations_need_typed_schemas_with_allof_body_test() {
+  let rb =
+    spec.RequestBody(
+      description: None,
+      content: dict.from_list([
+        #(
+          "application/json",
+          spec.MediaType(
+            schema: Some(
+              schema.Inline(
+                schema.AllOfSchema(
+                  metadata: schema.default_metadata(),
+                  schemas: [],
+                ),
+              ),
+            ),
+            example: None,
+            examples: dict.new(),
+            encoding: dict.new(),
+          ),
+        ),
+      ]),
+      required: True,
+    )
+  let op = make_operation([], Some(spec.Value(rb)))
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(True)
+}
+
+pub fn import_analysis_ref_params_return_false_test() {
+  // Ref (unresolved) parameters should return False for all checks
+  let op = make_operation([spec.Ref("#/components/parameters/SomeParam")], None)
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(False)
+  import_analysis.operations_have_optional_params([op])
+  |> should.equal(False)
+}
+
+pub fn import_analysis_ref_body_returns_false_test() {
+  // Ref (unresolved) request body should return False
+  let op =
+    make_operation([], Some(spec.Ref("#/components/requestBodies/SomeBody")))
+  import_analysis.operations_need_typed_schemas([op])
+  |> should.equal(False)
+  import_analysis.operations_have_optional_body([op])
+  |> should.equal(False)
+}
+
+pub fn import_analysis_multiple_operations_any_match_test() {
+  let inline_param =
+    make_param(
+      "name",
+      True,
+      spec.ParameterSchema(
+        schema.Inline(schema.StringSchema(
+          metadata: schema.default_metadata(),
+          format: None,
+          enum_values: [],
+          min_length: None,
+          max_length: None,
+          pattern: None,
+        )),
+      ),
+    )
+  let ref_param =
+    make_param(
+      "id",
+      True,
+      spec.ParameterSchema(schema.Reference(
+        ref: "#/components/schemas/UserId",
+        name: "UserId",
+      )),
+    )
+  let op_no_typed = make_operation([spec.Value(inline_param)], None)
+  let op_typed = make_operation([spec.Value(ref_param)], None)
+
+  // With multiple operations, list.any returns True if any match
+  import_analysis.operations_need_typed_schemas([op_no_typed, op_typed])
+  |> should.equal(True)
+
+  // All operations without typed schemas
+  import_analysis.operations_need_typed_schemas([op_no_typed])
+  |> should.equal(False)
 }


### PR DESCRIPTION
## Summary

- Extract duplicated operation-level import-needs predicates into a new `import_analysis.gleam` module with 3 shared functions: `operations_need_typed_schemas`, `operations_have_optional_params`, `operations_have_optional_body`
- Eliminate redundant `collect_operations` calls in `server.gleam`, `types.gleam`, `decoders.gleam`, and `validate.gleam` by hoisting the call to each module's entry point and threading the result through internal functions
- Replace inline duplicated analysis code in `client.gleam`, `types.gleam`, and `server.gleam` with calls to the shared functions

## Changes

- **New file**: `src/oaspec/codegen/import_analysis.gleam` — shared operation-level predicates for determining import requirements
- **server.gleam**: `generate()` now calls `collect_operations` once and passes the result to both `generate_handlers` and `generate_router`; `needs_option` uses shared sub-checks for optional params/body
- **types.gleam**: `generate()` now calls `collect_operations` once; `generate_request_types` uses shared functions for `needs_option` and `needs_types` (removing ~45 lines of inline analysis)
- **client.gleam**: `needs_typed_schemas` and `needs_option` use shared functions (removing ~35 lines of inline analysis)
- **decoders.gleam**: `generate()` now calls `collect_operations` once and passes through `generate_decoders`/`generate_encoders` to `generate_anonymous_decoders`/`generate_anonymous_encoders`
- **validate.gleam**: `validate()` now calls `collect_operations` once and passes to `validate_operations` and `validate_security_schemes`
- **test**: 11 new unit tests for the `import_analysis` module covering empty inputs, positive/negative cases, Ref variants, ObjectSchema/AllOfSchema body types, and multi-operation aggregation

## Design Decisions

- Only truly duplicated predicates were extracted. Module-specific checks (e.g., server's decode_helpers-based type checks, client's dyn_decode/security checks) remain inline to avoid over-abstraction.
- Schema-based checks in `decoders.gleam` and `guards.gleam` operate on different data structures (component schemas vs operations), so they were not extracted into the shared module.

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code generation by computing operations once and reusing results across all generators instead of redundant recomputation.
  * Centralized import requirement detection logic into dedicated analysis module to reduce code duplication.

* **Tests**
  * Added comprehensive test coverage for new import analysis functionality, including schema reference detection, optional parameter and body handling, and multi-operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->