### PR TITLE
feat(client): generate with_* auth configuration helpers for ClientConfig

### DIFF
--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -365,6 +365,9 @@ fn generate_client(ctx: Context) -> String {
     |> se.line("}")
     |> se.blank_line()
 
+  // Generate with_* helpers for security scheme configuration
+  let sb = generate_with_helpers(sb, security_schemes)
+
   // Generate default_base_url function from server template variables
   let sb = generate_default_base_url(sb, ctx)
 
@@ -907,4 +910,76 @@ fn generate_client_function(
   sb
   |> se.line("}")
   |> se.blank_line()
+}
+
+/// Generate with_* helper functions for security scheme configuration.
+fn generate_with_helpers(
+  sb: se.StringBuilder,
+  security_schemes: List(#(String, spec.RefOr(spec.SecurityScheme))),
+) -> se.StringBuilder {
+  list.fold(security_schemes, sb, fn(sb, entry) {
+    let #(scheme_name, scheme_ref) = entry
+    let field_name = naming.to_snake_case(scheme_name)
+    let doc = scheme_doc_comment(scheme_name, scheme_ref)
+    sb
+    |> se.doc_comment(doc)
+    |> se.line(
+      "pub fn with_"
+      <> field_name
+      <> "(config: ClientConfig, token: String) -> ClientConfig {",
+    )
+    |> se.indent(1, "ClientConfig(..config, " <> field_name <> ": Some(token))")
+    |> se.line("}")
+    |> se.blank_line()
+  })
+}
+
+/// Build a doc comment describing a security scheme helper.
+fn scheme_doc_comment(
+  scheme_name: String,
+  scheme_ref: spec.RefOr(spec.SecurityScheme),
+) -> String {
+  case scheme_ref {
+    spec.Value(spec.ApiKeyScheme(name: key_name, in_: spec.SchemeInHeader)) ->
+      "Set the API key for the "
+      <> scheme_name
+      <> " security scheme (header: "
+      <> key_name
+      <> ")."
+    spec.Value(spec.ApiKeyScheme(name: key_name, in_: spec.SchemeInQuery)) ->
+      "Set the API key for the "
+      <> scheme_name
+      <> " security scheme (query: "
+      <> key_name
+      <> ")."
+    spec.Value(spec.ApiKeyScheme(name: key_name, in_: spec.SchemeInCookie)) ->
+      "Set the API key for the "
+      <> scheme_name
+      <> " security scheme (cookie: "
+      <> key_name
+      <> ")."
+    spec.Value(spec.HttpScheme(scheme: "bearer", ..)) ->
+      "Set the bearer token for the " <> scheme_name <> " security scheme."
+    spec.Value(spec.HttpScheme(scheme: "basic", ..)) ->
+      "Set the basic auth credentials for the "
+      <> scheme_name
+      <> " security scheme."
+    spec.Value(spec.HttpScheme(scheme: "digest", ..)) ->
+      "Set the digest auth credentials for the "
+      <> scheme_name
+      <> " security scheme."
+    spec.Value(spec.HttpScheme(scheme: http_scheme, ..)) ->
+      "Set the token for the "
+      <> scheme_name
+      <> " security scheme ("
+      <> http_scheme
+      <> " auth)."
+    spec.Value(spec.OAuth2Scheme(..)) ->
+      "Set the OAuth2 token for the " <> scheme_name <> " security scheme."
+    spec.Value(spec.OpenIdConnectScheme(..)) ->
+      "Set the OpenID Connect token for the "
+      <> scheme_name
+      <> " security scheme."
+    _ -> "Set the credential for the " <> scheme_name <> " security scheme."
+  }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13110,8 +13110,10 @@ paths:
   let files = client_gen.generate(ctx)
   let assert [client_file] = files
   let content = client_file.content
-  // No with_* helpers should be present
-  string.contains(content, "pub fn with_")
+  // No auth with_* helpers should be present
+  string.contains(content, "pub fn with_api_key_auth(")
+  |> should.be_false()
+  string.contains(content, "pub fn with_bearer_auth(")
   |> should.be_false()
 }
 
@@ -13144,10 +13146,13 @@ security:
   let files = client_gen.generate(ctx)
   let assert [client_file] = files
   let content = client_file.content
-  // with_bearer_auth must come before default_base_url
+  // new must come before with_bearer_auth, which must come before default_base_url
+  let assert Ok(new_pos) =
+    find_substring_index(content, "pub fn new(")
   let assert Ok(with_pos) =
     find_substring_index(content, "pub fn with_bearer_auth(")
   let assert Ok(base_url_pos) =
     find_substring_index(content, "pub fn default_base_url(")
+  should.be_true(new_pos < with_pos)
   should.be_true(with_pos < base_url_pos)
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13147,8 +13147,7 @@ security:
   let assert [client_file] = files
   let content = client_file.content
   // new must come before with_bearer_auth, which must come before default_base_url
-  let assert Ok(new_pos) =
-    find_substring_index(content, "pub fn new(")
+  let assert Ok(new_pos) = find_substring_index(content, "pub fn new(")
   let assert Ok(with_pos) =
     find_substring_index(content, "pub fn with_bearer_auth(")
   let assert Ok(base_url_pos) =

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -12888,3 +12888,266 @@ paths:
   )
   |> should.be_true()
 }
