### PR TITLE
test(escript): add packaged artifact smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,6 @@ jobs:
 
       - name: Build escript
         run: gleam run -m gleescript
+
+      - name: Smoke-test built escript
+        run: bash scripts/smoke_escript.sh ./oaspec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build escript binary
         run: gleam run -m gleescript
 
-      - name: Verify binary works
-        run: ./oaspec --help
+      - name: Smoke-test built escript
+        run: bash scripts/smoke_escript.sh ./oaspec
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ docs:
 escript:
   gleam run -m gleescript
 
-smoke-escript:
+smoke-escript: escript
   bash scripts/smoke_escript.sh ./oaspec
 
 shellspec:

--- a/justfile
+++ b/justfile
@@ -27,6 +27,9 @@ docs:
 escript:
   gleam run -m gleescript
 
+smoke-escript:
+  bash scripts/smoke_escript.sh ./oaspec
+
 shellspec:
   shellspec
 
@@ -50,6 +53,7 @@ all: clean deps
   shellspec
   bash integration_test/run.sh
   gleam run -m gleescript
+  bash scripts/smoke_escript.sh ./oaspec
   @echo ""
   @echo "All checks passed."
 

--- a/scripts/smoke_escript.sh
+++ b/scripts/smoke_escript.sh
@@ -76,7 +76,7 @@ if ! GENERATE_OUTPUT="$(cd "$PROJECT_ROOT" && "$ARTIFACT_PATH" generate --config
   printf "%s\n" "$GENERATE_OUTPUT" >&2
   fail "generate smoke test failed"
 fi
-assert_output_contains "$GENERATE_OUTPUT" "Successfully generated 17 files"
+assert_output_contains "$GENERATE_OUTPUT" "Successfully generated "
 assert_file "$PROJECT_ROOT/test_output/api/types.gleam"
 assert_file "$PROJECT_ROOT/test_output/api/router.gleam"
 assert_file "$PROJECT_ROOT/test_output_client/api/client.gleam"

--- a/scripts/smoke_escript.sh
+++ b/scripts/smoke_escript.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ARTIFACT_PATH="${1:-$PROJECT_ROOT/oaspec}"
+ARTIFACT_DIR="$(cd "$(dirname "$ARTIFACT_PATH")" && pwd)"
+ARTIFACT_PATH="$ARTIFACT_DIR/$(basename "$ARTIFACT_PATH")"
+SMOKE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/oaspec-escript-smoke.XXXXXX")"
+
+info() { echo "==> $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+assert_output_contains() {
+  local output="$1"
+  local expected="$2"
+  case "$output" in
+    *"$expected"*) ;;
+    *) fail "Expected output to include: $expected" ;;
+  esac
+}
+
+assert_file() {
+  local path="$1"
+  [ -f "$path" ] || fail "Expected file to exist: $path"
+}
+
+cleanup() {
+  clean_generated_outputs
+  rm -rf "$SMOKE_DIR"
+}
+
+clean_generated_outputs() {
+  rm -rf "$PROJECT_ROOT/test_output" "$PROJECT_ROOT/test_output_client"
+}
+
+trap cleanup EXIT
+
+if command -v mise >/dev/null 2>&1; then
+  for tool in escript gleam; do
+    TOOL_PATH="$(cd "$PROJECT_ROOT" && mise which "$tool" 2>/dev/null || true)"
+    if [ -n "$TOOL_PATH" ]; then
+      PATH="$(dirname "$TOOL_PATH"):$PATH"
+      export PATH
+    fi
+  done
+fi
+
+[ -f "$ARTIFACT_PATH" ] || fail "Artifact not found: $ARTIFACT_PATH"
+
+clean_generated_outputs
+
+info "Smoke-testing packaged escript: init"
+if ! INIT_OUTPUT="$(cd "$SMOKE_DIR" && "$ARTIFACT_PATH" init 2>&1)"; then
+  printf "%s\n" "$INIT_OUTPUT" >&2
+  fail "init smoke test failed"
+fi
+assert_output_contains "$INIT_OUTPUT" "Created ./oaspec.yaml"
+assert_file "$SMOKE_DIR/oaspec.yaml"
+grep -Fq "input: openapi.yaml" "$SMOKE_DIR/oaspec.yaml" || fail "Generated init config is missing input"
+grep -Fq "package: api" "$SMOKE_DIR/oaspec.yaml" || fail "Generated init config is missing package"
+
+info "Smoke-testing packaged escript: validate"
+if ! VALIDATE_OUTPUT="$(cd "$PROJECT_ROOT" && "$ARTIFACT_PATH" validate --config=test/fixtures/oaspec.yaml 2>&1)"; then
+  printf "%s\n" "$VALIDATE_OUTPUT" >&2
+  fail "validate smoke test failed"
+fi
+assert_output_contains "$VALIDATE_OUTPUT" "Validation passed."
+[ ! -e "$PROJECT_ROOT/test_output" ] || fail "validate should not create test_output"
+[ ! -e "$PROJECT_ROOT/test_output_client" ] || fail "validate should not create test_output_client"
+
+info "Smoke-testing packaged escript: generate"
+clean_generated_outputs
+if ! GENERATE_OUTPUT="$(cd "$PROJECT_ROOT" && "$ARTIFACT_PATH" generate --config=test/fixtures/oaspec.yaml 2>&1)"; then
+  printf "%s\n" "$GENERATE_OUTPUT" >&2
+  fail "generate smoke test failed"
+fi
+assert_output_contains "$GENERATE_OUTPUT" "Successfully generated 17 files"
+assert_file "$PROJECT_ROOT/test_output/api/types.gleam"
+assert_file "$PROJECT_ROOT/test_output/api/router.gleam"
+assert_file "$PROJECT_ROOT/test_output_client/api/client.gleam"
+
+info "Packaged escript smoke tests passed."


### PR DESCRIPTION
## Summary
Add a lightweight smoke test that exercises the packaged `oaspec` escript through representative CLI commands instead of only checking `--help`.
Wire the same smoke test into local `just` commands, CI, and the release workflow so packaging regressions are caught earlier.

## Changes
- add `scripts/smoke_escript.sh` to verify `init`, `validate`, and `generate` against the built artifact
- add `just smoke-escript` and include the smoke test in `just all`
- run the smoke test after escript build in CI and release workflows

## Design Decisions
- keep the coverage intentionally narrow and fast so it validates artifact behavior without duplicating ShellSpec and integration coverage
- resolve `gleam` and `escript` via `mise` when available so the smoke test works in local environments and CI

Closes #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated smoke-test script and integrated it into CI, release, and local build recipes.
  * CI and release flows now run the smoke test after building artifacts to verify initialization, validation, and generation steps succeed and expected outputs are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->