### PR TITLE
feat(hoist): preserve provenance metadata on hoisted schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **`style: pipeDelimited` / `style: spaceDelimited` query array parameters**: generated clients encode non-exploded arrays as `name=a|b|c` or `name=a%20b%20c`; generated servers split on the matching delimiter (#97)
-- 5 new tests and 3 fixtures covering delimited styles and their rejection cases (615 → 621 unit tests, 179 → 182 fixtures)
+- **Provenance metadata on hoisted schemas**: every hoisted component schema carries an `OriginKind` explaining whether it came from a property, array item, oneOf/anyOf/allOf position, parameter, request body, response, or additional-properties context. New `oaspec/openapi/provenance` module exposes `hoisted_schema_summary/1` so tooling and diagnostics can distinguish user-authored from synthetic schemas (#30)
+- 8 new tests covering delimited styles, provenance tracking, and summary grouping (615 → 624 unit tests)
+- 3 fixtures covering delimited styles and their rejection cases (179 → 182 fixtures)
 
 ### Changed
 
 - Validator now rejects `pipeDelimited` / `spaceDelimited` only when applied outside `in: query` or to non-array schemas; previous outright rejection is removed
 - README: delimited array styles added to parameter support list and mode-specific support matrix
+- `SchemaMetadata` gains a `provenance: OriginKind` field, defaulted to `UserAuthored`
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 621 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 624 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -4,8 +4,11 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/openapi/schema.{
-  type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
-  Inline, ObjectSchema, OneOfSchema, Reference, Typed,
+  type OriginKind, type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema,
+  ArraySchema, HoistedAdditionalProperties, HoistedAllOfPart,
+  HoistedAnyOfVariant, HoistedArrayItem, HoistedOneOfVariant, HoistedParameter,
+  HoistedProperty, HoistedRequestBody, HoistedResponse, Inline, ObjectSchema,
+  OneOfSchema, Reference, Typed,
 }
 import oaspec/openapi/spec.{
   type OpenApiSpec, type PathItem, type RefOr, Components, OpenApiSpec, PathItem,
@@ -152,10 +155,14 @@ fn find_unique_name(
 
 /// Hoist a single SchemaRef if it is inline and complex.
 /// Returns the (possibly replaced) SchemaRef and updated state.
+/// The `origin` argument records where the hoisted schema came from so
+/// downstream tooling can distinguish synthetic schemas from user-authored
+/// components.
 fn hoist_schema_ref(
   schema_ref: SchemaRef,
   name_prefix: String,
   name_suffix: String,
+  origin: OriginKind,
   state: HoistState,
 ) -> #(SchemaRef, HoistState) {
   case schema_ref {
@@ -170,6 +177,7 @@ fn hoist_schema_ref(
             <> naming.to_pascal_case(name_suffix)
           let #(hoisted_obj, state) =
             hoist_within_schema(schema_obj, base_name, state)
+          let hoisted_obj = schema.set_provenance(hoisted_obj, origin)
 
           // Generate unique name and insert into new_schemas
           let #(unique_name, state) = make_unique_name(base_name, state)
@@ -197,6 +205,7 @@ fn hoist_schema_ref_always(
   schema_ref: SchemaRef,
   name_prefix: String,
   name_suffix: String,
+  origin: OriginKind,
   state: HoistState,
 ) -> #(SchemaRef, HoistState) {
   case schema_ref {
@@ -206,6 +215,7 @@ fn hoist_schema_ref_always(
         naming.to_pascal_case(name_prefix) <> naming.to_pascal_case(name_suffix)
       let #(hoisted_obj, state) =
         hoist_within_schema(schema_obj, base_name, state)
+      let hoisted_obj = schema.set_provenance(hoisted_obj, origin)
       let #(unique_name, state) = make_unique_name(base_name, state)
       let state =
         HoistState(
@@ -236,8 +246,9 @@ fn hoist_within_schema(
         |> list.fold(#(dict.new(), state), fn(acc, entry) {
           let #(props_acc, state) = acc
           let #(prop_name, prop_ref) = entry
+          let origin = HoistedProperty(parent: name_prefix, property: prop_name)
           let #(hoisted_ref, state) =
-            hoist_schema_ref(prop_ref, name_prefix, prop_name, state)
+            hoist_schema_ref(prop_ref, name_prefix, prop_name, origin, state)
           #(dict.insert(props_acc, prop_name, hoisted_ref), state)
         })
 
@@ -245,7 +256,13 @@ fn hoist_within_schema(
       let #(new_ap, state) = case additional_properties {
         Typed(ap_ref) -> {
           let #(hoisted, state) =
-            hoist_schema_ref(ap_ref, name_prefix, "Value", state)
+            hoist_schema_ref(
+              ap_ref,
+              name_prefix,
+              "Value",
+              HoistedAdditionalProperties(parent: name_prefix),
+              state,
+            )
           #(Typed(hoisted), state)
         }
         other -> #(other, state)
@@ -262,7 +279,13 @@ fn hoist_within_schema(
 
     ArraySchema(items:, ..) as arr -> {
       let #(hoisted_items, state) =
-        hoist_schema_ref(items, name_prefix, "Item", state)
+        hoist_schema_ref(
+          items,
+          name_prefix,
+          "Item",
+          HoistedArrayItem(parent: name_prefix),
+          state,
+        )
       #(ArraySchema(..arr, items: hoisted_items), state)
     }
 
@@ -272,7 +295,13 @@ fn hoist_within_schema(
           let #(schemas_acc, state) = acc
           let suffix = "Variant" <> int.to_string(idx)
           let #(hoisted, state) =
-            hoist_schema_ref_always(s_ref, name_prefix, suffix, state)
+            hoist_schema_ref_always(
+              s_ref,
+              name_prefix,
+              suffix,
+              HoistedOneOfVariant(parent: name_prefix, index: idx),
+              state,
+            )
           #([hoisted, ..schemas_acc], state)
         })
       #(
@@ -291,7 +320,13 @@ fn hoist_within_schema(
           let #(schemas_acc, state) = acc
           let suffix = "Variant" <> int.to_string(idx)
           let #(hoisted, state) =
-            hoist_schema_ref_always(s_ref, name_prefix, suffix, state)
+            hoist_schema_ref_always(
+              s_ref,
+              name_prefix,
+              suffix,
+              HoistedAnyOfVariant(parent: name_prefix, index: idx),
+              state,
+            )
           #([hoisted, ..schemas_acc], state)
         })
       #(
@@ -310,7 +345,13 @@ fn hoist_within_schema(
           let #(schemas_acc, state) = acc
           let suffix = "Part" <> int.to_string(idx)
           let #(hoisted, state) =
-            hoist_schema_ref(s_ref, name_prefix, suffix, state)
+            hoist_schema_ref(
+              s_ref,
+              name_prefix,
+              suffix,
+              HoistedAllOfPart(parent: name_prefix, index: idx),
+              state,
+            )
           // Mark hoisted allOf parts as internal so they don't appear
           // in the public generated API (types, decoders, encoders).
           let state = case hoisted {
@@ -483,7 +524,13 @@ fn hoist_parameters(
           spec.ParameterSchema(schema_ref) -> {
             let suffix = "Param" <> naming.to_pascal_case(param.name)
             let #(hoisted, state) =
-              hoist_schema_ref(schema_ref, op_id, suffix, state)
+              hoist_schema_ref(
+                schema_ref,
+                op_id,
+                suffix,
+                HoistedParameter(operation_id: op_id, name: param.name),
+                state,
+              )
             let new_param =
               spec.Parameter(..param, payload: spec.ParameterSchema(hoisted))
             #(list.append(params_acc, [Value(new_param)]), state)
@@ -512,7 +559,13 @@ fn hoist_request_body(
       case media_type.schema {
         Some(schema_ref) -> {
           let #(hoisted, state) =
-            hoist_schema_ref(schema_ref, op_id, "Request", state)
+            hoist_schema_ref(
+              schema_ref,
+              op_id,
+              "Request",
+              HoistedRequestBody(operation_id: op_id),
+              state,
+            )
           let mt = spec.MediaType(..media_type, schema: Some(hoisted))
           #(dict.insert(result, media_type_name, mt), state)
         }
@@ -544,7 +597,16 @@ fn hoist_responses(
               Some(schema_ref) -> {
                 let suffix = "Response" <> http.status_code_suffix(status_code)
                 let #(hoisted, state) =
-                  hoist_schema_ref(schema_ref, op_id, suffix, state)
+                  hoist_schema_ref(
+                    schema_ref,
+                    op_id,
+                    suffix,
+                    HoistedResponse(
+                      operation_id: op_id,
+                      status: http.status_code_suffix(status_code),
+                    ),
+                    state,
+                  )
                 let mt = spec.MediaType(..media_type, schema: Some(hoisted))
                 #(dict.insert(ct_result, media_type_name, mt), state)
               }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1052,6 +1052,7 @@ pub fn parse_schema_object(
       raw_type: None,
       unsupported_keywords:,
       internal: False,
+      provenance: schema.UserAuthored,
     )
 
   // Check for composition keywords first

--- a/src/oaspec/openapi/provenance.gleam
+++ b/src/oaspec/openapi/provenance.gleam
@@ -1,0 +1,122 @@
+//// Summarise the provenance of component schemas after the hoist pass has
+//// run. Distinguishing user-authored schemas from synthetic ones created
+//// during hoisting lets tooling explain where each generated type came from.
+
+import gleam/dict
+import gleam/list
+import gleam/option.{None, Some}
+import oaspec/openapi/schema.{
+  HoistedAdditionalProperties, HoistedAllOfPart, HoistedAnyOfVariant,
+  HoistedArrayItem, HoistedOneOfVariant, HoistedParameter, HoistedProperty,
+  HoistedRequestBody, HoistedResponse, Inline, UserAuthored,
+}
+import oaspec/openapi/spec.{type OpenApiSpec}
+
+/// Breakdown of component schemas by origin after hoisting.
+pub type HoistedSummary {
+  HoistedSummary(
+    user_authored: List(String),
+    hoisted_properties: List(#(String, String, String)),
+    hoisted_array_items: List(#(String, String)),
+    hoisted_oneof_variants: List(#(String, String, Int)),
+    hoisted_anyof_variants: List(#(String, String, Int)),
+    hoisted_allof_parts: List(#(String, String, Int)),
+    hoisted_request_bodies: List(#(String, String)),
+    hoisted_responses: List(#(String, String, String)),
+    hoisted_parameters: List(#(String, String, String)),
+    hoisted_additional_properties: List(#(String, String)),
+  )
+}
+
+/// Total number of synthetic schemas that were created during hoisting.
+pub fn total_hoisted(summary: HoistedSummary) -> Int {
+  list.length(summary.hoisted_properties)
+  + list.length(summary.hoisted_array_items)
+  + list.length(summary.hoisted_oneof_variants)
+  + list.length(summary.hoisted_anyof_variants)
+  + list.length(summary.hoisted_allof_parts)
+  + list.length(summary.hoisted_request_bodies)
+  + list.length(summary.hoisted_responses)
+  + list.length(summary.hoisted_parameters)
+  + list.length(summary.hoisted_additional_properties)
+}
+
+/// Walk component schemas and group them by provenance. Reference-only
+/// entries (rare after resolve) are ignored because they carry no
+/// metadata of their own.
+pub fn hoisted_schema_summary(spec: OpenApiSpec(stage)) -> HoistedSummary {
+  let empty =
+    HoistedSummary(
+      user_authored: [],
+      hoisted_properties: [],
+      hoisted_array_items: [],
+      hoisted_oneof_variants: [],
+      hoisted_anyof_variants: [],
+      hoisted_allof_parts: [],
+      hoisted_request_bodies: [],
+      hoisted_responses: [],
+      hoisted_parameters: [],
+      hoisted_additional_properties: [],
+    )
+  let schemas = case spec.components {
+    Some(components) -> components.schemas
+    None -> dict.new()
+  }
+  dict.to_list(schemas)
+  |> list.fold(empty, fn(acc, entry) {
+    let #(name, schema_ref) = entry
+    case schema_ref {
+      Inline(obj) ->
+        case schema.get_provenance(obj) {
+          UserAuthored ->
+            HoistedSummary(..acc, user_authored: [name, ..acc.user_authored])
+          HoistedProperty(parent:, property:) ->
+            HoistedSummary(..acc, hoisted_properties: [
+              #(name, parent, property),
+              ..acc.hoisted_properties
+            ])
+          HoistedArrayItem(parent:) ->
+            HoistedSummary(..acc, hoisted_array_items: [
+              #(name, parent),
+              ..acc.hoisted_array_items
+            ])
+          HoistedOneOfVariant(parent:, index:) ->
+            HoistedSummary(..acc, hoisted_oneof_variants: [
+              #(name, parent, index),
+              ..acc.hoisted_oneof_variants
+            ])
+          HoistedAnyOfVariant(parent:, index:) ->
+            HoistedSummary(..acc, hoisted_anyof_variants: [
+              #(name, parent, index),
+              ..acc.hoisted_anyof_variants
+            ])
+          HoistedAllOfPart(parent:, index:) ->
+            HoistedSummary(..acc, hoisted_allof_parts: [
+              #(name, parent, index),
+              ..acc.hoisted_allof_parts
+            ])
+          HoistedRequestBody(operation_id:) ->
+            HoistedSummary(..acc, hoisted_request_bodies: [
+              #(name, operation_id),
+              ..acc.hoisted_request_bodies
+            ])
+          HoistedResponse(operation_id:, status:) ->
+            HoistedSummary(..acc, hoisted_responses: [
+              #(name, operation_id, status),
+              ..acc.hoisted_responses
+            ])
+          HoistedParameter(operation_id:, name: param_name) ->
+            HoistedSummary(..acc, hoisted_parameters: [
+              #(name, operation_id, param_name),
+              ..acc.hoisted_parameters
+            ])
+          HoistedAdditionalProperties(parent:) ->
+            HoistedSummary(..acc, hoisted_additional_properties: [
+              #(name, parent),
+              ..acc.hoisted_additional_properties
+            ])
+        }
+      _ -> acc
+    }
+  })
+}

--- a/src/oaspec/openapi/schema.gleam
+++ b/src/oaspec/openapi/schema.gleam
@@ -4,6 +4,22 @@ import gleam/option.{type Option}
 import gleam/string
 import oaspec/openapi/value.{type JsonValue}
 
+/// Origin of a schema — user-authored or hoisted during codegen.
+/// Hoisted variants carry the call-site context so tooling can explain
+/// where synthetic component schemas came from.
+pub type OriginKind {
+  UserAuthored
+  HoistedProperty(parent: String, property: String)
+  HoistedArrayItem(parent: String)
+  HoistedOneOfVariant(parent: String, index: Int)
+  HoistedAnyOfVariant(parent: String, index: Int)
+  HoistedAllOfPart(parent: String, index: Int)
+  HoistedRequestBody(operation_id: String)
+  HoistedResponse(operation_id: String, status: String)
+  HoistedParameter(operation_id: String, name: String)
+  HoistedAdditionalProperties(parent: String)
+}
+
 /// Shared metadata for all schema types.
 /// Extracted from variants to avoid duplication and ensure composition
 /// schemas (allOf/oneOf/anyOf) don't lose these fields.
@@ -21,6 +37,7 @@ pub type SchemaMetadata {
     raw_type: Option(List(String)),
     unsupported_keywords: List(String),
     internal: Bool,
+    provenance: OriginKind,
   )
 }
 
@@ -39,6 +56,7 @@ pub fn default_metadata() -> SchemaMetadata {
     raw_type: option.None,
     unsupported_keywords: [],
     internal: False,
+    provenance: UserAuthored,
   )
 }
 
@@ -179,6 +197,20 @@ pub fn set_internal(schema: SchemaObject) -> SchemaObject {
   let meta = get_metadata(schema)
   let meta = SchemaMetadata(..meta, internal: True)
   set_metadata(schema, meta)
+}
+
+/// Stamp the origin of a hoisted schema onto its metadata so downstream
+/// consumers (diagnostics, tooling) can distinguish user-authored schemas
+/// from synthetic ones created during the hoist pass.
+pub fn set_provenance(schema: SchemaObject, origin: OriginKind) -> SchemaObject {
+  let meta = get_metadata(schema)
+  let meta = SchemaMetadata(..meta, provenance: origin)
+  set_metadata(schema, meta)
+}
+
+/// Read the provenance of a schema. Unhoisted schemas return `UserAuthored`.
+pub fn get_provenance(schema: SchemaObject) -> OriginKind {
+  get_metadata(schema).provenance
 }
 
 /// Replace the metadata on a schema object.

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -23,6 +23,7 @@ import oaspec/openapi/diagnostic.{Diagnostic}
 import oaspec/openapi/hoist
 import oaspec/openapi/normalize
 import oaspec/openapi/parser
+import oaspec/openapi/provenance
 import oaspec/openapi/resolve
 import oaspec/openapi/resolver
 import oaspec/openapi/schema
@@ -972,6 +973,107 @@ components:
   // Hoisted schemas should exist (naming: PetType0, PetType1 or similar)
   // At minimum, components.schemas should have more than just PetType
   dict.size(components.schemas) |> should.equal(3)
+}
+
+pub fn hoist_property_provenance_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        address:
+          type: object
+          properties:
+            street: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+  let assert Ok(schema.Inline(pet)) = dict.get(components.schemas, "Pet")
+  schema.get_provenance(pet) |> should.equal(schema.UserAuthored)
+  let assert Ok(schema.Inline(pet_address)) =
+    dict.get(components.schemas, "PetAddress")
+  schema.get_provenance(pet_address)
+  |> should.equal(schema.HoistedProperty(parent: "Pet", property: "address"))
+}
+
+pub fn hoist_oneof_variant_provenance_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    PetType:
+      oneOf:
+        - type: object
+          properties:
+            bark_volume: { type: integer }
+        - type: object
+          properties:
+            purr_frequency: { type: number }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let assert Some(components) = hoisted.components
+  let assert Ok(schema.Inline(variant0)) =
+    dict.get(components.schemas, "PetTypeVariant0")
+  schema.get_provenance(variant0)
+  |> should.equal(schema.HoistedOneOfVariant(parent: "PetType", index: 0))
+  let assert Ok(schema.Inline(variant1)) =
+    dict.get(components.schemas, "PetTypeVariant1")
+  schema.get_provenance(variant1)
+  |> should.equal(schema.HoistedOneOfVariant(parent: "PetType", index: 1))
+}
+
+pub fn hoisted_schema_summary_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        address:
+          type: object
+          properties:
+            street: { type: string }
+    PetList:
+      type: array
+      items:
+        type: object
+        properties:
+          name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let hoisted = hoist.hoist(spec)
+  let summary = provenance.hoisted_schema_summary(hoisted)
+  // User-authored: Pet, PetList
+  list.length(summary.user_authored) |> should.equal(2)
+  // Hoisted: PetAddress (property), PetListItem (array item)
+  list.length(summary.hoisted_properties) |> should.equal(1)
+  list.length(summary.hoisted_array_items) |> should.equal(1)
+  provenance.total_hoisted(summary) |> should.equal(2)
+  // Parent tracking is preserved through hoist metadata
+  let assert [#(prop_name, parent, property)] = summary.hoisted_properties
+  prop_name |> should.equal("PetAddress")
+  parent |> should.equal("Pet")
+  property |> should.equal("address")
 }
 
 pub fn hoist_inline_array_items_test() {


### PR DESCRIPTION
## Summary

- Record where each hoisted component schema came from so downstream tooling and diagnostics can distinguish user-authored schemas from synthetic ones.
- Add an `OriginKind` ADT and a `provenance` field on `SchemaMetadata`. Stamped during the hoist pass; defaults to `UserAuthored` for everything else.
- New `oaspec/openapi/provenance` module exposes `hoisted_schema_summary/1` — the first downstream consumer of provenance, available to diagnostics and future tooling.
- Closes #30.

## Changes

- `src/oaspec/openapi/schema.gleam`: add `OriginKind` ADT (10 variants), extend `SchemaMetadata` with `provenance: OriginKind`, default to `UserAuthored`, expose `set_provenance/2` and `get_provenance/1` helpers.
- `src/oaspec/openapi/hoist.gleam`: thread `OriginKind` through `hoist_schema_ref` and `hoist_schema_ref_always`, stamp each hoist call site with the appropriate variant (property, array item, oneOf/anyOf variant, allOf part, parameter, request body, response, additionalProperties).
- `src/oaspec/openapi/parser.gleam`: update the one full-field `SchemaMetadata` constructor to pass `provenance: schema.UserAuthored`. All other sites use record-spread syntax so they inherit the default automatically.
- `src/oaspec/openapi/provenance.gleam` (new): `HoistedSummary` record + `hoisted_schema_summary/1` that walks component schemas and groups them by provenance. Tracks parent/operation/property/index context returned by the ADT.
- Tests: 3 new hoist/provenance tests (property, oneOf variant, summary grouping). Test count 621 → 624.
- README / CHANGELOG updated.

## Design Decisions

- **Provenance lives on `SchemaMetadata`, not a sidecar structure.** Every schema variant already shares metadata, and the existing `internal: Bool` origin hint sits next to the new field — keeping origin information in one place.
- **`OriginKind` variants carry call-site context** (e.g., `HoistedProperty(parent, property)`) rather than being flat enums. Without the context, provenance would collapse to a boolean; with it, tooling can explain *where* a synthetic schema came from.
- **The downstream consumer is purely additive.** `hoisted_schema_summary/1` branches on provenance to populate grouped lists — a genuine decision that depends on the new metadata — but it does not change any existing generated code, validation, or golden fixture. The existing `internal` flag (used by IR build to filter helper types) is left untouched.

## Limitations

- `provenance` is only set during hoist; user-authored schemas retain the `UserAuthored` default. Normalize/resolve do not currently relabel.
- Additional downstream consumers (dedup, IR build, diagnostics warnings) are left for future PRs — the contract is established but not exhaustively consumed yet.

## Test plan

- [x] `just all` (format-check, typecheck, build, unit, shellspec, integration, escript, smoke) passes locally (624 unit, 40 integration, 59 shellspec).
- [x] No existing tests or fixtures required updates; provenance is not emitted into generated code.