### PR TITLE
feat(parser): resolve relative-file $ref for component schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Generated clients now emit a `<operation>_with_request` wrapper for every operation. The wrapper accepts the matching `request_types.*Request` record and delegates to the existing flat function — either API is valid. Operations that take a multi-content request body skip the wrapper because the flat API needs an extra `content_type` argument the request type does not carry (#31)
 - Drift-detection test between the capability registry and the README `## Current Boundaries` block: fails the suite if an `Unsupported`, `NotHandled`, or `ParsedNotUsed` entry is added to the registry without being mentioned in the README (#143). Fixes stale `operation servers` / `path servers` entries the registry had carried since #96 promoted them to Supported.
 
+### Added
+
+- Narrow external `$ref` support: `components.schemas` entries can now reference schemas in a sibling YAML/JSON file via relative-path fragment refs (`./other.yaml#/components/schemas/Foo`). `parse_file` resolves the ref by loading the target file, merging the referenced schema into the main spec, and rewriting the entry to a local ref. HTTP URLs, parameter/body/response external refs, and nested refs inside schemas remain unsupported — see `src/oaspec/openapi/external_loader.gleam` for the documented boundary (#145, subset of #98)
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 635 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 182 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 636 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 184 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,6 +13,7 @@ simplifile = ">= 2.0.0 and < 3.0.0"
 yay = ">= 2.0.0 and < 3.0.0"
 argv = ">= 1.0.0 and < 2.0.0"
 gleam_regexp = ">= 1.0.0 and < 2.0.0"
+filepath = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -23,6 +23,7 @@ packages = [
 
 [requirements]
 argv = { version = ">= 1.0.0 and < 2.0.0" }
+filepath = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }

--- a/src/oaspec/openapi/external_loader.gleam
+++ b/src/oaspec/openapi/external_loader.gleam
@@ -1,0 +1,188 @@
+//// Narrow support for external `$ref` values that point at component
+//// schemas in a sibling YAML/JSON file — `./other.yaml#/components/schemas/Foo`
+//// style. Walks `components.schemas`, pulls referenced schemas from the
+//// target file into the main spec, and rewrites the refs to local form.
+////
+//// Out of scope (see issue #98 parent):
+////   - external refs to parameters / request bodies / responses / path items
+////   - nested external refs inside ObjectSchema properties (only top-level
+////     component-schema entries are handled today)
+////   - HTTP/HTTPS URLs
+////   - name collisions across files (first writer wins; TODO: diagnose)
+
+import filepath
+import gleam/dict
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/result
+import gleam/string
+import oaspec/openapi/diagnostic.{type Diagnostic}
+import oaspec/openapi/schema.{type SchemaRef, Inline, Reference}
+import oaspec/openapi/spec.{
+  type Components, type OpenApiSpec, type Unresolved, Components, OpenApiSpec,
+}
+import simplifile
+
+/// Load every `components.schemas` entry whose value is an external
+/// filesystem ref, merge the referenced schema into the main spec, and
+/// rewrite the entry to a local ref. `base_dir` is the directory of the
+/// file this spec was loaded from (used to resolve relative paths).
+///
+/// If `base_dir` is None (spec loaded from string), external refs are
+/// treated as unresolvable and passed through unchanged — downstream
+/// validation still rejects them.
+pub fn resolve_external_component_refs(
+  spec: OpenApiSpec(Unresolved),
+  base_dir: option.Option(String),
+  parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  case spec.components, base_dir {
+    Some(components), Some(dir) ->
+      process_components(components, dir, parse_file)
+      |> result.map(fn(updated) {
+        OpenApiSpec(..spec, components: Some(updated))
+      })
+    _, _ -> Ok(spec)
+  }
+}
+
+fn process_components(
+  components: Components(Unresolved),
+  base_dir: String,
+  parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
+) -> Result(Components(Unresolved), Diagnostic) {
+  let entries = dict.to_list(components.schemas)
+  use new_entries <- result.try(
+    list.try_fold(entries, [], fn(acc, entry) {
+      let #(name, schema_ref) = entry
+      case extract_external_ref(schema_ref) {
+        Some(#(rel_path, fragment_name)) -> {
+          let resolved_path = filepath.join(base_dir, rel_path)
+          use loaded <- result.try(parse_file(resolved_path))
+          use target <- result.try(find_external_schema(
+            loaded,
+            fragment_name,
+            resolved_path,
+          ))
+          // Rewrite the entry to a local ref pointing at the imported schema,
+          // and emit the target schema under the same fragment name so a
+          // local lookup succeeds.
+          let local_ref =
+            Reference(
+              ref: "#/components/schemas/" <> fragment_name,
+              name: fragment_name,
+            )
+          Ok([#(name, local_ref), #(fragment_name, target), ..acc])
+        }
+        None -> Ok([#(name, schema_ref), ..acc])
+      }
+    }),
+  )
+  let merged =
+    list.fold(new_entries, dict.new(), fn(d, pair) {
+      dict.insert(d, pair.0, pair.1)
+    })
+  Ok(Components(..components, schemas: merged))
+}
+
+/// Detect a `./...#/components/schemas/Name` or `../...#/components/schemas/Name`
+/// ref. Returns `Some(#(file_path, schema_name))` when it matches, `None`
+/// otherwise.
+fn extract_external_ref(
+  schema_ref: SchemaRef,
+) -> option.Option(#(String, String)) {
+  case schema_ref {
+    Reference(ref:, ..) ->
+      case string.starts_with(ref, "./") || string.starts_with(ref, "../") {
+        True ->
+          case string.split_once(ref, "#") {
+            Ok(#(file_path, fragment)) ->
+              case string.starts_with(fragment, "/components/schemas/") {
+                True -> {
+                  let name =
+                    string.replace(fragment, "/components/schemas/", "")
+                  case string.contains(name, "/"), name {
+                    False, "" -> None
+                    False, _ -> Some(#(file_path, name))
+                    True, _ -> None
+                  }
+                }
+                False -> None
+              }
+            _ -> None
+          }
+        False -> None
+      }
+    _ -> None
+  }
+}
+
+fn find_external_schema(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(SchemaRef, Diagnostic) {
+  case loaded.components {
+    Some(components) ->
+      case dict.get(components.schemas, name) {
+        Ok(Inline(_) as s) -> Ok(s)
+        Ok(Reference(..)) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External schema '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref; chained external refs are not supported yet.",
+            hint: Some(
+              "Inline the external schema or flatten one level of indirection.",
+            ),
+          ))
+        Error(Nil) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External file '"
+              <> source_path
+              <> "' has no components.schemas."
+              <> name,
+            hint: Some(
+              "Verify the ref path and that the referenced file defines the schema.",
+            ),
+          ))
+      }
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some(
+          "Add a components.schemas section to the referenced file or inline the schema.",
+        ),
+      ))
+  }
+}
+
+/// Helper used by `parser.parse_file` to compute a spec's base directory.
+/// Empty-string (current working directory) is returned when the filepath
+/// module can't extract a parent — callers can then pass `Some("")` which
+/// resolves relative refs against CWD.
+pub fn base_dir_of(path: String) -> option.Option(String) {
+  case filepath.directory_name(path) {
+    "" -> Some(".")
+    dir -> Some(dir)
+  }
+}
+
+/// Read a file from disk. Extracted so tests can stub file I/O by passing
+/// their own `parse_file` callback.
+pub fn read_file(path: String) -> Result(String, Diagnostic) {
+  simplifile.read(path)
+  |> result.map_error(fn(_) {
+    diagnostic.file_error(detail: "Cannot read external file: " <> path)
+  })
+}

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -6,6 +6,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import oaspec/openapi/diagnostic.{type Diagnostic, NoSourceLoc, SourceLoc}
+import oaspec/openapi/external_loader
 import oaspec/openapi/schema.{
   type Discriminator, type SchemaObject, type SchemaRef, AllOfSchema,
   AnyOfSchema, ArraySchema, BooleanSchema, Discriminator, Inline, IntegerSchema,
@@ -29,6 +30,10 @@ import yay
 
 /// Parse an OpenAPI spec from a file path.
 /// Supports both YAML (.yaml, .yml) and JSON (.json) files.
+/// After parsing, resolves relative-file `$ref` values in
+/// `components.schemas` by loading the referenced files from disk and
+/// merging their schemas. Nested or parameter/response external refs are
+/// left to downstream validation.
 pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
   use content <- result.try(
     simplifile.read(path)
@@ -37,7 +42,12 @@ pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
     }),
   )
 
-  parse_string(content)
+  use spec <- result.try(parse_string(content))
+  external_loader.resolve_external_component_refs(
+    spec,
+    external_loader.base_dir_of(path),
+    parse_file,
+  )
 }
 
 /// Parse an OpenAPI spec from a YAML/JSON string.

--- a/test/fixtures/external_ref_main.yaml
+++ b/test/fixtures/external_ref_main.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Main
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: Items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      $ref: "./external_ref_shared.yaml#/components/schemas/Widget"

--- a/test/fixtures/external_ref_shared.yaml
+++ b/test/fixtures/external_ref_shared.yaml
@@ -1,0 +1,16 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Shared
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        label:
+          type: string

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3338,6 +3338,25 @@ components:
 }
 
 // --- drift detection between capability registry and README ---
+pub fn external_file_ref_for_component_schema_test() {
+  // A spec whose components.schemas entry is a ref to a schema in a
+  // sibling YAML file should parse cleanly: the referenced schema is
+  // merged into the main spec and the entry is rewritten to a local ref.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/external_ref_main.yaml")
+  spec.info.title |> should.equal("External Ref Main")
+  let assert Some(components) = spec.components
+  // The referenced Widget schema must have been merged in.
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: widget_props, ..))) =
+    dict.get(components.schemas, "Widget")
+  dict.has_key(widget_props, "id") |> should.be_true()
+  dict.has_key(widget_props, "label") |> should.be_true()
+  // The original Item entry now points at the local Widget.
+  let assert Ok(schema.Reference(ref: item_ref, ..)) =
+    dict.get(components.schemas, "Item")
+  item_ref |> should.equal("#/components/schemas/Widget")
+}
+
 pub fn capability_registry_names_appear_in_readme_boundaries_test() {
   // Every keyword the capability registry declares as Unsupported / NotHandled
   // / ParsedNotUsed must be mentioned by name inside the README's


### PR DESCRIPTION
## Summary

- First narrow slice of parent issue #98. Teaches `parser.parse_file` to recognise `./other.yaml#/components/schemas/Foo` style refs directly inside `components.schemas`, load the referenced file, and inline the schema into the main spec.
- Non-target refs (HTTP URLs, nested refs inside schemas, external parameter/response refs, chained external refs) stay rejected by the existing validator.
- Closes #145.

## Changes

- `src/oaspec/openapi/external_loader.gleam`: new module with `resolve_external_component_refs/3` and `base_dir_of/1`. The former walks `components.schemas`, resolves relative paths via `filepath.join`, calls back into the provided `parse_file` for the referenced file, and rewrites the entry to a local ref while merging the resolved schema under the same name.
- `src/oaspec/openapi/parser.gleam`: `parse_file` now calls the external loader after the initial parse, passing itself as the recursive parse callback.
- `gleam.toml`: promote `filepath` from transitive to direct dep.
- `test/fixtures/external_ref_main.yaml` + `external_ref_shared.yaml`: happy-path fixture where `components.schemas.Item` references `./external_ref_shared.yaml#/components/schemas/Widget`.
- `test/oaspec_test.gleam`: `external_file_ref_for_component_schema_test` asserts the Widget schema lands in the main spec's components and the Item entry is rewritten to `#/components/schemas/Widget`.
- `README.md`: test count 635 → 636, fixture count 182 → 184.
- `CHANGELOG.md`: new `Added` entry.

## Design Decisions

- **Resolve at parse-time, not at resolve-time.** The existing resolver is stateless and pure; threading file I/O through it would require a base-dir parameter everywhere. Running the external loader immediately after `parse_string` keeps the downstream pipeline unchanged — everything sees a uniform local-ref spec.
- **Pass `parse_file` as a callback.** Lets the loader recurse (external refs in external files keep working) without a circular module import and without smuggling file I/O into a pure module.
- **First writer wins.** If both the main spec and an external file define `components.schemas.Widget`, we don't attempt rename-on-collision — the loader just inserts the external copy. Name-collision diagnosis is a deliberate follow-up.
- **Scope limited to `components.schemas` top-level values.** Nested refs (e.g. an inline `ObjectSchema` whose property is an external ref) are not walked. That's a follow-up slice that needs a schema walker.

## Limitations

- HTTP / HTTPS URLs are not supported. Parent #98 tracks remote fetching.
- External refs to `parameters`, `requestBodies`, `responses`, `path-items` still fail validation.
- Nested schema refs (inside `properties`, `items`, etc.) still fail validation.
- Chained external refs (file A → file B → file C via external refs *inside* file B's schemas) produce a clean error instead of being resolved.

## Test plan

- [x] `just all` passes (636 unit tests, 40 integration, shellspec, smoke).
- [x] Manually verified the external loader path using the new fixtures.

Closes #145.