### PR TITLE
feat(guard): integrate generated guards into client/server execution flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 598 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 608 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 608 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 609 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -63,6 +63,14 @@ fn generate_command() -> glint.Command(Nil) {
       |> glint.flag_help("Treat warnings as errors"),
     )
 
+    use validate <- glint.flag(
+      glint.bool_flag("validate")
+      |> glint.flag_default(False)
+      |> glint.flag_help(
+        "Enable guard validation in generated server/client code",
+      ),
+    )
+
     glint.command_help(
       "Generate Gleam code from an OpenAPI specification",
       fn() {
@@ -79,6 +87,7 @@ fn generate_command() -> glint.Command(Nil) {
           let check_mode = check(flags) |> result.unwrap(False)
           let fail_on_warnings_mode =
             fail_on_warnings(flags) |> result.unwrap(False)
+          let validate_mode = validate(flags) |> result.unwrap(False)
 
           run_generate(
             config_path,
@@ -86,6 +95,7 @@ fn generate_command() -> glint.Command(Nil) {
             output_opt,
             check_mode,
             fail_on_warnings_mode,
+            validate_mode,
           )
         })
       },
@@ -164,6 +174,12 @@ package: api
 # Generation mode: server, client, or both (default: both).
 # mode: both
 
+# Enable guard validation in generated server/client code (default: false).
+# When enabled, generated routers validate request bodies against schema
+# constraints and return 422 on failure. Generated clients validate
+# request bodies before sending.
+# validate: false
+
 # Output settings (optional).
 # output:
 #   dir: ./gen                    # Base output directory (default: ./gen)
@@ -197,6 +213,7 @@ fn run_generate(
   output_opt: Option(String),
   check_mode: Bool,
   fail_on_warnings: Bool,
+  validate_mode: Bool,
 ) -> Nil {
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
@@ -204,6 +221,10 @@ fn run_generate(
   use cfg <- require(load_config(config_path, mode_opt, output_opt), fn(msg) {
     "Error: " <> msg
   })
+  let cfg = case validate_mode {
+    True -> config.with_validate(cfg, True)
+    False -> cfg
+  }
 
   io.println("Parsing OpenAPI spec: " <> cfg.input)
   use spec <- require(parser.parse_file(cfg.input), fn(e) {

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -6,6 +6,7 @@ import oaspec/codegen/client_request
 import oaspec/codegen/client_response
 import oaspec/codegen/client_security
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
 import oaspec/openapi/operations
@@ -278,6 +279,31 @@ fn generate_client(ctx: Context) -> String {
     }
     False -> imports
   }
+  // Import guards module when validation is enabled and any operation body has validators
+  let needs_guards =
+    ctx.config.validate
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) -> {
+          let content_entries = dict.to_list(rb.content)
+          case content_entries {
+            [#(_, mt)] ->
+              case mt.schema {
+                Some(schema.Reference(name:, ..)) ->
+                  guards.schema_has_validator(name, ctx)
+                _ -> False
+              }
+            _ -> False
+          }
+        }
+        _ -> False
+      }
+    })
+  let imports = case needs_guards {
+    True -> [ctx.config.package <> "/guards", ..imports]
+    False -> imports
+  }
 
   let sb =
     se.file_header(context.version)
@@ -335,6 +361,12 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(1, "ConnectionError(detail: String)")
     |> se.indent(1, "TimeoutError")
     |> se.indent(1, "DecodeError(detail: String)")
+  let sb = case ctx.config.validate {
+    True -> sb |> se.indent(1, "ValidationError(errors: List(String))")
+    False -> sb
+  }
+  let sb =
+    sb
     |> se.line("}")
     |> se.blank_line()
 
@@ -537,6 +569,59 @@ fn generate_client_function(
       <> response_type
       <> ", ClientError) {",
     )
+
+  // Determine if client-side guard validation is needed for the body
+  let client_guard_schema_name = case
+    ctx.config.validate,
+    operation.request_body
+  {
+    True, Some(Value(rb)) -> {
+      let content_entries = dict.to_list(rb.content)
+      case content_entries {
+        [#(_, mt)] ->
+          case mt.schema {
+            Some(schema.Reference(name:, ..)) ->
+              case guards.schema_has_validator(name, ctx) {
+                True -> Some(#(name, rb.required))
+                False -> None
+              }
+            _ -> None
+          }
+        _ -> None
+      }
+    }
+    _, _ -> None
+  }
+
+  // Open guard validation wrapper for required body
+  let sb = case client_guard_schema_name {
+    Some(#(name, True)) -> {
+      let validate_fn =
+        "guards.validate_" <> naming.to_snake_case(name) <> "(body)"
+      sb
+      |> se.indent(1, "case " <> validate_fn <> " {")
+      |> se.indent(2, "Error(errors) -> Error(ValidationError(errors:))")
+      |> se.indent(2, "Ok(_) -> {")
+    }
+    Some(#(name, False)) -> {
+      let validate_fn = "guards.validate_" <> naming.to_snake_case(name)
+      sb
+      |> se.indent(1, "let validation_errors = case body {")
+      |> se.indent(2, "Some(b) -> case " <> validate_fn <> "(b) {")
+      |> se.indent(3, "Error(errors) -> errors")
+      |> se.indent(3, "Ok(_) -> []")
+      |> se.indent(2, "}")
+      |> se.indent(2, "None -> []")
+      |> se.indent(1, "}")
+      |> se.indent(1, "case validation_errors {")
+      |> se.indent(
+        2,
+        "[_, ..] -> Error(ValidationError(errors: validation_errors))",
+      )
+      |> se.indent(2, "[] -> {")
+    }
+    None -> sb
+  }
 
   // Build URL with path params
   let sb = sb |> se.indent(1, "let path = \"" <> path <> "\"")
@@ -906,6 +991,15 @@ fn generate_client_function(
     |> se.indent(3, "}")
     |> se.indent(2, "}")
     |> se.indent(1, "}")
+
+  // Close guard validation wrapper
+  let sb = case client_guard_schema_name {
+    Some(_) ->
+      sb
+      |> se.indent(1, "}")
+      |> se.indent(1, "}")
+    None -> sb
+  }
 
   sb
   |> se.line("}")

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -16,6 +16,20 @@ import oaspec/openapi/schema.{
 import oaspec/util/naming
 import oaspec/util/string_extra as se
 
+/// Check whether a named component schema has a composite validator.
+/// Used by server/client generators to decide whether to emit guard calls.
+pub fn schema_has_validator(name: String, ctx: Context) -> Bool {
+  case ctx.spec.components {
+    Some(components) ->
+      case dict.get(components.schemas, name) {
+        Ok(schema_ref) ->
+          !list.is_empty(collect_guard_calls(name, schema_ref, ctx))
+        Error(_) -> False
+      }
+    None -> False
+  }
+}
+
 /// Generate guard/validation functions from OpenAPI schemas that have constraints.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
   let content = generate_guards(ctx)

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -23,7 +23,8 @@ pub fn schema_has_validator(name: String, ctx: Context) -> Bool {
     Some(components) ->
       case dict.get(components.schemas, name) {
         Ok(schema_ref) ->
-          !list.is_empty(collect_guard_calls(name, schema_ref, ctx))
+          !ir_build.is_internal_schema(schema_ref)
+          && !list.is_empty(collect_guard_calls(name, schema_ref, ctx))
         Error(_) -> False
       }
     None -> False

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
+import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
 import oaspec/codegen/server_request_decode as decode_helpers
@@ -502,7 +503,32 @@ fn generate_router(
     True -> list.append(std_imports, ["gleam/option.{None, Some}"])
     False -> std_imports
   }
-  let std_imports = case needs_json {
+  // json is also needed when guard validation is enabled (for 422 error responses)
+  let needs_json_for_guards =
+    ctx.config.validate
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          rb.required
+          && list.any(dict.to_list(rb.content), fn(entry) {
+            content_type.is_json_compatible(entry.0)
+          })
+          && {
+            case dict.to_list(rb.content) {
+              [#(_, mt)] ->
+                case mt.schema {
+                  Some(schema.Reference(name:, ..)) ->
+                    guards.schema_has_validator(name, ctx)
+                  _ -> False
+                }
+              _ -> False
+            }
+          }
+        _ -> False
+      }
+    })
+  let std_imports = case needs_json || needs_json_for_guards {
     True -> list.append(std_imports, ["gleam/json"])
     False -> std_imports
   }
@@ -537,6 +563,35 @@ fn generate_router(
         ctx.config.package <> "/response_types",
       ])
     False -> list.append(pkg_imports, [ctx.config.package <> "/response_types"])
+  }
+  // Import guards module when validation is enabled and any operation body has validators
+  let needs_guards =
+    ctx.config.validate
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          rb.required
+          && list.any(dict.to_list(rb.content), fn(entry) {
+            content_type.is_json_compatible(entry.0)
+            && {
+              case { dict.to_list(rb.content) } {
+                [#(_, mt)] ->
+                  case mt.schema {
+                    Some(schema.Reference(name:, ..)) ->
+                      guards.schema_has_validator(name, ctx)
+                    _ -> False
+                  }
+                _ -> False
+              }
+            }
+          })
+        _ -> False
+      }
+    })
+  let pkg_imports = case needs_guards {
+    True -> list.append(pkg_imports, [ctx.config.package <> "/guards"])
+    False -> pkg_imports
   }
 
   let all_imports = list.append(std_imports, pkg_imports)
@@ -960,6 +1015,33 @@ fn generate_safe_request_and_dispatch(
       |> se.indent(4, "Ok(" <> var_name <> "_parsed) -> {")
     })
 
