### PR TITLE
fix(guards): pluralize minLength/maxLength messages correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **`style: pipeDelimited` / `style: spaceDelimited` query array parameters**: generated clients encode non-exploded arrays as `name=a|b|c` or `name=a%20b%20c`; generated servers split on the matching delimiter (#97)
 - **Provenance metadata on hoisted schemas**: every hoisted component schema carries an `OriginKind` explaining whether it came from a property, array item, oneOf/anyOf/allOf position, parameter, request body, response, or additional-properties context. New `oaspec/openapi/provenance` module exposes `hoisted_schema_summary/1` so tooling and diagnostics can distinguish user-authored from synthetic schemas (#30)
 - `examples/petstore_client`: first runnable example of an oaspec-generated client, driven by a stub `send` function; wired to `just example-petstore` (#26)
-- 8 new tests covering delimited styles, provenance tracking, and summary grouping (615 → 624 unit tests)
+- 10 new tests covering delimited styles, provenance tracking, summary grouping, and guard pluralization (615 → 626 unit tests)
 - 3 fixtures covering delimited styles and their rejection cases (179 → 182 fixtures)
 
 ### Changed
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Validator now rejects `pipeDelimited` / `spaceDelimited` only when applied outside `in: query` or to non-array schemas; previous outright rejection is removed
 - README: delimited array styles added to parameter support list and mode-specific support matrix
 - `SchemaMetadata` gains a `provenance: OriginKind` field, defaulted to `UserAuthored`
+
+### Fixed
+
+- Generated `minLength` / `maxLength` guard messages now pluralize correctly — `1 character` (singular) vs. `N characters` (plural) (#121)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 624 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 626 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/guards.gleam
+++ b/examples/petstore_client/src/api/guards.gleam
@@ -9,7 +9,7 @@ pub fn validate_create_pet_request_name_length(
 ) -> Result(String, String) {
   let len = string.length(value)
   case len < 1 {
-    True -> Error("must be at least 1 characters")
+    True -> Error("must be at least 1 character")
     False ->
       case len > 100 {
         True -> Error("must be at most 100 characters")
@@ -22,7 +22,7 @@ pub fn validate_create_pet_request_name_length(
 pub fn validate_pet_name_length(value: String) -> Result(String, String) {
   let len = string.length(value)
   case len < 1 {
-    True -> Error("must be at least 1 characters")
+    True -> Error("must be at least 1 character")
     False ->
       case len > 100 {
         True -> Error("must be at most 100 characters")

--- a/golden/petstore/api/guards.gleam
+++ b/golden/petstore/api/guards.gleam
@@ -9,7 +9,7 @@ pub fn validate_create_pet_request_name_length(
 ) -> Result(String, String) {
   let len = string.length(value)
   case len < 1 {
-    True -> Error("must be at least 1 characters")
+    True -> Error("must be at least 1 character")
     False ->
       case len > 100 {
         True -> Error("must be at most 100 characters")
@@ -22,7 +22,7 @@ pub fn validate_create_pet_request_name_length(
 pub fn validate_pet_name_length(value: String) -> Result(String, String) {
   let len = string.length(value)
   case len < 1 {
-    True -> Error("must be at least 1 characters")
+    True -> Error("must be at least 1 character")
     False ->
       case len > 100 {
         True -> Error("must be at most 100 characters")

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -453,6 +453,15 @@ fn generate_string_pattern_guard(
   }
 }
 
+/// Word used in minLength/maxLength error messages.
+/// Singular when the bound is exactly one; plural otherwise.
+fn character_word(n: Int) -> String {
+  case n {
+    1 -> "character"
+    _ -> "characters"
+  }
+}
+
 /// Generate a string length validation guard.
 fn generate_string_guard(
   sb: se.StringBuilder,
@@ -487,7 +496,9 @@ fn generate_string_guard(
             2,
             "True -> Error(\"must be at least "
               <> int.to_string(min)
-              <> " characters\")",
+              <> " "
+              <> character_word(min)
+              <> "\")",
           )
           |> se.indent(2, "False ->")
           |> se.indent(3, "case len > " <> int.to_string(max) <> " {")
@@ -495,7 +506,9 @@ fn generate_string_guard(
             4,
             "True -> Error(\"must be at most "
               <> int.to_string(max)
-              <> " characters\")",
+              <> " "
+              <> character_word(max)
+              <> "\")",
           )
           |> se.indent(4, "False -> Ok(value)")
           |> se.indent(3, "}")
@@ -507,7 +520,9 @@ fn generate_string_guard(
             2,
             "True -> Error(\"must be at least "
               <> int.to_string(min)
-              <> " characters\")",
+              <> " "
+              <> character_word(min)
+              <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")
@@ -518,7 +533,9 @@ fn generate_string_guard(
             2,
             "True -> Error(\"must be at most "
               <> int.to_string(max)
-              <> " characters\")",
+              <> " "
+              <> character_word(max)
+              <> "\")",
           )
           |> se.indent(2, "False -> Ok(value)")
           |> se.indent(1, "}")

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,69 @@ components:
   |> should.be_true()
 }
 
+pub fn guards_minlength_one_uses_singular_character_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /u:
+    get:
+      operationId: u
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Short:
+      type: string
+      minLength: 1
+      maxLength: 1
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let assert [guard_file] = guards.generate(ctx)
+  string.contains(guard_file.content, "must be at least 1 character\"")
+  |> should.be_true()
+  string.contains(guard_file.content, "must be at most 1 character\"")
+  |> should.be_true()
+  // The plural form must not appear for 1-bounded messages.
+  string.contains(guard_file.content, "must be at least 1 characters")
+  |> should.be_false()
+  string.contains(guard_file.content, "must be at most 1 characters")
+  |> should.be_false()
+}
+
+pub fn guards_minmax_length_plural_above_one_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /u:
+    get:
+      operationId: u
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Medium:
+      type: string
+      minLength: 2
+      maxLength: 5
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let assert [guard_file] = guards.generate(ctx)
+  string.contains(guard_file.content, "must be at least 2 characters")
+  |> should.be_true()
+  string.contains(guard_file.content, "must be at most 5 characters")
+  |> should.be_true()
+}
+
 pub fn validate_top_level_string_pattern_generates_guard_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated string-length guards emit the plural `characters` word even when the bound is `1`, producing `must be at least 1 characters`.
- Add a tiny `character_word/1` helper in the guard codegen so messages render `1 character` and `N characters` correctly.
- Regenerate golden snapshots and the petstore example's `guards.gleam` to match the new output. Adds two unit tests that lock both forms.

## Changes

- `src/oaspec/codegen/guards.gleam`: new `character_word/1` helper; four emit sites (min+max and max-only cases) updated to use it.
- `test/oaspec_test.gleam`: two new tests — `guards_minlength_one_uses_singular_character_test` and `guards_minmax_length_plural_above_one_test`.
- `golden/petstore/api/guards.gleam` and `examples/petstore_client/src/api/guards.gleam`: regenerated with the corrected messages.
- `README.md`: unit test count 624 → 626.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- Added a local helper in the codegen module rather than exposing a runtime pluralizer in generated code. Pluralization is resolved at generation time — the emitted string is the final text — so there's no reason to pay runtime cost on each validation call.
- Kept the template untouched for integer and number ranges; they don't use words with plural forms, so only the string-length template needed the fix.

## Test plan

- [x] `just all` passes (626 unit tests, 40 integration, 59 shellspec, smoke).
- [x] `grep 'must be at' examples/petstore_client/src/api/guards.gleam` shows `1 character` (singular) and `100 characters` (plural).

Closes #121.