### PR TITLE
docs: clarify OAuth2 and OpenID Connect security support scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Coverage is strongest in these areas:
 - Parameters: path, query, header, and cookie parameters, including array serialization and `style: deepObject`
 - Request bodies: `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data`
 - Responses: typed status-code variants, `$ref` responses, `default` responses, and text or binary passthrough cases
-- Security: `apiKey`, HTTP auth schemes, OAuth2, and OpenID Connect
+- Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code.
 - Generation safety: name collision handling, keyword escaping, validation guards, and capability errors with clear failure modes
 
 <!-- BEGIN GENERATED:BOUNDARIES -->

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -102,7 +102,7 @@ pub fn registry() -> List(Capability) {
     Capability("contentSchema", "schema", Unsupported, "Not supported"),
     // Security
     Capability("apiKey", "security", Supported, "Header, query, cookie"),
-    Capability("http", "security", Supported, "Bearer and basic auth"),
+    Capability("http", "security", Supported, "Bearer, basic, and digest auth"),
     Capability(
       "oauth2",
       "security",

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -103,8 +103,18 @@ pub fn registry() -> List(Capability) {
     // Security
     Capability("apiKey", "security", Supported, "Header, query, cookie"),
     Capability("http", "security", Supported, "Bearer and basic auth"),
-    Capability("oauth2", "security", Supported, "OAuth2 flows with scopes"),
-    Capability("openIdConnect", "security", Supported, "OpenID Connect"),
+    Capability(
+      "oauth2",
+      "security",
+      Supported,
+      "Bearer token attachment only; token acquisition and refresh are not generated",
+    ),
+    Capability(
+      "openIdConnect",
+      "security",
+      Supported,
+      "Bearer token attachment only; discovery and token acquisition are not generated",
+    ),
     Capability("mutualTLS", "security", Unsupported, "Not supported"),
     // Parameters
     Capability(


### PR DESCRIPTION
## Summary

- Clarify that OAuth2 and OpenID Connect support is limited to bearer token attachment
- Token acquisition, refresh, and flow execution are not part of the generated code

## Changes

- `src/oaspec/capability.gleam`: Update capability notes for `oauth2` and `openIdConnect` to state that only bearer token attachment is generated
- `README.md`: Expand the security line in the OpenAPI Support section to list specific scheme types and note the OAuth2/OpenID Connect limitation

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenAPI Security coverage: specified apiKey placement options (header/query/cookie), enumerated supported HTTP authentication schemes (bearer, basic, digest), and documented OAuth2/OpenID Connect limitations where bearer token attachment is generated but token management is not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->