+  // Determine the body schema reference name (used for decode and guard validation)
+  let body_schema_ref_name = case operation.request_body {
+    Some(Value(rb)) -> {
+      let content_entries = dict.to_list(rb.content)
+      case content_entries {
+        [#(_ct_name, media_type)] ->
+          case media_type.schema {
+            Some(schema.Reference(name:, ..)) -> Some(name)
+            _ -> None
+          }
+        _ -> None
+      }
+    }
+    _ -> None
+  }
+
+  // Check if guard validation should be emitted for this body
+  let needs_guard_validation =
+    ctx.config.validate
+    && needs_body_guard
+    && {
+      case body_schema_ref_name {
+        Some(name) -> guards.schema_has_validator(name, ctx)
+        None -> False
+      }
+    }
+
   // Open body decode guard if needed
   let sb = case needs_body_guard, operation.request_body {
     True, Some(Value(rb)) -> {
@@ -986,6 +1068,18 @@ fn generate_safe_request_and_dispatch(
           }
         _ -> sb
       }
+    }
+    _, _ -> sb
+  }
+
+  // Open guard validation if needed (after body decode succeeds)
+  let sb = case needs_guard_validation, body_schema_ref_name {
+    True, Some(name) -> {
+      let validate_fn =
+        "guards.validate_" <> naming.to_snake_case(name) <> "(decoded_body)"
+      sb
+      |> se.indent(3, "case " <> validate_fn <> " {")
+      |> se.indent(4, "Ok(decoded_body) -> {")
     }
     _, _ -> sb
   }
