### PR TITLE
refactor(context): make Context an opaque type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Callback handler stubs (`fn <op>_callback_<name>_<suffix>() -> String`) are no longer emitted. They carried no request type, no response type, and no execution path, so they were more misleading than useful. Callbacks are still parsed and resolved; treat them as parsed-but-not-codegen until typed support is added (#117)
 - `middleware.gleam` is no longer part of the default generated surface. Its `Handler(req, res) = fn(req) -> Result(res, _)` shape did not compose with the generated client or server APIs, so it was a standalone demo module rather than a reusable artifact. The `oaspec/codegen/middleware` source module stays in the tree as a library-level helper for anyone assembling their own chain (#116)
 
+### Changed
+
+- `oaspec/codegen/context.Context` is now declared `pub opaque type`. External callers must use `context.new/2` to construct and `context.spec/1` / `context.config/1` to read fields instead of pattern-matching on the record. First step of parent issue #41; Config / Module / Declaration to follow (#136)
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/src/oaspec/codegen/allof_merge.gleam
+++ b/src/oaspec/codegen/allof_merge.gleam
@@ -34,7 +34,7 @@ pub fn merge_allof_schemas(
     fn(acc, s_ref, idx) {
       let resolved = case s_ref {
         Inline(obj) -> Ok(obj)
-        Reference(..) -> resolver.resolve_schema_ref(s_ref, ctx.spec)
+        Reference(..) -> resolver.resolve_schema_ref(s_ref, context.spec(ctx))
       }
       case resolved {
         Ok(ObjectSchema(properties:, required:, additional_properties:, ..)) -> {

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -95,7 +95,7 @@ fn generate_client(ctx: Context) -> String {
       case p.payload {
         ParameterSchema(Inline(schema.ArraySchema(..))) -> True
         ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, ctx.spec) {
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
             Ok(schema.ArraySchema(..)) -> True
             _ -> False
           }
@@ -176,7 +176,7 @@ fn generate_client(ctx: Context) -> String {
       }
     })
     || {
-      let security_schemes = case ctx.spec.components {
+      let security_schemes = case context.spec(ctx).components {
         Some(c) -> dict.to_list(c.security_schemes)
         _ -> []
       }
@@ -196,7 +196,7 @@ fn generate_client(ctx: Context) -> String {
   let needs_option =
     import_analysis.operations_have_optional_params(operations)
     || {
-      let security_schemes = case ctx.spec.components {
+      let security_schemes = case context.spec(ctx).components {
         Some(c) -> dict.to_list(c.security_schemes)
         _ -> []
       }
@@ -216,7 +216,7 @@ fn generate_client(ctx: Context) -> String {
           ..,
         ))) -> True
         ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, ctx.spec) {
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
             Ok(schema.IntegerSchema(..)) -> True
             Ok(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..)) ->
               True
@@ -232,8 +232,8 @@ fn generate_client(ctx: Context) -> String {
     // `gleam/result` is needed by the `use req <- result.try(...)` pattern
     // that every generated operation emits for URL parsing.
     "gleam/result",
-    ctx.config.package <> "/decode",
-    ctx.config.package <> "/response_types",
+    context.config(ctx).package <> "/decode",
+    context.config(ctx).package <> "/response_types",
   ]
   let base_imports = case needs_int {
     True -> ["gleam/int", ..base_imports]
@@ -246,7 +246,10 @@ fn generate_client(ctx: Context) -> String {
   let base_imports = case needs_typed_schemas {
     True ->
       list.append(
-        [ctx.config.package <> "/types", ctx.config.package <> "/encode"],
+        [
+          context.config(ctx).package <> "/types",
+          context.config(ctx).package <> "/encode",
+        ],
         base_imports,
       )
     False -> base_imports
@@ -289,7 +292,7 @@ fn generate_client(ctx: Context) -> String {
   }
 
   // result module needed for cookie-based apiKey security (reading existing cookie header)
-  let has_cookie_api_key = case ctx.spec.components {
+  let has_cookie_api_key = case context.spec(ctx).components {
     Some(c) ->
       list.any(dict.to_list(c.security_schemes), fn(entry) {
         case entry {
@@ -313,7 +316,7 @@ fn generate_client(ctx: Context) -> String {
   }
   // Import guards module when validation is enabled and any operation body has validators
   let needs_guards =
-    ctx.config.validate
+    context.config(ctx).validate
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       case operation.request_body {
@@ -333,7 +336,7 @@ fn generate_client(ctx: Context) -> String {
       }
     })
   let imports = case needs_guards {
-    True -> [ctx.config.package <> "/guards", ..imports]
+    True -> [context.config(ctx).package <> "/guards", ..imports]
     False -> imports
   }
 
@@ -342,7 +345,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.imports(imports)
 
   // Collect security schemes
-  let security_schemes = case ctx.spec.components {
+  let security_schemes = case context.spec(ctx).components {
     Some(components) -> ir_build.sorted_entries(components.security_schemes)
     _ -> []
   }
@@ -395,7 +398,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(1, "DecodeError(detail: String)")
     |> se.indent(1, "InvalidUrl(detail: String)")
     |> se.indent(1, "UnexpectedStatus(status: Int, body: String)")
-  let sb = case ctx.config.validate {
+  let sb = case context.config(ctx).validate {
     True -> sb |> se.indent(1, "ValidationError(errors: List(String))")
     False -> sb
   }
@@ -463,7 +466,7 @@ fn generate_default_base_url(
   sb: se.StringBuilder,
   ctx: Context,
 ) -> se.StringBuilder {
-  case ctx.spec.servers {
+  case context.spec(ctx).servers {
     [first_server, ..] -> {
       let variables = ir_build.sorted_entries(first_server.variables)
       let resolved_url =
@@ -606,7 +609,7 @@ fn generate_client_function(
 
   // Determine if client-side guard validation is needed for the body
   let client_guard_schema_name = case
-    ctx.config.validate,
+    context.config(ctx).validate,
     operation.request_body
   {
     True, Some(Value(rb)) -> {
@@ -974,7 +977,7 @@ fn generate_client_function(
   // applies only the first one whose credentials are all present.
   let effective_security = case operation.security {
     Some(sec) -> sec
-    None -> ctx.spec.security
+    None -> context.spec(ctx).security
   }
   let sb = case effective_security {
     [] -> sb

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -56,7 +56,10 @@ pub fn build_param_list(
 /// Convert a parameter to its Gleam type string.
 pub fn param_to_type(param: spec.Parameter(Resolved), ctx: Context) -> String {
   let base =
-    schema_dispatch.resolve_param_type(spec.parameter_schema(param), ctx.spec)
+    schema_dispatch.resolve_param_type(
+      spec.parameter_schema(param),
+      context.spec(ctx),
+    )
   case param.required {
     True -> base
     False -> "Option(" <> base <> ")"
@@ -71,7 +74,7 @@ pub fn param_to_string_expr(
 ) -> String {
   case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> {
-      let item_to_str = schema_dispatch.to_string_fn(items, ctx.spec)
+      let item_to_str = schema_dispatch.to_string_fn(items, context.spec(ctx))
       "string.join(list.map("
       <> param_name
       <> ", "
@@ -81,9 +84,10 @@ pub fn param_to_string_expr(
     ParameterSchema(Inline(s)) -> schema_dispatch.to_string_expr(s, param_name)
     ParameterSchema(Reference(..) as schema_ref) -> {
       // Resolve the $ref to determine the actual schema type
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema.ArraySchema(items:, ..)) -> {
-          let item_to_str = schema_dispatch.to_string_fn(items, ctx.spec)
+          let item_to_str =
+            schema_dispatch.to_string_fn(items, context.spec(ctx))
           "string.join(list.map("
           <> param_name
           <> ", "
@@ -94,7 +98,7 @@ pub fn param_to_string_expr(
           schema_dispatch.schema_ref_to_string_expr(
             schema_ref,
             param_name,
-            ctx.spec,
+            context.spec(ctx),
           )
       }
     }
@@ -118,18 +122,23 @@ pub fn to_str_for_optional_value(
 ) -> String {
   case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> {
-      let item_to_str = schema_dispatch.to_string_fn(items, ctx.spec)
+      let item_to_str = schema_dispatch.to_string_fn(items, context.spec(ctx))
       "string.join(list.map(v, " <> item_to_str <> "), \",\")"
     }
     ParameterSchema(Inline(s)) -> schema_dispatch.to_string_expr(s, "v")
     ParameterSchema(Reference(..) as schema_ref) -> {
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema.ArraySchema(items:, ..)) -> {
-          let item_to_str = schema_dispatch.to_string_fn(items, ctx.spec)
+          let item_to_str =
+            schema_dispatch.to_string_fn(items, context.spec(ctx))
           "string.join(list.map(v, " <> item_to_str <> "), \",\")"
         }
         _ ->
-          schema_dispatch.schema_ref_to_string_expr(schema_ref, "v", ctx.spec)
+          schema_dispatch.schema_ref_to_string_expr(
+            schema_ref,
+            "v",
+            context.spec(ctx),
+          )
       }
     }
     _ -> "v"
@@ -207,7 +216,7 @@ pub fn generate_multipart_body(
           required,
         )
         Some(Reference(..) as schema_ref) ->
-          case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
               #(ir_build.sorted_entries(properties), required)
             }
@@ -305,7 +314,7 @@ pub fn multipart_field_is_binary(
   case field_schema {
     Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema.StringSchema(format: Some("binary"), ..)) -> True
         _ -> False
       }
@@ -317,7 +326,7 @@ pub fn multipart_field_to_string_fn(
   field_schema: schema.SchemaRef,
   ctx: Context,
 ) -> String {
-  let result = schema_dispatch.to_string_fn(field_schema, ctx.spec)
+  let result = schema_dispatch.to_string_fn(field_schema, context.spec(ctx))
   // Return "" for identity functions since callers use "" to mean "no conversion"
   case result {
     "fn(x) { x }" -> ""
@@ -333,7 +342,11 @@ pub fn form_array_item_to_string(
 ) -> String {
   case field_schema {
     Inline(schema.ArraySchema(items:, ..)) ->
-      schema_dispatch.schema_ref_to_string_expr(items, "item", ctx.spec)
+      schema_dispatch.schema_ref_to_string_expr(
+        items,
+        "item",
+        context.spec(ctx),
+      )
     _ -> "string.inspect(item)"
   }
 }
@@ -350,7 +363,8 @@ pub fn generate_form_nested_object(
 ) -> se.StringBuilder {
   let resolved = case field_schema {
     Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(field_schema, ctx.spec)
+    Reference(..) ->
+      resolver.resolve_schema_ref(field_schema, context.spec(ctx))
   }
   let sub_props = case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> #(
@@ -390,7 +404,7 @@ pub fn generate_form_nested_object(
       let is_sub_object = case sub_ref {
         Inline(schema.ObjectSchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, ctx.spec) {
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
             Ok(schema.ObjectSchema(..)) -> True
             _ -> False
           }
@@ -488,7 +502,8 @@ pub fn generate_form_bracket_fields(
 ) -> se.StringBuilder {
   let resolved = case field_schema {
     Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(field_schema, ctx.spec)
+    Reference(..) ->
+      resolver.resolve_schema_ref(field_schema, context.spec(ctx))
   }
   case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
@@ -501,7 +516,7 @@ pub fn generate_form_bracket_fields(
         let is_obj = case prop_ref {
           Inline(schema.ObjectSchema(..)) -> True
           Reference(..) as sr ->
-            case resolver.resolve_schema_ref(sr, ctx.spec) {
+            case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
               Ok(schema.ObjectSchema(..)) -> True
               _ -> False
             }
@@ -593,7 +608,7 @@ pub fn generate_form_urlencoded_body(
           required,
         )
         Some(Reference(..) as schema_ref) ->
-          case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
               #(ir_build.sorted_entries(properties), required)
             }
@@ -613,7 +628,7 @@ pub fn generate_form_urlencoded_body(
       let is_array = case field_schema {
         Inline(schema.ArraySchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, ctx.spec) {
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
             Ok(schema.ArraySchema(..)) -> True
             _ -> False
           }
@@ -622,7 +637,7 @@ pub fn generate_form_urlencoded_body(
       let is_object = case field_schema {
         Inline(schema.ObjectSchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, ctx.spec) {
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
             Ok(schema.ObjectSchema(..)) -> True
             _ -> False
           }
@@ -746,7 +761,7 @@ pub fn is_exploded_array_param(
   let is_array = case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(..))) -> True
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, ctx.spec) {
+      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
         Ok(schema.ArraySchema(..)) -> True
         _ -> False
       }
@@ -785,7 +800,7 @@ pub fn is_delimited_array_param(
   let is_array = case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(..))) -> True
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, ctx.spec) {
+      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
         Ok(schema.ArraySchema(..)) -> True
         _ -> False
       }
@@ -814,7 +829,7 @@ pub fn generate_delimited_array_query_param(
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
       array_item_to_string_fn(items, ctx)
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, ctx.spec) {
+      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
         Ok(schema.ArraySchema(items:, ..)) ->
           array_item_to_string_fn(items, ctx)
         _ -> "fn(x) { x }"
@@ -880,7 +895,7 @@ pub fn generate_exploded_array_query_param(
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
       array_item_to_string_fn(items, ctx)
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, ctx.spec) {
+      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
         Ok(schema.ArraySchema(items:, ..)) ->
           array_item_to_string_fn(items, ctx)
         _ -> "fn(x) { x }"
@@ -933,7 +948,7 @@ pub fn is_deep_object_param(
 ) -> Bool {
   case param.payload {
     ParameterSchema(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema.ObjectSchema(..)) -> True
         _ -> False
       }
@@ -951,7 +966,7 @@ pub fn generate_deep_object_query_param(
 ) -> se.StringBuilder {
   let properties = case param.payload {
     ParameterSchema(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema.ObjectSchema(properties:, required:, ..)) -> #(
           ir_build.sorted_entries(properties),
           required,
@@ -1148,13 +1163,17 @@ pub fn schema_ref_to_string_expr(
   accessor: String,
   ctx: Context,
 ) -> String {
-  schema_dispatch.schema_ref_to_string_expr(schema_ref, accessor, ctx.spec)
+  schema_dispatch.schema_ref_to_string_expr(
+    schema_ref,
+    accessor,
+    context.spec(ctx),
+  )
 }
 
 /// Return a function expression that converts an array item to String.
 /// Used in generated code: `list.map(param, <fn>)`.
 pub fn array_item_to_string_fn(items: schema.SchemaRef, ctx: Context) -> String {
-  schema_dispatch.to_string_fn(items, ctx.spec)
+  schema_dispatch.to_string_fn(items, context.spec(ctx))
 }
 
 /// Convert a deepObject array item to a string expression.
@@ -1164,7 +1183,11 @@ pub fn deep_object_array_item_to_string(
 ) -> String {
   case prop_ref {
     Inline(schema.ArraySchema(items:, ..)) ->
-      schema_dispatch.schema_ref_to_string_expr(items, "item", ctx.spec)
+      schema_dispatch.schema_ref_to_string_expr(
+        items,
+        "item",
+        context.spec(ctx),
+      )
     _ -> "item"
   }
 }

--- a/src/oaspec/codegen/client_response.gleam
+++ b/src/oaspec/codegen/client_response.gleam
@@ -150,7 +150,7 @@ pub fn inline_schema_to_decoder(s: schema.SchemaObject) -> String {
 /// Return a function expression that converts an array item to String.
 /// Used in generated code: `list.map(param, <fn>)`.
 pub fn array_item_to_string_fn(items: schema.SchemaRef, ctx: Context) -> String {
-  schema_dispatch.to_string_fn(items, ctx.spec)
+  schema_dispatch.to_string_fn(items, context.spec(ctx))
 }
 
 /// Convert a deepObject array item to a string expression.
@@ -160,7 +160,11 @@ pub fn deep_object_array_item_to_string(
 ) -> String {
   case prop_ref {
     Inline(schema.ArraySchema(items:, ..)) ->
-      schema_dispatch.schema_ref_to_string_expr(items, "item", ctx.spec)
+      schema_dispatch.schema_ref_to_string_expr(
+        items,
+        "item",
+        context.spec(ctx),
+      )
     _ -> "item"
   }
 }

--- a/src/oaspec/codegen/client_security.gleam
+++ b/src/oaspec/codegen/client_security.gleam
@@ -186,7 +186,7 @@ fn generate_scheme_some_branch(
   scheme_ref: spec.SecuritySchemeRef,
   indent: Int,
 ) -> se.StringBuilder {
-  case ctx.spec.components {
+  case context.spec(ctx).components {
     Some(components) ->
       case dict.get(components.security_schemes, scheme_ref.scheme_name) {
         Ok(spec.Value(spec.ApiKeyScheme(
@@ -285,7 +285,7 @@ fn generate_scheme_apply(
   val_var: String,
   indent: Int,
 ) -> se.StringBuilder {
-  case ctx.spec.components {
+  case context.spec(ctx).components {
     Some(components) ->
       case dict.get(components.security_schemes, scheme_ref.scheme_name) {
         Ok(spec.Value(spec.ApiKeyScheme(

--- a/src/oaspec/codegen/context.gleam
+++ b/src/oaspec/codegen/context.gleam
@@ -6,13 +6,28 @@ pub const version = "0.12.0"
 
 /// Context for code generation, carrying all needed state.
 /// Only accepts a resolved spec — codegen must not operate on unresolved ASTs.
-pub type Context {
+///
+/// Opaque: external callers construct via `new/2` and read fields via
+/// the accessors `spec/1` / `config/1`. This keeps the internal shape
+/// free to evolve (e.g. add derived caches) without rippling into every
+/// pattern match across the codebase.
+pub opaque type Context {
   Context(spec: OpenApiSpec(Resolved), config: Config)
 }
 
 /// Create a new generation context from a resolved spec.
 pub fn new(spec: OpenApiSpec(Resolved), config: Config) -> Context {
   Context(spec:, config:)
+}
+
+/// The resolved OpenAPI spec this context wraps.
+pub fn spec(ctx: Context) -> OpenApiSpec(Resolved) {
+  ctx.spec
+}
+
+/// The generation config this context wraps.
+pub fn config(ctx: Context) -> Config {
+  ctx.config
 }
 
 /// Target for a generated file, indicating where it should be written.

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -49,7 +49,7 @@ fn generate_decoders(
   ctx: Context,
   operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> String {
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
@@ -90,7 +90,7 @@ fn generate_decoders(
     False -> ["gleam/dynamic/decode", "gleam/json"]
   }
   let base_imports = case needs_types {
-    True -> list.append(base_imports, [ctx.config.package <> "/types"])
+    True -> list.append(base_imports, [context.config(ctx).package <> "/types"])
     False -> base_imports
   }
   let imports = case needs_option {
@@ -102,7 +102,7 @@ fn generate_decoders(
     se.file_header(context.version)
     |> se.imports(imports)
 
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
@@ -1131,7 +1131,7 @@ fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
   case ref {
     Inline(schema) -> schema.is_nullable(schema)
     Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
+      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
         Ok(s) -> schema.is_nullable(s)
         Error(_) -> False
       }
@@ -1147,7 +1147,7 @@ fn generate_encoders(
   ctx: Context,
   operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> String {
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
@@ -1203,7 +1203,7 @@ fn generate_encoders(
     _, _ -> ["gleam/json"]
   }
   let imports = case needs_types {
-    True -> list.append(base_imports, [ctx.config.package <> "/types"])
+    True -> list.append(base_imports, [context.config(ctx).package <> "/types"])
     False -> base_imports
   }
 

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -19,7 +19,7 @@ import oaspec/util/string_extra as se
 /// Check whether a named component schema has a composite validator.
 /// Used by server/client generators to decide whether to emit guard calls.
 pub fn schema_has_validator(name: String, ctx: Context) -> Bool {
-  case ctx.spec.components {
+  case context.spec(ctx).components {
     Some(components) ->
       case dict.get(components.schemas, name) {
         Ok(schema_ref) ->
@@ -48,7 +48,7 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 
 /// Generate validation guard functions for schemas with constraints.
 fn generate_guards(ctx: Context) -> String {
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)
@@ -93,7 +93,8 @@ fn generate_guards(ctx: Context) -> String {
         False -> {
           let resolved = case schema_ref {
             Inline(s) -> Ok(s)
-            Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+            Reference(..) ->
+              resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
           }
           case resolved {
             Ok(ObjectSchema(..)) | Ok(AllOfSchema(..)) -> True
@@ -103,7 +104,7 @@ fn generate_guards(ctx: Context) -> String {
       }
     })
   let imports = case needs_types {
-    True -> [ctx.config.package <> "/types", ..imports]
+    True -> [context.config(ctx).package <> "/types", ..imports]
     False -> imports
   }
   // Import option module when composite validators handle optional fields
@@ -177,7 +178,7 @@ fn collect_schema_constraint_types(
 ) -> ConstraintTypes {
   let schema = case schema_ref {
     Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
   }
   case schema {
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
@@ -238,7 +239,7 @@ fn generate_guards_for_schema(
     Inline(schema) -> generate_guards_for_schema_object(sb, name, schema, ctx)
     Reference(name:, ..) -> {
       let resolved_name = name
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema) ->
           generate_guards_for_schema_object(sb, resolved_name, schema, ctx)
         _ -> sb
@@ -341,7 +342,7 @@ fn generate_field_guard(
 ) -> se.StringBuilder {
   let resolved = case prop_ref {
     Inline(schema) -> Ok(schema)
-    Reference(..) -> resolver.resolve_schema_ref(prop_ref, ctx.spec)
+    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
   }
   case resolved {
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
@@ -1221,7 +1222,7 @@ fn composite_validator_type(
 ) -> String {
   let schema = case schema_ref {
     Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
   }
   case schema {
     Ok(ObjectSchema(..)) | Ok(AllOfSchema(..)) ->
@@ -1246,7 +1247,7 @@ fn collect_guard_calls(
 ) -> List(GuardCall) {
   let schema = case schema_ref {
     Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
   }
   case schema {
     Ok(ObjectSchema(
@@ -1382,7 +1383,7 @@ fn collect_field_guard_calls(
 ) -> List(GuardCall) {
   let resolved = case prop_ref {
     Inline(schema) -> Ok(schema)
-    Reference(..) -> resolver.resolve_schema_ref(prop_ref, ctx.spec)
+    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
   }
   let accessor = "value." <> naming.to_snake_case(prop_name)
   case resolved {

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -26,7 +26,7 @@ import oaspec/util/naming
 
 /// Build an IR Module for the types.gleam file from component schemas.
 pub fn build_types_module(ctx: Context) -> Module {
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
         string.compare(a.0, b.0)

--- a/src/oaspec/codegen/schema_utils.gleam
+++ b/src/oaspec/codegen/schema_utils.gleam
@@ -21,7 +21,7 @@ pub fn schema_has_additional_properties(
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema_obj) ->
           schema_has_additional_properties(Inline(schema_obj), ctx)
         Error(_) -> False
@@ -42,7 +42,7 @@ pub fn schema_has_untyped_additional_properties(
         schema_has_untyped_additional_properties(s, ctx)
       })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema_obj) ->
           schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
         Error(_) -> False
@@ -65,7 +65,7 @@ pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_optional_fields(s, ctx) })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema_obj) -> schema_has_optional_fields(Inline(schema_obj), ctx)
         Error(_) -> False
       }
@@ -78,7 +78,7 @@ pub fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
   case ref {
     Inline(s) -> schema.is_nullable(s)
     Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
+      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
         Ok(s) -> schema.is_nullable(s)
         Error(_) -> False
       }
@@ -90,7 +90,7 @@ pub fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
   case ref {
     Inline(s) -> schema.get_metadata(s).read_only
     Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
+      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
         Ok(s) -> schema.get_metadata(s).read_only
         Error(_) -> False
       }
@@ -102,7 +102,7 @@ pub fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
   case ref {
     Inline(s) -> schema.get_metadata(s).write_only
     Reference(..) ->
-      case resolver.resolve_schema_ref(ref, ctx.spec) {
+      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
         Ok(s) -> schema.get_metadata(s).write_only
         Error(_) -> False
       }

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -42,8 +42,8 @@ fn generate_handlers(
   let sb =
     se.file_header(context.version)
     |> se.imports([
-      ctx.config.package <> "/request_types",
-      ctx.config.package <> "/response_types",
+      context.config(ctx).package <> "/request_types",
+      context.config(ctx).package <> "/response_types",
     ])
 
   let sb =
@@ -456,7 +456,7 @@ fn generate_router(
   }
   // json is also needed when guard validation is enabled (for 422 error responses)
   let needs_json_for_guards =
-    ctx.config.validate
+    context.config(ctx).validate
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       operation_needs_guard_validation(operation, ctx)
@@ -474,38 +474,41 @@ fn generate_router(
     False -> std_imports
   }
 
-  let pkg_imports = [ctx.config.package <> "/handlers"]
+  let pkg_imports = [context.config(ctx).package <> "/handlers"]
   let pkg_imports = case
     has_deep_object || has_form_urlencoded_body || has_multipart_body
   {
-    True -> list.append(pkg_imports, [ctx.config.package <> "/types"])
+    True -> list.append(pkg_imports, [context.config(ctx).package <> "/types"])
     False -> pkg_imports
   }
   let pkg_imports = case needs_decode {
-    True -> list.append(pkg_imports, [ctx.config.package <> "/decode"])
+    True -> list.append(pkg_imports, [context.config(ctx).package <> "/decode"])
     False -> pkg_imports
   }
   let pkg_imports = case needs_encode {
-    True -> list.append(pkg_imports, [ctx.config.package <> "/encode"])
+    True -> list.append(pkg_imports, [context.config(ctx).package <> "/encode"])
     False -> pkg_imports
   }
   let pkg_imports = case has_params_ops {
     True ->
       list.append(pkg_imports, [
-        ctx.config.package <> "/request_types",
-        ctx.config.package <> "/response_types",
+        context.config(ctx).package <> "/request_types",
+        context.config(ctx).package <> "/response_types",
       ])
-    False -> list.append(pkg_imports, [ctx.config.package <> "/response_types"])
+    False ->
+      list.append(pkg_imports, [
+        context.config(ctx).package <> "/response_types",
+      ])
   }
   // Import guards module when validation is enabled and any operation body has validators
   let needs_guards =
-    ctx.config.validate
+    context.config(ctx).validate
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       operation_needs_guard_validation(operation, ctx)
     })
   let pkg_imports = case needs_guards {
-    True -> list.append(pkg_imports, [ctx.config.package <> "/guards"])
+    True -> list.append(pkg_imports, [context.config(ctx).package <> "/guards"])
     False -> pkg_imports
   }
 
@@ -948,7 +951,7 @@ fn generate_safe_request_and_dispatch(
 
   // Check if guard validation should be emitted for this body
   let needs_guard_validation =
-    ctx.config.validate
+    context.config(ctx).validate
     && needs_body_guard
     && {
       case body_schema_ref_name {

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -74,7 +74,7 @@ pub fn body_field_kind(schema_ref: SchemaRef, ctx: Context) -> BodyFieldKind {
         _ -> BodyFieldUnknown
       }
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema_obj) -> body_field_kind_from_object(schema_obj, ctx)
         Error(_) -> BodyFieldUnknown
       }
@@ -359,7 +359,7 @@ pub fn is_deep_object_param(
 ) -> Bool {
   case param.in_, param.style, spec.parameter_schema(param) {
     spec.InQuery, Some(spec.DeepObjectStyle), Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(..)) -> True
         _ -> False
       }
@@ -375,7 +375,7 @@ fn deep_object_properties(
 ) -> List(DeepObjectProperty) {
   let details = case spec.parameter_schema(param) {
     Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(properties:, required:, ..)) -> #(properties, required)
         _ -> #(dict.new(), [])
       }
@@ -511,7 +511,7 @@ pub fn deep_object_has_additional_properties(
 ) -> Bool {
   case spec.parameter_schema(param) {
     Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(additional_properties: schema.Typed(_), ..)) -> True
         Ok(ObjectSchema(additional_properties: schema.Untyped, ..)) -> True
         _ -> False
@@ -619,7 +619,7 @@ pub fn object_properties_from_schema_ref(
 ) -> List(DeepObjectProperty) {
   let details = case schema_ref {
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(properties:, required:, ..)) -> #(properties, required)
         _ -> #(dict.new(), [])
       }
@@ -672,7 +672,7 @@ fn schema_ref_resolves_to_object(schema_ref: SchemaRef, ctx: Context) -> Bool {
   case schema_ref {
     Inline(ObjectSchema(..)) -> True
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(..)) -> True
         _ -> False
       }
@@ -687,7 +687,7 @@ fn schema_ref_additional_properties(
   case schema_ref {
     Inline(ObjectSchema(additional_properties:, ..)) -> additional_properties
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(ObjectSchema(additional_properties:, ..)) -> additional_properties
         _ -> Forbidden
       }

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -158,7 +158,7 @@ fn generate_request_types(
   let needs_types = import_analysis.operations_need_typed_schemas(operations)
 
   let base_imports = case needs_types {
-    True -> [ctx.config.package <> "/types"]
+    True -> [context.config(ctx).package <> "/types"]
     False -> []
   }
   let imports = case needs_option {
@@ -309,7 +309,7 @@ fn generate_response_types(
 ) -> String {
   let needs_types = responses_need_types_import(operations, ctx)
   let imports = case needs_types {
-    True -> [ctx.config.package <> "/types"]
+    True -> [context.config(ctx).package <> "/types"]
     False -> []
   }
   let sb =

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -271,7 +271,7 @@ fn validate_server_structured_param(
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case ctx.config.mode {
+  case context.config(ctx).mode {
     config.Client -> []
     _ -> {
       let schema_obj = resolve_schema_object(spec.parameter_schema(param), ctx)
@@ -414,7 +414,7 @@ fn validate_complex_param_schema(
         | Some(AnyOfSchema(..)) ->
           case param.in_ {
             spec.InPath ->
-              case ctx.config.mode {
+              case context.config(ctx).mode {
                 config.Client -> []
                 _ -> [
                   diagnostic.validation(
@@ -485,7 +485,7 @@ fn resolve_schema_object(
   case schema_ref {
     Some(Inline(schema_obj)) -> Some(schema_obj)
     Some(schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
         Ok(schema_obj) -> Some(schema_obj)
         Error(_) -> None
       }
@@ -658,7 +658,7 @@ fn validate_server_form_urlencoded_request_body(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case ctx.config.mode {
+  case context.config(ctx).mode {
     config.Client -> []
     _ ->
       case dict.get(content, "application/x-www-form-urlencoded") {
@@ -715,7 +715,7 @@ fn validate_server_request_body_content_types(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case ctx.config.mode {
+  case context.config(ctx).mode {
     config.Client -> []
     _ -> {
       let non_json_but_supported =
@@ -748,7 +748,7 @@ fn validate_server_multipart_request_body(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case ctx.config.mode {
+  case context.config(ctx).mode {
     config.Client -> []
     _ ->
       case dict.get(content, "multipart/form-data") {
@@ -913,7 +913,7 @@ fn validate_responses(
 
 /// Validate component schemas recursively.
 fn validate_component_schemas(ctx: Context) -> List(Diagnostic) {
-  let schemas = case ctx.spec.components {
+  let schemas = case context.spec(ctx).components {
     Some(components) -> dict.to_list(components.schemas)
     None -> []
   }
@@ -952,7 +952,7 @@ fn validate_schema_ref_recursive(
           ),
         ]
         True ->
-          case resolver.resolve_schema_ref(schema_ref, ctx.spec) {
+          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
             Ok(_) -> []
             Error(_) -> [
               diagnostic.validation(
@@ -1036,13 +1036,13 @@ fn validate_security_schemes(
   ctx: Context,
   operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> List(Diagnostic) {
-  let scheme_names = case ctx.spec.components {
+  let scheme_names = case context.spec(ctx).components {
     Some(components) -> dict.keys(components.security_schemes)
     None -> []
   }
 
   let global_errors =
-    list.flat_map(ctx.spec.security, fn(req) {
+    list.flat_map(context.spec(ctx).security, fn(req) {
       list.filter_map(req.schemes, fn(scheme_ref) {
         case list.contains(scheme_names, scheme_ref.scheme_name) {
           True -> Error(Nil)

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -17,7 +17,7 @@ pub fn generate_all(
   on_write: fn(String) -> Nil,
 ) -> Result(List(String), WriteError) {
   let files = gen.generate_all_files(ctx)
-  write_all(files, ctx.config, on_write)
+  write_all(files, context.config(ctx), on_write)
 }
 
 /// Write pre-generated files to disk based on configuration.

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -131,11 +131,11 @@ pub fn validate_only(
 /// Pure file generation: produce all GeneratedFile values without any IO.
 pub fn generate_all_files(ctx: Context) -> List(GeneratedFile) {
   let shared = generate_shared(ctx)
-  let server_files = case ctx.config.mode {
+  let server_files = case context.config(ctx).mode {
     Server | Both -> server.generate(ctx)
     Client -> []
   }
-  let client_files = case ctx.config.mode {
+  let client_files = case context.config(ctx).mode {
     Client | Both -> client.generate(ctx)
     Server -> []
   }

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -218,7 +218,7 @@ fn check_security_schemes(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
 /// This is the single source of truth for "parsed but not generated" diagnostics.
 /// Requires Context because some checks iterate over resolved operations.
 pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
-  let webhook_warnings = case dict.is_empty(ctx.spec.webhooks) {
+  let webhook_warnings = case dict.is_empty(context.spec(ctx).webhooks) {
     True -> []
     False -> [
       diagnostic.capability(
@@ -244,7 +244,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             let base_path =
               op_id <> ".responses." <> http.status_code_to_string(status_code)
             let multi_content_warnings = case
-              ctx.config.mode,
+              context.config(ctx).mode,
               list.length(dict.to_list(response.content))
             {
               config.Client, _ -> []
@@ -319,7 +319,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         }
       })
     })
-  let external_docs_warnings = case ctx.spec.external_docs {
+  let external_docs_warnings = case context.spec(ctx).external_docs {
     Some(_) -> [
       diagnostic.capability(
         severity: SeverityWarning,
@@ -333,7 +333,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
     ]
     None -> []
   }
-  let tag_warnings = case list.is_empty(ctx.spec.tags) {
+  let tag_warnings = case list.is_empty(context.spec(ctx).tags) {
     True -> []
     False -> [
       diagnostic.capability(
@@ -349,7 +349,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
   // code generation (server precedence: operation > path > top-level).
   let operation_server_warnings = []
   let path_server_warnings = []
-  let component_warnings = case ctx.spec.components {
+  let component_warnings = case context.spec(ctx).components {
     Some(components) -> {
       let header_w = case dict.is_empty(components.headers) {
         True -> []

--- a/src/oaspec/openapi/operations.gleam
+++ b/src/oaspec/openapi/operations.gleam
@@ -12,7 +12,7 @@ pub fn collect_operations(
   ctx: Context,
 ) -> List(#(String, Operation(Resolved), String, HttpMethod)) {
   let paths =
-    list.sort(dict.to_list(ctx.spec.paths), fn(a, b) {
+    list.sort(dict.to_list(context.spec(ctx).paths), fn(a, b) {
       string.compare(a.0, b.0)
     })
   list.flat_map(paths, fn(entry) {
@@ -53,7 +53,7 @@ pub fn collect_operations(
             // Some([...]) → use operation-level.
             let effective_security = case operation.security {
               Some(sec) -> sec
-              None -> ctx.spec.security
+              None -> context.spec(ctx).security
             }
             // Inherit path-level servers when operation doesn't define its own.
             // OpenAPI precedence: operation.servers > path_item.servers > spec.servers

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -718,7 +718,7 @@ pub fn parse_missing_responses_succeeds_with_empty_dict_test() {
 pub fn validate_missing_responses_rejects_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/missing_responses.yaml")
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -8433,7 +8433,7 @@ pub fn oss_libopenapi_burgershop_rejects_not_keyword_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_libopenapi_burgershop.yaml")
   // Generate fails via capability_check due to "not" keyword
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -8496,7 +8496,7 @@ pub fn oss_oapi_codegen_nullable_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_nullable.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8525,7 +8525,7 @@ pub fn oss_oapi_codegen_allof_additional_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_allof_additional.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8577,7 +8577,7 @@ pub fn oss_oapi_codegen_issue_312_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_312.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8607,7 +8607,7 @@ pub fn oss_oapi_codegen_issue_52_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_52.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8629,7 +8629,7 @@ pub fn oss_oapi_codegen_issue_1168_problem_json_generates_test() {
   // The full generate pipeline should succeed without validation errors.
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_1168.yaml")
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Ok(_summary) -> should.be_true(True)
     Error(_) -> should.be_true(False)
@@ -8656,7 +8656,7 @@ pub fn oss_oapi_codegen_issue_579_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_579.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8677,7 +8677,7 @@ pub fn oss_oapi_codegen_issue_2185_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_oapi_codegen_issue_2185.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8708,7 +8708,7 @@ pub fn oss_openapi_gen_issue_9719_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_openapi_gen_issue_9719.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8781,7 +8781,7 @@ pub fn oss_kiota_discriminator_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_kiota_discriminator.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8801,7 +8801,7 @@ pub fn oss_kiota_derived_types_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_kiota_derived_types.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8822,7 +8822,7 @@ pub fn oss_kiota_multi_security_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_kiota_multi_security.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -8975,7 +8975,7 @@ pub fn oss_openapi_gen_issue_11897_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_openapi_gen_issue_11897.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
@@ -9001,7 +9001,7 @@ pub fn oss_openapi_gen_issue_1666_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_openapi_gen_issue_1666.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
@@ -9027,7 +9027,7 @@ pub fn oss_openapi_gen_issue_18516_generates_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_openapi_gen_issue_18516.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
@@ -9691,7 +9691,7 @@ pub fn oss_swagger_parser_java_31_schema_siblings_rejects_test() {
       "test/fixtures/oss_swagger_parser_java_31_schema_siblings.yaml",
     )
   // Generate fails via capability_check due to dependentSchemas, if/then/else
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -9749,7 +9749,7 @@ pub fn unsupported_if_then_else_capability_check_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/unsupported_if_then_else.yaml")
   // Generate fails via capability_check
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -9767,7 +9767,7 @@ pub fn unsupported_prefix_items_capability_check_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/unsupported_prefix_items.yaml")
   // Generate fails via capability_check
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -9785,7 +9785,7 @@ pub fn unsupported_not_capability_check_test() {
   // Parse succeeds — lossless parser stores unsupported keywords
   let assert Ok(spec) = parser.parse_file("test/fixtures/unsupported_not.yaml")
   // Generate fails via capability_check
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -9802,7 +9802,7 @@ pub fn unsupported_defs_capability_check_test() {
   // Parse succeeds — lossless parser stores unsupported keywords
   let assert Ok(spec) = parser.parse_file("test/fixtures/unsupported_defs.yaml")
   // Generate fails via capability_check
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -9864,7 +9864,7 @@ pub fn schema_no_type_with_properties_parses_test() {
 pub fn validate_invalid_security_ref_rejects_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/invalid_security_ref.yaml")
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let error_details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -10045,7 +10045,7 @@ pub fn resolve_component_alias_test() {
   let assert Ok(spec.Ref(_)) = dict.get(components.parameters, "AliasedLimit")
 
   // After resolve (via generate pipeline): AliasEntry becomes ConcreteEntry
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Ok(_) -> should.be_true(True)
     Error(generate.ValidationErrors(errors:)) -> {
@@ -10069,7 +10069,7 @@ pub fn capability_check_uses_registry_test() {
   let assert Some(components) = spec.components
   dict.size(components.schemas) |> should.not_equal(0)
   // Generate fails via capability_check (not parser)
-  let result = generate.generate(spec, make_ctx_from_spec(spec).config)
+  let result = generate.generate(spec, context.config(make_ctx_from_spec(spec)))
   case result {
     Error(generate.ValidationErrors(errors:)) -> {
       let details = list.map(errors, fn(e) { diagnostic.to_string(e) })
@@ -10126,7 +10126,7 @@ pub fn yaml_error_has_source_location_test() {
 pub fn pipeline_end_to_end_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/petstore.yaml")
   let ctx = make_ctx_from_spec(spec)
-  let result = generate.generate(spec, ctx.config)
+  let result = generate.generate(spec, context.config(ctx))
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {


### PR DESCRIPTION
## Summary

- `oaspec/codegen/context.Context` was a plain `pub type`, so every codegen module pattern-matched on `ctx.spec` / `ctx.config` directly — any change to the record shape was a project-wide touch.
- Declare `Context` as `pub opaque type`. Construction goes through `context.new/2`; reads go through `context.spec/1` / `context.config/1`.
- First subset of parent issue #41. `Config` / `Module` / `Declaration` / `GeneratedFile` will be follow-ups.
- Closes #136.

## Changes

- `src/oaspec/codegen/context.gleam`: `pub type` → `pub opaque type`; add `spec/1` and `config/1` accessors with docs explaining the rationale.
- 17 other `src/**/*.gleam` files: replace ~116 field accesses of the form `ctx.spec` / `ctx.config` with `context.spec(ctx)` / `context.config(ctx)`. Mechanical substitution; no logic changed.
- `test/oaspec_test.gleam`: replace 14 `ctx.spec` / `ctx.config` hits and one `make_ctx_from_spec(spec).config` chain.
- `CHANGELOG.md`: new `Changed` entry under Unreleased pointing at parent #41.

## Design Decisions

- **Two read accessors, no field-level getters.** `Context` only has two fields; shipping explicit `spec/1` and `config/1` accessors keeps the API shape close to what the record previously exposed. When we need derived state (caches, computed lookups) we can add new accessors without revisiting call sites.
- **No builder / `with_*` mutators.** `Context` is read-only post-construction in this codebase. If a future change needs to rotate config or swap the spec, that's best modelled explicitly rather than pre-emptively.
- **Subset rather than big-bang.** Parent issue #41 covers four types. Doing all four in one PR yields a sprawling diff that's harder to review. Splitting by type keeps each change mechanical and independently revertible.

## Limitations

- `Config`, `Module`, `Declaration`, and `GeneratedFile` are still plain `pub type` — tracked by the parent issue.
- `FileTarget` and `GeneratedFile` in `context.gleam` intentionally stay as regular `pub type`s for now; they're data carriers without invariants.

## Test plan

- [x] `just all` passes (633 unit tests, 40 integration, shellspec, smoke).
- [x] No `ctx.spec` / `ctx.config` references remain outside `context.gleam` (grep is clean).

Closes #136.