### PR TITLE
fix(client): surface malformed URLs as InvalidUrl instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Generated enum decoders now include the rejected string in their failure message (e.g. `"PetStatus: unknown variant adopted"`) instead of dropping it (#125)
 - Generated clients distinguish unexpected HTTP statuses from decode failures via a new `UnexpectedStatus(status: Int, body: String)` variant on `ClientError`; previously an unknown status was reported as `DecodeError` and indistinguishable from JSON decode failures (#127)
 - `encode_dynamic` fallback now emits `json.null()` for unsupported classifications instead of the classified type name (e.g. `"Dict"`), which silently corrupted outgoing payloads (#129)
+- Generated clients no longer panic on malformed `base_url` or path: URL parse failures are reported via a new `ClientError.InvalidUrl(detail)` variant instead of crashing the caller (#131)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 630 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 631 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/client.gleam
+++ b/examples/petstore_client/src/api/client.gleam
@@ -9,6 +9,7 @@ import gleam/http/request
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/result
 import gleam/string
 import gleam/uri
 
@@ -30,6 +31,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  InvalidUrl(detail: String)
   UnexpectedStatus(status: Int, body: String)
 }
 
@@ -71,7 +73,11 @@ pub fn list_pets(
     "" -> path
     _ -> path <> "?" <> query_string
   }
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Get)
   case config.send(req) {
     Error(e) -> Error(e)
@@ -98,7 +104,11 @@ pub fn create_pet(
   body: types.CreatePetRequest,
 ) -> Result(response_types.CreatePetResponse, ClientError) {
   let path = "/pets"
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Post)
   let req = request.set_header(req, "content-type", "application/json")
   let req = request.set_body(req, encode.encode_create_pet_request(body))
@@ -130,7 +140,11 @@ pub fn get_pet(
   let path = "/pets/{petId}"
   let path =
     string.replace(path, "{petId}", uri.percent_encode(int.to_string(pet_id)))
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Get)
   case config.send(req) {
     Error(e) -> Error(e)
@@ -160,7 +174,11 @@ pub fn delete_pet(
   let path = "/pets/{petId}"
   let path =
     string.replace(path, "{petId}", uri.percent_encode(int.to_string(pet_id)))
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Delete)
   case config.send(req) {
     Error(e) -> Error(e)

--- a/examples/petstore_client/src/petstore_client_example.gleam
+++ b/examples/petstore_client/src/petstore_client_example.gleam
@@ -43,6 +43,7 @@ fn describe(err: client.ClientError) -> String {
     client.ConnectionError(detail) -> "connection: " <> detail
     client.TimeoutError -> "timeout"
     client.DecodeError(detail) -> "decode: " <> detail
+    client.InvalidUrl(detail) -> "invalid URL: " <> detail
     client.UnexpectedStatus(status:, body: _) ->
       "unexpected status: " <> int.to_string(status)
   }

--- a/golden/complex_supported/api/client.gleam
+++ b/golden/complex_supported/api/client.gleam
@@ -6,6 +6,7 @@ import api/response_types
 import api/types
 import gleam/http
 import gleam/http/request
+import gleam/result
 import gleam/string
 import gleam/uri
 
@@ -27,6 +28,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  InvalidUrl(detail: String)
   UnexpectedStatus(status: Int, body: String)
 }
 
@@ -49,7 +51,11 @@ pub fn post_search(
   body: Option(types.PostSearchRequest),
 ) -> Result(response_types.PostSearchResponse, ClientError) {
   let path = "/search"
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Post)
   let req = case body {
     Some(body) -> {
@@ -83,7 +89,11 @@ pub fn get_user(
 ) -> Result(response_types.GetUserResponse, ClientError) {
   let path = "/users/{userId}"
   let path = string.replace(path, "{userId}", uri.percent_encode(user_id))
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Get)
   case config.send(req) {
     Error(e) -> Error(e)
@@ -115,7 +125,11 @@ pub fn post_webhook(
   body: Option(types.WebhookEvent),
 ) -> Result(response_types.PostWebhookResponse, ClientError) {
   let path = "/webhook"
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Post)
   let req = case body {
     Some(body) -> {

--- a/golden/petstore/api/client.gleam
+++ b/golden/petstore/api/client.gleam
@@ -9,6 +9,7 @@ import gleam/http/request
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/result
 import gleam/string
 import gleam/uri
 
@@ -30,6 +31,7 @@ pub type ClientError {
   ConnectionError(detail: String)
   TimeoutError
   DecodeError(detail: String)
+  InvalidUrl(detail: String)
   UnexpectedStatus(status: Int, body: String)
 }
 
@@ -71,7 +73,11 @@ pub fn list_pets(
     "" -> path
     _ -> path <> "?" <> query_string
   }
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Get)
   case config.send(req) {
     Error(e) -> Error(e)
@@ -98,7 +104,11 @@ pub fn create_pet(
   body: types.CreatePetRequest,
 ) -> Result(response_types.CreatePetResponse, ClientError) {
   let path = "/pets"
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Post)
   let req = request.set_header(req, "content-type", "application/json")
   let req = request.set_body(req, encode.encode_create_pet_request(body))
@@ -130,7 +140,11 @@ pub fn get_pet(
   let path = "/pets/{petId}"
   let path =
     string.replace(path, "{petId}", uri.percent_encode(int.to_string(pet_id)))
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Get)
   case config.send(req) {
     Error(e) -> Error(e)
@@ -160,7 +174,11 @@ pub fn delete_pet(
   let path = "/pets/{petId}"
   let path =
     string.replace(path, "{petId}", uri.percent_encode(int.to_string(pet_id)))
-  let assert Ok(req) = request.to(config.base_url <> path)
+  let full_url = config.base_url <> path
+  use req <- result.try(
+    request.to(full_url)
+    |> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),
+  )
   let req = request.set_method(req, http.Delete)
   case config.send(req) {
     Error(e) -> Error(e)

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -229,6 +229,9 @@ fn generate_client(ctx: Context) -> String {
   let base_imports = [
     "gleam/http/request",
     "gleam/http",
+    // `gleam/result` is needed by the `use req <- result.try(...)` pattern
+    // that every generated operation emits for URL parsing.
+    "gleam/result",
     ctx.config.package <> "/decode",
     ctx.config.package <> "/response_types",
   ]
@@ -299,12 +302,12 @@ fn generate_client(ctx: Context) -> String {
   }
   let imports = case has_cookie_api_key {
     True -> {
-      // Need gleam/list for list.key_find and gleam/result for result.unwrap
-      let imports = case needs_list {
+      // Need gleam/list for list.key_find; gleam/result is already in
+      // base_imports unconditionally (used by every generated operation).
+      case needs_list {
         True -> imports
         False -> ["gleam/list", ..imports]
       }
-      ["gleam/result", ..imports]
     }
     False -> imports
   }
@@ -390,6 +393,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(1, "ConnectionError(detail: String)")
     |> se.indent(1, "TimeoutError")
     |> se.indent(1, "DecodeError(detail: String)")
+    |> se.indent(1, "InvalidUrl(detail: String)")
     |> se.indent(1, "UnexpectedStatus(status: Int, body: String)")
   let sb = case ctx.config.validate {
     True -> sb |> se.indent(1, "ValidationError(errors: List(String))")
@@ -802,12 +806,19 @@ fn generate_client_function(
     Some(url) -> "\"" <> url <> "\""
     None -> "config.base_url"
   }
+  // Fail with InvalidUrl instead of panicking on malformed base_url or path.
+  // `gleam/result` is included in base_imports unconditionally, so the `use`
+  // form below always compiles.
   let sb =
     sb
+    |> se.indent(1, "let full_url = " <> base_url_expr <> " <> path")
+    |> se.indent(1, "use req <- result.try(")
+    |> se.indent(2, "request.to(full_url)")
     |> se.indent(
-      1,
-      "let assert Ok(req) = request.to(" <> base_url_expr <> " <> path)",
+      2,
+      "|> result.map_error(fn(_) { InvalidUrl(detail: full_url) }),",
     )
+    |> se.indent(1, ")")
     |> se.indent(1, "let req = request.set_method(req, " <> http_method <> ")")
 
   // Only set content-type for requests with body

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,38 @@ components:
   |> should.be_true()
 }
 
+pub fn client_emits_invalid_url_variant_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // InvalidUrl is declared on ClientError.
+  string.contains(combined, "InvalidUrl(detail: String)") |> should.be_true()
+  // Operations no longer panic on request.to failures.
+  string.contains(combined, "use req <- result.try(") |> should.be_true()
+  string.contains(
+    combined,
+    "result.map_error(fn(_) { InvalidUrl(detail: full_url) })",
+  )
+  |> should.be_true()
+  // The old assert-pattern is gone.
+  string.contains(combined, "let assert Ok(req) = request.to")
+  |> should.be_false()
+}
+
 pub fn encode_dynamic_fallback_emits_null_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated operations used `let assert Ok(req) = request.to(config.base_url <> path)` as their first statement, which crashed the caller's process when `base_url` was malformed.
- Add an `InvalidUrl(detail: String)` variant on the generated `ClientError` and replace the assertion with a `use req <- result.try(...)` pattern that maps parse failures into that variant.
- Surfaced by CodeRabbit on #120. Closes #131.

## Changes

- `src/oaspec/codegen/client.gleam`:
  - new `InvalidUrl(detail: String)` variant on `ClientError`
  - every operation emits `use req <- result.try(request.to(full_url) |> result.map_error(...))` instead of `let assert`
  - `gleam/result` promoted to an unconditional base import (every operation now uses it); the cookie-apiKey branch that conditionally pulled it in is simplified
- `test/oaspec_test.gleam`: new `client_emits_invalid_url_variant_test` locks the `use`/`try` shape, the new variant, and the absence of the old `let assert`.
- `examples/petstore_client/src/petstore_client_example.gleam`: `describe` gains an arm for `InvalidUrl` so the example still compiles.
- `golden/petstore/api/client.gleam`, `golden/complex_supported/api/client.gleam`, `examples/petstore_client/src/api/client.gleam`: regenerated.
- `README.md`: unit test count 630 → 631.
- `CHANGELOG.md`: new `Fixed` entry under Unreleased.

## Design Decisions

- **`use`/`result.try` over a top-level `case`.** Gleam's `use` desugars to the same as `case` + `Ok/Error` matching, but keeps the rest of the function body flat instead of nesting it inside `Ok(req) -> { ... }`. Minimal diff to the rest of `build_operation`.
- **`result` as an unconditional import.** Making the import conditional per-operation adds complexity for no gain — every operation now uses `result.try`, so the import is always live.
- **Only `detail: String`, no structured diagnostic.** Consistent with the existing `ConnectionError(detail)` / `DecodeError(detail)` variants. The detail carries the failing URL, which is what a caller needs to log.

## Test plan

- [x] `just all` passes (631 unit tests, 40 integration, 59 shellspec, smoke).
- [x] `examples/petstore_client` regenerates, compiles, and still prints the two stub pets.

Closes #131.