@@ -1079,6 +1173,19 @@ fn generate_safe_request_and_dispatch(
     sb
     |> se.indent(3, "let response = handlers." <> fn_name <> "(request)")
     |> generate_response_conversion(response_type_name, operation, ctx)
+
+  // Close guard validation (returns 422 with error details)
+  let sb = case needs_guard_validation {
+    True ->
+      sb
+      |> se.indent(4, "}")
+      |> se.indent(
+        4,
+        "Error(errors) -> ServerResponse(status: 422, body: json.to_string(json.array(errors, json.string)), headers: [#(\"content-type\", \"application/json\")])",
+      )
+      |> se.indent(3, "}")
+    False -> sb
+  }
 
   // Close body decode guard
   let sb = case needs_body_guard {

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -508,25 +508,7 @@ fn generate_router(
     ctx.config.validate
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          rb.required
-          && list.any(dict.to_list(rb.content), fn(entry) {
-            content_type.is_json_compatible(entry.0)
-          })
-          && {
-            case dict.to_list(rb.content) {
-              [#(_, mt)] ->
-                case mt.schema {
-                  Some(schema.Reference(name:, ..)) ->
-                    guards.schema_has_validator(name, ctx)
-                  _ -> False
-                }
-              _ -> False
-            }
-          }
-        _ -> False
-      }
+      operation_needs_guard_validation(operation, ctx)
     })
   let std_imports = case needs_json || needs_json_for_guards {
     True -> list.append(std_imports, ["gleam/json"])
@@ -569,25 +551,7 @@ fn generate_router(
     ctx.config.validate
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          rb.required
-          && list.any(dict.to_list(rb.content), fn(entry) {
-            content_type.is_json_compatible(entry.0)
-            && {
-              case { dict.to_list(rb.content) } {
-                [#(_, mt)] ->
-                  case mt.schema {
-                    Some(schema.Reference(name:, ..)) ->
-                      guards.schema_has_validator(name, ctx)
-                    _ -> False
-                  }
-                _ -> False
-              }
-            }
-          })
-        _ -> False
-      }
+      operation_needs_guard_validation(operation, ctx)
     })
   let pkg_imports = case needs_guards {
     True -> list.append(pkg_imports, [ctx.config.package <> "/guards"])
@@ -1213,6 +1177,35 @@ fn generate_safe_request_and_dispatch(
     })
 
   sb
+}
+
+/// Check if an operation's request body needs guard validation.
+/// True when the body is required, JSON-compatible, references a named schema,
+/// and that schema has constraint-based validators.
+fn operation_needs_guard_validation(
+  operation: spec.Operation(Resolved),
+  ctx: Context,
+) -> Bool {
+  case operation.request_body {
+    Some(Value(rb)) ->
+      rb.required
+      && {
+        let content_entries = dict.to_list(rb.content)
+        list.any(content_entries, fn(entry) {
+          content_type.is_json_compatible(entry.0)
+        })
+        && case content_entries {
+          [#(_, mt)] ->
+            case mt.schema {
+              Some(schema.Reference(name:, ..)) ->
+                guards.schema_has_validator(name, ctx)
+              _ -> False
+            }
+          _ -> False
+        }
+      }
+    _ -> False
+  }
 }
 
 // Parameter parsing, body decoding, and request construction helpers

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -13,6 +13,7 @@ pub type Config {
     output_client: String,
     package: String,
     mode: GenerateMode,
+    validate: Bool,
   )
 }
 
