### PR TITLE
feat(parser): hoist external $ref inside components.parameters schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Nested external `$ref` inside `ArraySchema.items`: top-level array schemas whose `items` value is a relative-file fragment ref are hoisted under the same mechanism as property refs, sharing the cross-file collision tracker. Refs inside `additionalProperties` and composition branches remain unsupported (#151, subset of #98)
 - Nested external `$ref` inside `ObjectSchema.additionalProperties`: `Typed(SchemaRef)` values whose ref is relative-file are hoisted alongside property and items refs, reusing the same collision diagnostics. Refs inside composition branches remain unsupported (#153, subset of #98)
 - Nested external `$ref` inside composition branches (`allOf`, `oneOf`, `anyOf`): each variant in the schemas list is run through the same hoisting step as property and items refs. Collision diagnostics continue to fire across the shared imports tracker, so a composition branch that conflicts with a property ref in another schema still surfaces an error (#155, subset of #98)
+- External `$ref` inside `components.parameters.*.schema`: parameter schemas that point at a relative-file fragment ref are now hoisted into `components.schemas` and the inner ref is rewritten to local form, reusing the same collision diagnostics. Parameter objects referenced via `$ref` and `content` media-type payloads remain out of scope (#157, subset of #98)
 
 ## [0.12.0] - 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 647 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 199 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 649 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 201 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/openapi/external_loader.gleam
+++ b/src/oaspec/openapi/external_loader.gleam
@@ -9,9 +9,12 @@
 ////   - ArraySchema item values (`items: $ref: ...`)
 ////   - ObjectSchema additionalProperties values (`additionalProperties: $ref: ...`)
 ////   - composition branches (`oneOf`, `anyOf`, `allOf` variant refs)
+////   - `components.parameters.*.schema: $ref: ...` (parameter schema only)
 ////
 //// Out of scope (see issue #98 parent):
-////   - external refs in parameters / request bodies / responses / path items
+////   - external `$ref` pointing at a parameter object itself
+////   - external refs in `components.parameters.*.content` media maps
+////   - external refs in request bodies / responses / path items
 ////   - HTTP/HTTPS URLs
 ////
 //// Name collisions — when an external ref would overwrite an existing local
@@ -55,14 +58,23 @@ pub fn resolve_external_component_refs(
         parse_file,
         original_local_names,
       ))
-      use nested_resolved <- result.try(process_nested_property_refs(
-        top_resolved,
+      use #(nested_resolved, nested_imports) <- result.try(
+        process_nested_property_refs(
+          top_resolved,
+          dir,
+          parse_file,
+          original_local_names,
+          top_imported,
+        ),
+      )
+      use param_resolved <- result.try(process_parameter_schemas(
+        nested_resolved,
         dir,
         parse_file,
         original_local_names,
-        top_imported,
+        nested_imports,
       ))
-      Ok(OpenApiSpec(..spec, components: Some(nested_resolved)))
+      Ok(OpenApiSpec(..spec, components: Some(param_resolved)))
     }
     _, _ -> Ok(spec)
   }
@@ -155,7 +167,10 @@ fn process_nested_property_refs(
   parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
   original_local_names: List(String),
   top_imported: dict.Dict(String, String),
-) -> Result(Components(Unresolved), Diagnostic) {
+) -> Result(
+  #(Components(Unresolved), dict.Dict(String, #(String, SchemaRef))),
+  Diagnostic,
+) {
   let entries = dict.to_list(components.schemas)
   // Seed the nested-import tracker with every top-level external import so
   // a nested property that re-imports the same fragment from a different
@@ -286,7 +301,7 @@ fn process_nested_property_refs(
         False, _ -> d
       }
     })
-  Ok(Components(..components, schemas: merged))
+  Ok(#(Components(..components, schemas: merged), imports))
 }
 
 /// Placeholder target used to seed the nested-import tracker with top-level
@@ -295,6 +310,64 @@ fn process_nested_property_refs(
 /// on `Inline(_)` targets.
 fn no_target() -> SchemaRef {
   Reference(ref: "", name: "")
+}
+
+/// Walk `components.parameters`: for each inline `Parameter` whose payload is
+/// a `ParameterSchema(SchemaRef)` pointing at a relative-file external ref,
+/// hoist the target schema into `components.schemas` and rewrite the inner
+/// ref. Parameters expressed via `content` media type maps, `Ref` placeholders
+/// pointing at other parameter objects, and local refs all pass through.
+fn process_parameter_schemas(
+  components: Components(Unresolved),
+  base_dir: String,
+  parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
+  original_local_names: List(String),
+  seeded_imports: dict.Dict(String, #(String, SchemaRef)),
+) -> Result(Components(Unresolved), Diagnostic) {
+  let entries = dict.to_list(components.parameters)
+  use #(rewritten, imports) <- result.try(
+    list.try_fold(entries, #([], seeded_imports), fn(acc, entry) {
+      let #(collected, imports) = acc
+      let #(name, ref_or_param) = entry
+      case ref_or_param {
+        spec.Value(p) ->
+          case p.payload {
+            spec.ParameterSchema(schema_ref) -> {
+              use #(new_ref, new_imports) <- result.try(maybe_hoist_ref(
+                schema_ref,
+                base_dir,
+                parse_file,
+                imports,
+                original_local_names,
+              ))
+              let new_param =
+                spec.Parameter(..p, payload: spec.ParameterSchema(new_ref))
+              Ok(#([#(name, spec.Value(new_param)), ..collected], new_imports))
+            }
+            spec.ParameterContent(_) ->
+              Ok(#([#(name, ref_or_param), ..collected], imports))
+          }
+        spec.Ref(_) -> Ok(#([#(name, ref_or_param), ..collected], imports))
+      }
+    }),
+  )
+  let new_parameters =
+    list.fold(rewritten, dict.new(), fn(d, pair) {
+      dict.insert(d, pair.0, pair.1)
+    })
+  // Merge any newly-imported schemas into components.schemas that were not
+  // already present. Seeded entries carry a placeholder target and are
+  // filtered out by matching on `Inline(_)`.
+  let new_schemas =
+    dict.fold(imports, components.schemas, fn(d, frag_name, pair) {
+      let #(_source_path, target_schema) = pair
+      case dict.has_key(d, frag_name), target_schema {
+        True, _ -> d
+        False, Inline(_) -> dict.insert(d, frag_name, target_schema)
+        False, _ -> d
+      }
+    })
+  Ok(Components(..components, parameters: new_parameters, schemas: new_schemas))
 }
 
 /// Walk the properties dict of an ObjectSchema; for each property that is a

--- a/test/fixtures/external_ref_parameter_schema_collision_main.yaml
+++ b/test/fixtures/external_ref_parameter_schema_collision_main.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Parameter Schema Collision Main
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - color
+      properties:
+        color:
+          type: string
+  parameters:
+    WidgetHeader:
+      name: X-Widget
+      in: header
+      required: true
+      schema:
+        $ref: "./external_ref_nested_shared.yaml#/components/schemas/Widget"

--- a/test/fixtures/external_ref_parameter_schema_main.yaml
+++ b/test/fixtures/external_ref_parameter_schema_main.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.3"
+info:
+  title: External Ref Parameter Schema Main
+  version: "1.0.0"
+paths: {}
+components:
+  parameters:
+    WidgetHeader:
+      name: X-Widget
+      in: header
+      required: true
+      schema:
+        $ref: "./external_ref_nested_shared.yaml#/components/schemas/Widget"

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3410,6 +3410,36 @@ pub fn external_ref_nested_collision_across_files_rejected_test() {
   string.contains(msg, "already imported") |> should.be_true()
 }
 
+pub fn external_ref_in_parameter_schema_test() {
+  // A parameter defined under components.parameters whose schema is a
+  // relative-file $ref must hoist the target into components.schemas
+  // and rewrite the inner schema ref to local form.
+  let assert Ok(loaded) =
+    parser.parse_file("test/fixtures/external_ref_parameter_schema_main.yaml")
+  let assert Some(components) = loaded.components
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: widget_props, ..))) =
+    dict.get(components.schemas, "Widget")
+  dict.has_key(widget_props, "sku") |> should.be_true()
+  let assert Ok(spec.Value(param)) =
+    dict.get(components.parameters, "WidgetHeader")
+  let assert spec.ParameterSchema(schema.Reference(ref: schema_ref, ..)) =
+    param.payload
+  schema_ref |> should.equal("#/components/schemas/Widget")
+}
+
+pub fn external_ref_parameter_schema_collision_with_local_schema_rejected_test() {
+  // A local Widget plus a parameter whose schema imports a different
+  // Widget from an external file — silent-shadowing must fire.
+  let result =
+    parser.parse_file(
+      "test/fixtures/external_ref_parameter_schema_collision_main.yaml",
+    )
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "Widget") |> should.be_true()
+  string.contains(msg, "local schema") |> should.be_true()
+}
+
 pub fn external_ref_in_composition_branch_test() {
   // A composition schema (oneOf here) whose branch is a relative-file
   // $ref must hoist the target schema into components.schemas and


### PR DESCRIPTION
## Summary

- Extend external ref resolution to walk `components.parameters` and hoist any inline parameter's schema ref that points at a relative-file fragment.
- Share the nested imports tracker from the schema pass so collision diagnostics (local-shadowing and cross-file) fire for parameter schemas too.
- Parameter objects referenced via `\$ref` and `ParameterContent` media-type payloads pass through unchanged.

## Changes

- `src/oaspec/openapi/external_loader.gleam`: new `process_parameter_schemas` stage after `process_nested_property_refs`. The nested pass now returns its imports dict so the parameter pass can continue threading it. Module header updated.
- `test/fixtures/external_ref_parameter_schema_main.yaml`: happy-path fixture — a header parameter whose schema is an external ref reusing `external_ref_nested_shared.yaml`.
- `test/fixtures/external_ref_parameter_schema_collision_main.yaml`: negative fixture — local Widget plus a parameter schema importing a different Widget from a sibling file.
- `test/oaspec_test.gleam`: one happy-path test asserting the merged Widget schema and rewritten parameter ref; one negative test for the local-collision diagnostic.
- README + CHANGELOG updated.

## Design Decisions

- Made `process_nested_property_refs` return its imports dict rather than discarding it, so each subsequent pass threads the tracker forward instead of re-seeding from scratch. Collision checks across passes remain honest about what's already imported.
- Kept the parameter pass's merge step conservative: only insert a newly-imported schema into `components.schemas` if the slot is not already filled. This preserves the top-level resolver's authority when the same fragment name was imported at multiple stages.
- `ParameterContent` (media type maps) and `Ref` (parameter object refs in other files) are intentionally left untouched to keep this PR narrow.

## Part of

Parent issue #98 (external `\$ref` support). Closes #157.