### PR TITLE
refactor(codegen): port generate_response_types to the IR pipeline

### DIFF
--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -10,8 +10,8 @@ import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context}
 import oaspec/codegen/import_analysis
 import oaspec/codegen/ir.{
-  type Declaration, type Field, type Module, EnumType, Field, RecordType,
-  TypeAlias, UnionType, VariantWithType,
+  type Declaration, type Field, type Module, type Variant, EnumType, Field,
+  RecordType, TypeAlias, UnionType, VariantEmpty, VariantWithType,
 }
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/schema_utils
@@ -24,6 +24,7 @@ import oaspec/openapi/schema.{
   OneOfSchema, Reference, StringSchema, Typed, Untyped,
 }
 import oaspec/openapi/spec.{type Resolved, Value}
+import oaspec/util/content_type
 import oaspec/util/http
 import oaspec/util/naming
 
@@ -187,6 +188,194 @@ fn request_body_type(
         _ -> "String"
       }
     [] -> "String"
+  }
+}
+
+/// Build an IR Module for the response_types.gleam file from operations.
+/// Each operation with at least one response yields a `UnionType`
+/// declaration whose variants correspond to HTTP status codes. Variant
+/// payloads follow the same rules the former string-builder applied:
+/// empty responses become `VariantEmpty`; text/XML/octet-stream bodies
+/// become `VariantWithType("String")`; JSON (and other structured) bodies
+/// become `VariantWithType(<qualified schema type>)`.
+pub fn build_response_types_module(ctx: Context) -> Module {
+  let operations = operations.collect_operations(ctx)
+  let imports = case responses_need_types_import(operations) {
+    True -> [config.package(context.config(ctx)) <> "/types"]
+    False -> []
+  }
+  let declarations =
+    list.filter_map(operations, fn(op) {
+      let #(op_id, operation, _path, _method) = op
+      response_type_decl(op_id, operation)
+    })
+  ir.module(header: "", imports: imports, declarations: declarations)
+}
+
+fn responses_need_types_import(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_op_id, operation, _path, _method) = op
+    let responses = dict.to_list(operation.responses)
+    list.any(responses, fn(entry) {
+      let #(_status_code, ref_or) = entry
+      case ref_or {
+        Value(response) -> {
+          let content_entries = dict.to_list(response.content)
+          case content_entries {
+            [] -> False
+            [_, _, ..] -> False
+            [#(media_type_name, media_type)] ->
+              case content_type.from_string(media_type_name) {
+                content_type.TextPlain
+                | content_type.ApplicationXml
+                | content_type.TextXml
+                | content_type.ApplicationOctetStream -> False
+                _ ->
+                  case media_type.schema {
+                    Some(Reference(..)) -> True
+                    Some(Inline(ArraySchema(items: Reference(..), ..))) -> True
+                    Some(Inline(ObjectSchema(..))) -> True
+                    Some(Inline(OneOfSchema(..))) -> True
+                    Some(Inline(AnyOfSchema(..))) -> True
+                    Some(Inline(AllOfSchema(..))) -> True
+                    _ -> False
+                  }
+              }
+          }
+        }
+        _ -> False
+      }
+    })
+  })
+}
+
+fn response_type_decl(
+  op_id: String,
+  operation: spec.Operation(Resolved),
+) -> Result(Declaration, Nil) {
+  let type_name = naming.schema_to_type_name(op_id) <> "Response"
+  let responses = http.sort_response_entries(dict.to_list(operation.responses))
+  case responses {
+    [] -> Error(Nil)
+    _ -> {
+      let variants =
+        list.filter_map(responses, fn(entry) {
+          let #(status_code, ref_or) = entry
+          case ref_or {
+            Value(response) ->
+              Ok(response_variant(type_name, op_id, status_code, response))
+            _ -> Error(Nil)
+          }
+        })
+      Ok(ir.declaration(
+        doc: None,
+        type_def: UnionType(name: type_name, variants: variants),
+      ))
+    }
+  }
+}
+
+fn response_variant(
+  type_name: String,
+  op_id: String,
+  status_code: http.HttpStatusCode,
+  response: spec.Response(Resolved),
+) -> Variant {
+  let variant_name = type_name <> http.status_code_suffix(status_code)
+  let content_entries = sorted_entries(response.content)
+  case content_entries {
+    [] -> VariantEmpty(name: variant_name)
+    [_, _, ..] -> VariantWithType(name: variant_name, inner_type: "String")
+    [#(media_type_name, media_type)] ->
+      case content_type.from_string(media_type_name) {
+        content_type.TextPlain
+        | content_type.ApplicationXml
+        | content_type.TextXml
+        | content_type.ApplicationOctetStream ->
+          case media_type.schema {
+            Some(_) -> VariantWithType(name: variant_name, inner_type: "String")
+            None -> VariantEmpty(name: variant_name)
+          }
+        _ ->
+          case media_type.schema {
+            Some(ref) -> {
+              let suffix = "Response" <> http.status_code_suffix(status_code)
+              let inner_type = schema_ref_to_type_qualified(ref, op_id, suffix)
+              VariantWithType(name: variant_name, inner_type: inner_type)
+            }
+            None -> VariantEmpty(name: variant_name)
+          }
+      }
+  }
+}
+
+fn schema_ref_to_type_qualified(
+  ref: SchemaRef,
+  op_id: String,
+  suffix: String,
+) -> String {
+  case ref {
+    Inline(schema_obj) ->
+      schema_to_gleam_type_qualified(schema_obj, op_id, suffix)
+    Reference(name:, ..) -> "types." <> naming.schema_to_type_name(name)
+  }
+}
+
+fn schema_to_gleam_type_qualified(
+  schema_obj: SchemaObject,
+  op_id: String,
+  suffix: String,
+) -> String {
+  case schema_obj {
+    ArraySchema(items:, ..) ->
+      case items {
+        Reference(name:, ..) ->
+          "List(types." <> naming.schema_to_type_name(name) <> ")"
+        _ -> schema_dispatch.schema_type(schema_obj)
+      }
+    ObjectSchema(..) -> {
+      let type_name = naming.schema_to_type_name(op_id) <> suffix
+      "types." <> type_name
+    }
+    OneOfSchema(schemas:, ..) -> {
+      let all_refs =
+        list.all(schemas, fn(s) {
+          case s {
+            Reference(..) -> True
+            _ -> False
+          }
+        })
+      case all_refs {
+        True -> {
+          let type_name = naming.schema_to_type_name(op_id) <> suffix
+          "types." <> type_name
+        }
+        False -> schema_dispatch.schema_type(schema_obj)
+      }
+    }
+    AnyOfSchema(schemas:, ..) -> {
+      let all_refs =
+        list.all(schemas, fn(s) {
+          case s {
+            Reference(..) -> True
+            _ -> False
+          }
+        })
+      case all_refs {
+        True -> {
+          let type_name = naming.schema_to_type_name(op_id) <> suffix
+          "types." <> type_name
+        }
+        False -> schema_dispatch.schema_type(schema_obj)
+      }
+    }
+    AllOfSchema(..) -> {
+      let type_name = naming.schema_to_type_name(op_id) <> suffix
+      "types." <> type_name
+    }
+    _ -> schema_dispatch.schema_type(schema_obj)
   }
 }
 

--- a/src/oaspec/codegen/types.gleam
+++ b/src/oaspec/codegen/types.gleam
@@ -1,23 +1,15 @@
-import gleam/dict
-import gleam/list
-import gleam/option.{None, Some}
 import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/ir_render
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/schema_utils
-import oaspec/config
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{
-  type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
-  Inline, ObjectSchema, OneOfSchema, Reference,
+  type SchemaObject, type SchemaRef, Inline, Reference,
 }
-import oaspec/openapi/spec.{type Resolved, Value}
-import oaspec/util/content_type
-import oaspec/util/http
+import oaspec/openapi/spec.{type Resolved}
 import oaspec/util/naming
-import oaspec/util/string_extra as se
 
 /// Generate type definitions from OpenAPI schemas.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
@@ -52,83 +44,6 @@ fn generate_types(ctx: Context) -> String {
   |> ir_render.render()
 }
 
-/// Convert a SchemaRef to a qualified Gleam type string (with types. prefix).
-/// Used in response_types and request_types where types are in a separate module.
-fn schema_ref_to_type_qualified(
-  ref: SchemaRef,
-  op_id: String,
-  suffix: String,
-  ctx: Context,
-) -> String {
-  case ref {
-    Inline(schema_obj) ->
-      schema_to_gleam_type_qualified(schema_obj, op_id, suffix, ctx)
-    Reference(name:, ..) -> {
-      "types." <> naming.schema_to_type_name(name)
-    }
-  }
-}
-
-/// Convert a schema to a qualified Gleam type with types. prefix for compound types.
-fn schema_to_gleam_type_qualified(
-  schema_obj: SchemaObject,
-  op_id: String,
-  suffix: String,
-  ctx: Context,
-) -> String {
-  case schema_obj {
-    ArraySchema(items:, ..) ->
-      case items {
-        Reference(name:, ..) -> {
-          "List(types." <> naming.schema_to_type_name(name) <> ")"
-        }
-        _ -> schema_to_gleam_type(schema_obj, ctx)
-      }
-    // Inline objects, oneOf, anyOf, allOf → reference the anonymous type
-    ObjectSchema(..) -> {
-      let type_name = naming.schema_to_type_name(op_id) <> suffix
-      "types." <> type_name
-    }
-    OneOfSchema(schemas:, ..) -> {
-      let all_refs =
-        list.all(schemas, fn(s) {
-          case s {
-            Reference(..) -> True
-            _ -> False
-          }
-        })
-      case all_refs {
-        True -> {
-          let type_name = naming.schema_to_type_name(op_id) <> suffix
-          "types." <> type_name
-        }
-        False -> schema_to_gleam_type(schema_obj, ctx)
-      }
-    }
-    AnyOfSchema(schemas:, ..) -> {
-      let all_refs =
-        list.all(schemas, fn(s) {
-          case s {
-            Reference(..) -> True
-            _ -> False
-          }
-        })
-      case all_refs {
-        True -> {
-          let type_name = naming.schema_to_type_name(op_id) <> suffix
-          "types." <> type_name
-        }
-        False -> schema_to_gleam_type(schema_obj, ctx)
-      }
-    }
-    AllOfSchema(..) -> {
-      let type_name = naming.schema_to_type_name(op_id) <> suffix
-      "types." <> type_name
-    }
-    _ -> schema_to_gleam_type(schema_obj, ctx)
-  }
-}
-
 /// Convert a SchemaRef to a Gleam type string.
 pub fn schema_ref_to_type(ref: SchemaRef, _ctx: Context) -> String {
   case ref {
@@ -157,153 +72,18 @@ fn generate_request_types(
   |> ir_render.render()
 }
 
-/// Check if any response variant references the types module.
-fn responses_need_types_import(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-  _ctx: Context,
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_op_id, operation, _path, _method) = op
-    let responses = dict.to_list(operation.responses)
-    list.any(responses, fn(entry) {
-      let #(_status_code, ref_or) = entry
-      case ref_or {
-        Value(response) -> {
-          let content_entries = dict.to_list(response.content)
-          case content_entries {
-            [] -> False
-            [_, _, ..] -> False
-            [#(media_type_name, media_type)] ->
-              case content_type.from_string(media_type_name) {
-                content_type.TextPlain
-                | content_type.ApplicationXml
-                | content_type.TextXml
-                | content_type.ApplicationOctetStream -> False
-                _ ->
-                  case media_type.schema {
-                    Some(Reference(..)) -> True
-                    Some(Inline(ArraySchema(items: Reference(..), ..))) -> True
-                    Some(Inline(ObjectSchema(..))) -> True
-                    Some(Inline(OneOfSchema(..))) -> True
-                    Some(Inline(AnyOfSchema(..))) -> True
-                    Some(Inline(AllOfSchema(..))) -> True
-                    _ -> False
-                  }
-              }
-          }
-        }
-        _ -> False
-      }
-    })
-  })
-}
-
-/// Generate response types for all operations.
+/// Generate response types for all operations via the IR pipeline.
+/// Each operation becomes one `UnionType` with status-code-named
+/// variants. Payload rules (empty / String / qualified schema type) are
+/// preserved from the former string-builder output.
 fn generate_response_types(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  _operations: List(
+    #(String, spec.Operation(Resolved), String, spec.HttpMethod),
+  ),
 ) -> String {
-  let needs_types = responses_need_types_import(operations, ctx)
-  let imports = case needs_types {
-    True -> [config.package(context.config(ctx)) <> "/types"]
-    False -> []
-  }
-  let sb =
-    se.file_header(context.version)
-    |> se.imports(imports)
-
-  let sb =
-    list.fold(operations, sb, fn(sb, op) {
-      let #(op_id, operation, _path, _method) = op
-      generate_response_type(sb, op_id, operation, ctx)
-    })
-
-  se.to_string(sb)
-}
-
-/// Generate a response type for an operation.
-fn generate_response_type(
-  sb: se.StringBuilder,
-  op_id: String,
-  operation: spec.Operation(Resolved),
-  ctx: Context,
-) -> se.StringBuilder {
-  let type_name = naming.schema_to_type_name(op_id) <> "Response"
-  let responses = http.sort_response_entries(dict.to_list(operation.responses))
-
-  case list.is_empty(responses) {
-    True -> sb
-    False -> {
-      let sb = sb |> se.line("pub type " <> type_name <> " {")
-
-      let sb =
-        list.fold(responses, sb, fn(sb, entry) {
-          let #(status_code, ref_or) = entry
-          case ref_or {
-            Value(response) -> {
-              let variant_name = status_code_to_variant(status_code, type_name)
-              let content_entries = ir_build.sorted_entries(response.content)
-
-              case content_entries {
-                [] -> sb |> se.indent(1, variant_name)
-                // Multiple content types: use String to stay type-safe
-                // since different media types may decode to different Gleam types
-                [_, _, ..] -> sb |> se.indent(1, variant_name <> "(String)")
-                [#(media_type_name, media_type)] ->
-                  case content_type.from_string(media_type_name) {
-                    // text/plain, XML, octet-stream: always use String type
-                    content_type.TextPlain
-                    | content_type.ApplicationXml
-                    | content_type.TextXml
-                    | content_type.ApplicationOctetStream ->
-                      case media_type.schema {
-                        Some(_) ->
-                          sb
-                          |> se.indent(1, variant_name <> "(String)")
-                        None -> sb |> se.indent(1, variant_name)
-                      }
-                    // JSON and other content types use schema-derived type
-                    _ ->
-                      case media_type.schema {
-                        Some(ref) -> {
-                          let suffix =
-                            "Response" <> http.status_code_suffix(status_code)
-                          let inner_type =
-                            schema_ref_to_type_qualified(
-                              ref,
-                              op_id,
-                              suffix,
-                              ctx,
-                            )
-                          sb
-                          |> se.indent(
-                            1,
-                            variant_name <> "(" <> inner_type <> ")",
-                          )
-                        }
-                        None -> sb |> se.indent(1, variant_name)
-                      }
-                  }
-              }
-            }
-            _ -> sb
-          }
-        })
-
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Convert an HTTP status code to a Gleam variant name.
-/// Prefixed with the type name to avoid duplicate constructors across types.
-fn status_code_to_variant(
-  code: http.HttpStatusCode,
-  type_name: String,
-) -> String {
-  type_name <> http.status_code_suffix(code)
+  ir_build.build_response_types_module(ctx)
+  |> ir_render.render()
 }
 
 /// Result of merging allOf sub-schemas.


### PR DESCRIPTION
## Summary

- Move `generate_response_types` off direct string-building onto the existing IR pipeline.
- Second major non-type slice to land on IR after #177's `generate_request_types`. With this PR parent #29's Done When (at least one major non-type slice on IR + meaningful amount of duplicated generation code replaced) is clearly met.
- Byte-for-byte identical on-disk output after `gleam format` — verified by regenerating petstore and diffing against the committed `examples/server_adapter` snapshot.

## Changes

- `src/oaspec/codegen/ir_build.gleam`:
  - New `build_response_types_module`.
  - New private helpers: `responses_need_types_import`, `response_type_decl`, `response_variant`, `schema_ref_to_type_qualified`, `schema_to_gleam_type_qualified`.
  - Variant payload rules mirror the former generator: empty responses → `VariantEmpty`; text/xml/octet-stream bodies with schema → `VariantWithType("String")`; structured (JSON etc.) → `VariantWithType(<qualified schema type>)`; multiple content types → `VariantWithType("String")`.
- `src/oaspec/codegen/types.gleam`:
  - `generate_response_types` is a one-line delegator now.
  - Removed the obsolete `generate_response_type`, `status_code_to_variant`, `responses_need_types_import`, `schema_ref_to_type_qualified`, `schema_to_gleam_type_qualified` helpers.
  - Cleaned up imports; the module is ~60 lines of orchestration + re-exports.

## Design Decisions

- Moved the qualified-type helpers into `ir_build` because they're now internal to response-type construction. Keeping them in `types.gleam` would have split response-type logic across two files.
- Left `status_code_to_variant` folded into the inline variant name build. It was a one-liner (`type_name <> http.status_code_suffix(code)`) and the IR's `response_variant` helper is where that naming responsibility belongs now.

## Part of

Parent issue #29. Closes #179.