### PR TITLE
feat(server): support operation-level and path-level server overrides in generated clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 609 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 614 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 614 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 615 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 
@@ -220,7 +220,8 @@ These are the most important limitations today:
 
 - The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`
 - `xml` annotations are not handled by the parser
-- Some fields are parsed and preserved but not yet used by codegen: webhooks, externalDocs, tags, examples, links, operation servers, path servers, response headers, encoding
+- Some fields are parsed and preserved but not yet used by codegen: webhooks, externalDocs, tags, examples, links, response headers, encoding
+- Operation-level and path-level server overrides are supported in generated clients (precedence: operation > path > top-level)
 - The following are normalized to supported equivalents:
 - `const`: String const normalized to single-value enum
 - `type: [T, null]`: Normalized to nullable

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -623,6 +623,24 @@ fn generate_client_function(
     None -> sb
   }
 
+  // Determine effective base URL for this operation.
+  // OpenAPI precedence: operation.servers > path_item.servers > top-level servers.
+  // operation.servers is already populated with path-level servers by collect_operations.
+  let effective_server_url = case operation.servers {
+    [first_server, ..] -> {
+      let variables = ir_build.sorted_entries(first_server.variables)
+      let resolved = substitute_server_variables(first_server.url, variables)
+      Some(resolved)
+    }
+    [] -> None
+  }
+
+  // Add doc comment when this operation uses a server override
+  let sb = case effective_server_url {
+    Some(url) -> sb |> se.indent(1, "// Server override: " <> url)
+    None -> sb
+  }
+
   // Build URL with path params
   let sb = sb |> se.indent(1, "let path = \"" <> path <> "\"")
   let sb =
@@ -732,9 +750,16 @@ fn generate_client_function(
     spec.Trace -> "http.Trace"
   }
 
+  let base_url_expr = case effective_server_url {
+    Some(url) -> "\"" <> url <> "\""
+    None -> "config.base_url"
+  }
   let sb =
     sb
-    |> se.indent(1, "let assert Ok(req) = request.to(config.base_url <> path)")
+    |> se.indent(
+      1,
+      "let assert Ok(req) = request.to(" <> base_url_expr <> " <> path)",
+    )
     |> se.indent(1, "let req = request.set_method(req, " <> http_method <> ")")
 
   // Only set content-type for requests with body

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -7,8 +7,7 @@ import oaspec/capability
 import oaspec/codegen/context.{type Context}
 import oaspec/config
 import oaspec/openapi/diagnostic.{
-  type Diagnostic, SeverityError, SeverityWarning, TargetBoth, TargetClient,
-  TargetServer,
+  type Diagnostic, SeverityError, SeverityWarning, TargetBoth, TargetServer,
 }
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{
@@ -346,47 +345,10 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
       ),
     ]
   }
-  let operation_server_warnings =
-    list.flat_map(ops, fn(op) {
-      let #(op_id, operation, _path, _method) = op
-      case list.is_empty(operation.servers) {
-        True -> []
-        False -> [
-          diagnostic.capability(
-            severity: SeverityWarning,
-            target: TargetClient,
-            path: op_id <> ".servers",
-            detail: "Operation-level servers are parsed but client code generation uses only the top-level server URL.",
-            hint: Some(
-              "Only the first top-level server URL is used for default_base_url(). Override at runtime via ClientConfig if needed.",
-            ),
-          ),
-        ]
-      }
-    })
-  let path_server_warnings =
-    dict.to_list(ctx.spec.paths)
-    |> list.flat_map(fn(entry) {
-      let #(path, ref_or) = entry
-      case ref_or {
-        Value(path_item) ->
-          case list.is_empty(path_item.servers) {
-            True -> []
-            False -> [
-              diagnostic.capability(
-                severity: SeverityWarning,
-                target: TargetClient,
-                path: "paths." <> path <> ".servers",
-                detail: "Path-level servers are parsed but client code generation uses only the top-level server URL.",
-                hint: Some(
-                  "Only the first top-level server URL is used for default_base_url(). Override at runtime via ClientConfig if needed.",
-                ),
-              ),
-            ]
-          }
-        _ -> []
-      }
-    })
+  // Operation-level and path-level server overrides are now supported in client
+  // code generation (server precedence: operation > path > top-level).
+  let operation_server_warnings = []
+  let path_server_warnings = []
   let component_warnings = case ctx.spec.components {
     Some(components) -> {
       let header_w = case dict.is_empty(components.headers) {

--- a/src/oaspec/openapi/operations.gleam
+++ b/src/oaspec/openapi/operations.gleam
@@ -55,11 +55,18 @@ pub fn collect_operations(
               Some(sec) -> sec
               None -> ctx.spec.security
             }
+            // Inherit path-level servers when operation doesn't define its own.
+            // OpenAPI precedence: operation.servers > path_item.servers > spec.servers
+            let effective_servers = case operation.servers {
+              [_, ..] -> operation.servers
+              [] -> path_item.servers
+            }
             let operation =
               spec.Operation(
                 ..operation,
                 parameters: merged_params,
                 security: Some(effective_security),
+                servers: effective_servers,
               )
 
             let op_id = case operation.operation_id {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -10894,3 +10894,187 @@ pub fn config_validate_default_false_test() {
   let _ = simplifile.delete(temp_path)
   Nil
 }
+
+// ===========================================================================
+// Server override tests (issue #96)
+// ===========================================================================
+
+/// Client should use operation-level server override when present.
+pub fn server_override_operation_level_test() {
+  let ctx = make_ctx("test/fixtures/operation_server_override.yaml")
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // listItems (GET /items) should use config.base_url (no override)
+  // createItem (POST /items) should use https://write.example.com/v1
+
+  // The client should contain the override URL for createItem
+  string.contains(client_file.content, "\"https://write.example.com/v1\"")
+  |> should.be_true()
+
+  // The client should still use config.base_url for listItems
+  string.contains(client_file.content, "config.base_url")
+  |> should.be_true()
+
+  // Should have server override comment
+  string.contains(client_file.content, "Server override")
+  |> should.be_true()
+}
+
+/// Client should use path-level server override for all operations on that path.
+pub fn server_override_path_level_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Path Server Override Test
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /admin:
+    servers:
+      - url: https://admin.example.com
+    get:
+      operationId: listAdminItems
+      responses:
+        '200':
+          description: OK
+    post:
+      operationId: createAdminItem
+      responses:
+        '201':
+          description: Created
+  /public:
+    get:
+      operationId: listPublicItems
+      responses:
+        '200':
+          description: OK
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Admin operations should use path-level server
+  string.contains(client_file.content, "\"https://admin.example.com\"")
+  |> should.be_true()
+
+  // Public operation should use config.base_url
+  string.contains(client_file.content, "config.base_url")
+  |> should.be_true()
+}
+
+/// Operation-level server should override path-level server.
+pub fn server_override_operation_takes_precedence_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Precedence Test
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    servers:
+      - url: https://path.example.com
+    get:
+      operationId: listItems
+      responses:
+        '200':
+          description: OK
+    post:
+      operationId: createItem
+      servers:
+        - url: https://operation.example.com
+      responses:
+        '201':
+          description: Created
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // createItem (POST) should use operation-level server, NOT path-level
+  string.contains(client_file.content, "\"https://operation.example.com\"")
+  |> should.be_true()
+
+  // listItems (GET) should use path-level server (inherited)
+  string.contains(client_file.content, "\"https://path.example.com\"")
+  |> should.be_true()
+}
+
+/// Top-level-only specs should keep using config.base_url unchanged.
+pub fn server_override_top_level_only_unchanged_test() {
+  let ctx = make_ctx("test/fixtures/petstore.yaml")
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Should use config.base_url in all operations
+  string.contains(client_file.content, "config.base_url <> path")
+  |> should.be_true()
+
+  // Should NOT have any server override comments
+  string.contains(client_file.content, "Server override")
+  |> should.be_false()
+}
+
+/// No capability warnings should be emitted for operation/path-level servers.
+pub fn server_override_no_capability_warnings_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/operation_server_override.yaml")
+  let cfg =
+    config.Config(
+      input: "test/fixtures/operation_server_override.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let files = generate.generate(spec, cfg)
+  case files {
+    Ok(summary) -> {
+      // Should NOT have operation-level server warnings
+      let has_server_warning =
+        list.any(summary.warnings, fn(w) {
+          let msg = diagnostic.to_short_string(w)
+          string.contains(msg, "Operation-level servers")
+          || string.contains(msg, "Path-level servers")
+        })
+      has_server_warning |> should.be_false()
+    }
+    Error(_) -> should.fail()
+  }
+}

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -11078,3 +11078,50 @@ pub fn server_override_no_capability_warnings_test() {
     Error(_) -> should.fail()
   }
 }
+
+/// Relative server URLs should be supported as overrides.
+pub fn server_override_relative_url_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Relative Server URL Test
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /admin:
+    servers:
+      - url: /admin-api
+    get:
+      operationId: listAdmin
+      responses:
+        '200':
+          description: OK
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.Config(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+
+  // Should use the relative URL as override
+  string.contains(client_file.content, "\"/admin-api\"")
+  |> should.be_true()
+
+  // Should have server override comment
+  string.contains(client_file.content, "Server override")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Generated clients now respect OpenAPI server override precedence (operation-level > path-level > top-level). Operations with server overrides use the effective URL directly instead of `config.base_url`, while operations without overrides continue to use `config.base_url` for backward compatibility.

Closes #96

## Changes

- `src/oaspec/openapi/operations.gleam`: Inherit path-level servers to operations when the operation doesn't define its own, following OpenAPI server precedence
- `src/oaspec/codegen/client.gleam`: Use effective server URL per operation; apply `substitute_server_variables()` to resolve server variable defaults; add inline comment when server override is active
- `src/oaspec/openapi/capability_check.gleam`: Remove capability warnings for operation/path-level servers since they are now supported
- `test/oaspec_test.gleam`: Add 5 tests covering operation-level override, path-level override, precedence (operation > path), top-level-only backward compatibility, and capability warning removal
- `README.md`: Update unit test count (609 → 614)

## Design Decisions

- **Hardcoded override URLs**: When an operation has a server override, the generated code uses the resolved URL directly (e.g., `"https://write.example.com/v1" <> path`) rather than `config.base_url`. This ensures correct routing by default without requiring runtime configuration.
- **Server inheritance in operations collector**: Path-level servers are inherited into operations during collection (same location where parameter inheritance and security inheritance already happen), keeping the client generator simple.
- **Variable substitution**: Server variables in override URLs are resolved at generation time using default values, matching the existing behavior for top-level servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for operation-level and path-level server URL overrides in generated API clients. Operation-level servers take precedence over path-level servers, which inherit from configuration defaults.

* **Bug Fixes**
  * Removed unnecessary capability warnings for server override definitions.

* **Tests**
  * Added comprehensive test coverage for server override precedence and URL selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->