@@ -114,12 +115,23 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     },
   )
 
-  Ok(Config(input:, output_server:, output_client:, package:, mode:))
+  let validate = case yay.select_sugar(from: root, selector: "validate") {
+    Ok(yay.NodeBool(True)) -> True
+    Ok(yay.NodeStr("true")) -> True
+    _ -> False
+  }
+
+  Ok(Config(input:, output_server:, output_client:, package:, mode:, validate:))
 }
 
 /// Apply CLI overrides to a config.
 pub fn with_mode(config: Config, mode: GenerateMode) -> Config {
   Config(..config, mode:)
+}
+
+/// Apply validation mode override.
+pub fn with_validate(config: Config, validate: Bool) -> Config {
+  Config(..config, validate:)
 }
 
 /// Apply output base directory override.

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -115,11 +115,18 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     },
   )
 
-  let validate = case yay.select_sugar(from: root, selector: "validate") {
-    Ok(yay.NodeBool(True)) -> True
-    Ok(yay.NodeStr("true")) -> True
-    _ -> False
-  }
+  use validate <- result.try(
+    case yay.select_sugar(from: root, selector: "validate") {
+      Ok(yay.NodeBool(True)) | Ok(yay.NodeStr("true")) -> Ok(True)
+      Ok(yay.NodeBool(False)) | Ok(yay.NodeStr("false")) -> Ok(False)
+      Error(_) -> Ok(False)
+      Ok(_) ->
+        Error(InvalidValue(
+          field: "validate",
+          detail: "must be a boolean (true or false)",
+        ))
+    },
+  )
 
   Ok(Config(input:, output_server:, output_client:, package:, mode:, validate:))
 }

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -943,6 +943,7 @@ fn make_security_ctx(
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(test_spec, cfg)
 }

