### PR TITLE
docs(readme): document validate config field and generate --validate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Generated server code is written to `<dir>/<package>`. Generated client code is 
 | `input` | yes | - | Path to an OpenAPI 3.x spec in YAML or JSON |
 | `package` | no | `api` | Gleam module namespace prefix |
 | `mode` | no | `both` | `server`, `client`, or `both` |
+| `validate` | no | `false` | Enable guard validation in generated server/client code |
 | `output.dir` | no | `./gen` | Base output directory |
 | `output.server` | no | `<dir>/<package>` | Server output path |
 | `output.client` | no | `<dir>_client/<package>` | Client output path |
@@ -170,6 +171,7 @@ Generated server code is written to `<dir>/<package>`. Generated client code is 
 | `--output=<path>` | - | Override output base directory |
 | `--check` | `false` | Check that generated code matches existing files without writing |
 | `--fail-on-warnings` | `false` | Treat warnings as errors |
+| `--validate` | `false` | Enable guard validation in generated server/client code |
 
 ### CLI options for `validate`
 
@@ -185,6 +187,20 @@ Check a spec for unsupported patterns without generating code:
 ```sh
 oaspec validate --config=oaspec.yaml
 ```
+
+### Guard validation
+
+By default, generated code does not validate request bodies at runtime. Enable `validate` in the config file or pass `--validate` to `generate` to add schema-constraint checks:
+
+```yaml
+validate: true
+```
+
+```sh
+oaspec generate --config=oaspec.yaml --validate
+```
+
+When enabled, generated routers validate request bodies against schema constraints and return 422 on failure. Generated clients validate request bodies before sending.
 
 ### CI integration
 


### PR DESCRIPTION
## Summary

- Add `validate` to the configuration field table and `--validate` to the `generate` flag table
- Add a new "Guard validation" subsection explaining what runtime validation does
- Align wording with the CLI help text and `oaspec init` template comments

## Changes

- **README.md**: Add `validate` config field row (after `mode`, before `output.dir`), add `--validate` CLI flag row, and add "Guard validation" subsection between "Validate" and "CI integration"

## Design Decisions

- Placed `validate` after `mode` in the config table to match the field order in the `oaspec init` template
- Used the exact same description string as the CLI help and init template: "Enable guard validation in generated server/client code"
- Kept the subsection brief — one paragraph explaining the runtime effect — to avoid duplicating the validate command docs

Closes #184