### PR TITLE
test(capability): detect drift between registry and README boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Generated clients now emit a `<operation>_with_request` wrapper for every operation. The wrapper accepts the matching `request_types.*Request` record and delegates to the existing flat function — either API is valid. Operations that take a multi-content request body skip the wrapper because the flat API needs an extra `content_type` argument the request type does not carry (#31)
+- Drift-detection test between the capability registry and the README `## Current Boundaries` block: fails the suite if an `Unsupported`, `NotHandled`, or `ParsedNotUsed` entry is added to the registry without being mentioned in the README (#143). Fixes stale `operation servers` / `path servers` entries the registry had carried since #96 promoted them to Supported.
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 634 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 635 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -178,18 +178,9 @@ pub fn registry() -> List(Capability) {
     Capability("examples", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("links", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("xml", "scope", NotHandled, "XML annotations ignored"),
-    Capability(
-      "operation servers",
-      "scope",
-      ParsedNotUsed,
-      "Client uses top-level only",
-    ),
-    Capability(
-      "path servers",
-      "scope",
-      ParsedNotUsed,
-      "Client uses top-level only",
-    ),
+    // operation-level and path-level server overrides are supported as of #96
+    // (generated clients resolve operation > path > top-level). They are no
+    // longer listed here — absence from the registry means Supported.
     Capability(
       "response headers",
       "scope",

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3337,6 +3337,33 @@ components:
   |> should.be_true()
 }
 
+// --- drift detection between capability registry and README ---
+pub fn capability_registry_names_appear_in_readme_boundaries_test() {
+  // Every keyword the capability registry declares as Unsupported / NotHandled
+  // / ParsedNotUsed must be mentioned by name inside the README's
+  // `<!-- BEGIN GENERATED:BOUNDARIES -->` / `<!-- END GENERATED:BOUNDARIES -->`
+  // block. This catches the common drift case where someone adds a new
+  // unsupported keyword to the registry but forgets to update the README.
+  let assert Ok(readme) = simplifile.read("README.md")
+  let assert Ok(#(_before, after_begin)) =
+    string.split_once(readme, "<!-- BEGIN GENERATED:BOUNDARIES -->")
+  let assert Ok(#(boundaries_block, _after)) =
+    string.split_once(after_begin, "<!-- END GENERATED:BOUNDARIES -->")
+  list.each(capability.registry(), fn(c) {
+    case c.level {
+      capability.Unsupported | capability.NotHandled | capability.ParsedNotUsed ->
+        case string.contains(boundaries_block, c.name) {
+          True -> Nil
+          False -> {
+            // Surface which name is missing in the failure output.
+            c.name |> should.equal("<should appear in README>")
+          }
+        }
+      _ -> Nil
+    }
+  })
+}
+
 // --- Finding 3: README says optional path params supported but parser rejects ---
 pub fn readme_no_optional_path_param_claim_test() {
   let assert Ok(readme) = simplifile.read("README.md")


### PR DESCRIPTION
## Summary

- First slice of parent issue #102 (\"unify support classification\"). Adds a unit test that fails when the capability registry grows an `Unsupported`, `NotHandled`, or `ParsedNotUsed` entry without the keyword appearing in the README boundaries block.
- Surfaces and fixes two stale registry entries that have been drifting since #96 (\"operation servers\" / \"path servers\" are supported now).
- Closes #143.

## Changes

- `test/oaspec_test.gleam`: new `capability_registry_names_appear_in_readme_boundaries_test` parses the README, extracts the `<!-- BEGIN GENERATED:BOUNDARIES -->` / `<!-- END GENERATED:BOUNDARIES -->` block, then iterates the registry and asserts each non-supported capability's `name` appears in the block.
- `src/oaspec/capability.gleam`: remove the `operation servers` and `path servers` entries that had `ParsedNotUsed` level. Since #96 these are fully supported; absence from the registry means Supported. A comment in their place records the move.
- `README.md`: unit test count 634 → 635.
- `CHANGELOG.md`: new `Fixed` entry noting the registry cleanup.

## Design Decisions

- **Substring check, not exact string match.** The README already mixes auto-generated lines (`<!-- BEGIN GENERATED -->` block) with hand-authored ones (\"Operation-level and path-level server overrides...\"), so a whole-block equality check would be too brittle. The minimum useful invariant is \"every registry entry is at least *mentioned* in the boundaries doc\" — any human-verified exact text wording lives in the markdown, not in Gleam.
- **Non-supported levels only.** `Normalizable` capabilities are documented differently (as \"normalized to\" rather than \"not supported\"), so skipping them avoids false positives.
- **Fix the registry rather than the test.** When the test first ran it failed on `operation servers` — the right answer was to remove a stale entry, not to loosen the check.

## Limitations

- Parent issue #102 still has two more slices to do: content-type helper unification (b), validation-model unification (c). This PR only closes slice (a).
- The test asserts the registry name appears *anywhere* in the block, not that it's categorised correctly inside the block (e.g. it can't tell if you put an \"Unsupported\" keyword under \"parsed but not used\" by mistake). A stricter renderer-equivalence test is a natural follow-up.

## Test plan

- [x] `just all` passes (635 unit tests, 40 integration, shellspec, smoke).
- [x] Manually confirmed the test fails if an arbitrary fake capability is added to the registry.

Closes #143.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added drift-detection test to validate capability documentation consistency with registry

* **Documentation**
  * Updated test coverage count in README
  * Added changelog entry for registry documentation validation

* **Chores**
  * Cleaned up capability registry to accurately reflect supported server configuration features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->