--- a/test/golden_test.gleam
+++ b/test/golden_test.gleam
@@ -33,6 +33,7 @@ fn golden_generate(spec_path: String) -> List(context.GeneratedFile) {
       output_client: "./golden_unused/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let assert Ok(summary) = generate.generate(spec, cfg)
   summary.files

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -122,6 +122,7 @@ pub fn config_package_dir_mismatch_test() {
       output_client: "./gen/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = config.validate_output_package_match(cfg)
   should.be_error(result)
@@ -135,6 +136,7 @@ pub fn config_client_dir_mismatch_test() {
       output_client: "./gen/wrong_client",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = config.validate_output_package_match(cfg)
   should.be_error(result)
@@ -148,6 +150,7 @@ pub fn config_package_dir_match_test() {
       output_client: "./gen_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = config.validate_output_package_match(cfg)
   should.be_ok(result)
@@ -472,6 +475,7 @@ fn make_ctx_from_spec(spec) -> context.Context {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(resolved, cfg)
 }
@@ -557,6 +561,7 @@ fn make_ctx(spec_path: String) -> context.Context {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(resolved, cfg)
 }
@@ -1826,6 +1831,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let assert Error(generate.ValidationErrors(errors:)) =
     generate.validate_only(spec, cfg)
@@ -1867,6 +1873,7 @@ webhooks:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let assert Ok(summary) = generate.validate_only(spec, cfg)
   // Should have at least one warning (webhooks parsed but unused)
@@ -2184,6 +2191,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -2234,6 +2242,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -2281,6 +2290,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -2997,6 +3007,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   should.be_ok(result)
@@ -3518,6 +3529,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3560,6 +3572,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3601,6 +3614,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3644,6 +3658,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3685,6 +3700,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3728,6 +3744,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -3845,6 +3862,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3891,6 +3909,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3934,6 +3953,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -3977,6 +3997,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -4022,6 +4043,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -4067,6 +4089,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let errors = validate.validate(ctx)
@@ -4414,6 +4437,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -4571,6 +4595,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -4619,6 +4644,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -4665,6 +4691,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5271,6 +5298,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5334,6 +5362,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5392,6 +5421,7 @@ components:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5447,6 +5477,7 @@ webhooks:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   // Generation must succeed even with warnings
   let result = generate.generate(spec, cfg)
@@ -5841,6 +5872,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5883,6 +5915,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -5921,6 +5954,7 @@ paths:
         output_client: "./test_output_client/api",
         package: "api",
         mode: config.Client,
+        validate: False,
       ),
     )
   let files = client_gen.generate(ctx)
@@ -6507,6 +6541,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Client,
+      validate: False,
     )
   generate.generate(spec, cfg)
   |> should.be_ok()
@@ -6610,6 +6645,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let assert Ok(summary) = generate.generate(spec, cfg)
   { summary.warnings != [] }
@@ -7514,6 +7550,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let files = server_gen.generate(ctx)
@@ -7609,6 +7646,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let errors = validate.validate(ctx)
@@ -7662,6 +7700,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let files = server_gen.generate(ctx)
@@ -7718,6 +7757,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let errors = validate.validate(ctx)
@@ -7769,6 +7809,7 @@ paths:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let files = server_gen.generate(ctx)
@@ -7820,6 +7861,7 @@ components:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let errors = validate.validate(ctx)
@@ -7875,6 +7917,7 @@ components:
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Server,
+      validate: False,
     )
   let ctx = context.new(spec, cfg)
   let errors = validate.validate(ctx)
