### PR TITLE
feat(client): surface unexpected HTTP status as a dedicated error variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Generated `minLength` / `maxLength` guard messages now pluralize correctly — `1 character` (singular) vs. `N characters` (plural) (#121)
 - Generated client query strings now preserve the declared OpenAPI parameter order; previously the prepending loop reversed it (#123)
 - Generated enum decoders now include the rejected string in their failure message (e.g. `"PetStatus: unknown variant adopted"`) instead of dropping it (#125)
+- Generated clients distinguish unexpected HTTP statuses from decode failures via a new `UnexpectedStatus(status: Int, body: String)` variant on `ClientError`; previously an unknown status was reported as `DecodeError` and indistinguishable from JSON decode failures (#127)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 628 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 629 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/client.gleam
+++ b/examples/petstore_client/src/api/client.gleam
@@ -30,6 +30,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  UnexpectedStatus(status: Int, body: String)
 }
 
 /// Create a new client configuration.
@@ -84,10 +85,7 @@ pub fn list_pets(
           }
         }
         401 -> Ok(response_types.ListPetsResponseUnauthorized)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -117,10 +115,7 @@ pub fn create_pet(
         }
         400 -> Ok(response_types.CreatePetResponseBadRequest)
         401 -> Ok(response_types.CreatePetResponseUnauthorized)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -150,10 +145,7 @@ pub fn get_pet(
         }
         401 -> Ok(response_types.GetPetResponseUnauthorized)
         404 -> Ok(response_types.GetPetResponseNotFound)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -177,10 +169,7 @@ pub fn delete_pet(
         204 -> Ok(response_types.DeletePetResponseNoContent)
         401 -> Ok(response_types.DeletePetResponseUnauthorized)
         404 -> Ok(response_types.DeletePetResponseNotFound)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }

--- a/examples/petstore_client/src/petstore_client_example.gleam
+++ b/examples/petstore_client/src/petstore_client_example.gleam
@@ -43,6 +43,8 @@ fn describe(err: client.ClientError) -> String {
     client.ConnectionError(detail) -> "connection: " <> detail
     client.TimeoutError -> "timeout"
     client.DecodeError(detail) -> "decode: " <> detail
+    client.UnexpectedStatus(status:, body: _) ->
+      "unexpected status: " <> int.to_string(status)
   }
 }
 

--- a/golden/complex_supported/api/client.gleam
+++ b/golden/complex_supported/api/client.gleam
@@ -6,7 +6,6 @@ import api/response_types
 import api/types
 import gleam/http
 import gleam/http/request
-import gleam/int
 import gleam/string
 import gleam/uri
 
@@ -28,6 +27,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  UnexpectedStatus(status: Int, body: String)
 }
 
 /// Create a new client configuration.
@@ -70,10 +70,7 @@ pub fn post_search(
               Error(DecodeError(detail: "Failed to decode response body"))
           }
         }
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -106,10 +103,7 @@ pub fn get_user(
               Error(DecodeError(detail: "Failed to decode response body"))
           }
         }
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -136,10 +130,7 @@ pub fn post_webhook(
     Ok(resp) -> {
       case resp.status {
         200 -> Ok(response_types.PostWebhookResponseOk)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }

--- a/golden/petstore/api/client.gleam
+++ b/golden/petstore/api/client.gleam
@@ -30,6 +30,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  UnexpectedStatus(status: Int, body: String)
 }
 
 /// Create a new client configuration.
@@ -84,10 +85,7 @@ pub fn list_pets(
           }
         }
         401 -> Ok(response_types.ListPetsResponseUnauthorized)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -117,10 +115,7 @@ pub fn create_pet(
         }
         400 -> Ok(response_types.CreatePetResponseBadRequest)
         401 -> Ok(response_types.CreatePetResponseUnauthorized)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -150,10 +145,7 @@ pub fn get_pet(
         }
         401 -> Ok(response_types.GetPetResponseUnauthorized)
         404 -> Ok(response_types.GetPetResponseNotFound)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }
@@ -177,10 +169,7 @@ pub fn delete_pet(
         204 -> Ok(response_types.DeletePetResponseNoContent)
         401 -> Ok(response_types.DeletePetResponseUnauthorized)
         404 -> Ok(response_types.DeletePetResponseNotFound)
-        _ ->
-          Error(DecodeError(
-            detail: "Unexpected status: " <> int.to_string(resp.status),
-          ))
+        _ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))
       }
     }
   }

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -203,13 +203,39 @@ fn generate_client(ctx: Context) -> String {
       !list.is_empty(security_schemes)
     }
 
