### PR TITLE
fix(decode): surface rejected value in enum decoder failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Generated `minLength` / `maxLength` guard messages now pluralize correctly — `1 character` (singular) vs. `N characters` (plural) (#121)
 - Generated client query strings now preserve the declared OpenAPI parameter order; previously the prepending loop reversed it (#123)
+- Generated enum decoders now include the rejected string in their failure message (e.g. `"PetStatus: unknown variant adopted"`) instead of dropping it (#125)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 627 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 628 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/decode.gleam
+++ b/examples/petstore_client/src/api/decode.gleam
@@ -128,7 +128,11 @@ pub fn pet_status_decoder() -> decode.Decoder(types.PetStatus) {
     "available" -> decode.success(types.PetStatusAvailable)
     "pending" -> decode.success(types.PetStatusPending)
     "sold" -> decode.success(types.PetStatusSold)
-    _ -> decode.failure(types.PetStatusAvailable, "PetStatus")
+    _ ->
+      decode.failure(
+        types.PetStatusAvailable,
+        "PetStatus: unknown variant " <> value,
+      )
   }
 }
 

--- a/golden/complex_supported/api/decode.gleam
+++ b/golden/complex_supported/api/decode.gleam
@@ -11,7 +11,11 @@ pub fn admin_user_type_decoder() -> decode.Decoder(types.AdminUserType) {
   case value {
     "admin" -> decode.success(types.AdminUserTypeAdmin)
     "regular" -> decode.success(types.AdminUserTypeRegular)
-    _ -> decode.failure(types.AdminUserTypeAdmin, "AdminUserType")
+    _ ->
+      decode.failure(
+        types.AdminUserTypeAdmin,
+        "AdminUserType: unknown variant " <> value,
+      )
   }
 }
 
@@ -28,7 +32,7 @@ pub fn filter_op_decoder() -> decode.Decoder(types.FilterOp) {
     "ne" -> decode.success(types.FilterOpNe)
     "gt" -> decode.success(types.FilterOpGt)
     "lt" -> decode.success(types.FilterOpLt)
-    _ -> decode.failure(types.FilterOpEq, "FilterOp")
+    _ -> decode.failure(types.FilterOpEq, "FilterOp: unknown variant " <> value)
   }
 }
 
@@ -43,7 +47,11 @@ pub fn regular_user_type_decoder() -> decode.Decoder(types.RegularUserType) {
   case value {
     "admin" -> decode.success(types.RegularUserTypeAdmin)
     "regular" -> decode.success(types.RegularUserTypeRegular)
-    _ -> decode.failure(types.RegularUserTypeAdmin, "RegularUserType")
+    _ ->
+      decode.failure(
+        types.RegularUserTypeAdmin,
+        "RegularUserType: unknown variant " <> value,
+      )
   }
 }
 
@@ -58,7 +66,8 @@ pub fn user_type_decoder() -> decode.Decoder(types.UserType) {
   case value {
     "admin" -> decode.success(types.UserTypeAdmin)
     "regular" -> decode.success(types.UserTypeRegular)
-    _ -> decode.failure(types.UserTypeAdmin, "UserType")
+    _ ->
+      decode.failure(types.UserTypeAdmin, "UserType: unknown variant " <> value)
   }
 }
 

--- a/golden/petstore/api/decode.gleam
+++ b/golden/petstore/api/decode.gleam
@@ -128,7 +128,11 @@ pub fn pet_status_decoder() -> decode.Decoder(types.PetStatus) {
     "available" -> decode.success(types.PetStatusAvailable)
     "pending" -> decode.success(types.PetStatusPending)
     "sold" -> decode.success(types.PetStatusSold)
-    _ -> decode.failure(types.PetStatusAvailable, "PetStatus")
+    _ ->
+      decode.failure(
+        types.PetStatusAvailable,
+        "PetStatus: unknown variant " <> value,
+      )
   }
 }
 

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -682,7 +682,7 @@ fn generate_enum_decoder(
       <> first_variant_suffix
       <> ", \""
       <> type_name
-      <> "\")",
+      <> ": unknown variant \" <> value)",
   )
   |> se.indent(1, "}")
   |> se.line("}")

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,34 @@ components:
   |> should.be_true()
 }
 
+pub fn enum_decoder_failure_includes_rejected_value_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /u:
+    get:
+      operationId: u
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Status:
+      type: string
+      enum: [active, inactive]
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // Failure branch must interpolate `value` so callers can see the bad string.
+  string.contains(combined, "\"Status: unknown variant \" <> value")
+  |> should.be_true()
+}
+
 pub fn client_query_params_preserve_declared_order_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated enum decoders dropped the offending input string when they hit an unknown variant — `decode.failure(..., \"PetStatus\")` — making spec/server drift hard to debug.
- Include the rejected value in the failure label: `\"PetStatus: unknown variant \" <> value`.
- Surfaced by CodeRabbit on #120.

## Changes

- `src/oaspec/codegen/decoders.gleam`: emit `"<TypeName>: unknown variant " <> value` in the fallback branch of every generated enum decoder.
- `test/oaspec_test.gleam`: `enum_decoder_failure_includes_rejected_value_test` asserts the new message format.
- `golden/petstore/api/decode.gleam`, `golden/complex_supported/api/decode.gleam`, `examples/petstore_client/src/api/decode.gleam`: regenerated.
- `README.md`: unit test count 627 → 628.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- Interpolate `value` directly into a plain label (e.g. `"PetStatus: unknown variant adopted"`) rather than wrapping it in quotes or a structured diagnostic. Keeps the emitted expression simple and matches the level of detail already produced by other generated failure sites.
- Only the unknown-variant branch changed; the success arms and the enum generation structure stay the same, so there is no risk of variant name drift.

## Test plan

- [x] `just all` passes (628 unit tests, 40 integration, 59 shellspec, smoke).
- [x] `grep 'unknown variant' examples/petstore_client/src/api/decode.gleam` shows the new interpolated string.

Closes #125.