@@ -8341,6 +8384,7 @@ pub fn oss_openapi_gen_petstore_server_generates_client_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Client,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -8726,6 +8770,7 @@ pub fn oss_kin_openapi_components_json_rejects_invalid_scheme_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -9248,6 +9293,7 @@ pub fn oss_swagger_parser_java_31_security_rejects_mutualtls_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -9415,6 +9461,7 @@ pub fn inline_not_keyword_rejected_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -9469,6 +9516,7 @@ pub fn external_param_ref_rejects_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   // Must produce a diagnostic error, not panic
   let result = generate.generate(spec, cfg)
@@ -9494,6 +9542,7 @@ pub fn wrong_kind_ref_rejects_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10085,6 +10134,7 @@ pub fn error_missing_path_param_test() {
           output_client: "./test_output_client/api",
           package: "api",
           mode: config.Both,
+          validate: False,
         )
       let ctx = context.new(resolved, cfg)
       let diagnostics = validate.validate(ctx)
@@ -10337,6 +10387,7 @@ pub fn e2e_wildcard_status_codes_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10355,6 +10406,7 @@ pub fn e2e_format_types_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10374,6 +10426,7 @@ pub fn e2e_complex_discriminator_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10392,6 +10445,7 @@ pub fn e2e_enum_edge_cases_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10411,6 +10465,7 @@ pub fn e2e_mixed_param_locations_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10430,6 +10485,7 @@ pub fn e2e_inline_nested_objects_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10449,6 +10505,7 @@ pub fn e2e_optional_required_combinations_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10467,6 +10524,7 @@ pub fn e2e_no_servers_test() {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   let result = generate.generate(spec, cfg)
   case result {
@@ -10474,4 +10532,306 @@ pub fn e2e_no_servers_test() {
     Error(generate.ValidationErrors(errors:)) ->
       list.length(errors) |> should.not_equal(0)
   }
+}
+
+// ===========================================================================
+// Guard integration tests (issue #22)
+// ===========================================================================
+
+/// Helper: create a context with validate=True from a YAML string.
+fn make_validate_ctx_from_yaml(yaml: String) -> context.Context {
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: True,
+    )
+  context.new(resolved, cfg)
+}
+
+/// Petstore spec YAML fragment with constrained request body.
+const guard_integration_spec = "
+openapi: 3.0.3
+info:
+  title: Guard Integration Test
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePetRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Bad Request
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    CreatePetRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+"
+
+/// Server router should include guard validation when validate=True.
+pub fn guard_integration_server_router_validates_body_test() {
+  let ctx = make_validate_ctx_from_yaml(guard_integration_spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // Should import guards module
+  string.contains(router_file.content, "api/guards")
+  |> should.be_true()
+
+  // Should call guards.validate_create_pet_request after body decode
+  string.contains(
+    router_file.content,
+    "guards.validate_create_pet_request(decoded_body)",
+  )
+  |> should.be_true()
+
+  // Should return 422 on validation failure
+  string.contains(router_file.content, "status: 422")
+  |> should.be_true()
+
+  // Should include errors in JSON response body
+  string.contains(router_file.content, "json.array(errors, json.string)")
+  |> should.be_true()
+}
+
+/// Server router should NOT include guard validation when validate=False.
+pub fn guard_integration_server_no_validation_when_disabled_test() {
+  let assert Ok(spec) = parser.parse_string(guard_integration_spec)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // Should NOT import guards module
+  string.contains(router_file.content, "api/guards")
+  |> should.be_false()
+
+  // Should NOT call guards.validate
+  string.contains(router_file.content, "guards.validate_")
+  |> should.be_false()
+
+  // Should NOT return 422
+  string.contains(router_file.content, "status: 422")
+  |> should.be_false()
+}
+
+/// Client should include guard validation when validate=True.
+pub fn guard_integration_client_validates_body_test() {
+  let ctx = make_validate_ctx_from_yaml(guard_integration_spec)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Should import guards module
+  string.contains(client_file.content, "api/guards")
+  |> should.be_true()
+
+  // Should include ValidationError variant
+  string.contains(client_file.content, "ValidationError(errors: List(String))")
+  |> should.be_true()
+
+  // Should call guards.validate_create_pet_request
+  string.contains(
+    client_file.content,
+    "guards.validate_create_pet_request(body)",
+  )
+  |> should.be_true()
+}
+
+/// Client should NOT include guard validation when validate=False.
+pub fn guard_integration_client_no_validation_when_disabled_test() {
+  let assert Ok(spec) = parser.parse_string(guard_integration_spec)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Should NOT import guards module
+  string.contains(client_file.content, "api/guards")
+  |> should.be_false()
+
+  // Should NOT include ValidationError variant
+  string.contains(client_file.content, "ValidationError")
+  |> should.be_false()
+
+  // Should NOT call guards.validate
+  string.contains(client_file.content, "guards.validate_")
+  |> should.be_false()
+}
+
+/// Guard validation should only apply to schemas that actually have constraints.
+pub fn guard_integration_no_validation_for_unconstrained_body_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Item:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+"
+  let ctx = make_validate_ctx_from_yaml(yaml)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // No constraints on Item schema, so no guard validation
+  string.contains(router_file.content, "guards.validate_")
+  |> should.be_false()
+
+  string.contains(router_file.content, "status: 422")
+  |> should.be_false()
+}
+
+/// guards.schema_has_validator returns True for schemas with constraints.
+pub fn guard_schema_has_validator_test() {
+  let ctx = make_validate_ctx_from_yaml(guard_integration_spec)
+  guards.schema_has_validator("CreatePetRequest", ctx)
+  |> should.be_true()
+}
+
+/// guards.schema_has_validator returns False for schemas without constraints.
+pub fn guard_schema_has_no_validator_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Simple:
+      type: object
+      properties:
+        name:
+          type: string
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  guards.schema_has_validator("Simple", ctx)
+  |> should.be_false()
+}
+
+/// guards.schema_has_validator returns False for non-existent schemas.
+pub fn guard_schema_has_validator_nonexistent_test() {
+  let ctx = make_validate_ctx_from_yaml(guard_integration_spec)
+  guards.schema_has_validator("NonExistent", ctx)
+  |> should.be_false()
+}
+
+/// Config load should parse validate field from YAML.
+pub fn config_validate_field_test() {
+  let yaml_content = "input: test.yaml\npackage: api\nvalidate: true\n"
+  let temp_path = "/tmp/oaspec_validate_test.yaml"
+  let assert Ok(Nil) = simplifile.write(temp_path, yaml_content)
+  let assert Ok(cfg) = config.load(temp_path)
+  cfg.validate |> should.be_true()
+  let _ = simplifile.delete(temp_path)
+  Nil
+}
+
+/// Config load should default validate to False when not specified.
+pub fn config_validate_default_false_test() {
+  let yaml_content = "input: test.yaml\npackage: api\n"
+  let temp_path = "/tmp/oaspec_validate_default_test.yaml"
+  let assert Ok(Nil) = simplifile.write(temp_path, yaml_content)
+  let assert Ok(cfg) = config.load(temp_path)
+  cfg.validate |> should.be_false()
+  let _ = simplifile.delete(temp_path)
+  Nil
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -10641,6 +10641,10 @@ pub fn guard_integration_server_router_validates_body_test() {
   // Should include errors in JSON response body
   string.contains(router_file.content, "json.array(errors, json.string)")
   |> should.be_true()
+
+  // Decode error path should still return 400 (distinct from 422 validation)
+  string.contains(router_file.content, "status: 400")
+  |> should.be_true()
 }
 
 /// Server router should NOT include guard validation when validate=False.
@@ -10730,6 +10734,61 @@ pub fn guard_integration_client_no_validation_when_disabled_test() {
   // Should NOT call guards.validate
   string.contains(client_file.content, "guards.validate_")
   |> should.be_false()
+}
+
+/// Client should validate optional request bodies with Some/None handling.
+pub fn guard_integration_client_validates_optional_body_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Optional Body Test
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /pets:
+    patch:
+      operationId: updatePet
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePetRequest'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    UpdatePetRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+"
+  let ctx = make_validate_ctx_from_yaml(yaml)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Should import guards module
+  string.contains(client_file.content, "api/guards")
+  |> should.be_true()
+
+  // Should include ValidationError variant
+  string.contains(client_file.content, "ValidationError")
+  |> should.be_true()
+
+  // Should call guards.validate for optional body with Some pattern
+  string.contains(client_file.content, "guards.validate_update_pet_request")
+  |> should.be_true()
+
+  // Should handle None case (no validation for absent body)
+  string.contains(client_file.content, "None -> []")
+  |> should.be_true()
 }
 
 /// Guard validation should only apply to schemas that actually have constraints.

