### PR TITLE
feat(client): emit request-object wrappers alongside flat API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `oaspec/config.Config` is now declared `pub opaque type`. Construct via `config.new/6` or `config.load/1`; read fields via `config.input/1`, `config.package/1`, `config.mode/1`, `config.output_server/1`, `config.output_client/1`, `config.validate/1`. Second step of parent issue #41 (#138)
 - `oaspec/codegen/ir.Module` and `oaspec/codegen/ir.Declaration` are now declared `pub opaque type`. Construct via `ir.module/3` / `ir.declaration/2`; read via `ir.module_header/1`, `ir.module_imports/1`, `ir.module_declarations/1`, `ir.declaration_doc/1`, `ir.declaration_type_def/1`. Third step of parent issue #41 (#140)
 
+### Added
+
+- Generated clients now emit a `<operation>_with_request` wrapper for every operation. The wrapper accepts the matching `request_types.*Request` record and delegates to the existing flat function — either API is valid. Operations that take a multi-content request body skip the wrapper because the flat API needs an extra `content_type` argument the request type does not carry (#31)
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 633 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 634 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/examples/petstore_client/src/api/client.gleam
+++ b/examples/petstore_client/src/api/client.gleam
@@ -2,6 +2,7 @@
 
 import api/decode
 import api/encode
+import api/request_types
 import api/response_types
 import api/types
 import gleam/http
@@ -97,6 +98,14 @@ pub fn list_pets(
   }
 }
 
+/// Request-object wrapper. Delegates to list_pets/N with fields unpacked from the request record.
+pub fn list_pets_with_request(
+  config: ClientConfig,
+  req: request_types.ListPetsRequest,
+) -> Result(response_types.ListPetsResponse, ClientError) {
+  list_pets(config, req.limit, req.offset)
+}
+
 /// Create a pet
 /// Creates a new pet in the store
 pub fn create_pet(
@@ -129,6 +138,14 @@ pub fn create_pet(
       }
     }
   }
+}
+
+/// Request-object wrapper. Delegates to create_pet/N with fields unpacked from the request record.
+pub fn create_pet_with_request(
+  config: ClientConfig,
+  req: request_types.CreatePetRequest,
+) -> Result(response_types.CreatePetResponse, ClientError) {
+  create_pet(config, req.body)
 }
 
 /// Get a pet by ID
@@ -165,6 +182,14 @@ pub fn get_pet(
   }
 }
 
+/// Request-object wrapper. Delegates to get_pet/N with fields unpacked from the request record.
+pub fn get_pet_with_request(
+  config: ClientConfig,
+  req: request_types.GetPetRequest,
+) -> Result(response_types.GetPetResponse, ClientError) {
+  get_pet(config, req.pet_id)
+}
+
 /// Delete a pet
 /// Deletes a pet by its ID
 pub fn delete_pet(
@@ -191,4 +216,12 @@ pub fn delete_pet(
       }
     }
   }
+}
+
+/// Request-object wrapper. Delegates to delete_pet/N with fields unpacked from the request record.
+pub fn delete_pet_with_request(
+  config: ClientConfig,
+  req: request_types.DeletePetRequest,
+) -> Result(response_types.DeletePetResponse, ClientError) {
+  delete_pet(config, req.pet_id)
 }

--- a/golden/complex_supported/api/client.gleam
+++ b/golden/complex_supported/api/client.gleam
@@ -2,6 +2,7 @@
 
 import api/decode
 import api/encode
+import api/request_types
 import api/response_types
 import api/types
 import gleam/http
@@ -82,6 +83,14 @@ pub fn post_search(
   }
 }
 
+/// Request-object wrapper. Delegates to post_search/N with fields unpacked from the request record.
+pub fn post_search_with_request(
+  config: ClientConfig,
+  req: request_types.PostSearchRequest,
+) -> Result(response_types.PostSearchResponse, ClientError) {
+  post_search(config, req.body)
+}
+
 /// Get user with polymorphic response
 pub fn get_user(
   config: ClientConfig,
@@ -119,6 +128,14 @@ pub fn get_user(
   }
 }
 
+/// Request-object wrapper. Delegates to get_user/N with fields unpacked from the request record.
+pub fn get_user_with_request(
+  config: ClientConfig,
+  req: request_types.GetUserRequest,
+) -> Result(response_types.GetUserResponse, ClientError) {
+  get_user(config, req.user_id)
+}
+
 /// Receive webhook
 pub fn post_webhook(
   config: ClientConfig,
@@ -148,4 +165,12 @@ pub fn post_webhook(
       }
     }
   }
+}
+
+/// Request-object wrapper. Delegates to post_webhook/N with fields unpacked from the request record.
+pub fn post_webhook_with_request(
+  config: ClientConfig,
+  req: request_types.PostWebhookRequest,
+) -> Result(response_types.PostWebhookResponse, ClientError) {
+  post_webhook(config, req.body)
 }

