### PR TITLE
refactor(config): make Config an opaque type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - `oaspec/codegen/context.Context` is now declared `pub opaque type`. External callers must use `context.new/2` to construct and `context.spec/1` / `context.config/1` to read fields instead of pattern-matching on the record. First step of parent issue #41; Config / Module / Declaration to follow (#136)
+- `oaspec/config.Config` is now declared `pub opaque type`. Construct via `config.new/6` or `config.load/1`; read fields via `config.input/1`, `config.package/1`, `config.mode/1`, `config.output_server/1`, `config.output_client/1`, `config.validate/1`. Second step of parent issue #41 (#138)
 
 ## [0.12.0] - 2026-04-12
 

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -226,8 +226,8 @@ fn run_generate(
     False -> cfg
   }
 
-  io.println("Parsing OpenAPI spec: " <> cfg.input)
-  use spec <- require(parser.parse_file(cfg.input), fn(e) {
+  io.println("Parsing OpenAPI spec: " <> config.input(cfg))
+  use spec <- require(parser.parse_file(config.input(cfg)), fn(e) {
     "Error: " <> parser.parse_error_to_string(e)
   })
 
@@ -400,8 +400,8 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
     "Error: " <> msg
   })
 
-  io.println("Parsing OpenAPI spec: " <> cfg.input)
-  use spec <- require(parser.parse_file(cfg.input), fn(e) {
+  io.println("Parsing OpenAPI spec: " <> config.input(cfg))
+  use spec <- require(parser.parse_file(config.input(cfg)), fn(e) {
     "Error: " <> parser.parse_error_to_string(e)
   })
 

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -9,6 +9,7 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
 import oaspec/codegen/ir_build
+import oaspec/config
 import oaspec/openapi/operations
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{Inline, Reference}
@@ -232,8 +233,8 @@ fn generate_client(ctx: Context) -> String {
     // `gleam/result` is needed by the `use req <- result.try(...)` pattern
     // that every generated operation emits for URL parsing.
     "gleam/result",
-    context.config(ctx).package <> "/decode",
-    context.config(ctx).package <> "/response_types",
+    config.package(context.config(ctx)) <> "/decode",
+    config.package(context.config(ctx)) <> "/response_types",
   ]
   let base_imports = case needs_int {
     True -> ["gleam/int", ..base_imports]
@@ -247,8 +248,8 @@ fn generate_client(ctx: Context) -> String {
     True ->
       list.append(
         [
-          context.config(ctx).package <> "/types",
-          context.config(ctx).package <> "/encode",
+          config.package(context.config(ctx)) <> "/types",
+          config.package(context.config(ctx)) <> "/encode",
         ],
         base_imports,
       )
@@ -316,7 +317,7 @@ fn generate_client(ctx: Context) -> String {
   }
   // Import guards module when validation is enabled and any operation body has validators
   let needs_guards =
-    context.config(ctx).validate
+    config.validate(context.config(ctx))
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       case operation.request_body {
@@ -336,7 +337,7 @@ fn generate_client(ctx: Context) -> String {
       }
     })
   let imports = case needs_guards {
-    True -> [context.config(ctx).package <> "/guards", ..imports]
+    True -> [config.package(context.config(ctx)) <> "/guards", ..imports]
     False -> imports
   }
 
@@ -398,7 +399,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(1, "DecodeError(detail: String)")
     |> se.indent(1, "InvalidUrl(detail: String)")
     |> se.indent(1, "UnexpectedStatus(status: Int, body: String)")
-  let sb = case context.config(ctx).validate {
+  let sb = case config.validate(context.config(ctx)) {
     True -> sb |> se.indent(1, "ValidationError(errors: List(String))")
     False -> sb
   }
@@ -609,7 +610,7 @@ fn generate_client_function(
 
   // Determine if client-side guard validation is needed for the body
   let client_guard_schema_name = case
-    context.config(ctx).validate,
+    config.validate(context.config(ctx)),
     operation.request_body
   {
     True, Some(Value(rb)) -> {

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -7,6 +7,7 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/types as type_gen
+import oaspec/config
 import oaspec/openapi/dedup
 import oaspec/openapi/operations
 import oaspec/openapi/resolver
@@ -90,7 +91,10 @@ fn generate_decoders(
     False -> ["gleam/dynamic/decode", "gleam/json"]
   }
   let base_imports = case needs_types {
-    True -> list.append(base_imports, [context.config(ctx).package <> "/types"])
+    True ->
+      list.append(base_imports, [
+        config.package(context.config(ctx)) <> "/types",
+      ])
     False -> base_imports
   }
   let imports = case needs_option {
@@ -1203,7 +1207,10 @@ fn generate_encoders(
     _, _ -> ["gleam/json"]
   }
   let imports = case needs_types {
-    True -> list.append(base_imports, [context.config(ctx).package <> "/types"])
+    True ->
+      list.append(base_imports, [
+        config.package(context.config(ctx)) <> "/types",
+      ])
     False -> base_imports
   }
 

--- a/src/oaspec/codegen/guards.gleam
+++ b/src/oaspec/codegen/guards.gleam
@@ -8,6 +8,7 @@ import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/types as type_gen
+import oaspec/config
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, ArraySchema, Inline,
@@ -104,7 +105,7 @@ fn generate_guards(ctx: Context) -> String {
       }
     })
   let imports = case needs_types {
-    True -> [context.config(ctx).package <> "/types", ..imports]
+    True -> [config.package(context.config(ctx)) <> "/types", ..imports]
     False -> imports
   }
   // Import option module when composite validators handle optional fields

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -6,6 +6,7 @@ import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
 import oaspec/codegen/server_request_decode as decode_helpers
+import oaspec/config
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec.{type Resolved, Value}
@@ -42,8 +43,8 @@ fn generate_handlers(
   let sb =
     se.file_header(context.version)
     |> se.imports([
-      context.config(ctx).package <> "/request_types",
-      context.config(ctx).package <> "/response_types",
+      config.package(context.config(ctx)) <> "/request_types",
+      config.package(context.config(ctx)) <> "/response_types",
     ])
 
   let sb =
@@ -456,7 +457,7 @@ fn generate_router(
   }
   // json is also needed when guard validation is enabled (for 422 error responses)
   let needs_json_for_guards =
-    context.config(ctx).validate
+    config.validate(context.config(ctx))
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       operation_needs_guard_validation(operation, ctx)
@@ -474,41 +475,51 @@ fn generate_router(
     False -> std_imports
   }
 
-  let pkg_imports = [context.config(ctx).package <> "/handlers"]
+  let pkg_imports = [config.package(context.config(ctx)) <> "/handlers"]
   let pkg_imports = case
     has_deep_object || has_form_urlencoded_body || has_multipart_body
   {
-    True -> list.append(pkg_imports, [context.config(ctx).package <> "/types"])
+    True ->
+      list.append(pkg_imports, [config.package(context.config(ctx)) <> "/types"])
     False -> pkg_imports
   }
   let pkg_imports = case needs_decode {
-    True -> list.append(pkg_imports, [context.config(ctx).package <> "/decode"])
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/decode",
+      ])
     False -> pkg_imports
   }
   let pkg_imports = case needs_encode {
-    True -> list.append(pkg_imports, [context.config(ctx).package <> "/encode"])
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/encode",
+      ])
     False -> pkg_imports
   }
   let pkg_imports = case has_params_ops {
     True ->
       list.append(pkg_imports, [
-        context.config(ctx).package <> "/request_types",
-        context.config(ctx).package <> "/response_types",
+        config.package(context.config(ctx)) <> "/request_types",
+        config.package(context.config(ctx)) <> "/response_types",
       ])
     False ->
       list.append(pkg_imports, [
-        context.config(ctx).package <> "/response_types",
+        config.package(context.config(ctx)) <> "/response_types",
       ])
   }
   // Import guards module when validation is enabled and any operation body has validators
   let needs_guards =
-    context.config(ctx).validate
+    config.validate(context.config(ctx))
     && list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       operation_needs_guard_validation(operation, ctx)
     })
   let pkg_imports = case needs_guards {
-    True -> list.append(pkg_imports, [context.config(ctx).package <> "/guards"])
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/guards",
+      ])
     False -> pkg_imports
   }
 
