### PR TITLE
ci(release): add missing checks to match main CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,31 @@ jobs:
           wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
           chmod +x /usr/local/bin/rebar3
 
-      - run: gleam deps download
-      - run: gleam format --check src/ test/
-      - run: gleam build --warnings-as-errors
-      - run: gleam test
+      - name: Install ShellSpec
+        run: |
+          curl -fsSL https://git.io/shellspec | sh -s -- --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Download dependencies
+        run: gleam deps download
+
+      - name: Format check
+        run: gleam format --check src/ test/
+
+      - name: Type check
+        run: gleam check
+
+      - name: Build (warnings as errors)
+        run: gleam build --warnings-as-errors
+
+      - name: Unit tests
+        run: gleam test
+
+      - name: ShellSpec tests
+        run: shellspec
+
+      - name: Integration tests
+        run: bash integration_test/run.sh
 
       - name: Build escript binary
         run: gleam run -m gleescript


### PR DESCRIPTION
## Summary
- Add the missing ShellSpec and integration test steps to the release workflow's build job
- Ensure the release pipeline exercises the same validation surface as the main CI before publishing

## Changes
- **`.github/workflows/release.yml`**: Added ShellSpec installation, `gleam check` (type check), `shellspec` tests, and `bash integration_test/run.sh` to the `build` job, matching the exact check sequence in `ci.yml`

## Design Decisions
- Added individual steps rather than using `just all`, because `just all` starts with `clean` which would delete build artifacts mid-workflow
- Matched the exact step names and order from `ci.yml` for consistency and easy auditing
- Kept the scope minimal — only the release workflow is changed, CI remains untouched

Closes #101