### PR TITLE
feat(capability): surface server-only validation restrictions in the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ These are the most important limitations today:
 - `xml` annotations are not handled by the parser
 - Some fields are parsed and preserved but not yet used by codegen: callbacks, webhooks, externalDocs, tags, examples, links, response headers, encoding
 - Operation-level and path-level server overrides are supported in generated clients (precedence: operation > path > top-level)
+- Server-mode code generation rejects the following spec configurations (supported in client mode): `server: complex path parameters`, `server: non-primitive query array items`, `server: non-primitive header array items`, `server: complex deepObject properties`, `server: mixed form-urlencoded request`, `server: complex form-urlencoded fields`, `server: mixed multipart request`, `server: complex multipart fields`, `server: unsupported request content type`
 - The following are normalized to supported equivalents:
 - `const`: String const normalized to single-value enum
 - `type: [T, null]`: Normalized to nullable

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -183,6 +183,64 @@ pub fn registry() -> List(Capability) {
       Supported,
       "XML passthrough; no structural decoding yet",
     ),
+    // Server-mode validation restrictions — features the parser accepts
+    // but the server-code generator rejects. Names match the phrasing
+    // used in the corresponding `validate.gleam` diagnostic details so
+    // the README drift test keeps docs honest.
+    Capability(
+      "server: complex path parameters",
+      "server-validation",
+      Unsupported,
+      "Path parameters must be scalar (string, integer, number, boolean)",
+    ),
+    Capability(
+      "server: non-primitive query array items",
+      "server-validation",
+      Unsupported,
+      "Query array parameters require inline primitive items",
+    ),
+    Capability(
+      "server: non-primitive header array items",
+      "server-validation",
+      Unsupported,
+      "Header array parameters require inline primitive items",
+    ),
+    Capability(
+      "server: complex deepObject properties",
+      "server-validation",
+      Unsupported,
+      "deepObject properties must be primitive scalars or primitive array leaves",
+    ),
+    Capability(
+      "server: mixed form-urlencoded request",
+      "server-validation",
+      Unsupported,
+      "application/x-www-form-urlencoded must be the sole request content type",
+    ),
+    Capability(
+      "server: complex form-urlencoded fields",
+      "server-validation",
+      Unsupported,
+      "Form fields must be primitive scalars, primitive arrays, or shallow nested objects (max 5 levels)",
+    ),
+    Capability(
+      "server: mixed multipart request",
+      "server-validation",
+      Unsupported,
+      "multipart/form-data must be the sole request content type",
+    ),
+    Capability(
+      "server: complex multipart fields",
+      "server-validation",
+      Unsupported,
+      "Multipart fields must be primitive scalars (or arrays of them)",
+    ),
+    Capability(
+      "server: unsupported request content type",
+      "server-validation",
+      Unsupported,
+      "Server router only supports application/json, application/x-www-form-urlencoded, and multipart/form-data",
+    ),
     // Codegen scope
     Capability("webhooks", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("externalDocs", "scope", ParsedNotUsed, "Parsed but no codegen"),


### PR DESCRIPTION
## Summary

- Final slice under parent #102. `validate.gleam` has ~10 `TargetServer`-mode rejection rules for spec configurations the server code generator can't handle (complex path parameters, deep-nested form fields, multipart restrictions, etc.). They lived only in `validate.gleam`, so the registry and README didn't know about them.
- Add one `Unsupported` entry per rule to `capability.registry()` under a new `"server-validation"` category. Names and notes mirror the diagnostic details in `validate.gleam`.
- Update README's `## Current Boundaries` block to include the new names. The existing drift test (#144) keeps future additions honest.

## Changes

- `src/oaspec/capability.gleam`: 9 new `Capability` entries under `"server-validation"` / `Unsupported`, covering every `TargetServer`-mode rejection currently in `validate.gleam`.
- `README.md`: new line in the boundaries block listing those names, all prefixed with `server: ` for scannability.

No behavior change in validation — `validate.gleam` still emits the same diagnostics; the registry is now just the documented source of truth for their existence.

## Design Decisions

- Kept the `validate.gleam` rejection logic in place rather than rewriting it to consult the registry. The rules involve complex structural checks (e.g., "multipart fields must be primitive scalars") that aren't expressible as a simple registry lookup. Treating the registry as a docs / drift-detection overlay is a lighter touch.
- Used level `Unsupported` even though these features ARE supported client-side, because the drift test only tracks `Unsupported | NotHandled | ParsedNotUsed`. The note text (`server: ...`) makes the mode scope clear in the rendered README.
- Deliberately didn't add a new `Mode` field to `Capability` — that's a bigger type refactor and not required by #102's Done When.

## Part of

Parent issue #102 (unify support classification). Closes #181. With this merged, parent #102 can close: support rules, documentation, and drift detection are all pinned to the registry.