### PR TITLE
fix(client): preserve declared query parameter order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Generated `minLength` / `maxLength` guard messages now pluralize correctly — `1 character` (singular) vs. `N characters` (plural) (#121)
+- Generated client query strings now preserve the declared OpenAPI parameter order; previously the prepending loop reversed it (#123)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 626 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 627 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/client.gleam
+++ b/examples/petstore_client/src/api/client.gleam
@@ -7,6 +7,7 @@ import api/types
 import gleam/http
 import gleam/http/request
 import gleam/int
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam/uri
@@ -64,7 +65,7 @@ pub fn list_pets(
     ]
     None -> query_parts
   }
-  let query_string = string.join(query_parts, "&")
+  let query_string = string.join(list.reverse(query_parts), "&")
   let path = case query_string {
     "" -> path
     _ -> path <> "?" <> query_string

--- a/golden/petstore/api/client.gleam
+++ b/golden/petstore/api/client.gleam
@@ -7,6 +7,7 @@ import api/types
 import gleam/http
 import gleam/http/request
 import gleam/int
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam/uri
@@ -64,7 +65,7 @@ pub fn list_pets(
     ]
     None -> query_parts
   }
-  let query_string = string.join(query_parts, "&")
+  let query_string = string.join(list.reverse(query_parts), "&")
   let path = case query_string {
     "" -> path
     _ -> path <> "?" <> query_string

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -88,6 +88,9 @@ fn generate_client(ctx: Context) -> String {
   let needs_list =
     has_form_urlencoded
     || has_multi_content_response
+    // Every operation with query parameters uses `list.reverse` before
+    // joining, so we need `gleam/list` whenever any query parameter exists.
+    || list.any(all_params, fn(p) { p.in_ == spec.InQuery })
     || list.any(all_params, fn(p) {
       case p.payload {
         ParameterSchema(Inline(schema.ArraySchema(..))) -> True
@@ -744,7 +747,10 @@ fn generate_client_function(
         })
       let sb =
         sb
-        |> se.indent(1, "let query_string = string.join(query_parts, \"&\")")
+        |> se.indent(
+          1,
+          "let query_string = string.join(list.reverse(query_parts), \"&\")",
+        )
         |> se.indent(1, "let path = case query_string {")
         |> se.indent(2, "\"\" -> path")
         |> se.indent(2, "_ -> path <> \"?\" <> query_string")

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,36 @@ components:
   |> should.be_true()
 }
 
+pub fn client_query_params_preserve_declared_order_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer }
+        - name: offset
+          in: query
+          schema: { type: integer }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // The emitted joiner should reverse before joining to match declared order.
+  string.contains(combined, "string.join(list.reverse(query_parts), \"&\")")
+  |> should.be_true()
+}
+
 pub fn guards_minlength_one_uses_singular_character_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated clients reversed the OpenAPI-declared query parameter order because each parameter was prepended to the accumulator.
- Keep the prepend loop but call `list.reverse` once before `string.join`. No behaviour change for strict-unordered servers; logs / fixtures / goldens are readable now.
- Surfaced by CodeRabbit on #120.

## Changes

- `src/oaspec/codegen/client.gleam`: emit `string.join(list.reverse(query_parts), \"&\")` and widen the `needs_list` detector so any operation with at least one query parameter pulls in `gleam/list`.
- `test/oaspec_test.gleam`: new `client_query_params_preserve_declared_order_test` that asserts the `list.reverse(query_parts)` shape is present in the generated client.
- `golden/petstore/api/client.gleam`, `examples/petstore_client/src/api/client.gleam`: regenerated with the new order.
- `README.md`: unit test count 626 → 627.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- Prepending is the idiomatic accumulation pattern on Gleam linked lists — a trailing `list.reverse` restores declared order without regressing the O(n) build cost to O(n²).
- Widened `needs_list` using `p.in_ == spec.InQuery` rather than adding a dedicated flag. Any change to emission that depends on list ops in the query path now already has the import.

## Test plan

- [x] `just all` passes (627 unit tests, 40 integration, 59 shellspec, smoke).
- [x] Regenerated `examples/petstore_client/src/api/client.gleam` emits `list.reverse` and the example still runs (`cd examples/petstore_client && gleam run` prints the two pets).

Closes #123.