### PR TITLE
fix(guards): generate pattern validation guards

### DIFF
--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -189,15 +189,17 @@ fn collect_schema_constraint_types(
     | Ok(ArraySchema(max_items: Some(_), ..))
     | Ok(ArraySchema(unique_items: True, ..)) ->
       ConstraintTypes(..acc, has_list: True)
-    Ok(ObjectSchema(min_properties: Some(_), ..))
-    | Ok(ObjectSchema(max_properties: Some(_), ..)) ->
-      ConstraintTypes(..acc, has_dict: True)
-    Ok(ObjectSchema(properties:, ..)) ->
+    Ok(ObjectSchema(properties:, min_properties:, max_properties:, ..)) -> {
+      let acc = case min_properties, max_properties {
+        None, None -> acc
+        _, _ -> ConstraintTypes(..acc, has_dict: True)
+      }
       dict.to_list(properties)
       |> list.fold(acc, fn(a, prop) {
         let #(_, prop_ref) = prop
         collect_schema_constraint_types(a, prop_ref, ctx)
       })
+    }
     Ok(AllOfSchema(schemas:, ..)) ->
       list.fold(schemas, acc, fn(a, s) {
         collect_schema_constraint_types(a, s, ctx)

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -165,13 +165,17 @@ fn collect_schema_constraint_types(
     Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
   }
   case schema {
-    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) ->
-      case min_length, max_length, pattern {
-        None, None, None -> acc
-        _, _, Some(_) ->
-          ConstraintTypes(..acc, has_string: True, has_regexp: True)
-        _, _, None -> ConstraintTypes(..acc, has_string: True)
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
+      let acc = case min_length, max_length {
+        None, None -> acc
+        _, _ -> ConstraintTypes(..acc, has_string: True)
       }
+
+      case pattern {
+        Some(_) -> ConstraintTypes(..acc, has_regexp: True)
+        None -> acc
+      }
+    }
     Ok(IntegerSchema(minimum: Some(_), ..))
     | Ok(IntegerSchema(maximum: Some(_), ..))
     | Ok(IntegerSchema(exclusive_minimum: Some(_), ..))
@@ -402,8 +406,8 @@ fn generate_string_pattern_guard(
     Some(pattern) -> {
       let fn_name = guard_function_name(schema_name, prop_name, "pattern")
       let pattern_literal = gleam_string_literal(pattern)
-      let invalid_pattern_message =
-        gleam_string_literal("invalid pattern: " <> pattern)
+      let invalid_pattern_prefix =
+        gleam_string_literal("invalid pattern: " <> pattern <> ": ")
       let mismatch_message =
         gleam_string_literal("must match pattern: " <> pattern)
       sb
@@ -421,7 +425,12 @@ fn generate_string_pattern_guard(
       |> se.indent(3, "True -> Ok(value)")
       |> se.indent(3, "False -> Error(" <> mismatch_message <> ")")
       |> se.indent(2, "}")
-      |> se.indent(2, "Error(_) -> Error(" <> invalid_pattern_message <> ")")
+      |> se.indent(
+        2,
+        "Error(regexp.CompileError(error:, ..)) -> Error("
+          <> invalid_pattern_prefix
+          <> " <> error)",
+      )
       |> se.indent(1, "}")
       |> se.line("}")
       |> se.blank_line()

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -52,6 +52,10 @@ fn generate_guards(ctx: Context) -> String {
     True -> ["gleam/string", ..imports]
     False -> imports
   }
+  let imports = case constraint_types.has_regexp {
+    True -> ["gleam/regexp", ..imports]
+    False -> imports
+  }
   let imports = case constraint_types.has_list {
     True -> ["gleam/list", ..imports]
     False -> imports
@@ -126,6 +130,7 @@ fn generate_guards(ctx: Context) -> String {
 type ConstraintTypes {
   ConstraintTypes(
     has_string: Bool,
+    has_regexp: Bool,
     has_integer: Bool,
     has_float: Bool,
     has_list: Bool,
@@ -141,7 +146,7 @@ fn collect_constraint_types(
 ) -> ConstraintTypes {
   list.fold(
     schemas,
-    ConstraintTypes(False, False, False, False, False, False),
+    ConstraintTypes(False, False, False, False, False, False, False),
     fn(acc, entry) {
       let #(_name, schema_ref) = entry
       collect_schema_constraint_types(acc, schema_ref, ctx)
@@ -160,9 +165,13 @@ fn collect_schema_constraint_types(
     Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
   }
   case schema {
-    Ok(StringSchema(min_length: Some(_), ..))
-    | Ok(StringSchema(max_length: Some(_), ..)) ->
-      ConstraintTypes(..acc, has_string: True)
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) ->
+      case min_length, max_length, pattern {
+        None, None, None -> acc
+        _, _, Some(_) ->
+          ConstraintTypes(..acc, has_string: True, has_regexp: True)
+        _, _, None -> ConstraintTypes(..acc, has_string: True)
+      }
     Ok(IntegerSchema(minimum: Some(_), ..))
     | Ok(IntegerSchema(maximum: Some(_), ..))
     | Ok(IntegerSchema(exclusive_minimum: Some(_), ..))
@@ -251,8 +260,10 @@ fn generate_guards_for_schema_object(
       })
     }
     // Top-level string/integer constraints (type aliases with constraints)
-    StringSchema(min_length:, max_length:, ..) ->
-      generate_string_guard(sb, name, "", min_length, max_length)
+    StringSchema(min_length:, max_length:, pattern:, ..) -> {
+      let sb = generate_string_guard(sb, name, "", min_length, max_length)
+      generate_string_pattern_guard(sb, name, "", pattern)
+    }
     IntegerSchema(
       minimum:,
       maximum:,
@@ -312,8 +323,17 @@ fn generate_field_guard(
     Reference(..) -> resolver.resolve_schema_ref(prop_ref, ctx.spec)
   }
   case resolved {
-    Ok(StringSchema(min_length:, max_length:, ..)) ->
-      generate_string_guard(sb, schema_name, prop_name, min_length, max_length)
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
+      let sb =
+        generate_string_guard(
+          sb,
+          schema_name,
+          prop_name,
+          min_length,
+          max_length,
+        )
+      generate_string_pattern_guard(sb, schema_name, prop_name, pattern)
+    }
     Ok(IntegerSchema(
       minimum:,
       maximum:,
@@ -365,6 +385,45 @@ fn generate_field_guard(
       generate_unique_items_guard(sb, schema_name, prop_name, unique_items)
     }
     _ -> sb
+  }
+}
+
+/// Generate a string pattern validation guard.
+fn generate_string_pattern_guard(
+  sb: se.StringBuilder,
+  schema_name: String,
+  prop_name: String,
+  pattern: Option(String),
+) -> se.StringBuilder {
+  case pattern {
+    None -> sb
+    Some(pattern) -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "pattern")
+      let pattern_literal = gleam_string_literal(pattern)
+      let invalid_pattern_message =
+        gleam_string_literal("invalid pattern: " <> pattern)
+      let mismatch_message =
+        gleam_string_literal("must match pattern: " <> pattern)
+      sb
+      |> se.line(
+        "/// Validate string pattern for "
+        <> schema_name
+        <> field_label(prop_name)
+        <> ".",
+      )
+      |> se.line(
+        "pub fn " <> fn_name <> "(value: String) -> Result(String, String) {",
+      )
+      |> se.indent(1, "case regexp.from_string(" <> pattern_literal <> ") {")
+      |> se.indent(2, "Ok(re) -> case regexp.check(re, value) {")
+      |> se.indent(3, "True -> Ok(value)")
+      |> se.indent(3, "False -> Error(" <> mismatch_message <> ")")
+      |> se.indent(2, "}")
+      |> se.indent(2, "Error(_) -> Error(" <> invalid_pattern_message <> ")")
+      |> se.indent(1, "}")
+      |> se.line("}")
+      |> se.blank_line()
+    }
   }
 }
 
@@ -1032,6 +1091,18 @@ fn field_label(prop_name: String) -> String {
   }
 }
 
+/// Render a runtime string literal for generated Gleam source.
+fn gleam_string_literal(value: String) -> String {
+  let escaped =
+    value
+    |> string.replace("\\", "\\\\")
+    |> string.replace("\"", "\\\"")
+    |> string.replace("\n", "\\n")
+    |> string.replace("\r", "\\r")
+    |> string.replace("\t", "\\t")
+  "\"" <> escaped <> "\""
+}
+
 /// Generate a composite validate function for a schema that calls all
 /// individual field validators. This enables auto-validation by calling
 /// a single function rather than individual field guards.
@@ -1166,13 +1237,21 @@ fn collect_guard_calls(
         collect_field_guard_calls(name, prop_name, prop_ref, is_required, ctx)
       })
     }
-    Ok(StringSchema(min_length:, max_length:, ..)) ->
-      case min_length, max_length {
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
+      let calls = case min_length, max_length {
         None, None -> []
         _, _ -> [
           #(guard_function_name(name, "", "length"), "value", True),
         ]
       }
+      case pattern {
+        None -> calls
+        Some(_) ->
+          list.append(calls, [
+            #(guard_function_name(name, "", "pattern"), "value", True),
+          ])
+      }
+    }
     Ok(IntegerSchema(
       minimum:,
       maximum:,
@@ -1264,8 +1343,8 @@ fn collect_field_guard_calls(
   }
   let accessor = "value." <> naming.to_snake_case(prop_name)
   case resolved {
-    Ok(StringSchema(min_length:, max_length:, ..)) ->
-      case min_length, max_length {
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
+      let calls = case min_length, max_length {
         None, None -> []
         _, _ -> [
           #(
@@ -1275,6 +1354,18 @@ fn collect_field_guard_calls(
           ),
         ]
       }
+      case pattern {
+        None -> calls
+        Some(_) ->
+          list.append(calls, [
+            #(
+              guard_function_name(schema_name, prop_name, "pattern"),
+              accessor,
+              is_required,
+            ),
+          ])
+      }
+    }
     Ok(IntegerSchema(
       minimum:,
       maximum:,

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1975,6 +1975,49 @@ components:
   |> should.be_true()
 }
 
+pub fn validate_object_property_count_still_collects_nested_string_constraints_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    User:
+      type: object
+      minProperties: 1
+      properties:
+        username:
+          type: string
+          minLength: 3
+          pattern: '^[a-zA-Z0-9_-]+$'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = guards.generate(ctx)
+  let assert [guard_file] = files
+
+  string.contains(guard_file.content, "import gleam/dict.{type Dict}")
+  |> should.be_true()
+  string.contains(guard_file.content, "import gleam/string")
+  |> should.be_true()
+  string.contains(guard_file.content, "import gleam/regexp")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_user_properties")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_user_username_length")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_user_username_pattern")
+  |> should.be_true()
+}
+
 // --- Feature: Callbacks are ignored during parsing (Phase 4-4) ---
 
 pub fn parse_ignores_callbacks_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1973,6 +1973,10 @@ components:
   |> should.be_true()
   string.contains(guard_file.content, "validate_username_pattern(value)")
   |> should.be_true()
+  string.contains(guard_file.content, "import gleam/regexp")
+  |> should.be_true()
+  string.contains(guard_file.content, "regexp.check(re, value)")
+  |> should.be_true()
 }
 
 pub fn validate_object_property_count_still_collects_nested_string_constraints_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1890,7 +1890,7 @@ webhooks:
 // --- Feature: Validation constraints generate guards (Phase 4-3) ---
 
 pub fn validate_constraints_generate_guards_test() {
-  // Schemas with minLength/maxLength/minimum/maximum should produce guard functions.
+  // Schemas with string and numeric constraints should produce guard functions.
   let yaml =
     "
 openapi: 3.0.3
@@ -1913,6 +1913,7 @@ components:
           type: string
           minLength: 3
           maxLength: 50
+          pattern: '^[a-zA-Z0-9]+$'
         age:
           type: integer
           minimum: 0
@@ -1932,7 +1933,45 @@ components:
   // Should contain validation functions for constrained fields
   string.contains(guard_file.content, "validate_user_username_length")
   |> should.be_true()
+  string.contains(guard_file.content, "validate_user_username_pattern")
+  |> should.be_true()
   string.contains(guard_file.content, "validate_user_age_range")
+  |> should.be_true()
+  string.contains(guard_file.content, "import gleam/regexp")
+  |> should.be_true()
+  string.contains(guard_file.content, "regexp.check(re, value)")
+  |> should.be_true()
+}
+
+pub fn validate_top_level_string_pattern_generates_guard_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Username:
+      type: string
+      pattern: '^[a-zA-Z0-9_-]+$'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = guards.generate(ctx)
+  let assert [guard_file] = files
+
+  string.contains(guard_file.content, "validate_username_pattern")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_username(value: String)")
+  |> should.be_true()
+  string.contains(guard_file.content, "validate_username_pattern(value)")
   |> should.be_true()
 }
 


### PR DESCRIPTION
## Summary
This PR makes generated guards honor `pattern` constraints on string schemas.
Field-level properties and top-level string aliases now emit regex-based validators, and composite validators invoke them automatically.

## Changes
- detect string `pattern` constraints when collecting generated guard imports and add `gleam/regexp` only when needed
- generate `validate_*_pattern` functions with escaped regex literals and explicit mismatch or invalid-pattern errors
- wire pattern validators into composite guard generation and add coverage for both object fields and top-level string aliases

## Design Decisions
- keep pattern validation separate from existing length validation so current guard names and call sites remain stable
- compile the regex inside each generated validator and return a guard error if the pattern cannot be compiled

## Limitations
- regexes are compiled per validation call; this keeps the change scoped to issue `#95` without reshaping generated module structure

Closes #95


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates runtime regex validators for string pattern constraints (top-level aliases and object fields); imports regex support only when needed, emits distinct errors for invalid regex vs mismatch, and preserves existing length validators and object property count handling.

* **Tests**
  * Added tests covering pattern-based validator generation for top-level strings and nested object properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->