### PR TITLE
feat(params): support pipeDelimited and spaceDelimited query arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`style: pipeDelimited` / `style: spaceDelimited` query array parameters**: generated clients encode non-exploded arrays as `name=a|b|c` or `name=a%20b%20c`; generated servers split on the matching delimiter (#97)
+- 5 new tests and 3 fixtures covering delimited styles and their rejection cases (615 → 621 unit tests, 179 → 182 fixtures)
+
+### Changed
+
+- Validator now rejects `pipeDelimited` / `spaceDelimited` only when applied outside `in: query` or to non-array schemas; previous outright rejection is removed
+- README: delimited array styles added to parameter support list and mode-specific support matrix
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 615 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 179 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 621 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 
@@ -205,7 +205,7 @@ Coverage is strongest in these areas:
 
 - Schemas: component schemas, primitive aliases, enums, nullable fields, arrays, objects, `allOf`, `oneOf`, `anyOf`, and typed `additionalProperties`
 - References: local `$ref` resolution for schemas, parameters, request bodies, responses, and path items, including circular-reference detection
-- Parameters: path, query, header, and cookie parameters, including array serialization and `style: deepObject`
+- Parameters: path, query, header, and cookie parameters, including array serialization (`style: form`, `style: pipeDelimited`, `style: spaceDelimited`) and objects via `style: deepObject`
 - Request bodies: `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data`
 - Responses: typed status-code variants, `$ref` responses, `default` responses, and text or binary passthrough cases
 - Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code.
@@ -255,6 +255,7 @@ These are the most important limitations today:
 | Path / query / header / cookie parameters | yes | yes | |
 | `style: deepObject` parameters | restricted | yes | Server: only primitive scalars and primitive arrays |
 | Array query parameters | restricted | yes | Server: only inline primitive item schemas |
+| `style: pipeDelimited` / `style: spaceDelimited` query arrays | yes | yes | Query array parameters only; primitive item types. Non-exploded joins with `\|` / `%20`, exploded degenerates to form-style `name=a&name=b`. |
 | `application/x-www-form-urlencoded` | restricted | yes | Server: must be sole content type; only primitive fields and shallow nested objects |
 | `multipart/form-data` | restricted | yes | Server: must be sole content type; only primitive scalar fields |
 | Security (apiKey, HTTP, OAuth2, OpenID Connect) | yes | yes | Client attaches credentials via config; OAuth2/OpenID Connect: bearer token only |

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -686,43 +686,58 @@ fn generate_client_function(
                     ctx,
                   )
                 False ->
-                  case p.required {
-                    True -> {
-                      let to_str =
-                        client_request.to_str_for_required(p, param_name, ctx)
-                      let encoded =
-                        client_security.maybe_percent_encode(to_str, p)
-                      sb
-                      |> se.indent(
-                        1,
-                        "let query_parts = [\""
-                          <> p.name
-                          <> "=\" <> "
-                          <> encoded
-                          <> ", ..query_parts]",
+                  case client_request.is_delimited_array_param(p, ctx) {
+                    Some(joiner) ->
+                      client_request.generate_delimited_array_query_param(
+                        sb,
+                        p,
+                        param_name,
+                        joiner,
+                        ctx,
                       )
-                    }
-                    False -> {
-                      let to_str =
-                        client_request.to_str_for_optional_value(p, ctx)
-                      let encoded =
-                        client_security.maybe_percent_encode(to_str, p)
-                      sb
-                      |> se.indent(
-                        1,
-                        "let query_parts = case " <> param_name <> " {",
-                      )
-                      |> se.indent(
-                        2,
-                        "Some(v) -> [\""
-                          <> p.name
-                          <> "=\" <> "
-                          <> encoded
-                          <> ", ..query_parts]",
-                      )
-                      |> se.indent(2, "None -> query_parts")
-                      |> se.indent(1, "}")
-                    }
+                    None ->
+                      case p.required {
+                        True -> {
+                          let to_str =
+                            client_request.to_str_for_required(
+                              p,
+                              param_name,
+                              ctx,
+                            )
+                          let encoded =
+                            client_security.maybe_percent_encode(to_str, p)
+                          sb
+                          |> se.indent(
+                            1,
+                            "let query_parts = [\""
+                              <> p.name
+                              <> "=\" <> "
+                              <> encoded
+                              <> ", ..query_parts]",
+                          )
+                        }
+                        False -> {
+                          let to_str =
+                            client_request.to_str_for_optional_value(p, ctx)
+                          let encoded =
+                            client_security.maybe_percent_encode(to_str, p)
+                          sb
+                          |> se.indent(
+                            1,
+                            "let query_parts = case " <> param_name <> " {",
+                          )
+                          |> se.indent(
+                            2,
+                            "Some(v) -> [\""
+                              <> p.name
+                              <> "=\" <> "
+                              <> encoded
+                              <> ", ..query_parts]",
+                          )
+                          |> se.indent(2, "None -> query_parts")
+                          |> se.indent(1, "}")
+                        }
+                      }
                   }
               }
           }

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -754,22 +754,24 @@ pub fn is_exploded_array_param(
   }
   case is_array {
     False -> False
-    True -> {
-      // explode defaults to true for style: form (the default for query params).
-      // pipeDelimited / spaceDelimited also default to explode=true per OpenAPI.
-      let effective_explode = case param.explode {
-        option.Some(v) -> v
-        option.None ->
-          case param.style {
-            option.Some(spec.FormStyle)
-            | option.Some(spec.PipeDelimitedStyle)
-            | option.Some(spec.SpaceDelimitedStyle)
-            | option.None -> True
-            _ -> False
-          }
+    True -> effective_explode(param)
+  }
+}
+
+/// Per OpenAPI 3.x: explode defaults to true only for `form` (and
+/// `deepObject`); for all other styles — including simple, pipeDelimited,
+/// and spaceDelimited — the default is false. None style on a query
+/// parameter is equivalent to form.
+fn effective_explode(param: spec.Parameter(Resolved)) -> Bool {
+  case param.explode {
+    option.Some(v) -> v
+    option.None ->
+      case param.style {
+        option.Some(spec.FormStyle)
+        | option.Some(spec.DeepObjectStyle)
+        | option.None -> True
+        _ -> False
       }
-      effective_explode
-    }
   }
 }
 
@@ -789,7 +791,9 @@ pub fn is_delimited_array_param(
       }
     _ -> False
   }