+
+// --- with_* auth configuration helper tests ---
+
+pub fn with_helpers_generated_for_api_key_and_bearer_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    BearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - ApiKeyAuth: []
+  - BearerAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  // with_api_key_auth helper must be generated
+  string.contains(
+    content,
+    "pub fn with_api_key_auth(config: ClientConfig, token: String) -> ClientConfig {",
+  )
+  |> should.be_true()
+  string.contains(content, "ClientConfig(..config, api_key_auth: Some(token))")
+  |> should.be_true()
+  // with_bearer_auth helper must be generated
+  string.contains(
+    content,
+    "pub fn with_bearer_auth(config: ClientConfig, token: String) -> ClientConfig {",
+  )
+  |> should.be_true()
+  string.contains(content, "ClientConfig(..config, bearer_auth: Some(token))")
+  |> should.be_true()
+}
+
+pub fn with_helpers_doc_comment_for_api_key_header_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - ApiKeyAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  string.contains(
+    content,
+    "/// Set the API key for the ApiKeyAuth security scheme (header: X-API-Key).",
+  )
+  |> should.be_true()
+}
+
+pub fn with_helpers_doc_comment_for_api_key_query_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    QueryAuth:
+      type: apiKey
+      in: query
+      name: api_key
+security:
+  - QueryAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  string.contains(
+    content,
+    "/// Set the API key for the QueryAuth security scheme (query: api_key).",
+  )
+  |> should.be_true()
+  string.contains(
+    content,
+    "pub fn with_query_auth(config: ClientConfig, token: String) -> ClientConfig {",
+  )
+  |> should.be_true()
+}
+
+pub fn with_helpers_doc_comment_for_cookie_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    CookieAuth:
+      type: apiKey
+      in: cookie
+      name: session_id
+security:
+  - CookieAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  string.contains(
+    content,
+    "/// Set the API key for the CookieAuth security scheme (cookie: session_id).",
+  )
+  |> should.be_true()
+}
+
+pub fn with_helpers_doc_comment_for_oauth2_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    OAuth2Auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            read: Read access
+security:
+  - OAuth2Auth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  string.contains(
+    content,
+    "/// Set the OAuth2 token for the OAuth2Auth security scheme.",
+  )
+  |> should.be_true()
+}
+
+pub fn with_helpers_not_generated_when_no_security_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  // No with_* helpers should be present
+  string.contains(content, "pub fn with_")
+  |> should.be_false()
+}
+
+pub fn with_helpers_appear_before_default_base_url_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - BearerAuth: []
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  let content = client_file.content
+  // with_bearer_auth must come before default_base_url
+  let assert Ok(with_pos) =
+    find_substring_index(content, "pub fn with_bearer_auth(")
+  let assert Ok(base_url_pos) =
+    find_substring_index(content, "pub fn default_base_url(")
+  should.be_true(with_pos < base_url_pos)
+}


### PR DESCRIPTION
## Summary
- Generate `with_<scheme_name>` helper functions for each security scheme in the OpenAPI spec
- Each helper sets the credential on `ClientConfig` and returns the updated config (builder pattern)
- Doc comments describe the scheme type and relevant details (e.g., header name, query parameter name)

## Changes
- **`src/oaspec/codegen/client.gleam`**: Added `generate_with_helpers` and `scheme_doc_comment` functions that iterate over security schemes and emit `with_*` functions with scheme-specific doc comments after the `new()` constructor
- **`test/oaspec_test.gleam`**: Added 7 tests covering API key (header/query/cookie), bearer, OAuth2, no-security, and ordering

## Design Decisions
- Helpers use the simple record update pattern (`ClientConfig(..config, field: Some(token))`) — idiomatic Gleam, zero overhead
- No `clear_*` functions — users can use `ClientConfig(..config, field: None)` directly, keeping the generated API surface minimal
- Doc comments vary by scheme type to provide actionable context (e.g., which header name to use for API key auth)
- Helpers are generated between `new()` and `default_base_url()` so they group naturally with config construction

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client libraries now include per-security-scheme "with_*" helper methods to set credentials on the client config, with contextual doc comments for common scheme types (API Key, Bearer, OAuth2, OpenID Connect, etc.).

* **Tests**
  * Added tests ensuring helpers are generated (or not), emit correct doc text, and appear in the expected order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->