### PR TITLE
fix(encode): emit json.null() for unsupported dynamic classifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Generated client query strings now preserve the declared OpenAPI parameter order; previously the prepending loop reversed it (#123)
 - Generated enum decoders now include the rejected string in their failure message (e.g. `"PetStatus: unknown variant adopted"`) instead of dropping it (#125)
 - Generated clients distinguish unexpected HTTP statuses from decode failures via a new `UnexpectedStatus(status: Int, body: String)` variant on `ClientError`; previously an unknown status was reported as `DecodeError` and indistinguishable from JSON decode failures (#127)
+- `encode_dynamic` fallback now emits `json.null()` for unsupported classifications instead of the classified type name (e.g. `"Dict"`), which silently corrupted outgoing payloads (#129)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 629 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 630 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/encode.gleam
+++ b/examples/petstore_client/src/api/encode.gleam
@@ -107,6 +107,6 @@ fn encode_dynamic(value: dynamic.Dynamic) -> json.Json {
       json.bool(b)
     }
     "Nil" -> json.null()
-    _ -> json.string(dynamic.classify(value))
+    _ -> json.null()
   }
 }

--- a/golden/complex_supported/api/encode.gleam
+++ b/golden/complex_supported/api/encode.gleam
@@ -316,6 +316,6 @@ fn encode_dynamic(value: dynamic.Dynamic) -> json.Json {
       json.bool(b)
     }
     "Nil" -> json.null()
-    _ -> json.string(dynamic.classify(value))
+    _ -> json.null()
   }
 }

--- a/golden/petstore/api/encode.gleam
+++ b/golden/petstore/api/encode.gleam
@@ -107,6 +107,6 @@ fn encode_dynamic(value: dynamic.Dynamic) -> json.Json {
       json.bool(b)
     }
     "Nil" -> json.null()
-    _ -> json.string(dynamic.classify(value))
+    _ -> json.null()
   }
 }

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -1254,7 +1254,11 @@ fn generate_encoders(
       |> se.indent(3, "json.bool(b)")
       |> se.indent(2, "}")
       |> se.indent(2, "\"Nil\" -> json.null()")
-      |> se.indent(2, "_ -> json.string(dynamic.classify(value))")
+      // Fallback: unsupported dynamic classifications (List, Dict, Tuple,
+      // etc.) emit `json.null()` rather than the type name as a string.
+      // Emitting the type name silently corrupts payloads; null at least
+      // fails loud when the receiving end doesn't tolerate it.
+      |> se.indent(2, "_ -> json.null()")
       |> se.indent(1, "}")
       |> se.line("}")
       |> se.blank_line()

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,37 @@ components:
   |> should.be_true()
 }
 
+pub fn encode_dynamic_fallback_emits_null_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /u:
+    get:
+      operationId: u
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Bag:
+      type: object
+      additionalProperties: true
+      properties:
+        name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // Fallback branch must emit json.null(), never the classified type name.
+  string.contains(combined, "_ -> json.null()") |> should.be_true()
+  string.contains(combined, "json.string(dynamic.classify(value))")
+  |> should.be_false()
+}
+
 pub fn client_emits_unexpected_status_variant_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- `encode_dynamic/1` in the generated `encode.gleam` silently mapped unsupported classifications (e.g. `List`, `Dict`, `Tuple`) to a JSON string containing the type name — corrupting outgoing payloads without surfacing any error.
- Emit `json.null()` instead so the data loss is at least a well-formed JSON value and servers can reject it loudly.
- Surfaced by CodeRabbit on #120.

## Changes

- `src/oaspec/codegen/decoders.gleam`: fallback branch of `encode_dynamic/1` now emits `json.null()` with a comment explaining the reasoning.
- `test/oaspec_test.gleam`: `encode_dynamic_fallback_emits_null_test` asserts the new emit and that the old `json.string(dynamic.classify(value))` form no longer appears.
- `golden/petstore/api/encode.gleam`, `golden/complex_supported/api/encode.gleam`, `examples/petstore_client/src/api/encode.gleam`: regenerated.
- `README.md`: unit test count 629 → 630.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- **Null over an exception.** `let assert` in the fallback would crash the encoding pipeline for otherwise-encodable records that happen to contain a problematic `additional_properties` value. Null preserves the rest of the encoded record and makes the lost field visible to the server.
- **No recursive List/Dict handling yet.** A full recursive `encode_dynamic` that walks lists and maps would be useful but is a larger change and belongs in its own issue. The fallback fix here is the minimal safe behaviour.

## Test plan

- [x] `just all` passes (630 unit tests, 40 integration, 59 shellspec, smoke).
- [x] Regenerated goldens and the petstore example's `encode.gleam` both show `_ -> json.null()` in the fallback.

Closes #129.