-  let is_non_exploded = param.explode == option.Some(False)
+  // Use spec-default explode rules (false for pipe/space) so that omitting
+  // `explode` yields the delimited path, matching OpenAPI semantics.
+  let is_non_exploded = !effective_explode(param)
   case is_array, is_non_exploded, param.style {
     True, True, option.Some(spec.PipeDelimitedStyle) -> option.Some("|")
     True, True, option.Some(spec.SpaceDelimitedStyle) -> option.Some(" ")
@@ -817,28 +821,33 @@ pub fn generate_delimited_array_query_param(
       }
     _ -> "fn(x) { x }"
   }
+  // Empty arrays produce no query entry, matching the existing exploded path.
   case param.required {
     True ->
       sb
+      |> se.indent(1, "let query_parts = case " <> param_name <> " {")
+      |> se.indent(2, "[] -> query_parts")
+      |> se.indent(2, "items -> {")
       |> se.indent(
-        1,
-        "let joined = string.join(list.map("
-          <> param_name
-          <> ", "
+        3,
+        "let joined = string.join(list.map(items, "
           <> item_to_str
           <> "), \""
           <> joiner
           <> "\")",
       )
       |> se.indent(
-        1,
-        "let query_parts = [\""
+        3,
+        "[\""
           <> param.name
           <> "=\" <> uri.percent_encode(joined), ..query_parts]",
       )
+      |> se.indent(2, "}")
+      |> se.indent(1, "}")
     False ->
       sb
       |> se.indent(1, "let query_parts = case " <> param_name <> " {")
+      |> se.indent(2, "Some([]) -> query_parts")
       |> se.indent(2, "Some(items) -> {")
       |> se.indent(
         3,

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -755,17 +755,108 @@ pub fn is_exploded_array_param(
   case is_array {
     False -> False
     True -> {
-      // explode defaults to true for style: form (which is the default for query params)
+      // explode defaults to true for style: form (the default for query params).
+      // pipeDelimited / spaceDelimited also default to explode=true per OpenAPI.
       let effective_explode = case param.explode {
         option.Some(v) -> v
         option.None ->
           case param.style {
-            option.Some(spec.FormStyle) | option.None -> True
+            option.Some(spec.FormStyle)
+            | option.Some(spec.PipeDelimitedStyle)
+            | option.Some(spec.SpaceDelimitedStyle)
+            | option.None -> True
             _ -> False
           }
       }
       effective_explode
     }
+  }
+}
+
+/// Returns Some(joiner) if the parameter is a non-exploded delimited array
+/// (pipeDelimited or spaceDelimited). Returns None for everything else
+/// including form arrays — we keep that on the existing path.
+pub fn is_delimited_array_param(
+  param: spec.Parameter(Resolved),
+  ctx: Context,
+) -> option.Option(String) {
+  let is_array = case param.payload {
+    ParameterSchema(Inline(schema.ArraySchema(..))) -> True
+    ParameterSchema(Reference(..) as sr) ->
+      case resolver.resolve_schema_ref(sr, ctx.spec) {
+        Ok(schema.ArraySchema(..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
+  let is_non_exploded = param.explode == option.Some(False)
+  case is_array, is_non_exploded, param.style {
+    True, True, option.Some(spec.PipeDelimitedStyle) -> option.Some("|")
+    True, True, option.Some(spec.SpaceDelimitedStyle) -> option.Some(" ")
+    _, _, _ -> option.None
+  }
+}
+
+/// Generate non-exploded delimited array query parameter:
+/// tags=a|b|c (pipeDelimited) or tags=a%20b%20c (spaceDelimited).
+pub fn generate_delimited_array_query_param(
+  sb: se.StringBuilder,
+  param: spec.Parameter(Resolved),
+  param_name: String,
+  joiner: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  let item_to_str = case param.payload {
+    ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
+      array_item_to_string_fn(items, ctx)
+    ParameterSchema(Reference(..) as sr) ->
+      case resolver.resolve_schema_ref(sr, ctx.spec) {
+        Ok(schema.ArraySchema(items:, ..)) ->
+          array_item_to_string_fn(items, ctx)
+        _ -> "fn(x) { x }"
+      }
+    _ -> "fn(x) { x }"
+  }
+  case param.required {
+    True ->
+      sb
+      |> se.indent(
+        1,
+        "let joined = string.join(list.map("
+          <> param_name
+          <> ", "
+          <> item_to_str
+          <> "), \""
+          <> joiner
+          <> "\")",
+      )
+      |> se.indent(
+        1,
+        "let query_parts = [\""
+          <> param.name
+          <> "=\" <> uri.percent_encode(joined), ..query_parts]",
+      )
+    False ->
+      sb
+      |> se.indent(1, "let query_parts = case " <> param_name <> " {")
+      |> se.indent(2, "Some(items) -> {")
+      |> se.indent(
+        3,
+        "let joined = string.join(list.map(items, "
+          <> item_to_str
+          <> "), \""
+          <> joiner
+          <> "\")",
+      )
+      |> se.indent(
+        3,
+        "[\""
+          <> param.name
+          <> "=\" <> uri.percent_encode(joined), ..query_parts]",
+      )
+      |> se.indent(2, "}")
+      |> se.indent(2, "None -> query_parts")
+      |> se.indent(1, "}")
   }
 }
 

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -154,7 +154,7 @@ pub fn query_required_expr(
   query_required_expr_with_schema(
     key,
     spec.parameter_schema(param),
-    param.explode,
+    Some(effective_explode_for_query(param)),
     param.style,
   )
 }
@@ -250,9 +250,22 @@ pub fn query_optional_expr(
   query_optional_expr_with_schema(
     key,
     spec.parameter_schema(param),
-    param.explode,
+    Some(effective_explode_for_query(param)),
     param.style,
   )
+}
+
+/// Per OpenAPI 3.x: explode defaults to true only for `form` (and
+/// `deepObject`); for all other styles the default is false.
+fn effective_explode_for_query(param: spec.Parameter(Resolved)) -> Bool {
+  case param.explode {
+    Some(v) -> v
+    None ->
+      case param.style {
+        Some(spec.FormStyle) | Some(spec.DeepObjectStyle) | None -> True
+        _ -> False
+      }
+  }
 }
 
 pub fn query_optional_expr_with_schema(

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -18,6 +18,16 @@ import oaspec/util/naming
 /// This is compatible with Gleam's bool.to_string which produces "True"/"False".
 pub const bool_parse_expr = "case string.lowercase(v) { \"true\" -> True _ -> False }"
 
+/// Delimiter literal for splitting non-exploded array query values.
+/// Percent decoding is assumed to have already happened upstream (wisp/mist).
+fn split_delimiter_literal(style: Option(spec.ParameterStyle)) -> String {
+  case style {
+    Some(spec.PipeDelimitedStyle) -> "|"
+    Some(spec.SpaceDelimitedStyle) -> " "
+    _ -> ","
+  }
+}
+
 pub type DeepObjectProperty {
   DeepObjectProperty(
     name: String,
@@ -145,6 +155,7 @@ pub fn query_required_expr(
     key,
     spec.parameter_schema(param),
     param.explode,
+    param.style,
   )
 }
 
@@ -152,7 +163,9 @@ pub fn query_required_expr_with_schema(
   key: String,
   schema_ref: Option(SchemaRef),
   explode: Option(Bool),
+  style: Option(spec.ParameterStyle),
 ) -> String {
+  let delim = split_delimiter_literal(style)
   let base = "{ let assert Ok([v, ..]) = dict.get(query, \"" <> key <> "\") v }"
   case schema_ref {
     Some(Inline(schema.ArraySchema(items: Inline(schema.StringSchema(..)), ..))) ->
@@ -160,7 +173,9 @@ pub fn query_required_expr_with_schema(
         Some(False) ->
           "{ let assert Ok([v, ..]) = dict.get(query, \""
           <> key
-          <> "\") list.map(string.split(v, \",\"), fn(item) { string.trim(item) }) }"
+          <> "\") list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { string.trim(item) }) }"
         _ ->
           "{ let assert Ok(vs) = dict.get(query, \""
           <> key
@@ -171,7 +186,9 @@ pub fn query_required_expr_with_schema(
         Some(False) ->
           "{ let assert Ok([v, ..]) = dict.get(query, \""
           <> key
-          <> "\") list.map(string.split(v, \",\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = int.parse(trimmed) n }) }"
+          <> "\") list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = int.parse(trimmed) n }) }"
         _ ->
           "{ let assert Ok(vs) = dict.get(query, \""
           <> key
@@ -182,7 +199,9 @@ pub fn query_required_expr_with_schema(
         Some(False) ->
           "{ let assert Ok([v, ..]) = dict.get(query, \""
           <> key
-          <> "\") list.map(string.split(v, \",\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = float.parse(trimmed) n }) }"
+          <> "\") list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = float.parse(trimmed) n }) }"
         _ ->
           "{ let assert Ok(vs) = dict.get(query, \""
           <> key
@@ -193,7 +212,9 @@ pub fn query_required_expr_with_schema(
         Some(False) ->
           "{ let assert Ok([v, ..]) = dict.get(query, \""
           <> key
-          <> "\") list.map(string.split(v, \",\"), fn(item) { let v = string.trim(item) "
+          <> "\") list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let v = string.trim(item) "
           <> bool_parse_expr
           <> " }) }"
         _ ->
@@ -230,6 +251,7 @@ pub fn query_optional_expr(
     key,
     spec.parameter_schema(param),
     param.explode,
+    param.style,
   )
 }
 
@@ -237,14 +259,18 @@ pub fn query_optional_expr_with_schema(
   key: String,
   schema_ref: Option(SchemaRef),
   explode: Option(Bool),
+  style: Option(spec.ParameterStyle),
 ) -> String {
+  let delim = split_delimiter_literal(style)
   case schema_ref {
     Some(Inline(schema.ArraySchema(items: Inline(schema.StringSchema(..)), ..))) ->
       case explode {
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \",\"), fn(item) { string.trim(item) })) _ -> None }"
+          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { string.trim(item) })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -255,7 +281,9 @@ pub fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \",\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = int.parse(trimmed) n })) _ -> None }"
+          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = int.parse(trimmed) n })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -266,7 +294,9 @@ pub fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \",\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = float.parse(trimmed) n })) _ -> None }"
+          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let trimmed = string.trim(item) let assert Ok(n) = float.parse(trimmed) n })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -277,7 +307,9 @@ pub fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \",\"), fn(item) { let v = string.trim(item) "
+          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> delim
+          <> "\"), fn(item) { let v = string.trim(item) "
           <> bool_parse_expr
           <> " })) _ -> None }"
         _ ->
@@ -416,12 +448,14 @@ fn deep_object_constructor_expr(
             prop_key,
             Some(prop.schema_ref),
             Some(True),
+            None,
           )
         False ->
           query_optional_expr_with_schema(
             prop_key,
             Some(prop.schema_ref),
             Some(True),
+            None,
           )
       }
       prop.field_name <> ": " <> value_expr

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -160,8 +160,9 @@ fn extract_path_template_names(path: String) -> List(String) {
 }
 
 /// Validate parameters for unsupported serialization styles.
-/// Supported: form (default), deepObject (query+object), exploded array.
-/// Unsupported: matrix, label, simple, spaceDelimited, pipeDelimited.
+/// Supported: form (default), deepObject (query+object), exploded array,
+/// pipeDelimited / spaceDelimited (query+array only).
+/// Unsupported: matrix, label.
 fn validate_parameters(
   op_id: String,
   params: List(spec.Parameter(Resolved)),
@@ -170,18 +171,21 @@ fn validate_parameters(
   list.flat_map(params, fn(p) {
     let path = op_id <> ".parameters." <> p.name
     let style_errors = case p.style {
-      Some(spec.MatrixStyle)
-      | Some(spec.LabelStyle)
-      | Some(spec.SpaceDelimitedStyle)
-      | Some(spec.PipeDelimitedStyle) -> [
+      Some(spec.MatrixStyle) | Some(spec.LabelStyle) -> [
         diagnostic.validation(
           severity: SeverityError,
           target: TargetBoth,
           path: path,
-          detail: "Parameter style is not supported. Supported styles: form, deepObject, simple.",
-          hint: Some("Use style 'form', 'simple', or 'deepObject' instead."),
+          detail: "Parameter style is not supported. Supported styles: form, simple, deepObject, pipeDelimited, spaceDelimited.",
+          hint: Some(
+            "Use style 'form', 'simple', 'deepObject', 'pipeDelimited', or 'spaceDelimited' instead.",
+          ),
         ),
       ]
+      Some(spec.PipeDelimitedStyle) ->
+        validate_delimited_style(path, p, "pipeDelimited", ctx)
+      Some(spec.SpaceDelimitedStyle) ->
+        validate_delimited_style(path, p, "spaceDelimited", ctx)
       _ -> []
     }
     // Parameter.payload is ParameterContent when Parameter.content is used instead of schema.
@@ -215,6 +219,51 @@ fn validate_parameters(
       cookie_errors,
     ])
   })
+}
+
+/// Validate pipeDelimited / spaceDelimited parameter styles.
+/// Both are only meaningful for array-typed query parameters; reject elsewhere.
+fn validate_delimited_style(
+  path: String,
+  param: spec.Parameter(Resolved),
+  style_name: String,
+  ctx: Context,
+) -> List(Diagnostic) {
+  let location_errors = case param.in_ {
+    spec.InQuery -> []
+    _ -> [
+      diagnostic.validation(
+        severity: SeverityError,
+        target: TargetBoth,
+        path: path,
+        detail: "Parameter style '"
+          <> style_name
+          <> "' is only supported for 'in: query'.",
+        hint: Some(
+          "Move this parameter to 'in: query' or switch to a style valid for its location.",
+        ),
+      ),
+    ]
+  }
+  let schema_errors = case
+    resolve_schema_object(spec.parameter_schema(param), ctx)
+  {
+    Some(ArraySchema(..)) -> []
+    _ -> [
+      diagnostic.validation(
+        severity: SeverityError,
+        target: TargetBoth,
+        path: path,
+        detail: "Parameter style '"
+          <> style_name
+          <> "' requires an array schema.",
+        hint: Some(
+          "Change the schema to 'type: array' or switch to style 'form'.",
+        ),
+      ),
+    ]
+  }
+  list.flatten([location_errors, schema_errors])
 }
 
 fn validate_server_structured_param(

--- a/test/fixtures/delimited_param_styles.yaml
+++ b/test/fixtures/delimited_param_styles.yaml
@@ -16,6 +16,14 @@ paths:
             type: array
             items:
               type: string
+        - name: tags
+          in: query
+          description: Pipe-delimited with spec-default explode (omitted, should be false)
+          style: pipeDelimited
+          schema:
+            type: array
+            items:
+              type: string
         - name: colors_exploded
           in: query
           description: Pipe-delimited, exploded (behaves like form exploded)

--- a/test/fixtures/delimited_param_styles.yaml
+++ b/test/fixtures/delimited_param_styles.yaml
@@ -1,0 +1,57 @@
+openapi: "3.0.3"
+info:
+  title: Delimited Parameter Styles API
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: colors
+          in: query
+          description: Pipe-delimited, non-exploded
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: colors_exploded
+          in: query
+          description: Pipe-delimited, exploded (behaves like form exploded)
+          style: pipeDelimited
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: sizes
+          in: query
+          description: Space-delimited, non-exploded
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: sizes_exploded
+          in: query
+          description: Space-delimited, exploded (behaves like form exploded)
+          style: spaceDelimited
+          explode: true
+          schema:
+            type: array
+            items:
+              type: integer
+      responses:
+        "200":
+          description: Items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string

--- a/test/fixtures/pipe_delimited_in_header_rejects.yaml
+++ b/test/fixtures/pipe_delimited_in_header_rejects.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.3"
+info:
+  title: Pipe Delimited In Header Rejects
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: X-Tags
+          in: header
+          description: Pipe-delimited is only valid for query parameters
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Items
+          content:
+            application/json:
+              schema:
+                type: object

--- a/test/fixtures/space_delimited_non_array_rejects.yaml
+++ b/test/fixtures/space_delimited_non_array_rejects.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.3"
+info:
+  title: Space Delimited Non Array Rejects
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: label
+          in: query
+          description: spaceDelimited requires an array schema
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Items
+          content:
+            application/json:
+              schema:
+                type: object

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -9828,7 +9828,28 @@ pub fn parse_delimited_param_styles_test() {
   spec.info.title |> should.equal("Delimited Parameter Styles API")
   let assert Ok(spec.Value(path_item)) = dict.get(spec.paths, "/items")
   let assert Some(op) = path_item.get
-  list.length(op.parameters) |> should.equal(4)
+  list.length(op.parameters) |> should.equal(5)
+  let by_name =
+    list.fold(op.parameters, dict.new(), fn(acc, pref) {
+      let p = spec.unwrap_ref(pref)
+      dict.insert(acc, p.name, p)
+    })
+  let assert Ok(colors) = dict.get(by_name, "colors")
+  colors.style |> should.equal(Some(spec.PipeDelimitedStyle))
+  colors.explode |> should.equal(Some(False))
+  let assert Ok(tags) = dict.get(by_name, "tags")
+  tags.style |> should.equal(Some(spec.PipeDelimitedStyle))
+  // explode omitted — preserved as None; codegen applies the spec default.
+  tags.explode |> should.equal(None)
+  let assert Ok(colors_exploded) = dict.get(by_name, "colors_exploded")
+  colors_exploded.style |> should.equal(Some(spec.PipeDelimitedStyle))
+  colors_exploded.explode |> should.equal(Some(True))
+  let assert Ok(sizes) = dict.get(by_name, "sizes")
+  sizes.style |> should.equal(Some(spec.SpaceDelimitedStyle))
+  sizes.explode |> should.equal(Some(False))
+  let assert Ok(sizes_exploded) = dict.get(by_name, "sizes_exploded")
+  sizes_exploded.style |> should.equal(Some(spec.SpaceDelimitedStyle))
+  sizes_exploded.explode |> should.equal(Some(True))
 }
 
 pub fn validate_accepts_delimited_param_styles_test() {
@@ -10057,15 +10078,26 @@ pub fn generate_delimited_param_styles_client_test() {
   let ctx = make_ctx("test/fixtures/delimited_param_styles.yaml")
   let client_files = client_gen.generate(ctx)
   let combined = list.fold(client_files, "", fn(acc, f) { acc <> f.content })
-  // Non-exploded pipe/space paths should join array items with the style
-  // delimiter before percent-encoding the whole value.
-  string.contains(combined, "string.join(list.map(items,") |> should.be_true()
+  // Non-exploded pipe/space params (colors + tags for pipe, sizes for space)
+  // should join array items with the style delimiter before percent-encoding
+  // the whole value.
   string.contains(combined, "\"colors=\" <> uri.percent_encode(joined)")
+  |> should.be_true()
+  string.contains(combined, "\"tags=\" <> uri.percent_encode(joined)")
   |> should.be_true()
   string.contains(combined, "\"sizes=\" <> uri.percent_encode(joined)")
   |> should.be_true()
   string.contains(combined, "), \"|\")") |> should.be_true()
   string.contains(combined, "), \" \")") |> should.be_true()
+  // Exploded params must stay on the existing form-style path and must NOT
+  // be emitted as a single joined value.
+  string.contains(
+    combined,
+    "\"colors_exploded=\" <> uri.percent_encode(joined)",
+  )
+  |> should.be_false()
+  string.contains(combined, "\"sizes_exploded=\" <> uri.percent_encode(joined)")
+  |> should.be_false()
 }
 
 pub fn generate_delimited_param_styles_server_test() {
@@ -10075,6 +10107,11 @@ pub fn generate_delimited_param_styles_server_test() {
   // Non-exploded server decode should split on the style-specific delimiter.
   string.contains(combined, "string.split(v, \"|\")") |> should.be_true()
   string.contains(combined, "string.split(v, \" \")") |> should.be_true()
+  // The pipe-delimited split appears for both `colors` and the
+  // explode-omitted `tags` parameter; count occurrences to lock that in.
+  let pipe_split_count =
+    string.split(combined, "string.split(v, \"|\")") |> list.length()
+  { pipe_split_count >= 3 } |> should.be_true()
 }
 
 pub fn generate_empty_response_body_server_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -9822,6 +9822,42 @@ pub fn parse_array_param_styles_test() {
   list.length(op.parameters) |> should.not_equal(0)
 }
 
+pub fn parse_delimited_param_styles_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/delimited_param_styles.yaml")
+  spec.info.title |> should.equal("Delimited Parameter Styles API")
+  let assert Ok(spec.Value(path_item)) = dict.get(spec.paths, "/items")
+  let assert Some(op) = path_item.get
+  list.length(op.parameters) |> should.equal(4)
+}
+
+pub fn validate_accepts_delimited_param_styles_test() {
+  let ctx = make_ctx("test/fixtures/delimited_param_styles.yaml")
+  validate.validate(ctx) |> should.equal([])
+}
+
+pub fn pipe_delimited_in_header_rejects_test() {
+  let ctx = make_ctx("test/fixtures/pipe_delimited_in_header_rejects.yaml")
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) {
+    string.contains(s, "pipeDelimited")
+    && string.contains(s, "only supported for 'in: query'")
+  })
+  |> should.be_true()
+}
+
+pub fn space_delimited_non_array_rejects_test() {
+  let ctx = make_ctx("test/fixtures/space_delimited_non_array_rejects.yaml")
+  let errors = validate.validate(ctx)
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) {
+    string.contains(s, "spaceDelimited")
+    && string.contains(s, "requires an array schema")
+  })
+  |> should.be_true()
+}
+
 pub fn parse_empty_response_body_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/empty_response_body.yaml")
@@ -10015,6 +10051,30 @@ pub fn generate_array_param_styles_server_test() {
   let ctx = make_ctx("test/fixtures/array_param_styles.yaml")
   let server_files = server_gen.generate(ctx)
   list.length(server_files) |> should.not_equal(0)
+}
+
+pub fn generate_delimited_param_styles_client_test() {
+  let ctx = make_ctx("test/fixtures/delimited_param_styles.yaml")
+  let client_files = client_gen.generate(ctx)
+  let combined = list.fold(client_files, "", fn(acc, f) { acc <> f.content })
+  // Non-exploded pipe/space paths should join array items with the style
+  // delimiter before percent-encoding the whole value.
+  string.contains(combined, "string.join(list.map(items,") |> should.be_true()
+  string.contains(combined, "\"colors=\" <> uri.percent_encode(joined)")
+  |> should.be_true()
+  string.contains(combined, "\"sizes=\" <> uri.percent_encode(joined)")
+  |> should.be_true()
+  string.contains(combined, "), \"|\")") |> should.be_true()
+  string.contains(combined, "), \" \")") |> should.be_true()
+}
+
+pub fn generate_delimited_param_styles_server_test() {
+  let ctx = make_ctx("test/fixtures/delimited_param_styles.yaml")
+  let server_files = server_gen.generate(ctx)
+  let combined = list.fold(server_files, "", fn(acc, f) { acc <> f.content })
+  // Non-exploded server decode should split on the style-specific delimiter.
+  string.contains(combined, "string.split(v, \"|\")") |> should.be_true()
+  string.contains(combined, "string.split(v, \" \")") |> should.be_true()
 }
 
 pub fn generate_empty_response_body_server_test() {


### PR DESCRIPTION
## Summary

- Accept `style: pipeDelimited` and `style: spaceDelimited` for array-typed query parameters end-to-end (validator, client codegen, server codegen).
- Non-exploded forms join items with `|` or `%20` on the client and split on the same delimiter on the server. Exploded forms degenerate to the existing form-style `name=a&name=b` path.
- Matrix, label, and content-based parameters are still rejected, with an updated diagnostic listing the now-supported styles.
- Closes #97.

## Changes

- `validate.gleam`: replace blanket rejection with a targeted `validate_delimited_style` helper that only errors when pipe/space delimited styles are used outside `in: query` or on non-array schemas.
- `client_request.gleam`: add `is_delimited_array_param` and `generate_delimited_array_query_param`; extend `is_exploded_array_param` so pipe/space default `explode=true` per spec.
- `client.gleam`: wire the new helper into the query-parameter dispatch between the exploded-array and scalar branches.
- `server_request_decode.gleam`: thread `param.style` through `query_required_expr_with_schema` / `query_optional_expr_with_schema`, pick the split delimiter via `split_delimiter_literal`.
- Fixtures: one positive (`delimited_param_styles.yaml`) covering pipe/space × exploded/non-exploded, plus two negative fixtures for in:header and non-array rejection.
- Tests: 5 new tests (parse, validate-accepts, client gen, server gen, two rejection tests). Test count 615 → 621, fixture count 179 → 182.
- README / CHANGELOG: document the new supported styles in the parameter bullet, support matrix, and Unreleased section.

## Design Decisions

- Percent-encoding: the joined value is run through `uri.percent_encode`, which produces `%20` for space (RFC 3986) and `%7C` for `|`. This is always safe; servers that accept literal `|` will still parse the percent-encoded form. The server split happens after the upstream HTTP layer percent-decodes the query value, matching how the existing comma split already behaves.
- Matrix/label deferred: they change the URL structure (path-segment prefixes) and require a separate design; keeping this PR tight to Issue #97's Done condition (\"at least one additional parameter serialization family\").
- `split_delimiter_literal` defaults to `,` so existing `form explode=false` callers continue to split on comma without any caller changes.

## Limitations

- `pipeDelimited` / `spaceDelimited` are only supported for `in: query` array parameters with primitive item types, matching the existing array query-parameter restriction.
- Matrix, label, and `content`-based parameters remain unsupported and are rejected with an updated diagnostic.

## Test plan

- [x] `just all` (format-check, typecheck, build, unit, shellspec, integration, escript, smoke) — all pass locally (621 unit tests, 40 integration tests, 59 shellspec examples)
- [x] Inspected generated client/server output for the new fixture to confirm `string.join(..., \"|\")` / `string.split(v, \" \")` etc. appear as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `pipeDelimited` (`|`) and `spaceDelimited` (space) styles for query array parameters.
  * Clients now serialize arrays as single delimited values (e.g., `tags=a|b|c`).
  * Servers now properly deserialize delimited query parameters back into arrays.
  * Validation updated to accept these styles for query array parameters only.

* **Documentation**
  * Updated README with delimited parameter style support details and feature coverage matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->