### PR TITLE
docs: recommend just all instead of just ci in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,10 @@ gleam deps download
 ### Verification
 
 ```bash
-just ci
+just all
 ```
+
+> **Note**: `just ci` runs only format check, typecheck, build, and unit tests. Use `just all` to also run ShellSpec CLI tests and integration tests.
 
 ## Development Workflow
 
@@ -108,7 +110,7 @@ We actively encourage the use of AI coding assistants to improve productivity an
 
 1. **Review all generated code**: Always review and understand AI-generated code before committing
 2. **Maintain consistency**: Ensure AI-generated code follows the coding standards described in this document and the project's conventions
-3. **Test thoroughly**: AI-generated code must pass `just ci`
+3. **Test thoroughly**: AI-generated code must pass `just all`
 
 ## Creating Pull Requests
 


### PR DESCRIPTION
## Summary

- Update CONTRIBUTING.md to recommend `just all` instead of `just ci` for full verification
- Add a note explaining that `just ci` is a subset that skips ShellSpec and integration tests

## Changes

- **Line 35 (Verification section)**: Changed `just ci` to `just all` and added explanatory note
- **Line 111 (AI-Assisted Development)**: Changed `just ci` to `just all` for test thoroughness guideline

## Design Decisions

- Chose Option 2 from the issue (update CONTRIBUTING.md) rather than Option 1 (modify `just ci` recipe), because changing the `just ci` recipe could affect existing CI workflows or contributor habits that depend on a fast subset check

Closes #64