+  // `gleam/int` is only needed when the generated client actually stringifies
+  // integers — integer path, query, header, or cookie parameters. Form /
+  // multipart bodies and responses handle integer encoding via the encoder
+  // / decoder modules, not directly in client.gleam.
+  let needs_int =
+    list.any(all_params, fn(p) {
+      case p.payload {
+        ParameterSchema(Inline(schema.IntegerSchema(..))) -> True
+        ParameterSchema(Inline(schema.ArraySchema(
+          items: Inline(schema.IntegerSchema(..)),
+          ..,
+        ))) -> True
+        ParameterSchema(Reference(..) as sr) ->
+          case resolver.resolve_schema_ref(sr, ctx.spec) {
+            Ok(schema.IntegerSchema(..)) -> True
+            Ok(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..)) ->
+              True
+            _ -> False
+          }
+        _ -> False
+      }
+    })
+
   let base_imports = [
     "gleam/http/request",
     "gleam/http",
-    "gleam/int",
     ctx.config.package <> "/decode",
     ctx.config.package <> "/response_types",
   ]
+  let base_imports = case needs_int {
+    True -> ["gleam/int", ..base_imports]
+    False -> base_imports
+  }
   let base_imports = case needs_option {
     True -> ["gleam/option.{type Option, None, Some}", ..base_imports]
     False -> base_imports
@@ -364,6 +390,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(1, "ConnectionError(detail: String)")
     |> se.indent(1, "TimeoutError")
     |> se.indent(1, "DecodeError(detail: String)")
+    |> se.indent(1, "UnexpectedStatus(status: Int, body: String)")
   let sb = case ctx.config.validate {
     True -> sb |> se.indent(1, "ValidationError(errors: List(String))")
     False -> sb
@@ -1029,7 +1056,7 @@ fn generate_client_function(
       sb
       |> se.indent(
         4,
-        "_ -> Error(DecodeError(detail: \"Unexpected status: \" <> int.to_string(resp.status)))",
+        "_ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))",
       )
   }
   let sb =

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,38 @@ components:
   |> should.be_true()
 }
 
+pub fn client_emits_unexpected_status_variant_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // Type declares the new variant.
+  string.contains(combined, "UnexpectedStatus(status: Int, body: String)")
+  |> should.be_true()
+  // Catch-all arms emit the new variant instead of DecodeError.
+  string.contains(
+    combined,
+    "_ -> Error(UnexpectedStatus(status: resp.status, body: resp.body))",
+  )
+  |> should.be_true()
+  // The old DecodeError-as-status-wrapper form should not appear anymore.
+  string.contains(combined, "DecodeError(detail: \"Unexpected status:")
+  |> should.be_false()
+}
+
 pub fn enum_decoder_failure_includes_rejected_value_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated clients previously reported unknown HTTP statuses as `DecodeError`, conflating transport/protocol errors with JSON decode failures.
- Add `UnexpectedStatus(status: Int, body: String)` to the generated `ClientError` type and emit it from every operation's catch-all branch. `DecodeError` now covers only decode failures.
- Surfaced by CodeRabbit on #120. Closes #127.

## Changes

- `src/oaspec/codegen/client.gleam`: new `UnexpectedStatus(status: Int, body: String)` variant on `ClientError`; catch-all arms emit `Error(UnexpectedStatus(status: resp.status, body: resp.body))` instead of `Error(DecodeError(detail: \"Unexpected status: ...\"))`. `gleam/int` import demoted to conditional (only when integer parameters are present) because the catch-all no longer needs it.
- `test/oaspec_test.gleam`: `client_emits_unexpected_status_variant_test` locks both the variant declaration and the catch-all shape.
- `examples/petstore_client/src/petstore_client_example.gleam`: `describe` extended with a `UnexpectedStatus` arm so the example compiles against the new type.
- `golden/petstore/api/client.gleam`, `golden/complex_supported/api/client.gleam`, `examples/petstore_client/src/api/client.gleam`: regenerated.
- `README.md`: unit test count 628 → 629.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- Carry the raw body alongside the status so callers can render or log it without another round-trip. Keeping it as a plain `String` avoids introducing a new dependency or decoder.
- Leave `DecodeError` in place for JSON decode failures. Callers that only care about a single failure bucket can still match on `Error(_)` — the refinement is opt-in.
- Demote `gleam/int` to a conditional import rather than keeping it unconditional: before this PR it was only used inside the catch-all, so leaving it as a fixed import would produce `unused imported module` warnings in projects built with `warnings-as-errors`.

## Test plan

- [x] `just all` passes (629 unit tests, 40 integration, 59 shellspec, smoke).
- [x] `examples/petstore_client` regenerates, compiles, and still prints the two pets (`cd examples/petstore_client && gleam run`).

Closes #127.