### PR TITLE
docs: add platform guidance to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ pub fn list_pets(req: request_types.ListPetsRequest)
 
 ## Quickstart
 
-### Install from GitHub release
+### Install from GitHub release (Linux / macOS)
 
-Requires Erlang/OTP 27+.
+Requires Erlang/OTP 27+. The release binary is an Erlang escript that runs on any platform with Erlang installed.
 
 ```sh
 curl -fSL -o oaspec https://github.com/nao1215/oaspec/releases/latest/download/oaspec
@@ -88,17 +88,26 @@ chmod +x oaspec
 sudo mv oaspec /usr/local/bin/
 ```
 
-### Build from source
+> **Windows**: Download the `oaspec` file from the [latest release](https://github.com/nao1215/oaspec/releases/latest) and run it with `escript oaspec <command>`. Erlang/OTP 27+ must be on your `PATH`.
 
-Requires Gleam 1.15+, Erlang/OTP 27+, and `rebar3`.
+### Build from source (all platforms)
+
+Requires Gleam 1.15+, Erlang/OTP 27+, and `rebar3`. Works on Linux, macOS, and Windows.
 
 ```sh
 git clone https://github.com/nao1215/oaspec.git
 cd oaspec
 gleam deps download
 gleam run -m gleescript
+```
+
+On Linux/macOS, move the binary into your PATH:
+
+```sh
 sudo mv oaspec /usr/local/bin/
 ```
+
+On Windows, move `oaspec` to a directory on your `PATH` and run it with `escript oaspec <command>`.
 
 ### Generate code
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ chmod +x oaspec
 sudo mv oaspec /usr/local/bin/
 ```
 
-> **Windows**: Download the `oaspec` file from the [latest release](https://github.com/nao1215/oaspec/releases/latest) and run it with `escript oaspec <command>`. Erlang/OTP 27+ must be on your `PATH`.
+> On Windows, download `oaspec` from the [latest release](https://github.com/nao1215/oaspec/releases/latest) and run it with `escript oaspec <command>`. Erlang/OTP 27+ must be on your `PATH`.
 
 ### Build from source (all platforms)
 


### PR DESCRIPTION
## Summary

- Add platform labels and Windows guidance to the install instructions in README
- Clarify that the release binary is an Erlang escript (cross-platform with Erlang installed)

## Changes

- **Install from GitHub release**: Add "(Linux / macOS)" label, note that the binary is an Erlang escript, add Windows guidance (`escript oaspec <command>`)
- **Build from source**: Add "(all platforms)" label, separate the `sudo mv` step from the build commands, add Windows-specific instructions

## Design Decisions

- Kept the existing `curl | chmod | mv` pipeline as the primary path since it's the most common case
- Added Windows guidance as a blockquote note rather than a separate section, since the project doesn't provide a native Windows installer
- Noted `escript` as the Windows execution method since Erlang escripts have a Unix shebang header that doesn't work directly on Windows

Closes #62