### PR TITLE
feat(content-type): support JSON/XML structured syntax suffix media types

### DIFF
--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -156,6 +156,12 @@ pub fn registry() -> List(Capability) {
       "Form bodies",
     ),
     Capability("multipart/form-data", "request", Supported, "Multipart upload"),
+    Capability(
+      "+json/+xml suffix",
+      "content-type",
+      Supported,
+      "Structured syntax suffix media types (e.g. application/problem+json)",
+    ),
     // Responses
     Capability("application/json", "response", Supported, "JSON responses"),
     Capability("text/plain", "response", Supported, "Text passthrough"),

--- a/src/oaspec/codegen/client_response.gleam
+++ b/src/oaspec/codegen/client_response.gleam
@@ -3,6 +3,7 @@ import oaspec/codegen/context.{type Context}
 import oaspec/codegen/schema_dispatch
 import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec
+import oaspec/util/content_type
 import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
@@ -17,8 +18,11 @@ pub fn generate_single_content_response(
   op_id: String,
   ctx: Context,
 ) -> se.StringBuilder {
-  case media_type_name {
-    "text/plain" | "application/xml" | "text/xml" | "application/octet-stream" ->
+  case content_type.from_string(media_type_name) {
+    content_type.TextPlain
+    | content_type.ApplicationXml
+    | content_type.TextXml
+    | content_type.ApplicationOctetStream ->
       case media_type.schema {
         Some(_) ->
           sb

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -9,6 +9,7 @@ import oaspec/codegen/server_request_decode as decode_helpers
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec.{type Resolved, Value}
+import oaspec/util/content_type
 import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
@@ -411,13 +412,13 @@ fn generate_router(
             let content_entries = dict.to_list(response.content)
             case content_entries {
               [#(media_type_name, media_type)] ->
-                case media_type_name {
-                  "application/json" ->
+                case content_type.is_json_compatible(media_type_name) {
+                  True ->
                     case media_type.schema {
                       Some(_) -> True
                       None -> False
                     }
-                  _ -> False
+                  False -> False
                 }
               _ -> False
             }
@@ -434,7 +435,7 @@ fn generate_router(
         Some(Value(rb)) ->
           list.any(dict.to_list(rb.content), fn(entry) {
             let #(content_type, _) = entry
-            content_type == "application/json"
+            content_type.is_json_compatible(content_type)
           })
         _ -> False
       }
@@ -1051,8 +1052,8 @@ fn generate_response_conversion(
                       <> ", body: \"\", headers: [])",
                   )
                 [#(media_type_name, media_type)] ->
-                  case media_type_name {
-                    "application/json" ->
+                  case content_type.from_string(media_type_name) {
+                    content_type.ApplicationJson ->
                       case media_type.schema {
                         Some(_) -> {
                           let encode_fn =
@@ -1066,7 +1067,9 @@ fn generate_response_conversion(
                               <> status_int
                               <> ", body: json.to_string("
                               <> encode_fn
-                              <> "(data)), headers: [#(\"content-type\", \"application/json\")])",
+                              <> "(data)), headers: [#(\"content-type\", \""
+                              <> media_type_name
+                              <> "\")])",
                           )
                         }
                         None ->
@@ -1080,10 +1083,10 @@ fn generate_response_conversion(
                               <> ", body: \"\", headers: [])",
                           )
                       }
-                    "text/plain"
-                    | "application/xml"
-                    | "text/xml"
-                    | "application/octet-stream" ->
+                    content_type.TextPlain
+                    | content_type.ApplicationXml
+                    | content_type.TextXml
+                    | content_type.ApplicationOctetStream ->
                       case media_type.schema {
                         Some(_) ->
                           sb

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -10,6 +10,7 @@ import oaspec/openapi/schema.{
   Reference, Untyped,
 }
 import oaspec/openapi/spec.{type Resolved, Value}
+import oaspec/util/content_type
 import oaspec/util/naming
 
 /// Expression that case-insensitively parses a string to Bool.
@@ -1436,37 +1437,46 @@ pub fn generate_body_decode_expr(
 ) -> String {
   let content_entries = dict.to_list(rb.content)
   case content_entries {
-    [#("application/json", media_type)] -> {
-      let decode_fn = case media_type.schema {
-        Some(Reference(name:, ..)) ->
-          "decode.decode_" <> naming.to_snake_case(name) <> "(body)"
-        _ ->
-          "decode.decode_"
-          <> naming.to_snake_case(op_id)
-          <> "_request_body(body)"
+    [#(ct_name, media_type)] ->
+      case content_type.from_string(ct_name) {
+        content_type.ApplicationJson -> {
+          let decode_fn = case media_type.schema {
+            Some(Reference(name:, ..)) ->
+              "decode.decode_" <> naming.to_snake_case(name) <> "(body)"
+            _ ->
+              "decode.decode_"
+              <> naming.to_snake_case(op_id)
+              <> "_request_body(body)"
+          }
+          case rb.required {
+            True -> "{ let assert Ok(decoded) = " <> decode_fn <> " decoded }"
+            False ->
+              "case body { \"\" -> None _ -> { case "
+              <> decode_fn
+              <> " { Ok(decoded) -> Some(decoded) _ -> None } } }"
+          }
+        }
+        content_type.FormUrlEncoded -> {
+          let body_expr = form_urlencoded_body_constructor_expr(rb, op_id, ctx)
+          case rb.required {
+            True -> body_expr
+            False -> "case body { \"\" -> None _ -> Some(" <> body_expr <> ") }"
+          }
+        }
+        content_type.MultipartFormData -> {
+          let body_expr = multipart_body_constructor_expr(rb, op_id, ctx)
+          case rb.required {
+            True -> body_expr
+            False -> "case body { \"\" -> None _ -> Some(" <> body_expr <> ") }"
+          }
+        }
+        _ -> {
+          case rb.required {
+            True -> "body"
+            False -> "case body { \"\" -> None _ -> Some(body) }"
+          }
+        }
       }
-      case rb.required {
-        True -> "{ let assert Ok(decoded) = " <> decode_fn <> " decoded }"
-        False ->
-          "case body { \"\" -> None _ -> { case "
-          <> decode_fn
-          <> " { Ok(decoded) -> Some(decoded) _ -> None } } }"
-      }
-    }
-    [#("application/x-www-form-urlencoded", _media_type)] -> {
-      let body_expr = form_urlencoded_body_constructor_expr(rb, op_id, ctx)
-      case rb.required {
-        True -> body_expr
-        False -> "case body { \"\" -> None _ -> Some(" <> body_expr <> ") }"
-      }
-    }
-    [#("multipart/form-data", _media_type)] -> {
-      let body_expr = multipart_body_constructor_expr(rb, op_id, ctx)
-      case rb.required {
-        True -> body_expr
-        False -> "case body { \"\" -> None _ -> Some(" <> body_expr <> ") }"
-      }
-    }
     _ -> {
       case rb.required {
         True -> "body"

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -15,6 +15,7 @@ import oaspec/openapi/schema.{
   Reference, StringSchema,
 }
 import oaspec/openapi/spec.{type Resolved, Value}
+import oaspec/util/content_type
 import oaspec/util/http
 import oaspec/util/naming
 import oaspec/util/string_extra as se
@@ -277,11 +278,11 @@ fn responses_need_types_import(
             [] -> False
             [_, _, ..] -> False
             [#(media_type_name, media_type)] ->
-              case media_type_name {
-                "text/plain"
-                | "application/xml"
-                | "text/xml"
-                | "application/octet-stream" -> False
+              case content_type.from_string(media_type_name) {
+                content_type.TextPlain
+                | content_type.ApplicationXml
+                | content_type.TextXml
+                | content_type.ApplicationOctetStream -> False
                 _ ->
                   case media_type.schema {
                     Some(Reference(..)) -> True
@@ -353,12 +354,12 @@ fn generate_response_type(
                 // since different media types may decode to different Gleam types
                 [_, _, ..] -> sb |> se.indent(1, variant_name <> "(String)")
                 [#(media_type_name, media_type)] ->
-                  case media_type_name {
+                  case content_type.from_string(media_type_name) {
                     // text/plain, XML, octet-stream: always use String type
-                    "text/plain"
-                    | "application/xml"
-                    | "text/xml"
-                    | "application/octet-stream" ->
+                    content_type.TextPlain
+                    | content_type.ApplicationXml
+                    | content_type.TextXml
+                    | content_type.ApplicationOctetStream ->
                       case media_type.schema {
                         Some(_) ->
                           sb

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -467,9 +467,9 @@ fn validate_request_body(
             path: op_id <> ".requestBody",
             detail: "Content type '"
               <> media_type
-              <> "' is not supported. Supported request content types: application/json, multipart/form-data, application/x-www-form-urlencoded.",
+              <> "' is not supported. Supported request content types: application/json (and +json suffix types), multipart/form-data, application/x-www-form-urlencoded.",
             hint: Some(
-              "Use application/json, multipart/form-data, or application/x-www-form-urlencoded.",
+              "Use application/json (or a +json suffix type like application/problem+json), multipart/form-data, or application/x-www-form-urlencoded.",
             ),
           ),
         ]
@@ -846,9 +846,9 @@ fn validate_responses(
             path: path,
             detail: "Response content type '"
               <> media_type_name
-              <> "' is not supported. Supported response content types: application/json, text/plain, application/octet-stream, application/xml, text/xml.",
+              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/octet-stream, application/xml (and +xml suffix types), text/xml.",
             hint: Some(
-              "Use application/json, text/plain, application/octet-stream, application/xml, or text/xml.",
+              "Use application/json (or a +json suffix type), text/plain, application/octet-stream, application/xml (or a +xml suffix type), or text/xml.",
             ),
           ),
         ]

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -1,3 +1,5 @@
+import gleam/string
+
 /// Supported content types for code generation.
 pub type ContentType {
   ApplicationJson
@@ -11,6 +13,8 @@ pub type ContentType {
 }
 
 /// Parse a content type string into a ContentType.
+/// Recognizes structured syntax suffixes: types ending with `+json` are
+/// treated as JSON-compatible, and types ending with `+xml` as XML-compatible.
 pub fn from_string(content_type: String) -> ContentType {
   case content_type {
     "application/json" -> ApplicationJson
@@ -20,8 +24,28 @@ pub fn from_string(content_type: String) -> ContentType {
     "application/octet-stream" -> ApplicationOctetStream
     "application/xml" -> ApplicationXml
     "text/xml" -> TextXml
-    other -> UnsupportedContentType(other)
+    other ->
+      case string.ends_with(other, "+json") {
+        True -> ApplicationJson
+        False ->
+          case string.ends_with(other, "+xml") {
+            True -> ApplicationXml
+            False -> UnsupportedContentType(other)
+          }
+      }
   }
+}
+
+/// Check if a content type string is JSON-compatible.
+/// Matches "application/json" and any type with a "+json" suffix.
+pub fn is_json_compatible(s: String) -> Bool {
+  s == "application/json" || string.ends_with(s, "+json")
+}
+
+/// Check if a content type string is XML-compatible.
+/// Matches "application/xml", "text/xml", and any type with a "+xml" suffix.
+pub fn is_xml_compatible(s: String) -> Bool {
+  s == "application/xml" || s == "text/xml" || string.ends_with(s, "+xml")
 }
 
 /// Convert a ContentType back to its string representation.

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -8217,18 +8217,15 @@ pub fn oss_oapi_codegen_issue_1168_allof_discriminator_parses_test() {
   dict.size(components.schemas) |> should.not_equal(0)
 }
 
-pub fn oss_oapi_codegen_issue_1168_rejects_problem_json_test() {
-  // application/problem+json is not a supported response content type.
-  // With lazy ref resolution, inline $ref responses are kept as Ref(...).
-  // The full generate pipeline resolves them and catches validation errors.
+pub fn oss_oapi_codegen_issue_1168_problem_json_generates_test() {
+  // application/problem+json is now supported as a JSON-compatible suffix type.
+  // The full generate pipeline should succeed without validation errors.
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1168.yaml")
   let result = generate.generate(spec, make_ctx_from_spec(spec).config)
   case result {
-    Error(generate.ValidationErrors(errors)) ->
-      list.length(errors) |> should.not_equal(0)
-    // If codegen succeeds with warnings, that's also acceptable
-    Ok(summary) -> list.length(summary.warnings) |> should.not_equal(0)
+    Ok(_summary) -> should.be_true(True)
+    Error(_) -> should.be_true(False)
   }
 }
 
@@ -13154,4 +13151,144 @@ security:
     find_substring_index(content, "pub fn default_base_url(")
   should.be_true(new_pos < with_pos)
   should.be_true(with_pos < base_url_pos)
+}
+
+// --- content_type structured syntax suffix tests ---
+
+pub fn content_type_from_string_problem_json_test() {
+  content_type.from_string("application/problem+json")
+  |> should.equal(content_type.ApplicationJson)
+}
+
+pub fn content_type_from_string_json_patch_json_test() {
+  content_type.from_string("application/json-patch+json")
+  |> should.equal(content_type.ApplicationJson)
+}
+
+pub fn content_type_from_string_vendor_json_test() {
+  content_type.from_string("application/vnd.api+json")
+  |> should.equal(content_type.ApplicationJson)
+}
+
+pub fn content_type_from_string_soap_xml_test() {
+  content_type.from_string("application/soap+xml")
+  |> should.equal(content_type.ApplicationXml)
+}
+
+pub fn content_type_from_string_plain_json_unchanged_test() {
+  content_type.from_string("application/json")
+  |> should.equal(content_type.ApplicationJson)
+}
+
+pub fn content_type_from_string_unsupported_unchanged_test() {
+  content_type.from_string("image/png")
+  |> should.equal(content_type.UnsupportedContentType("image/png"))
+}
+
+pub fn content_type_is_json_compatible_true_test() {
+  content_type.is_json_compatible("application/problem+json")
+  |> should.be_true()
+}
+
+pub fn content_type_is_json_compatible_plain_json_test() {
+  content_type.is_json_compatible("application/json")
+  |> should.be_true()
+}
+
+pub fn content_type_is_json_compatible_false_test() {
+  content_type.is_json_compatible("text/plain")
+  |> should.be_false()
+}
+
+pub fn content_type_is_xml_compatible_suffix_test() {
+  content_type.is_xml_compatible("application/soap+xml")
+  |> should.be_true()
+}
+
+pub fn content_type_is_xml_compatible_plain_xml_test() {
+  content_type.is_xml_compatible("application/xml")
+  |> should.be_true()
+}
+
+pub fn content_type_is_xml_compatible_false_test() {
+  content_type.is_xml_compatible("application/json")
+  |> should.be_false()
+}
+
+pub fn json_suffix_request_body_validates_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /errors:
+    post:
+      operationId: reportError
+      requestBody:
+        required: true
+        content:
+          application/problem+json:
+            schema:
+              $ref: '#/components/schemas/Problem'
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Problem:
+      type: object
+      properties:
+        title:
+          type: string
+        status:
+          type: integer
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  // Should generate client code without validation errors
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  // The content-type header should use the original media type
+  string.contains(client_file.content, "application/problem+json")
+  |> should.be_true()
+}
+
+pub fn json_suffix_response_generates_typed_decode_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /errors:
+    get:
+      operationId: getError
+      responses:
+        '200':
+          description: ok
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+components:
+  schemas:
+    Problem:
+      type: object
+      properties:
+        title:
+          type: string
+        status:
+          type: integer
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+  // Should use JSON decode (not string passthrough)
+  string.contains(client_file.content, "decode.decode_problem(resp.body)")
+  |> should.be_true()
 }


### PR DESCRIPTION
## Summary
- Support structured syntax suffix media types like `application/problem+json` and `application/vnd.api+json`
- Types ending with `+json` are treated as JSON-compatible, types ending with `+xml` as XML-compatible

## Changes
- **`src/oaspec/util/content_type.gleam`**: Enhanced `from_string` to recognize `+json`/`+xml` suffixes; added `is_json_compatible` and `is_xml_compatible` helper functions
- **`src/oaspec/codegen/server_request_decode.gleam`**: Replaced exact string matching with `content_type.from_string` for body decode dispatch
- **`src/oaspec/codegen/server.gleam`**: Replaced exact `"application/json"` checks with `content_type.is_json_compatible` and `content_type.from_string`
- **`src/oaspec/codegen/client_response.gleam`**: Replaced string pattern matching with `content_type.from_string` for response type dispatch
- **`src/oaspec/codegen/types.gleam`**: Replaced string pattern matching with `content_type.from_string` for response variant type determination
- **`src/oaspec/codegen/validate.gleam`**: Updated error messages to mention `+json`/`+xml` suffix support
- **`src/oaspec/capability.gleam`**: Added capability entry for structured syntax suffix types
- **`test/oaspec_test.gleam`**: Added 14 tests for suffix parsing, compatibility checks, and end-to-end generation; updated existing test that previously expected rejection of `application/problem+json`

## Design Decisions
- Enhanced `from_string` to map suffixed types to existing `ContentType` variants (e.g., `ApplicationJson`) rather than adding new variants, so all downstream code works automatically
- Added `is_json_compatible`/`is_xml_compatible` helpers for code gen sites that need to check raw strings
- Preserved original media type strings in generated content-type headers (e.g., server responses use `application/problem+json`, not `application/json`)

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured syntax suffix media types (e.g., `application/problem+json`, `application/soap+xml`)
  * Content types with `+json` and `+xml` suffixes are now recognized in request and response handling

* **Bug Fixes**
  * Fixed validation and code generation to properly support vendor-specific and suffix-based content types

* **Tests**
  * Added comprehensive tests for structured syntax media type compatibility and code generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->