### PR TITLE
feat(capability): add response XML content-type entries to the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Generated clients now emit a `<operation>_with_request` wrapper for every operation. The wrapper accepts the matching `request_types.*Request` record and delegates to the existing flat function — either API is valid. Operations that take a multi-content request body skip the wrapper because the flat API needs an extra `content_type` argument the request type does not carry (#31)
 - Drift-detection test between the capability registry and the README `## Current Boundaries` block: fails the suite if an `Unsupported`, `NotHandled`, or `ParsedNotUsed` entry is added to the registry without being mentioned in the README (#143). Fixes stale `operation servers` / `path servers` entries the registry had carried since #96 promoted them to Supported.
+- Capability registry now lists `application/xml` and `text/xml` under the `response` category as Supported (XML passthrough, no structural decoding). New drift test asserts every MIME type that `content_type.is_supported_response` accepts has a Supported entry in the registry, so the capability registry is on its way to becoming the single source of truth for content-type support (#173, subset of #102).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 664 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 218 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 665 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 218 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -171,6 +171,18 @@ pub fn registry() -> List(Capability) {
       Supported,
       "Binary passthrough",
     ),
+    Capability(
+      "application/xml",
+      "response",
+      Supported,
+      "XML passthrough; no structural decoding yet",
+    ),
+    Capability(
+      "text/xml",
+      "response",
+      Supported,
+      "XML passthrough; no structural decoding yet",
+    ),
     // Codegen scope
     Capability("webhooks", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("externalDocs", "scope", ParsedNotUsed, "Parsed but no codegen"),

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3818,6 +3818,35 @@ pub fn external_ref_nested_in_object_property_test() {
     dict.get(envelope_props, "note")
 }
 
+pub fn capability_registry_covers_content_type_response_helpers_test() {
+  // Every MIME string that `content_type.is_supported_response` accepts
+  // as directly-supported must have a Supported entry in the capability
+  // registry under the "response" category. This keeps the registry as
+  // the single source of truth and catches drift the first time
+  // somebody toggles support for a MIME without updating the registry.
+  let mimes_we_flag_supported = [
+    "application/json",
+    "text/plain",
+    "application/octet-stream",
+    "application/xml",
+    "text/xml",
+  ]
+  let registry_response_names =
+    capability.registry()
+    |> list.filter(fn(c) {
+      c.category == "response" && c.level == capability.Supported
+    })
+    |> list.map(fn(c) { c.name })
+  list.each(mimes_we_flag_supported, fn(mime) {
+    let parsed = content_type.from_string(mime)
+    content_type.is_supported_response(parsed) |> should.be_true()
+    case list.contains(registry_response_names, mime) {
+      True -> Nil
+      False -> mime |> should.equal("<expected in capability registry>")
+    }
+  })
+}
+
 pub fn capability_registry_names_appear_in_readme_boundaries_test() {
   // Every keyword the capability registry declares as Unsupported / NotHandled
   // / ParsedNotUsed must be mentioned by name inside the README's


### PR DESCRIPTION
## Summary

- Add `application/xml` and `text/xml` Supported entries under the `response` category in the capability registry.
- Add a drift test asserting every MIME type that `content_type.is_supported_response` accepts has a Supported entry in the registry.
- No behavior change; this ties the two previously independent support lists together so the registry is ready to become the single source of truth.

## Changes

- `src/oaspec/capability.gleam`: new registry entries for `application/xml` and `text/xml` under the `response` category, Supported, with a note about passthrough semantics.
- `test/oaspec_test.gleam`: new `capability_registry_covers_content_type_response_helpers_test` drift test.
- README + CHANGELOG updated.

## Design Decisions

- Response-side first because `is_supported_response` is the simpler of the two helpers and it was the place where the two lists had diverged most visibly (XML was in the code but not in the registry). The request-side helper and the full "helpers look up the registry" rewrite are deliberate follow-ups for #102(b) full scope.
- Kept the existing two-entry-per-MIME shape (one under `request`, one under `response`) rather than introducing a new mode-support field. Consolidating that is part of the larger #102(b) work and not worth churning the registry for a narrow first step.

## Part of

Parent issue #102 (unify support classification). Closes #173.