@@ -951,7 +962,7 @@ fn generate_safe_request_and_dispatch(
 
   // Check if guard validation should be emitted for this body
   let needs_guard_validation =
-    context.config(ctx).validate
+    config.validate(context.config(ctx))
     && needs_body_guard
     && {
       case body_schema_ref_name {

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -8,6 +8,7 @@ import oaspec/codegen/ir_build
 import oaspec/codegen/ir_render
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/schema_utils
+import oaspec/config
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
@@ -158,7 +159,7 @@ fn generate_request_types(
   let needs_types = import_analysis.operations_need_typed_schemas(operations)
 
   let base_imports = case needs_types {
-    True -> [context.config(ctx).package <> "/types"]
+    True -> [config.package(context.config(ctx)) <> "/types"]
     False -> []
   }
   let imports = case needs_option {
@@ -309,7 +310,7 @@ fn generate_response_types(
 ) -> String {
   let needs_types = responses_need_types_import(operations, ctx)
   let imports = case needs_types {
-    True -> [context.config(ctx).package <> "/types"]
+    True -> [config.package(context.config(ctx)) <> "/types"]
     False -> []
   }
   let sb =

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -271,7 +271,7 @@ fn validate_server_structured_param(
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case context.config(ctx).mode {
+  case config.mode(context.config(ctx)) {
     config.Client -> []
     _ -> {
       let schema_obj = resolve_schema_object(spec.parameter_schema(param), ctx)
@@ -414,7 +414,7 @@ fn validate_complex_param_schema(
         | Some(AnyOfSchema(..)) ->
           case param.in_ {
             spec.InPath ->
-              case context.config(ctx).mode {
+              case config.mode(context.config(ctx)) {
                 config.Client -> []
                 _ -> [
                   diagnostic.validation(
@@ -658,7 +658,7 @@ fn validate_server_form_urlencoded_request_body(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case context.config(ctx).mode {
+  case config.mode(context.config(ctx)) {
     config.Client -> []
     _ ->
       case dict.get(content, "application/x-www-form-urlencoded") {
@@ -715,7 +715,7 @@ fn validate_server_request_body_content_types(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case context.config(ctx).mode {
+  case config.mode(context.config(ctx)) {
     config.Client -> []
     _ -> {
       let non_json_but_supported =
@@ -748,7 +748,7 @@ fn validate_server_multipart_request_body(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case context.config(ctx).mode {
+  case config.mode(context.config(ctx)) {
     config.Client -> []
     _ ->
       case dict.get(content, "multipart/form-data") {

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -34,11 +34,11 @@ pub fn write_all(
   let client_files =
     list.filter(files, fn(f) { f.target == context.ClientTarget })
 
-  let server_path = cfg.output_server
-  let client_path = cfg.output_client
+  let server_path = config.output_server(cfg)
+  let client_path = config.output_client(cfg)
   let written_files = []
 
-  use written_files <- result.try(case cfg.mode {
+  use written_files <- result.try(case config.mode(cfg) {
     Server | Both -> {
       use _ <- result.try(ensure_directory(server_path))
       write_files(shared_files, server_path, written_files, on_write)
@@ -49,7 +49,7 @@ pub fn write_all(
     Client -> Ok(written_files)
   })
 
-  use written_files <- result.try(case cfg.mode {
+  use written_files <- result.try(case config.mode(cfg) {
     Client | Both -> {
       use _ <- result.try(ensure_directory(client_path))
       write_files(shared_files, client_path, written_files, on_write)
@@ -104,10 +104,10 @@ pub fn resolve_paths(
   let client_files =
     list.filter(files, fn(f) { f.target == context.ClientTarget })
 
-  let server_path = cfg.output_server
-  let client_path = cfg.output_client
+  let server_path = config.output_server(cfg)
+  let client_path = config.output_client(cfg)
 
-  let server_entries = case cfg.mode {
+  let server_entries = case config.mode(cfg) {
     Server | Both ->
       list.map(list.append(shared_files, server_files), fn(f) {
         #(server_path <> "/" <> f.path, f.content)
@@ -115,7 +115,7 @@ pub fn resolve_paths(
     Client -> []
   }
 
-  let client_entries = case cfg.mode {
+  let client_entries = case config.mode(cfg) {
     Client | Both ->
       list.map(list.append(shared_files, client_files), fn(f) {
         #(client_path <> "/" <> f.path, f.content)
@@ -128,10 +128,10 @@ pub fn resolve_paths(
 
 /// Return the output directories that would be written to for the given config.
 pub fn output_dirs(cfg: config.Config) -> List(String) {
-  case cfg.mode {
-    Server -> [cfg.output_server]
-    Client -> [cfg.output_client]
-    Both -> [cfg.output_server, cfg.output_client]
+  case config.mode(cfg) {
+    Server -> [config.output_server(cfg)]
+    Client -> [config.output_client(cfg)]
+    Both -> [config.output_server(cfg), config.output_client(cfg)]
   }
 }
 

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -6,7 +6,12 @@ import simplifile
 import yay
 
 /// Configuration for oaspec code generation.
-pub type Config {
+///
+/// Opaque: external callers construct via `new/6` and read fields via
+/// the accessors below. Mutators (`with_mode`, `with_validate`,
+/// `with_output`) live in this module too, so every change to a
+/// `Config` value goes through an explicit function.
+pub opaque type Config {
   Config(
     input: String,
     output_server: String,
@@ -15,6 +20,50 @@ pub type Config {
     mode: GenerateMode,
     validate: Bool,
   )
+}
+
+/// Construct a new `Config` from its six fields. Prefer `load/1` in
+/// production code; `new/6` is primarily for tests and ad-hoc tooling
+/// that assembles a config in memory.
+pub fn new(
+  input input: String,
+  output_server output_server: String,
+  output_client output_client: String,
+  package package: String,
+  mode mode: GenerateMode,
+  validate validate: Bool,
+) -> Config {
+  Config(input:, output_server:, output_client:, package:, mode:, validate:)
+}
+
+/// Path to the OpenAPI spec this config was built for.
+pub fn input(cfg: Config) -> String {
+  cfg.input
+}
+
+/// Output directory for server-side generated files.
+pub fn output_server(cfg: Config) -> String {
+  cfg.output_server
+}
+
+/// Output directory for client-side generated files.
+pub fn output_client(cfg: Config) -> String {
+  cfg.output_client
+}
+
+/// Gleam package name (module prefix) for generated files.
+pub fn package(cfg: Config) -> String {
+  cfg.package
+}
+
+/// Generation mode: server, client, or both.
+pub fn mode(cfg: Config) -> GenerateMode {
+  cfg.mode
+}
+
+/// Whether guard-based runtime validation is enabled.
+pub fn validate(cfg: Config) -> Bool {
+  cfg.validate
 }
 
 /// Generation mode.

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -61,7 +61,7 @@ fn prepare_context(
   // Check for unsupported features using capability registry
   let capability_issues =
     capability_check.check(spec)
-    |> validate.filter_by_mode(cfg.mode)
+    |> validate.filter_by_mode(config.mode(cfg))
   let capability_errors = validate.errors_only(capability_issues)
   let capability_warnings = validate.warnings_only(capability_issues)
   use _ <- result.try(case list.is_empty(capability_errors) {
@@ -81,12 +81,12 @@ fn prepare_context(
   // Check for parsed-but-unused features (capability warnings)
   let preserved_warnings =
     capability_check.check_preserved(ctx)
-    |> diagnostic.filter_by_mode(cfg.mode)
+    |> diagnostic.filter_by_mode(config.mode(cfg))
 
   // Validate spec for unsupported features
   let validation_issues =
     validate.validate(ctx)
-    |> validate.filter_by_mode(cfg.mode)
+    |> validate.filter_by_mode(config.mode(cfg))
   let blocking_errors = validate.errors_only(validation_issues)
   let validation_warnings = validate.warnings_only(validation_issues)
   use _ <- result.try(case list.is_empty(blocking_errors) {
@@ -131,11 +131,11 @@ pub fn validate_only(
 /// Pure file generation: produce all GeneratedFile values without any IO.
 pub fn generate_all_files(ctx: Context) -> List(GeneratedFile) {
   let shared = generate_shared(ctx)
-  let server_files = case context.config(ctx).mode {
+  let server_files = case config.mode(context.config(ctx)) {
     Server | Both -> server.generate(ctx)
     Client -> []
   }
-  let client_files = case context.config(ctx).mode {
+  let client_files = case config.mode(context.config(ctx)) {
     Client | Both -> client.generate(ctx)
     Server -> []
   }

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -244,7 +244,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             let base_path =
               op_id <> ".responses." <> http.status_code_to_string(status_code)
             let multi_content_warnings = case
-              context.config(ctx).mode,
+              config.mode(context.config(ctx)),
               list.length(dict.to_list(response.content))
             {
               config.Client, _ -> []

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -937,7 +937,7 @@ fn make_security_ctx(
       json_schema_dialect: None,
     )
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",

--- a/test/golden_test.gleam
+++ b/test/golden_test.gleam
@@ -27,7 +27,7 @@ pub fn main() {
 fn golden_generate(spec_path: String) -> List(context.GeneratedFile) {
   let assert Ok(spec) = parser.parse_file(spec_path)
   let cfg =
-    config.Config(
+    config.new(
       input: spec_path,
       output_server: "./golden_unused/api",
       output_client: "./golden_unused/api",

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -94,10 +94,10 @@ pub fn deduplicate_names_empty_test() {
 
 pub fn load_config_test() {
   let assert Ok(cfg) = config.load("test/fixtures/oaspec.yaml")
-  cfg.input |> should.equal("test/fixtures/petstore.yaml")
-  cfg.output_server |> should.equal("./test_output/api")
-  cfg.output_client |> should.equal("./test_output_client/api")
-  cfg.package |> should.equal("api")
+  config.input(cfg) |> should.equal("test/fixtures/petstore.yaml")
+  config.output_server(cfg) |> should.equal("./test_output/api")
+  config.output_client(cfg) |> should.equal("./test_output_client/api")
+  config.package(cfg) |> should.equal("api")
 }
 
 pub fn config_not_found_test() {
@@ -117,7 +117,7 @@ pub fn parse_mode_test() {
 
 pub fn config_package_dir_mismatch_test() {
   let cfg =
-    config.Config(
+    config.new(
       input: "openapi.yaml",
       output_server: "./gen/wrong_name",
       output_client: "./gen/api",
@@ -131,7 +131,7 @@ pub fn config_package_dir_mismatch_test() {
 
 pub fn config_client_dir_mismatch_test() {
   let cfg =
-    config.Config(
+    config.new(
       input: "openapi.yaml",
       output_server: "./gen/api",
       output_client: "./gen/wrong_client",
@@ -145,7 +145,7 @@ pub fn config_client_dir_mismatch_test() {
 
 pub fn config_package_dir_match_test() {
   let cfg =
-    config.Config(
+    config.new(
       input: "openapi.yaml",
       output_server: "./gen/api",
       output_client: "./gen_client/api",
@@ -470,7 +470,7 @@ paths:
 fn make_ctx_from_spec(spec) -> context.Context {
   let assert Ok(resolved) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -556,7 +556,7 @@ fn make_ctx(spec_path: String) -> context.Context {
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: spec_path,
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -1927,7 +1927,7 @@ paths:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -1969,7 +1969,7 @@ webhooks:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -2559,7 +2559,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -2610,7 +2610,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -2658,7 +2658,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -3375,7 +3375,7 @@ paths:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -3897,7 +3897,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -3940,7 +3940,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -3982,7 +3982,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4026,7 +4026,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4068,7 +4068,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4112,7 +4112,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4230,7 +4230,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4277,7 +4277,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4321,7 +4321,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4365,7 +4365,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4411,7 +4411,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4457,7 +4457,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4805,7 +4805,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -4963,7 +4963,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5012,7 +5012,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5059,7 +5059,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5666,7 +5666,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5730,7 +5730,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5789,7 +5789,7 @@ components:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -5845,7 +5845,7 @@ webhooks:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -6240,7 +6240,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -6283,7 +6283,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -6322,7 +6322,7 @@ paths:
   let ctx =
     context.new(
       spec,
-      config.Config(
+      config.new(
         input: "test.yaml",
         output_server: "./test_output/api",
         output_client: "./test_output_client/api",
@@ -6909,7 +6909,7 @@ paths:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -7013,7 +7013,7 @@ paths:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -7918,7 +7918,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8014,7 +8014,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8068,7 +8068,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8125,7 +8125,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8177,7 +8177,7 @@ paths:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8229,7 +8229,7 @@ components:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8285,7 +8285,7 @@ components:
   let assert Ok(spec) = parser.parse_string(yaml)
   let assert Ok(spec) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -8752,7 +8752,7 @@ pub fn oss_openapi_gen_petstore_server_generates_client_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_openapi_gen_petstore_server.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -9138,7 +9138,7 @@ pub fn oss_kin_openapi_components_json_rejects_invalid_scheme_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_kin_openapi_components.json")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -9661,7 +9661,7 @@ pub fn oss_swagger_parser_java_31_security_rejects_mutualtls_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/oss_swagger_parser_java_31_security.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -9829,7 +9829,7 @@ pub fn inline_not_keyword_rejected_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/inline_not_keyword.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -9884,7 +9884,7 @@ pub fn external_param_ref_rejects_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/external_param_ref.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -9910,7 +9910,7 @@ pub fn external_param_ref_rejects_test() {
 pub fn wrong_kind_ref_rejects_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/wrong_kind_ref.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10599,7 +10599,7 @@ pub fn error_missing_path_param_test() {
       let resolved = hoist.hoist(resolved)
       let resolved = dedup.dedup(resolved)
       let cfg =
-        config.Config(
+        config.new(
           input: "test.yaml",
           output_server: "./test_output/api",
           output_client: "./test_output_client/api",
@@ -10852,7 +10852,7 @@ pub fn e2e_wildcard_status_codes_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/wildcard_status_codes.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/wildcard_status_codes.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10871,7 +10871,7 @@ pub fn e2e_wildcard_status_codes_test() {
 pub fn e2e_format_types_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/format_types.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/format_types.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10891,7 +10891,7 @@ pub fn e2e_complex_discriminator_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/complex_discriminator.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/complex_discriminator.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10910,7 +10910,7 @@ pub fn e2e_complex_discriminator_test() {
 pub fn e2e_enum_edge_cases_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/enum_edge_cases.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/enum_edge_cases.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10930,7 +10930,7 @@ pub fn e2e_mixed_param_locations_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/mixed_param_locations.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/mixed_param_locations.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10950,7 +10950,7 @@ pub fn e2e_inline_nested_objects_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/inline_nested_objects.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/inline_nested_objects.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10970,7 +10970,7 @@ pub fn e2e_optional_required_combinations_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/optional_required_combinations.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/optional_required_combinations.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -10989,7 +10989,7 @@ pub fn e2e_optional_required_combinations_test() {
 pub fn e2e_no_servers_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/no_servers.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/no_servers.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11016,7 +11016,7 @@ fn make_validate_ctx_from_yaml(yaml: String) -> context.Context {
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11125,7 +11125,7 @@ pub fn guard_integration_server_no_validation_when_disabled_test() {
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11181,7 +11181,7 @@ pub fn guard_integration_client_no_validation_when_disabled_test() {
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11350,7 +11350,7 @@ pub fn config_validate_field_test() {
   let temp_path = "/tmp/oaspec_validate_test.yaml"
   let assert Ok(Nil) = simplifile.write(temp_path, yaml_content)
   let assert Ok(cfg) = config.load(temp_path)
-  cfg.validate |> should.be_true()
+  config.validate(cfg) |> should.be_true()
   let _ = simplifile.delete(temp_path)
   Nil
 }
@@ -11361,7 +11361,7 @@ pub fn config_validate_default_false_test() {
   let temp_path = "/tmp/oaspec_validate_default_test.yaml"
   let assert Ok(Nil) = simplifile.write(temp_path, yaml_content)
   let assert Ok(cfg) = config.load(temp_path)
-  cfg.validate |> should.be_false()
+  config.validate(cfg) |> should.be_false()
   let _ = simplifile.delete(temp_path)
   Nil
 }
@@ -11429,7 +11429,7 @@ paths:
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11483,7 +11483,7 @@ paths:
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11526,7 +11526,7 @@ pub fn server_override_no_capability_warnings_test() {
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/operation_server_override.yaml")
   let cfg =
-    config.Config(
+    config.new(
       input: "test/fixtures/operation_server_override.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -11575,7 +11575,7 @@ paths:
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",

--- a/test/test_helpers.gleam
+++ b/test/test_helpers.gleam
@@ -14,7 +14,7 @@ import oaspec/openapi/spec
 pub fn make_ctx_from_spec(spec) -> context.Context {
   let assert Ok(resolved) = resolve.resolve(spec)
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -32,7 +32,7 @@ pub fn make_ctx(spec_path: String) -> context.Context {
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let cfg =
-    config.Config(
+    config.new(
       input: spec_path,
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
@@ -163,7 +163,7 @@ pub fn make_minimal_ctx() -> context.Context {
       json_schema_dialect: None,
     )
   let cfg =
-    config.Config(
+    config.new(
       input: "test.yaml",
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",

--- a/test/writer_test.gleam
+++ b/test/writer_test.gleam
@@ -16,7 +16,7 @@ pub fn main() {
 // --- Writer Tests ---
 
 fn test_config(mode: config.GenerateMode) -> config.Config {
-  config.Config(
+  config.new(
     input: "test.yaml",
     output_server: "./gen/api",
     output_client: "./gen_client/api",


### PR DESCRIPTION
## Summary

- Second step of parent issue #41 (after #136 promoted `Context`).
- `oaspec/config.Config` is now `pub opaque type`. Construct through `config.new/6` or `config.load/1`; read via the six field accessors.
- Behaviour unchanged; all existing tests pass.
- Closes #138.

## Changes

- `src/oaspec/config.gleam`: `pub type` → `pub opaque type`; add `new/6` constructor (labelled args) and `input/1`, `output_server/1`, `output_client/1`, `package/1`, `mode/1`, `validate/1` accessors.
- All src modules that read fields via `context.config(ctx).<field>` or `cfg.<field>` now call the accessor equivalent. `import oaspec/config` added where missing.
- Tests: 71 `config.Config(...)` constructions become `config.new(...)`; `cfg.<field>` reads become accessor calls.
- `CHANGELOG.md`: new `Changed` entry under Unreleased.

## Design Decisions

- **Labelled `new/6`.** The record had six fields with no default story; preserving the field names at the API level keeps the call sites readable. An alternative builder pattern (`config.default() |> config.with_input(...)`) would be cleaner if defaults existed, but they don't today.
- **Keep `with_mode` / `with_validate` / `with_output`.** These mutators already existed and were the right shape — they take and return `Config`, so opaquing the type doesn't break them.
- **Don't ripple through the load pipeline.** `config.load/1` still uses the internal `Config(..)` constructor because it lives inside `config.gleam` — it doesn't need `new/6`.

## Limitations

- Parent issue #41 still has `Module` and `Declaration` in `codegen/ir.gleam`. Those get their own follow-up PR.

## Test plan

- [x] `just all` passes (633 unit tests, 40 integration, shellspec, smoke).
- [x] `grep -rn \"config\\.Config(\\|cfg\\.input\\|cfg\\.mode\\|cfg\\.validate\\|cfg\\.package\\|cfg\\.output_\\|context\\.config(ctx)\\.\" src/ test/` returns only the definitions inside `config.gleam` itself.

Closes #138.