### PR TITLE
refactor(server): stop emitting misleading callback handler stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `encode_dynamic` fallback now emits `json.null()` for unsupported classifications instead of the classified type name (e.g. `"Dict"`), which silently corrupted outgoing payloads (#129)
 - Generated clients no longer panic on malformed `base_url` or path: URL parse failures are reported via a new `ClientError.InvalidUrl(detail)` variant instead of crashing the caller (#131)
 
+### Removed
+
+- Callback handler stubs (`fn <op>_callback_<name>_<suffix>() -> String`) are no longer emitted. They carried no request type, no response type, and no execution path, so they were more misleading than useful. Callbacks are still parsed and resolved; treat them as parsed-but-not-codegen until typed support is added (#117)
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 631 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 632 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 
@@ -227,7 +227,7 @@ These are the most important limitations today:
 
 - The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`
 - `xml` annotations are not handled by the parser
-- Some fields are parsed and preserved but not yet used by codegen: webhooks, externalDocs, tags, examples, links, response headers, encoding
+- Some fields are parsed and preserved but not yet used by codegen: callbacks, webhooks, externalDocs, tags, examples, links, response headers, encoding
 - Operation-level and path-level server overrides are supported in generated clients (precedence: operation > path > top-level)
 - The following are normalized to supported equivalents:
 - `const`: String const normalized to single-value enum

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -521,10 +521,8 @@ pub fn register_webhook(req: request_types.RegisterWebhookRequest) -> response_t
   response_types.RegisterWebhookResponseCreated
 }
 
-/// Callback handler stub for onEvent
-pub fn register_webhook_callback_on_event_callback_url() -> String {
-  "callback_ok"
-}
+// Note: callbacks are parsed but no longer produce handler stubs — see
+// issue #117.
 GLEAM_EOF
 
 cat > "$CALLBACK_DIR/gleam.toml" << 'TOML_EOF'

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -5,7 +5,6 @@ import gleam/string
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
-import oaspec/codegen/ir_build
 import oaspec/codegen/server_request_decode as decode_helpers
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{Inline, Reference}
@@ -53,13 +52,11 @@ fn generate_handlers(
       generate_handler(sb, op_id, operation, ctx)
     })
 
-  // Generate callback handler stubs
-  let sb =
-    list.fold(operations, sb, fn(sb, op) {
-      let #(op_id, operation, _path, _method) = op
-      generate_callback_handlers(sb, op_id, operation)
-    })
-
+  // Callbacks are parsed and resolved but NOT emitted as handler stubs.
+  // The previous stubs had the shape `fn(...) -> String` with no request
+  // type, no response type, and no execution path — more misleading than
+  // useful. Callback support is now documented as parsed-but-not-codegen
+  // until a typed codegen story exists (see issue #117).
   se.to_string(sb)
 }
 
@@ -115,52 +112,6 @@ fn generate_handler(
   |> se.indent(1, "panic as \"unimplemented: " <> fn_name <> "\"")
   |> se.line("}")
   |> se.blank_line()
-}
-
-/// Generate callback handler stubs for an operation's callbacks.
-fn generate_callback_handlers(
-  sb: se.StringBuilder,
-  op_id: String,
-  operation: spec.Operation(Resolved),
-) -> se.StringBuilder {
-  let callbacks = ir_build.sorted_entries(operation.callbacks)
-  list.fold(callbacks, sb, fn(sb, entry) {
-    let #(callback_name, callback) = entry
-    let callback_entries = ir_build.sorted_entries(callback.entries)
-    list.fold(callback_entries, sb, fn(sb, cb_entry) {
-      let #(url_expression, _path_item) = cb_entry
-      let fn_name =
-        naming.operation_to_function_name(op_id)
-        <> "_callback_"
-        <> naming.to_snake_case(callback_name)
-        <> "_"
-        <> naming.to_snake_case(url_expression_to_suffix(url_expression))
-      sb
-      |> se.doc_comment(
-        "Callback handler stub for " <> callback_name <> " on " <> op_id,
-      )
-      |> se.doc_comment("URL: " <> url_expression)
-      |> se.line("pub fn " <> fn_name <> "() -> String {")
-      |> se.indent(1, "panic as \"unimplemented: " <> fn_name <> "\"")
-      |> se.line("}")
-      |> se.blank_line()
-    })
-  })
-}
-
-/// Extract a short suffix from a URL expression for function naming.
-fn url_expression_to_suffix(url_expression: String) -> String {
-  // Take the last path segment, stripping any template expressions
-  let parts = string.split(url_expression, "/")
-  case list.last(parts) {
-    Ok(last) ->
-      last
-      |> string.replace("{", "")
-      |> string.replace("}", "")
-      |> string.replace("$", "")
-      |> string.replace("#", "")
-    Error(_) -> "handler"
-  }
 }
 
 /// Generate a router module that dispatches requests.

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,40 @@ components:
   |> should.be_true()
 }
 
+pub fn callbacks_do_not_emit_handler_stubs_test() {
+  // Callbacks must parse successfully but must not produce the old
+  // misleading `fn(...) -> String` handler stubs (see issue #117).
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /subscribe:
+    post:
+      operationId: subscribe
+      responses:
+        '201': { description: subscribed }
+      callbacks:
+        onEvent:
+          '{$request.body#/callbackUrl}':
+            post:
+              operationId: onEventCallback
+              responses:
+                '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  // The old stub pattern must be gone.
+  string.contains(combined, "subscribe_callback_on_event_") |> should.be_false()
+  string.contains(combined, "Callback handler stub for")
+  |> should.be_false()
+  string.contains(combined, "-> String {") |> should.be_false()
+}
+
 pub fn client_emits_invalid_url_variant_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Callback handler stubs were generated as `fn <op>_callback_<name>_<suffix>() -> String { panic ... }` — disconnected from request types, response types, routing, and execution. Misleading as a \"supported feature\" indicator.
- Delete callback stub generation. Callbacks are still parsed and resolved; the documented support boundary is now parsed-but-not-codegen until a typed story exists.
- Chose Issue #117's option 2 (\"stop emitting\") because it is minimal and removes a footgun; option 1 (typed callback artifacts) deserves its own follow-up issue.

## Changes

- `src/oaspec/codegen/server.gleam`: remove `generate_callback_handlers/3`, its call site, the `url_expression_to_suffix/1` helper it used, and the now-unused `ir_build` import.
- `integration_test/run.sh`: the `callback_test` scenario used to inject a `register_webhook_callback_on_event_callback_url() -> String` stub into the generated `handlers.gleam`; that stub is removed and replaced with a comment pointing at #117.
- `test/oaspec_test.gleam`: new `callbacks_do_not_emit_handler_stubs_test` locks the fact that a spec with callbacks produces no `_callback_` function, no `-> String` handler, and no `Callback handler stub for` doc comment.
- `README.md`: \"parsed but not yet used by codegen\" bullet gains `callbacks` alongside webhooks / externalDocs / etc.
- `CHANGELOG.md`: new `Removed` entry under Unreleased.

## Design Decisions

- **Remove rather than keep-and-document.** Leaving the misleading stub with a README caveat would still ship the surface area to users' editors and autocompletes. Removing it is the cleanest boundary.
- **Don't touch parsing or resolution.** Those are correct today and other tooling (diagnostics, future codegen) already relies on the parsed callback tree. Only the server codegen step changes.
- **No compatibility shim.** The generated stubs were named `<op>_callback_*` — very unlikely to collide with user code. If a downstream project did import them, the error is a clear \"Unknown module value\" pointing directly at the removed surface.

## Limitations

- Typed callback codegen (Issue #117's option 1) is deferred. A follow-up can introduce request/response types for callback operations and a dispatch path. This PR only closes the misleading behaviour.

## Test plan

- [x] `just all` passes (632 unit tests, 40 integration, 59 shellspec, smoke).
- [x] Golden snapshots regenerate cleanly (the petstore/complex-supported fixtures don't use callbacks, so their goldens are unchanged; the callback integration test's handwritten `handlers.gleam` still compiles after the stub was removed).

Closes #117.