### PR TITLE
fix(scripts): correct misleading sync-check messages and add regression tests

### DIFF
--- a/scripts/check_sync.sh
+++ b/scripts/check_sync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# check_sync.sh — Verify version, test counts, and capability boundaries
-# are consistent across gleam.toml, context.gleam, README.md, and CHANGELOG.md.
+# check_sync.sh — Verify version and test count consistency
+# across gleam.toml, context.gleam, README.md, and CHANGELOG.md.
 # Exit 1 on any drift.
 
 set -euo pipefail
@@ -61,8 +61,8 @@ fi
 echo ""
 if [ "$errors" -gt 0 ]; then
   echo "FAILED: $errors inconsistencies found."
-  echo "Fix manually or run: scripts/update_sync.sh"
+  echo "Fix the inconsistencies listed above manually."
   exit 1
 else
-  echo "All checks passed. Versions, counts, and boundaries are in sync."
+  echo "All checks passed. Versions and counts are in sync."
 fi

--- a/spec/check_sync_spec.sh
+++ b/spec/check_sync_spec.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+# Regression tests for scripts/check_sync.sh.
+# Ensures the sync-check output accurately describes what it validates
+# and that failure guidance points to a real remediation path.
+
+Describe 'check_sync.sh'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  check_sync() {
+    cd "$PROJECT_ROOT" && bash scripts/check_sync.sh 2>&1
+  }
+
+  check_sync_with_version_drift() {
+    cd "$PROJECT_ROOT"
+    cp gleam.toml gleam.toml.bak
+    sed -i 's/^version = .*/version = "99.99.99"/' gleam.toml
+    set +e
+    bash scripts/check_sync.sh 2>&1
+    rc=$?
+    set -e
+    mv gleam.toml.bak gleam.toml
+    return $rc
+  }
+
+  Describe 'success path'
+    It 'passes on a consistent repo'
+      When run check_sync
+      The status should be success
+      The output should include 'Versions and counts are in sync'
+    End
+
+    It 'reports version consistency check'
+      When run check_sync
+      The output should include 'Checking version consistency'
+    End
+
+    It 'reports test count check'
+      When run check_sync
+      The output should include 'Checking test counts in README'
+    End
+
+    It 'does not mention capability boundaries'
+      When run check_sync
+      The output should not include 'boundaries'
+    End
+
+    It 'does not reference update_sync.sh'
+      When run check_sync
+      The output should not include 'update_sync.sh'
+    End
+  End
+
+  Describe 'failure path'
+    It 'exits with error on version drift'
+      When run check_sync_with_version_drift
+      The status should be failure
+      The output should include 'DRIFT:'
+      The output should include 'FAILED:'
+    End
+
+    It 'shows actionable remediation guidance on failure'
+      When run check_sync_with_version_drift
+      The status should be failure
+      The output should include 'Fix the inconsistencies listed above manually'
+    End
+  End
+End


### PR DESCRIPTION
## Summary

- Remove inaccurate "capability boundaries" claims from `check_sync.sh` header comment and success message — the script only validates version strings and README test counts
- Replace broken `scripts/update_sync.sh` reference in failure output with actionable manual-fix guidance
- Add ShellSpec regression tests covering both success and failure paths to prevent messaging drift

## Changes

- **scripts/check_sync.sh**: Narrow header comment, success message, and failure hint to match actual scope (version + test count consistency)
- **spec/check_sync_spec.sh**: New ShellSpec test file with 7 examples — verifies output labels, absence of stale terms, and failure-path behavior (DRIFT detection, exit code, remediation message)

## Design Decisions

- Chose to narrow messaging rather than expand implementation (adding capability-boundary checking) because Issue #187 specifically flags the *claim*, not a missing feature
- Did not create `update_sync.sh` — the DRIFT messages already tell the maintainer exactly which values disagree, making manual fixes trivial

Closes #187