### PR TITLE
feat(parser): diagnose name collisions when resolving external $ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Narrow external `$ref` support: `components.schemas` entries can now reference schemas in a sibling YAML/JSON file via relative-path fragment refs (`./other.yaml#/components/schemas/Foo`). `parse_file` resolves the ref by loading the target file, merging the referenced schema into the main spec, and rewriting the entry to a local ref. HTTP URLs, parameter/body/response external refs, and nested refs inside schemas remain unsupported — see `src/oaspec/openapi/external_loader.gleam` for the documented boundary (#145, subset of #98)
+- External `$ref` name-collision diagnostics: when an external component-schema ref would overwrite an existing local schema, or when two external refs pull the same fragment name from different source files, the parser now emits a clear `Diagnostic` instead of silently dropping one side. Re-importing the same name from the same file remains idempotent (#147, subset of #98)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 636 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 184 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 638 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 187 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 638 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 187 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 638 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 189 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/openapi/external_loader.gleam
+++ b/src/oaspec/openapi/external_loader.gleam
@@ -8,7 +8,11 @@
 ////   - nested external refs inside ObjectSchema properties (only top-level
 ////     component-schema entries are handled today)
 ////   - HTTP/HTTPS URLs
-////   - name collisions across files (first writer wins; TODO: diagnose)
+////
+//// Name collisions — when an external ref would overwrite an existing local
+//// schema, or when two external refs pull in the same fragment name from
+//// different files — are surfaced as `Diagnostic` errors rather than
+//// silently dropping one side.
 
 import filepath
 import gleam/dict
@@ -52,12 +56,25 @@ fn process_components(
   parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
 ) -> Result(Components(Unresolved), Diagnostic) {
   let entries = dict.to_list(components.schemas)
-  use new_entries <- result.try(
-    list.try_fold(entries, [], fn(acc, entry) {
+  let original_local_names = local_schema_names(entries)
+  use #(new_entries, _imported) <- result.try(
+    list.try_fold(entries, #([], dict.new()), fn(acc, entry) {
+      let #(pending, imported) = acc
       let #(name, schema_ref) = entry
       case extract_external_ref(schema_ref) {
         Some(#(rel_path, fragment_name)) -> {
           let resolved_path = filepath.join(base_dir, rel_path)
+          use _ <- result.try(check_local_collision(
+            name,
+            fragment_name,
+            resolved_path,
+            original_local_names,
+          ))
+          use _ <- result.try(check_cross_file_collision(
+            fragment_name,
+            resolved_path,
+            imported,
+          ))
           use loaded <- result.try(parse_file(resolved_path))
           use target <- result.try(find_external_schema(
             loaded,
@@ -72,9 +89,15 @@ fn process_components(
               ref: "#/components/schemas/" <> fragment_name,
               name: fragment_name,
             )
-          Ok([#(name, local_ref), #(fragment_name, target), ..acc])
+          let pending = [
+            #(name, local_ref),
+            #(fragment_name, target),
+            ..pending
+          ]
+          let imported = dict.insert(imported, fragment_name, resolved_path)
+          Ok(#(pending, imported))
         }
-        None -> Ok([#(name, schema_ref), ..acc])
+        None -> Ok(#([#(name, schema_ref), ..pending], imported))
       }
     }),
   )
@@ -83,6 +106,84 @@ fn process_components(
       dict.insert(d, pair.0, pair.1)
     })
   Ok(Components(..components, schemas: merged))
+}
+
+/// Names in the current spec that are *not themselves* external refs.
+/// These are the schemas the external loader must not silently overwrite.
+fn local_schema_names(entries: List(#(String, SchemaRef))) -> List(String) {
+  list.filter_map(entries, fn(entry) {
+    case extract_external_ref(entry.1) {
+      Some(_) -> Error(Nil)
+      None -> Ok(entry.0)
+    }
+  })
+}
+
+/// Reject an external ref whose fragment name would collide with a schema
+/// already defined locally in the same spec. The case where the entry name
+/// equals the fragment name (`Widget: $ref: './other.yaml#/.../Widget'`) is
+/// intentionally allowed — we treat it as the user asking for that slot to
+/// hold the imported schema.
+fn check_local_collision(
+  entry_name: String,
+  fragment_name: String,
+  source_path: String,
+  original_local_names: List(String),
+) -> Result(Nil, Diagnostic) {
+  case entry_name == fragment_name {
+    True -> Ok(Nil)
+    False ->
+      case list.contains(original_local_names, fragment_name) {
+        False -> Ok(Nil)
+        True ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External $ref imports schema '"
+              <> fragment_name
+              <> "' from '"
+              <> source_path
+              <> "', but a local schema with the same name is already defined.",
+            hint: Some(
+              "Rename one of the colliding schemas, or point the external ref at a file whose fragment name is unique.",
+            ),
+          ))
+      }
+  }
+}
+
+/// Reject two external refs that both pull the same fragment name from
+/// different source files. Re-importing the same name from the same path is
+/// allowed (idempotent) to keep error messages narrow.
+fn check_cross_file_collision(
+  fragment_name: String,
+  resolved_path: String,
+  imported: dict.Dict(String, String),
+) -> Result(Nil, Diagnostic) {
+  case dict.get(imported, fragment_name) {
+    Error(_) -> Ok(Nil)
+    Ok(prev_path) ->
+      case prev_path == resolved_path {
+        True -> Ok(Nil)
+        False ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: resolved_path,
+            detail: "External $ref imports schema '"
+              <> fragment_name
+              <> "' from '"
+              <> resolved_path
+              <> "', but the same name was already imported from '"
+              <> prev_path
+              <> "'.",
+            hint: Some(
+              "Rename one of the schemas in the source files so imports do not collide.",
+            ),
+          ))
+      }
+  }
 }
 
 /// Detect a `./...#/components/schemas/Name` or `../...#/components/schemas/Name`

--- a/test/fixtures/external_ref_collision_cross_main.yaml
+++ b/test/fixtures/external_ref_collision_cross_main.yaml
@@ -1,0 +1,11 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Cross-File Collision Main
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    ItemA:
+      $ref: "./external_ref_collision_file_a.yaml#/components/schemas/Widget"
+    ItemB:
+      $ref: "./external_ref_collision_file_b.yaml#/components/schemas/Widget"

--- a/test/fixtures/external_ref_collision_file_a.yaml
+++ b/test/fixtures/external_ref_collision_file_a.yaml
@@ -1,0 +1,14 @@
+openapi: "3.0.3"
+info:
+  title: Collision File A
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - from_a
+      properties:
+        from_a:
+          type: string

--- a/test/fixtures/external_ref_collision_file_b.yaml
+++ b/test/fixtures/external_ref_collision_file_b.yaml
@@ -1,0 +1,14 @@
+openapi: "3.0.3"
+info:
+  title: Collision File B
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - from_b
+      properties:
+        from_b:
+          type: string

--- a/test/fixtures/external_ref_collision_main.yaml
+++ b/test/fixtures/external_ref_collision_main.yaml
@@ -1,0 +1,16 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Collision Main
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - local_field
+      properties:
+        local_field:
+          type: string
+    Item:
+      $ref: "./external_ref_collision_shared.yaml#/components/schemas/Widget"

--- a/test/fixtures/external_ref_collision_shared.yaml
+++ b/test/fixtures/external_ref_collision_shared.yaml
@@ -1,0 +1,14 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Collision Shared
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - shared_field
+      properties:
+        shared_field:
+          type: string

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3357,6 +3357,31 @@ pub fn external_file_ref_for_component_schema_test() {
   item_ref |> should.equal("#/components/schemas/Widget")
 }
 
+pub fn external_ref_collision_with_local_schema_rejected_test() {
+  // Main spec defines a local `Widget` AND another entry (`Item`) that
+  // imports a different `Widget` from a sibling file. Silently merging
+  // would overwrite the local Widget — parse_file must surface a
+  // diagnostic instead.
+  let result =
+    parser.parse_file("test/fixtures/external_ref_collision_main.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "Widget") |> should.be_true()
+  string.contains(msg, "local schema") |> should.be_true()
+}
+
+pub fn external_ref_collision_across_files_rejected_test() {
+  // Two external refs import the same fragment name `Widget` from two
+  // distinct sibling files. The second import collides with the first
+  // and must surface a diagnostic.
+  let result =
+    parser.parse_file("test/fixtures/external_ref_collision_cross_main.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "Widget") |> should.be_true()
+  string.contains(msg, "already imported") |> should.be_true()
+}
+
 pub fn capability_registry_names_appear_in_readme_boundaries_test() {
   // Every keyword the capability registry declares as Unsupported / NotHandled
   // / ParsedNotUsed must be mentioned by name inside the README's


### PR DESCRIPTION
## Summary

- External `\$ref` resolver now emits a clear `Diagnostic` when merging a referenced schema would silently overwrite an existing entry.
- Covers two collision cases: local schema vs external import, and two external imports of the same fragment name from different files.
- Re-importing the same name from the same file stays idempotent.

## Changes

- `src/oaspec/openapi/external_loader.gleam`: track originally-local schema names and an `imported_from` dict across the fold; guard each external ref with `check_local_collision` and `check_cross_file_collision` before the file read.
- `test/fixtures/external_ref_collision_*.yaml` (5 new fixtures): one pair for local collision, a trio for cross-file collision.
- `test/oaspec_test.gleam`: two new tests asserting both collision messages.
- README test / fixture counters and CHANGELOG entry updated.

## Design Decisions

- Allowing `Widget: \$ref: './other.yaml#/.../Widget'` to survive is deliberate. Treating it as a collision would break the most natural way to pull an external schema into an existing slot.
- Same-file, same-name re-import is treated as idempotent rather than an error to keep the diagnostic narrow. Users who rely on dedup elsewhere shouldn't have to rewrite their specs.
- Collision detection runs before the child file is parsed, so an erroneous import does not trigger unnecessary file I/O.

## Part of

Parent issue #98 (external `\$ref` support). Closes #147.