--- a/test/test_helpers.gleam
+++ b/test/test_helpers.gleam
@@ -20,6 +20,7 @@ pub fn make_ctx_from_spec(spec) -> context.Context {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(resolved, cfg)
 }
@@ -37,6 +38,7 @@ pub fn make_ctx(spec_path: String) -> context.Context {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(resolved, cfg)
 }
@@ -167,6 +169,7 @@ pub fn make_minimal_ctx() -> context.Context {
       output_client: "./test_output_client/api",
       package: "api",
       mode: config.Both,
+      validate: False,
     )
   context.new(minimal_spec, cfg)
 }

--- a/test/writer_test.gleam
+++ b/test/writer_test.gleam
@@ -22,6 +22,7 @@ fn test_config(mode: config.GenerateMode) -> config.Config {
     output_client: "./gen_client/api",
     package: "api",
     mode: mode,
+    validate: False,
   )
 }
 


### PR DESCRIPTION
## Summary

Integrate generated guard validation into server router and client execution flows as an opt-in feature. When `validate: true` is set in config (or `--validate` CLI flag), generated routers validate decoded request bodies against schema constraints and return 422 on failure, and generated clients validate request bodies before sending.

Closes #22

## Changes

- `src/oaspec/config.gleam`: Add `validate: Bool` field to `Config` type with YAML and CLI support
- `src/oaspec/cli.gleam`: Add `--validate` flag to `generate` command, document in init template
- `src/oaspec/codegen/guards.gleam`: Add `schema_has_validator/2` public function to check if a schema has constraints
- `src/oaspec/codegen/server.gleam`: Generate guard validation after JSON body decode when enabled; return 422 with JSON error array on failure; conditionally import `guards` and `json` modules
- `src/oaspec/codegen/client.gleam`: Generate `ValidationError(errors: List(String))` variant in `ClientError`; validate required/optional bodies before encoding; conditionally import `guards` module
- `test/oaspec_test.gleam`: Add 10 guard integration tests covering server, client, config parsing, and edge cases
- `README.md`: Update unit test count (598 → 608)

## Design Decisions

- **Opt-in via config**: Guard validation is off by default (`validate: false`) to avoid breaking existing users. This matches the issue requirement for a config switch.
- **Server returns 422**: Decode failures return 400 (malformed JSON), while validation failures return 422 (well-formed but invalid data) with a JSON array of error strings. This provides a clear error surface distinction.
- **Client returns ValidationError**: A new `ClientError` variant is only generated when validation is enabled, keeping the error type minimal when not needed.
- **Schema-aware**: Guard validation is only emitted for request bodies that reference component schemas with actual constraints. Unconstrained schemas and inline schemas are skipped.
- **Optional body support**: Client-side validation handles both required and optional (`Option(T)`) request bodies correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--validate` CLI flag to enable request body validation in generated code
  * New `validate` setting in `oaspec.yaml` configuration file
  * Generated client and server code now performs request body validation with detailed error reporting (422 responses for server)

* **Documentation**
  * Updated README with increased unit test count (598 → 608)

* **Tests**
  * Expanded test suite with comprehensive validation behavior coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->