--- a/golden/petstore/api/client.gleam
+++ b/golden/petstore/api/client.gleam
@@ -2,6 +2,7 @@
 
 import api/decode
 import api/encode
+import api/request_types
 import api/response_types
 import api/types
 import gleam/http
@@ -97,6 +98,14 @@ pub fn list_pets(
   }
 }
 
+/// Request-object wrapper. Delegates to list_pets/N with fields unpacked from the request record.
+pub fn list_pets_with_request(
+  config: ClientConfig,
+  req: request_types.ListPetsRequest,
+) -> Result(response_types.ListPetsResponse, ClientError) {
+  list_pets(config, req.limit, req.offset)
+}
+
 /// Create a pet
 /// Creates a new pet in the store
 pub fn create_pet(
@@ -129,6 +138,14 @@ pub fn create_pet(
       }
     }
   }
+}
+
+/// Request-object wrapper. Delegates to create_pet/N with fields unpacked from the request record.
+pub fn create_pet_with_request(
+  config: ClientConfig,
+  req: request_types.CreatePetRequest,
+) -> Result(response_types.CreatePetResponse, ClientError) {
+  create_pet(config, req.body)
 }
 
 /// Get a pet by ID
@@ -165,6 +182,14 @@ pub fn get_pet(
   }
 }
 
+/// Request-object wrapper. Delegates to get_pet/N with fields unpacked from the request record.
+pub fn get_pet_with_request(
+  config: ClientConfig,
+  req: request_types.GetPetRequest,
+) -> Result(response_types.GetPetResponse, ClientError) {
+  get_pet(config, req.pet_id)
+}
+
 /// Delete a pet
 /// Deletes a pet by its ID
 pub fn delete_pet(
@@ -191,4 +216,12 @@ pub fn delete_pet(
       }
     }
   }
+}
+
+/// Request-object wrapper. Delegates to delete_pet/N with fields unpacked from the request record.
+pub fn delete_pet_with_request(
+  config: ClientConfig,
+  req: request_types.DeletePetRequest,
+) -> Result(response_types.DeletePetResponse, ClientError) {
+  delete_pet(config, req.pet_id)
 }

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -255,6 +255,12 @@ fn generate_client(ctx: Context) -> String {
       )
     False -> base_imports
   }
+  // `request_types` is always needed now because every operation emits a
+  // `_with_request` wrapper that references `request_types.*Request`.
+  let base_imports = [
+    config.package(context.config(ctx)) <> "/request_types",
+    ..base_imports
+  ]
   let base_imports = case needs_string {
     True -> ["gleam/string", ..base_imports]
     False -> base_imports
@@ -1089,9 +1095,51 @@ fn generate_client_function(
     None -> sb
   }
 
-  sb
-  |> se.line("}")
-  |> se.blank_line()
+  let sb =
+    sb
+    |> se.line("}")
+    |> se.blank_line()
+
+  // Emit a request-object wrapper that accepts a request_types.*Request
+  // value and delegates to the flat function above. Skipped for operations
+  // that take a multi-content body (they need an extra `content_type`
+  // argument the request type does not carry).
+  case
+    client_request.build_request_object_call_args(
+      path_params,
+      query_params,
+      header_params,
+      cookie_params,
+      operation,
+    )
+  {
+    Some(call_args) -> {
+      let request_type = naming.schema_to_type_name(op_id) <> "Request"
+      let extra = case call_args {
+        "" -> ""
+        _ -> ", " <> call_args
+      }
+      sb
+      |> se.doc_comment(
+        "Request-object wrapper. Delegates to "
+        <> fn_name
+        <> "/N with fields unpacked from the request record.",
+      )
+      |> se.line(
+        "pub fn "
+        <> fn_name
+        <> "_with_request(config: ClientConfig, req: request_types."
+        <> request_type
+        <> ") -> Result(response_types."
+        <> response_type
+        <> ", ClientError) {",
+      )
+      |> se.indent(1, fn_name <> "(config" <> extra <> ")")
+      |> se.line("}")
+      |> se.blank_line()
+    }
+    None -> sb
+  }
 }
 
 /// Generate with_* helper functions for security scheme configuration.

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -1,5 +1,5 @@
 import gleam/list
-import gleam/option.{Some}
+import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context}
 import oaspec/codegen/ir_build
@@ -9,6 +9,47 @@ import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec.{type Resolved, ParameterSchema, Value}
 import oaspec/util/naming
 import oaspec/util/string_extra as se
+
+/// Build the call-site argument list for the `_with_request` wrapper that
+/// unpacks a `request_types.*Request` record into the flat client function
+/// it delegates to. Returns `None` if the operation uses a multi-content
+/// body (where the flat API also takes a `content_type` argument that the
+/// request type does not carry).
+pub fn build_request_object_call_args(
+  path_params: List(spec.Parameter(Resolved)),
+  query_params: List(spec.Parameter(Resolved)),
+  header_params: List(spec.Parameter(Resolved)),
+  cookie_params: List(spec.Parameter(Resolved)),
+  operation: spec.Operation(Resolved),
+) -> Option(String) {
+  let all_params =
+    list.append(path_params, query_params)
+    |> list.append(header_params)
+    |> list.append(cookie_params)
+  let has_body = case operation.request_body {
+    Some(_) -> True
+    None -> False
+  }
+  // Operations with no parameters and no body produce no `<Op>Request` type,
+  // so there is nothing for the wrapper to accept. Skip the wrapper.
+  case list.is_empty(all_params), has_body {
+    True, False -> None
+    _, _ -> {
+      let param_refs =
+        list.map(all_params, fn(p) { "req." <> naming.to_snake_case(p.name) })
+      case operation.request_body {
+        Some(Value(rb)) -> {
+          let content_entries = ir_build.sorted_entries(rb.content)
+          case content_entries {
+            [_, _, ..] -> None
+            _ -> Some(string.join(list.append(param_refs, ["req.body"]), ", "))
+          }
+        }
+        _ -> Some(string.join(param_refs, ", "))
+      }
+    }
+  }
+}
 
 /// Build parameter list for function signature.
 pub fn build_param_list(

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2042,6 +2042,42 @@ components:
   |> should.be_true()
 }
 
+pub fn client_emits_with_request_wrappers_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+        - name: expand
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let combined = list.fold(files, "", fn(acc, f) { acc <> f.content })
+  string.contains(
+    combined,
+    "pub fn get_item_with_request(config: ClientConfig, req: request_types.GetItemRequest)",
+  )
+  |> should.be_true()
+  string.contains(combined, "get_item(config, req.id, req.expand)")
+  |> should.be_true()
+  string.contains(combined, "/request_types") |> should.be_true()
+}
+
 pub fn middleware_gleam_is_not_emitted_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Generated clients only exposed the flat positional signature (`list_pets(config, limit, offset)`); users wanting to compose a request as a value had to destructure at every call site.
- Emit a `<op>_with_request(config, req: request_types.<Op>Request)` wrapper for every operation with at least one parameter or a request body. The wrapper delegates to the flat function, so both APIs stay valid.
- Closes #31.

## Changes

- `src/oaspec/codegen/client_request.gleam`: new `build_request_object_call_args/5` helper that returns the wrapper's delegation arg list, or `None` when the wrapper should be skipped (no params + no body, or multi-content body).
- `src/oaspec/codegen/client.gleam`: add `request_types` to the unconditional base imports; after each flat function body, emit the matching `<op>_with_request` wrapper.
- `golden/{petstore,complex_supported}/api/client.gleam`, `examples/petstore_client/src/api/client.gleam`: regenerated with wrappers.
- `test/oaspec_test.gleam`: `client_emits_with_request_wrappers_test` locks the wrapper signature, delegation body, and `request_types` import.
- `README.md`: unit test count 633 → 634.
- `CHANGELOG.md`: new `Added` entry under Unreleased.

## Design Decisions

- **Non-destructive: keep the flat API.** Existing callers and existing tests don't need to change; the wrapper is opt-in. Replacing the flat API would be a breaking change for every downstream consumer.
- **Explicit relationship.** The wrapper's only job is `list_pets(config, req.limit, req.offset)` — literally one line of unpacking. Readers can see at a glance that the two APIs are equivalent.
- **Skip when the record can't exist.** `listPets` in `secure_api.yaml` has no params and no body, so `request_types.gleam` never declares a `ListPetsRequest`. Emitting a wrapper that references a non-existent type would be a type error; skipping honours the invariant that the wrapper's request-type argument always resolves.
- **Skip for multi-content bodies.** The flat API for multi-content takes an extra `content_type` argument that the request record doesn't model. That pair-of-APIs is a legitimate design question the request-object alternative can't transparently absorb — deferring to a follow-up if users want it.

## Limitations

- Wrappers are only added for operations with at least one parameter or a body. No-args operations keep the flat signature only.
- Multi-content request body operations don't get a wrapper.
- The flat API is not deprecated; consider that a future decision.

## Test plan

- [x] `just all` passes (634 unit tests, 40 integration, 59 shellspec, smoke).
- [x] `examples/petstore_client` regenerates and runs; the flat calls in `petstore_client_example.gleam` still work, and the new wrappers appear in the generated `client.gleam`.

Closes #31.