### PR TITLE
feat(parser): preserve source locations for semantic parse and resolve diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 667 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 218 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 673 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 218 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -77,27 +77,35 @@ pub fn yaml_error(detail detail: String, loc loc: SourceLoc) -> Diagnostic {
   )
 }
 
-pub fn missing_field(path path: String, field field: String) -> Diagnostic {
+pub fn missing_field(
+  path path: String,
+  field field: String,
+  loc loc: SourceLoc,
+) -> Diagnostic {
   Diagnostic(
     code: "missing_field",
     phase: PhaseParse,
     severity: SeverityError,
     target: TargetBoth,
     pointer: path,
-    source_loc: NoSourceLoc,
+    source_loc: loc,
     message: "Missing required field: " <> field,
     hint: Some("Check your OpenAPI spec structure."),
   )
 }
 
-pub fn invalid_value(path path: String, detail detail: String) -> Diagnostic {
+pub fn invalid_value(
+  path path: String,
+  detail detail: String,
+  loc loc: SourceLoc,
+) -> Diagnostic {
   Diagnostic(
     code: "invalid_value",
     phase: PhaseParse,
     severity: SeverityError,
     target: TargetBoth,
     pointer: path,
-    source_loc: NoSourceLoc,
+    source_loc: loc,
     message: detail,
     hint: None,
   )
@@ -111,6 +119,7 @@ pub fn resolve_error(
   path path: String,
   detail detail: String,
   hint hint: Option(String),
+  loc loc: SourceLoc,
 ) -> Diagnostic {
   Diagnostic(
     code: "resolve_error",
@@ -118,7 +127,7 @@ pub fn resolve_error(
     severity: SeverityError,
     target: TargetBoth,
     pointer: path,
-    source_loc: NoSourceLoc,
+    source_loc: loc,
     message: detail,
     hint: hint,
   )

--- a/src/oaspec/openapi/location_index.gleam
+++ b/src/oaspec/openapi/location_index.gleam
@@ -1,0 +1,66 @@
+import gleam/dict.{type Dict}
+import gleam/list
+import oaspec/openapi/diagnostic.{type SourceLoc, NoSourceLoc, SourceLoc}
+
+/// An index mapping dotted JSON-pointer paths to source locations.
+/// Built by parsing YAML with yamerl (which preserves line/column),
+/// then looked up when emitting diagnostics.
+pub opaque type LocationIndex {
+  LocationIndex(entries: Dict(String, SourceLoc))
+}
+
+/// Build a location index from raw YAML/JSON content.
+/// On failure (e.g. invalid YAML), returns an empty index.
+pub fn build(content: String) -> LocationIndex {
+  case do_build(content) {
+    Ok(pairs) -> {
+      let entries =
+        list.fold(pairs, dict.new(), fn(acc, pair) {
+          let #(path, #(line, col)) = pair
+          dict.insert(acc, path, SourceLoc(line:, column: col))
+        })
+      LocationIndex(entries:)
+    }
+    Error(_) -> empty()
+  }
+}
+
+/// An empty index (no location information available).
+pub fn empty() -> LocationIndex {
+  LocationIndex(entries: dict.new())
+}
+
+/// Look up the source location for a given path.
+/// Returns `NoSourceLoc` if the path is not in the index.
+pub fn lookup(index: LocationIndex, path: String) -> SourceLoc {
+  case dict.get(index.entries, path) {
+    Ok(loc) -> loc
+    Error(_) -> NoSourceLoc
+  }
+}
+
+/// Look up the source location for a field within a parent path.
+/// Tries `parent.field` first, then falls back to `parent`, then `NoSourceLoc`.
+pub fn lookup_field(
+  index: LocationIndex,
+  parent: String,
+  field: String,
+) -> SourceLoc {
+  let field_path = case parent {
+    "" -> field
+    _ -> parent <> "." <> field
+  }
+  case dict.get(index.entries, field_path) {
+    Ok(loc) -> loc
+    Error(_) ->
+      case dict.get(index.entries, parent) {
+        Ok(loc) -> loc
+        Error(_) -> NoSourceLoc
+      }
+  }
+}
+
+@external(erlang, "yaml_loc_ffi", "build_location_index")
+fn do_build(
+  content: String,
+) -> Result(List(#(String, #(Int, Int))), Nil)

--- a/src/oaspec/openapi/location_index.gleam
+++ b/src/oaspec/openapi/location_index.gleam
@@ -61,6 +61,4 @@ pub fn lookup_field(
 }
 
 @external(erlang, "yaml_loc_ffi", "build_location_index")
-fn do_build(
-  content: String,
-) -> Result(List(#(String, #(Int, Int))), Nil)
+fn do_build(content: String) -> Result(List(#(String, #(Int, Int))), Nil)

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -7,6 +7,7 @@ import gleam/result
 import gleam/string
 import oaspec/openapi/diagnostic.{type Diagnostic, NoSourceLoc, SourceLoc}
 import oaspec/openapi/external_loader
+import oaspec/openapi/location_index.{type LocationIndex}
 import oaspec/openapi/schema.{
   type Discriminator, type SchemaObject, type SchemaRef, AllOfSchema,
   AnyOfSchema, ArraySchema, BooleanSchema, Discriminator, Inline, IntegerSchema,
@@ -79,11 +80,15 @@ pub fn parse_string(
   })
 
   let root = yay.document_root(doc)
-  parse_root(root)
+  let index = location_index.build(content)
+  parse_root(root, index)
 }
 
 /// Parse the root OpenAPI object.
-fn parse_root(node: yay.Node) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+fn parse_root(
+  node: yay.Node,
+  index: LocationIndex,
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
   // openapi field may be a string ("3.0.3") or a YAML number (3.0 parsed as float)
   use openapi <- result.try(
     yay.extract_string(node, "openapi")
@@ -97,20 +102,24 @@ fn parse_root(node: yay.Node) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
       })
     })
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "", field: "openapi")
+      diagnostic.missing_field(
+        path: "",
+        field: "openapi",
+        loc: location_index.lookup_field(index, "", "openapi"),
+      )
     }),
   )
 
-  use info <- result.try(parse_info(node))
+  use info <- result.try(parse_info(node, index))
 
   // Parse components FIRST so we can resolve $ref during path parsing.
   // Components section is optional, but if present it must parse correctly.
-  use components <- result.try(parse_optional_components(node))
+  use components <- result.try(parse_optional_components(node, index))
 
-  use paths <- result.try(parse_paths(node, components))
-  use servers <- result.try(parse_servers(node))
-  use security <- result.try(parse_security_requirements(node, ""))
-  use webhooks <- result.try(parse_webhooks(node, components))
+  use paths <- result.try(parse_paths(node, components, index))
+  use servers <- result.try(parse_servers(node, index))
+  use security <- result.try(parse_security_requirements(node, "", index))
+  use webhooks <- result.try(parse_webhooks(node, components, index))
   let tags = parse_tags(node)
   let external_docs = parse_optional_external_docs(node)
   let json_schema_dialect =
@@ -135,10 +144,11 @@ fn parse_root(node: yay.Node) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
 /// Returns Ok(None) if not present, Ok(Some(..)) if valid, Error if malformed.
 fn parse_optional_components(
   root: yay.Node,
+  index: LocationIndex,
 ) -> Result(Option(Components(Unresolved)), Diagnostic) {
   case yay.select_sugar(from: root, selector: "components") {
     Ok(_) -> {
-      use comps <- result.try(parse_components(root))
+      use comps <- result.try(parse_components(root, index))
       Ok(Some(comps))
     }
     Error(_) -> Ok(None)
@@ -146,25 +156,37 @@ fn parse_optional_components(
 }
 
 /// Parse the info object.
-fn parse_info(root: yay.Node) -> Result(Info, Diagnostic) {
+fn parse_info(root: yay.Node, index: LocationIndex) -> Result(Info, Diagnostic) {
   use info_node <- result.try(
     yay.select_sugar(from: root, selector: "info")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "", field: "info")
+      diagnostic.missing_field(
+        path: "",
+        field: "info",
+        loc: location_index.lookup_field(index, "", "info"),
+      )
     }),
   )
 
   use title <- result.try(
     yay.extract_string(info_node, "title")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "info", field: "title")
+      diagnostic.missing_field(
+        path: "info",
+        field: "title",
+        loc: location_index.lookup_field(index, "info", "title"),
+      )
     }),
   )
 
   use version <- result.try(
     yay.extract_string(info_node, "version")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "info", field: "version")
+      diagnostic.missing_field(
+        path: "info",
+        field: "version",
+        loc: location_index.lookup_field(index, "info", "version"),
+      )
     }),
   )
 
@@ -195,19 +217,30 @@ fn parse_info(root: yay.Node) -> Result(Info, Diagnostic) {
 }
 
 /// Parse servers array.
-fn parse_servers(root: yay.Node) -> Result(List(Server), Diagnostic) {
+fn parse_servers(
+  root: yay.Node,
+  index: LocationIndex,
+) -> Result(List(Server), Diagnostic) {
   case yay.select_sugar(from: root, selector: "servers") {
-    Ok(yay.NodeSeq(items)) -> list.try_map(items, parse_server)
+    Ok(yay.NodeSeq(items)) ->
+      list.try_map(items, fn(item) { parse_server(item, index) })
     _ -> Ok([])
   }
 }
 
 /// Parse a single server object.
-fn parse_server(node: yay.Node) -> Result(Server, Diagnostic) {
+fn parse_server(
+  node: yay.Node,
+  index: LocationIndex,
+) -> Result(Server, Diagnostic) {
   use url <- result.try(
     yay.extract_string(node, "url")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "servers", field: "url")
+      diagnostic.missing_field(
+        path: "servers",
+        field: "url",
+        loc: location_index.lookup_field(index, "servers", "url"),
+      )
     }),
   )
 
@@ -224,6 +257,7 @@ fn parse_server(node: yay.Node) -> Result(Server, Diagnostic) {
 fn parse_paths(
   root: yay.Node,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(PathItem(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: root, selector: "paths") {
     Ok(yay.NodeMap(entries)) -> {
@@ -246,6 +280,7 @@ fn parse_paths(
                         value_node,
                         path,
                         components,
+                        index,
                       ))
                       Ok(Value(pi))
                     }
@@ -267,6 +302,7 @@ fn parse_path_item(
   node: yay.Node,
   path: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(PathItem(Unresolved), Diagnostic) {
   let summary =
     yay.extract_optional_string(node, "summary")
@@ -277,47 +313,65 @@ fn parse_path_item(
     |> result.unwrap(None)
 
   // Operations are optional, but if present must parse correctly.
-  use get <- result.try(parse_optional_operation(node, "get", path, components))
+  use get <- result.try(parse_optional_operation(
+    node,
+    "get",
+    path,
+    components,
+    index,
+  ))
   use post <- result.try(parse_optional_operation(
     node,
     "post",
     path,
     components,
+    index,
   ))
-  use put <- result.try(parse_optional_operation(node, "put", path, components))
+  use put <- result.try(parse_optional_operation(
+    node,
+    "put",
+    path,
+    components,
+    index,
+  ))
   use delete <- result.try(parse_optional_operation(
     node,
     "delete",
     path,
     components,
+    index,
   ))
   use patch <- result.try(parse_optional_operation(
     node,
     "patch",
     path,
     components,
+    index,
   ))
   use head <- result.try(parse_optional_operation(
     node,
     "head",
     path,
     components,
+    index,
   ))
   use options <- result.try(parse_optional_operation(
     node,
     "options",
     path,
     components,
+    index,
   ))
   use trace <- result.try(parse_optional_operation(
     node,
     "trace",
     path,
     components,
+    index,
   ))
 
-  use parameters <- result.try(parse_parameters_list(node, components))
-  use servers <- result.try(parse_servers(node))
+  use parameters <- result.try(parse_parameters_list(node, components, index))
+  use servers <- result.try(parse_servers(node, index))
 
   Ok(PathItem(
     summary:,
@@ -342,6 +396,7 @@ fn parse_optional_operation(
   method_key: String,
   path: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Option(Operation(Unresolved)), Diagnostic) {
   case yay.select_sugar(from: node, selector: method_key) {
     Ok(_) -> {
@@ -350,6 +405,7 @@ fn parse_optional_operation(
         method_key,
         path,
         components,
+        index,
       ))
       Ok(Some(op))
     }
@@ -363,15 +419,20 @@ fn parse_operation_at(
   method_key: String,
   path: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Operation(Unresolved), Diagnostic) {
   use op_node <- result.try(
     yay.select_sugar(from: node, selector: method_key)
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path:, field: method_key)
+      diagnostic.missing_field(
+        path:,
+        field: method_key,
+        loc: location_index.lookup_field(index, path, method_key),
+      )
     }),
   )
 
-  parse_operation(op_node, path <> "." <> method_key, components)
+  parse_operation(op_node, path <> "." <> method_key, components, index)
 }
 
 /// Parse a single operation.
@@ -379,6 +440,7 @@ fn parse_operation(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Operation(Unresolved), Diagnostic) {
   let operation_id =
     yay.extract_optional_string(node, "operationId")
@@ -402,13 +464,14 @@ fn parse_operation(
     |> result.unwrap(None)
     |> option.unwrap(False)
 
-  use parameters <- result.try(parse_parameters_list(node, components))
+  use parameters <- result.try(parse_parameters_list(node, components, index))
 
   // requestBody is optional; absent is Ok(None), present-but-broken is Error.
   use request_body <- result.try(parse_optional_request_body(
     node,
     context,
     components,
+    index,
   ))
 
   // responses is REQUIRED per OpenAPI 3.x
@@ -416,12 +479,17 @@ fn parse_operation(
     node,
     context,
     components,
+    index,
   ))
 
-  use security <- result.try(parse_optional_security_requirements(node, context))
+  use security <- result.try(parse_optional_security_requirements(
+    node,
+    context,
+    index,
+  ))
 
-  use callbacks <- result.try(parse_callbacks(node, context, components))
-  use op_servers <- result.try(parse_servers(node))
+  use callbacks <- result.try(parse_callbacks(node, context, components, index))
+  use op_servers <- result.try(parse_servers(node, index))
   let external_docs = parse_optional_external_docs(node)
 
   Ok(Operation(
@@ -446,10 +514,16 @@ fn parse_optional_request_body(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Option(RefOr(RequestBody(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "requestBody") {
     Ok(_) -> {
-      use rb <- result.try(parse_request_body_at(node, context, components))
+      use rb <- result.try(parse_request_body_at(
+        node,
+        context,
+        components,
+        index,
+      ))
       Ok(Some(rb))
     }
     Error(_) -> Ok(None)
@@ -463,21 +537,25 @@ fn parse_responses_required(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(
   dict.Dict(http.HttpStatusCode, RefOr(Response(Unresolved))),
   Diagnostic,
 ) {
-  parse_responses(node, context, components)
+  parse_responses(node, context, components, index)
 }
 
 /// Parse parameters list from a node.
 fn parse_parameters_list(
   node: yay.Node,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(List(RefOr(Parameter(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "parameters") {
     Ok(yay.NodeSeq(items)) ->
-      list.try_map(items, fn(item) { parse_parameter(item, components) })
+      list.try_map(items, fn(item) {
+        parse_parameter(item, components, index)
+      })
     _ -> Ok([])
   }
 }
@@ -486,6 +564,7 @@ fn parse_parameters_list(
 fn parse_parameter(
   node: yay.Node,
   _components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(RefOr(Parameter(Unresolved)), Diagnostic) {
   // Check for $ref first
   case yay.extract_optional_string(node, "$ref") {
@@ -496,18 +575,30 @@ fn parse_parameter(
       use name <- result.try(
         yay.extract_string(node, "name")
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "parameter", field: "name")
+          diagnostic.missing_field(
+            path: "parameter",
+            field: "name",
+            loc: location_index.lookup_field(index, "parameter", "name"),
+          )
         }),
       )
 
       use in_str <- result.try(
         yay.extract_string(node, "in")
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "parameter." <> name, field: "in")
+          diagnostic.missing_field(
+            path: "parameter." <> name,
+            field: "in",
+            loc: location_index.lookup_field(
+              index,
+              "parameter." <> name,
+              "in",
+            ),
+          )
         }),
       )
 
-      use in_ <- result.try(parse_parameter_in(in_str))
+      use in_ <- result.try(parse_parameter_in(in_str, index))
 
       let description =
         yay.extract_optional_string(node, "description")
@@ -523,6 +614,7 @@ fn parse_parameter(
           Error(diagnostic.invalid_value(
             path: "parameter." <> name,
             detail: "Path parameters must have required: true",
+            loc: location_index.lookup(index, "parameter." <> name),
           ))
         spec.InPath, _ -> Ok(True)
         _, Some(v) -> Ok(v)
@@ -540,6 +632,7 @@ fn parse_parameter(
             use sr <- result.try(parse_schema_ref(
               schema_node,
               "parameter.schema",
+              index,
             ))
             Ok(Ok(sr))
           }
@@ -553,7 +646,7 @@ fn parse_parameter(
           |> result.unwrap(None)
         {
           Some(s) -> {
-            use parsed <- result.try(parse_parameter_style(s))
+            use parsed <- result.try(parse_parameter_style(s, index))
             Ok(Some(parsed))
           }
           None -> Ok(None)
@@ -569,7 +662,7 @@ fn parse_parameter(
         |> result.unwrap(None)
         |> option.unwrap(False)
 
-      use content <- result.try(parse_content_map(node))
+      use content <- result.try(parse_content_map(node, index))
       let examples = value.extract_map(node, "examples")
 
       let payload = case param_schema {
@@ -596,7 +689,10 @@ fn parse_parameter(
 }
 
 /// Parse parameter location string.
-fn parse_parameter_in(value: String) -> Result(ParameterIn, Diagnostic) {
+fn parse_parameter_in(
+  value: String,
+  index: LocationIndex,
+) -> Result(ParameterIn, Diagnostic) {
   case value {
     "path" -> Ok(spec.InPath)
     "query" -> Ok(spec.InQuery)
@@ -608,6 +704,7 @@ fn parse_parameter_in(value: String) -> Result(ParameterIn, Diagnostic) {
         detail: "Unknown parameter location: "
           <> value
           <> ". Must be one of: path, query, header, cookie",
+        loc: location_index.lookup(index, "parameter.in"),
       ))
   }
 }
@@ -615,6 +712,7 @@ fn parse_parameter_in(value: String) -> Result(ParameterIn, Diagnostic) {
 /// Map a style string to a ParameterStyle ADT value.
 fn parse_parameter_style(
   value: String,
+  index: LocationIndex,
 ) -> Result(spec.ParameterStyle, Diagnostic) {
   case value {
     "form" -> Ok(spec.FormStyle)
@@ -630,6 +728,7 @@ fn parse_parameter_style(
         detail: "Unknown parameter style: '"
           <> value
           <> "'. Must be one of: form, simple, deepObject, matrix, label, spaceDelimited, pipeDelimited",
+        loc: location_index.lookup(index, "parameter.style"),
       ))
   }
 }
@@ -637,6 +736,7 @@ fn parse_parameter_style(
 /// Map an apiKey "in" string to a SecuritySchemeIn ADT value.
 fn parse_security_scheme_in(
   value: String,
+  index: LocationIndex,
 ) -> Result(spec.SecuritySchemeIn, Diagnostic) {
   case value {
     "header" -> Ok(spec.SchemeInHeader)
@@ -648,6 +748,7 @@ fn parse_security_scheme_in(
         detail: "Unknown apiKey location: "
           <> value
           <> ". Must be one of: header, query, cookie",
+        loc: location_index.lookup(index, "securityScheme.in"),
       ))
   }
 }
@@ -657,11 +758,16 @@ fn parse_request_body_at(
   node: yay.Node,
   context: String,
   _components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(RefOr(RequestBody(Unresolved)), Diagnostic) {
   use rb_node <- result.try(
     yay.select_sugar(from: node, selector: "requestBody")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: context, field: "requestBody")
+      diagnostic.missing_field(
+        path: context,
+        field: "requestBody",
+        loc: location_index.lookup_field(index, context, "requestBody"),
+      )
     }),
   )
 
@@ -669,7 +775,7 @@ fn parse_request_body_at(
   case yay.extract_optional_string(rb_node, "$ref") {
     Ok(Some(ref_str)) -> Ok(Ref(ref_str))
     _ -> {
-      use rb <- result.try(parse_request_body(rb_node, context))
+      use rb <- result.try(parse_request_body(rb_node, context, index))
       Ok(Value(rb))
     }
   }
@@ -679,6 +785,7 @@ fn parse_request_body_at(
 fn parse_request_body(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(RequestBody(Unresolved), Diagnostic) {
   let description =
     yay.extract_optional_string(node, "description")
@@ -690,7 +797,7 @@ fn parse_request_body(
     |> option.unwrap(False)
 
   // content is REQUIRED per OpenAPI spec
-  use content <- result.try(parse_required_content(node, context))
+  use content <- result.try(parse_required_content(node, context, index))
 
   Ok(RequestBody(description:, content:, required:))
 }
@@ -699,6 +806,7 @@ fn parse_request_body(
 fn parse_required_content(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(Dict(String, MediaType), Diagnostic) {
   case yay.select_sugar(from: node, selector: "content") {
     Ok(yay.NodeMap(entries)) -> {
@@ -712,6 +820,7 @@ fn parse_required_content(
                   use sr <- result.try(parse_schema_ref(
                     schema_node,
                     context <> ".schema",
+                    index,
                   ))
                   Ok(Some(sr))
                 }
@@ -720,7 +829,7 @@ fn parse_required_content(
             )
             let mt_example = value.extract_optional(value_node, "example")
             let mt_examples = value.extract_map(value_node, "examples")
-            use mt_encoding <- result.try(parse_encoding_map(value_node))
+            use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,
               media_type_name,
@@ -740,6 +849,11 @@ fn parse_required_content(
       Error(diagnostic.missing_field(
         path: context <> ".requestBody",
         field: "content",
+        loc: location_index.lookup_field(
+          index,
+          context <> ".requestBody",
+          "content",
+        ),
       ))
   }
 }
@@ -748,6 +862,7 @@ fn parse_required_content(
 fn parse_content(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(Dict(String, MediaType), Diagnostic) {
   case yay.select_sugar(from: node, selector: "content") {
     Ok(yay.NodeMap(entries)) -> {
@@ -761,6 +876,7 @@ fn parse_content(
                   use sr <- result.try(parse_schema_ref(
                     schema_node,
                     context <> ".schema",
+                    index,
                   ))
                   Ok(Some(sr))
                 }
@@ -769,7 +885,7 @@ fn parse_content(
             )
             let mt_example = value.extract_optional(value_node, "example")
             let mt_examples = value.extract_map(value_node, "examples")
-            use mt_encoding <- result.try(parse_encoding_map(value_node))
+            use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,
               media_type_name,
@@ -794,6 +910,7 @@ fn parse_responses(
   node: yay.Node,
   _context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Dict(http.HttpStatusCode, RefOr(Response(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
@@ -809,6 +926,7 @@ fn parse_responses(
                     use resp <- result.try(parse_response(
                       value_node,
                       components,
+                      index,
                     ))
                     Ok(dict.insert(acc, code, resp))
                   }
@@ -816,7 +934,7 @@ fn parse_responses(
                 }
             }
           yay.NodeInt(code) -> {
-            use resp <- result.try(parse_response(value_node, components))
+            use resp <- result.try(parse_response(value_node, components, index))
             Ok(dict.insert(acc, http.Status(code), resp))
           }
           _ -> Ok(acc)
@@ -831,6 +949,7 @@ fn parse_responses(
 fn parse_response(
   node: yay.Node,
   _components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(RefOr(Response(Unresolved)), Diagnostic) {
   // Check for $ref first
   case yay.extract_optional_string(node, "$ref") {
@@ -841,12 +960,16 @@ fn parse_response(
         yay.extract_string(node, "description")
         |> result.map(Some)
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "response", field: "description")
+          diagnostic.missing_field(
+            path: "response",
+            field: "description",
+            loc: location_index.lookup_field(index, "response", "description"),
+          )
         }),
       )
 
-      use content <- result.try(parse_content(node, "response"))
-      use headers <- result.try(parse_headers_map(node))
+      use content <- result.try(parse_content(node, "response", index))
+      use headers <- result.try(parse_headers_map(node, index))
       use links <- result.try(parse_links_map(node))
 
       Ok(Value(Response(description:, content:, headers:, links:)))
@@ -857,21 +980,32 @@ fn parse_response(
 /// Parse the components section.
 fn parse_components(
   root: yay.Node,
+  index: LocationIndex,
 ) -> Result(Components(Unresolved), Diagnostic) {
   use components_node <- result.try(
     yay.select_sugar(from: root, selector: "components")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "", field: "components")
+      diagnostic.missing_field(
+        path: "",
+        field: "components",
+        loc: location_index.lookup_field(index, "", "components"),
+      )
     }),
   )
 
-  use schemas <- result.try(parse_schemas_map(components_node))
-  use parameters <- result.try(parse_parameters_map(components_node))
-  use request_bodies <- result.try(parse_request_bodies_map(components_node))
-  use responses <- result.try(parse_responses_map(components_node))
-  use security_schemes <- result.try(parse_security_schemes_map(components_node))
-  use path_items <- result.try(parse_path_items_map(components_node))
-  use headers <- result.try(parse_headers_map(components_node))
+  use schemas <- result.try(parse_schemas_map(components_node, index))
+  use parameters <- result.try(parse_parameters_map(components_node, index))
+  use request_bodies <- result.try(parse_request_bodies_map(
+    components_node,
+    index,
+  ))
+  use responses <- result.try(parse_responses_map(components_node, index))
+  use security_schemes <- result.try(parse_security_schemes_map(
+    components_node,
+    index,
+  ))
+  use path_items <- result.try(parse_path_items_map(components_node, index))
+  use headers <- result.try(parse_headers_map(components_node, index))
   let examples = value.extract_map(components_node, "examples")
   use links <- result.try(parse_links_map(components_node))
 
@@ -891,6 +1025,7 @@ fn parse_components(
 /// Parse the schemas map from components.
 fn parse_schemas_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, SchemaRef), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "schemas") {
     Ok(yay.NodeMap(entries)) -> {
@@ -901,6 +1036,7 @@ fn parse_schemas_map(
             use schema_ref <- result.try(parse_schema_ref(
               value_node,
               "components.schemas." <> name,
+              index,
             ))
             Ok(dict.insert(acc, name, schema_ref))
           }
@@ -915,6 +1051,7 @@ fn parse_schemas_map(
 /// Parse the parameters map from components.
 fn parse_parameters_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(Parameter(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "parameters") {
     Ok(yay.NodeMap(entries)) -> {
@@ -925,7 +1062,11 @@ fn parse_parameters_map(
             case yay.extract_optional_string(value_node, "$ref") {
               Ok(Some(ref_str)) -> Ok(dict.insert(acc, name, Ref(ref_str)))
               _ -> {
-                use param <- result.try(parse_parameter(value_node, None))
+                use param <- result.try(parse_parameter(
+                  value_node,
+                  None,
+                  index,
+                ))
                 Ok(dict.insert(acc, name, param))
               }
             }
@@ -941,6 +1082,7 @@ fn parse_parameters_map(
 /// Parse the requestBodies map from components.
 fn parse_request_bodies_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(RequestBody(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "requestBodies") {
     Ok(yay.NodeMap(entries)) -> {
@@ -954,6 +1096,7 @@ fn parse_request_bodies_map(
                 use rb <- result.try(parse_request_body(
                   value_node,
                   "components.requestBodies." <> name,
+                  index,
                 ))
                 Ok(dict.insert(acc, name, Value(rb)))
               }
@@ -970,6 +1113,7 @@ fn parse_request_bodies_map(
 /// Parse the responses map from components.
 fn parse_responses_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(Response(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
@@ -980,7 +1124,7 @@ fn parse_responses_map(
             case yay.extract_optional_string(value_node, "$ref") {
               Ok(Some(ref_str)) -> Ok(dict.insert(acc, name, Ref(ref_str)))
               _ -> {
-                use resp <- result.try(parse_response(value_node, None))
+                use resp <- result.try(parse_response(value_node, None, index))
                 Ok(dict.insert(acc, name, resp))
               }
             }
@@ -997,11 +1141,12 @@ fn parse_responses_map(
 pub fn parse_schema_ref(
   node: yay.Node,
   path: String,
+  index: LocationIndex,
 ) -> Result(SchemaRef, Diagnostic) {
   case yay.extract_optional_string(node, "$ref") {
     Ok(Some(ref)) -> Ok(schema.make_reference(ref))
     _ -> {
-      use schema_obj <- result.try(parse_schema_object(node, path))
+      use schema_obj <- result.try(parse_schema_object(node, path, index))
       Ok(Inline(schema_obj))
     }
   }
@@ -1011,6 +1156,7 @@ pub fn parse_schema_ref(
 pub fn parse_schema_object(
   node: yay.Node,
   path: String,
+  index: LocationIndex,
 ) -> Result(SchemaObject, Diagnostic) {
   let nullable =
     yay.extract_optional_bool(node, "nullable")
@@ -1069,7 +1215,7 @@ pub fn parse_schema_object(
   case yay.select_sugar(from: node, selector: "allOf") {
     Ok(yay.NodeSeq(items)) -> {
       use schemas <- result.try(
-        list.try_map(items, parse_schema_ref(_, path <> ".allOf")),
+        list.try_map(items, parse_schema_ref(_, path <> ".allOf", index)),
       )
       Ok(AllOfSchema(metadata:, schemas:))
     }
@@ -1077,12 +1223,12 @@ pub fn parse_schema_object(
       case yay.select_sugar(from: node, selector: "oneOf") {
         Ok(yay.NodeSeq(items)) -> {
           use schemas <- result.try(
-            list.try_map(items, parse_schema_ref(_, path <> ".oneOf")),
+            list.try_map(items, parse_schema_ref(_, path <> ".oneOf", index)),
           )
           use discriminator <- result.try(
             case yay.select_sugar(from: node, selector: "discriminator") {
               Ok(_) -> {
-                use d <- result.try(parse_discriminator(node))
+                use d <- result.try(parse_discriminator(node, index))
                 Ok(Some(d))
               }
               Error(_) -> Ok(None)
@@ -1094,12 +1240,12 @@ pub fn parse_schema_object(
           case yay.select_sugar(from: node, selector: "anyOf") {
             Ok(yay.NodeSeq(items)) -> {
               use schemas <- result.try(
-                list.try_map(items, parse_schema_ref(_, path <> ".anyOf")),
+                list.try_map(items, parse_schema_ref(_, path <> ".anyOf", index)),
               )
               use discriminator <- result.try(
                 case yay.select_sugar(from: node, selector: "discriminator") {
                   Ok(_) -> {
-                    use d <- result.try(parse_discriminator(node))
+                    use d <- result.try(parse_discriminator(node, index))
                     Ok(Some(d))
                   }
                   Error(_) -> Ok(None)
@@ -1107,7 +1253,7 @@ pub fn parse_schema_object(
               )
               Ok(AnyOfSchema(metadata:, schemas:, discriminator:))
             }
-            _ -> parse_typed_schema(node, metadata, path)
+            _ -> parse_typed_schema(node, metadata, path, index)
           }
       }
   }
@@ -1135,6 +1281,7 @@ fn parse_typed_schema(
   node: yay.Node,
   metadata: schema.SchemaMetadata,
   path: String,
+  index: LocationIndex,
 ) -> Result(SchemaObject, Diagnostic) {
   // OpenAPI 3.1 allows type to be an array, e.g. type: [string, 'null'].
   // Extract the primary type and detect nullable from the array form.
@@ -1280,8 +1427,14 @@ fn parse_typed_schema(
     "array" -> {
       use items <- result.try(
         case yay.select_sugar(from: node, selector: "items") {
-          Ok(items_node) -> parse_schema_ref(items_node, path <> ".items")
-          _ -> Error(diagnostic.missing_field(path: path, field: "items"))
+          Ok(items_node) ->
+            parse_schema_ref(items_node, path <> ".items", index)
+          _ ->
+            Error(diagnostic.missing_field(
+              path: path,
+              field: "items",
+              loc: location_index.lookup_field(index, path, "items"),
+            ))
         },
       )
       let min_items =
@@ -1296,7 +1449,7 @@ fn parse_typed_schema(
     }
 
     "object" -> {
-      use properties <- result.try(parse_properties(node, path))
+      use properties <- result.try(parse_properties(node, path, index))
       let required = case yay.extract_string_list(node, "required") {
         Ok(r) -> r
         _ -> []
@@ -1309,6 +1462,7 @@ fn parse_typed_schema(
             use sr <- result.try(parse_schema_ref(
               ap_node,
               path <> ".additionalProperties",
+              index,
             ))
             Ok(schema.Typed(sr))
           }
@@ -1338,6 +1492,7 @@ fn parse_typed_schema(
         detail: "Unrecognized schema type '"
           <> unrecognized
           <> "'. Supported types: string, integer, number, boolean, array, object.",
+        loc: location_index.lookup(index, path <> ".type"),
       ))
   }
 }
@@ -1346,6 +1501,7 @@ fn parse_typed_schema(
 fn parse_properties(
   node: yay.Node,
   path: String,
+  index: LocationIndex,
 ) -> Result(Dict(String, SchemaRef), Diagnostic) {
   case yay.select_sugar(from: node, selector: "properties") {
     Ok(yay.NodeMap(entries)) -> {
@@ -1356,6 +1512,7 @@ fn parse_properties(
             use schema_ref <- result.try(parse_schema_ref(
               value_node,
               path <> "." <> prop_name,
+              index,
             ))
             Ok(dict.insert(acc, prop_name, schema_ref))
           }
@@ -1368,18 +1525,33 @@ fn parse_properties(
 }
 
 /// Parse discriminator from a node.
-fn parse_discriminator(node: yay.Node) -> Result(Discriminator, Diagnostic) {
+fn parse_discriminator(
+  node: yay.Node,
+  index: LocationIndex,
+) -> Result(Discriminator, Diagnostic) {
   use disc_node <- result.try(
     yay.select_sugar(from: node, selector: "discriminator")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "schema", field: "discriminator")
+      diagnostic.missing_field(
+        path: "schema",
+        field: "discriminator",
+        loc: location_index.lookup_field(index, "schema", "discriminator"),
+      )
     }),
   )
 
   use property_name <- result.try(
     yay.extract_string(disc_node, "propertyName")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "discriminator", field: "propertyName")
+      diagnostic.missing_field(
+        path: "discriminator",
+        field: "propertyName",
+        loc: location_index.lookup_field(
+          index,
+          "discriminator",
+          "propertyName",
+        ),
+      )
     }),
   )
 
@@ -1401,6 +1573,7 @@ pub fn parse_error_to_string(error: Diagnostic) -> String {
 /// malformed.
 fn parse_security_schemes_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(spec.SecurityScheme)), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "securitySchemes") {
     Ok(yay.NodeMap(entries)) -> {
@@ -1411,7 +1584,10 @@ fn parse_security_schemes_map(
             case yay.extract_optional_string(value_node, "$ref") {
               Ok(Some(ref_str)) -> Ok(dict.insert(acc, name, Ref(ref_str)))
               _ -> {
-                use scheme <- result.try(parse_security_scheme(value_node))
+                use scheme <- result.try(parse_security_scheme(
+                  value_node,
+                  index,
+                ))
                 Ok(dict.insert(acc, name, Value(scheme)))
               }
             }
@@ -1427,6 +1603,7 @@ fn parse_security_schemes_map(
 /// Parse the pathItems map from components.
 fn parse_path_items_map(
   components_node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(PathItem(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "pathItems") {
     Ok(yay.NodeMap(entries)) -> {
@@ -1441,6 +1618,7 @@ fn parse_path_items_map(
                   value_node,
                   "components.pathItems." <> name,
                   None,
+                  index,
                 ))
                 Ok(dict.insert(acc, name, Value(path_item)))
               }
@@ -1457,11 +1635,16 @@ fn parse_path_items_map(
 /// Parse a single security scheme.
 fn parse_security_scheme(
   node: yay.Node,
+  index: LocationIndex,
 ) -> Result(spec.SecurityScheme, Diagnostic) {
   use type_str <- result.try(
     yay.extract_string(node, "type")
     |> result.map_error(fn(_) {
-      diagnostic.missing_field(path: "securityScheme", field: "type")
+      diagnostic.missing_field(
+        path: "securityScheme",
+        field: "type",
+        loc: location_index.lookup_field(index, "securityScheme", "type"),
+      )
     }),
   )
 
@@ -1470,16 +1653,32 @@ fn parse_security_scheme(
       use name <- result.try(
         yay.extract_string(node, "name")
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "securityScheme.apiKey", field: "name")
+          diagnostic.missing_field(
+            path: "securityScheme.apiKey",
+            field: "name",
+            loc: location_index.lookup_field(
+              index,
+              "securityScheme.apiKey",
+              "name",
+            ),
+          )
         }),
       )
       use in_str <- result.try(
         yay.extract_string(node, "in")
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "securityScheme.apiKey", field: "in")
+          diagnostic.missing_field(
+            path: "securityScheme.apiKey",
+            field: "in",
+            loc: location_index.lookup_field(
+              index,
+              "securityScheme.apiKey",
+              "in",
+            ),
+          )
         }),
       )
-      case parse_security_scheme_in(in_str) {
+      case parse_security_scheme_in(in_str, index) {
         Ok(in_) -> Ok(spec.ApiKeyScheme(name:, in_:))
         Error(_) ->
           Error(diagnostic.invalid_value(
@@ -1487,6 +1686,7 @@ fn parse_security_scheme(
             detail: "Only 'header', 'query' and 'cookie' are supported for apiKey. Got: '"
               <> in_str
               <> "'",
+            loc: location_index.lookup(index, "securityScheme.apiKey.in"),
           ))
       }
     }
@@ -1494,7 +1694,15 @@ fn parse_security_scheme(
       use scheme <- result.try(
         yay.extract_string(node, "scheme")
         |> result.map_error(fn(_) {
-          diagnostic.missing_field(path: "securityScheme.http", field: "scheme")
+          diagnostic.missing_field(
+            path: "securityScheme.http",
+            field: "scheme",
+            loc: location_index.lookup_field(
+              index,
+              "securityScheme.http",
+              "scheme",
+            ),
+          )
         }),
       )
       let bearer_format =
@@ -1519,6 +1727,11 @@ fn parse_security_scheme(
           diagnostic.missing_field(
             path: "securityScheme.openIdConnect",
             field: "openIdConnectUrl",
+            loc: location_index.lookup_field(
+              index,
+              "securityScheme.openIdConnect",
+              "openIdConnectUrl",
+            ),
           )
         }),
       )
@@ -1585,11 +1798,12 @@ fn parse_oauth2_flows(node: yay.Node) -> dict.Dict(String, spec.OAuth2Flow) {
 fn parse_security_requirements(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(List(SecurityRequirement), Diagnostic) {
   case yay.select_sugar(from: node, selector: "security") {
     Ok(yay.NodeSeq(items)) ->
       list.try_map(items, fn(item) {
-        parse_security_requirement_object(item, context)
+        parse_security_requirement_object(item, context, index)
       })
     _ -> Ok([])
   }
@@ -1601,12 +1815,13 @@ fn parse_security_requirements(
 fn parse_optional_security_requirements(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(Option(List(SecurityRequirement)), Diagnostic) {
   case yay.select_sugar(from: node, selector: "security") {
     Ok(yay.NodeSeq(items)) -> {
       use reqs <- result.try(
         list.try_map(items, fn(item) {
-          parse_security_requirement_object(item, context)
+          parse_security_requirement_object(item, context, index)
         }),
       )
       Ok(Some(reqs))
@@ -1621,6 +1836,7 @@ fn parse_optional_security_requirements(
 fn parse_security_requirement_object(
   node: yay.Node,
   context: String,
+  index: LocationIndex,
 ) -> Result(SecurityRequirement, Diagnostic) {
   case node {
     yay.NodeMap(entries) -> {
@@ -1638,6 +1854,10 @@ fn parse_security_requirement_object(
                         Error(diagnostic.invalid_value(
                           path: context <> ".security." <> scheme_name,
                           detail: "Scope must be a string",
+                          loc: location_index.lookup(
+                            index,
+                            context <> ".security." <> scheme_name,
+                          ),
                         ))
                     }
                   })
@@ -1646,6 +1866,10 @@ fn parse_security_requirement_object(
                   Error(diagnostic.invalid_value(
                     path: context <> ".security." <> scheme_name,
                     detail: "Scopes must be an array of strings",
+                    loc: location_index.lookup(
+                      index,
+                      context <> ".security." <> scheme_name,
+                    ),
                   ))
               })
               Ok(spec.SecuritySchemeRef(scheme_name:, scopes:))
@@ -1654,6 +1878,7 @@ fn parse_security_requirement_object(
               Error(diagnostic.invalid_value(
                 path: context <> ".security",
                 detail: "Security requirement key must be a string",
+                loc: location_index.lookup(index, context <> ".security"),
               ))
           }
         }),
@@ -1664,6 +1889,7 @@ fn parse_security_requirement_object(
       Error(diagnostic.invalid_value(
         path: context <> ".security",
         detail: "Security requirement must be an object",
+        loc: location_index.lookup(index, context <> ".security"),
       ))
   }
 }
@@ -1675,6 +1901,7 @@ fn parse_callbacks(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(dict.Dict(String, Callback(Unresolved)), Diagnostic) {
   case yay.select_sugar(from: node, selector: "callbacks") {
     Ok(yay.NodeMap(entries)) -> {
@@ -1686,6 +1913,7 @@ fn parse_callbacks(
               value_node,
               context,
               components,
+              index,
             ))
             Ok(dict.insert(acc, callback_name, callback))
           }
@@ -1703,6 +1931,7 @@ fn parse_callback_object(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Callback(Unresolved), Diagnostic) {
   case node {
     yay.NodeMap(entries) -> {
@@ -1722,6 +1951,7 @@ fn parse_callback_object(
                     path_item_node,
                     context <> ".callbacks." <> url_expression,
                     components,
+                    index,
                   ))
                   Ok([#(url_expression, Value(path_item)), ..acc])
                 }
@@ -1736,6 +1966,11 @@ fn parse_callback_object(
           Error(diagnostic.missing_field(
             path: context <> ".callbacks",
             field: "url expression",
+            loc: location_index.lookup_field(
+              index,
+              context <> ".callbacks",
+              "url expression",
+            ),
           ))
         _ -> Ok(Callback(entries: dict.from_list(parsed_entries)))
       }
@@ -1744,6 +1979,11 @@ fn parse_callback_object(
       Error(diagnostic.missing_field(
         path: context <> ".callbacks",
         field: "url expression",
+        loc: location_index.lookup_field(
+          index,
+          context <> ".callbacks",
+          "url expression",
+        ),
       ))
   }
 }
@@ -1859,6 +2099,7 @@ fn parse_tags(node: yay.Node) -> List(Tag) {
 fn parse_webhooks(
   node: yay.Node,
   components: Option(Components(Unresolved)),
+  index: LocationIndex,
 ) -> Result(Dict(String, RefOr(PathItem(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "webhooks") {
     Ok(yay.NodeMap(entries)) -> {
@@ -1877,6 +2118,7 @@ fn parse_webhooks(
                   value_node,
                   "webhooks." <> name,
                   components,
+                  index,
                 ))
                 Ok(dict.insert(acc, name, Value(path_item)))
               }
@@ -1893,6 +2135,7 @@ fn parse_webhooks(
 /// Parse a content map (non-result version for use in Parameter).
 fn parse_content_map(
   node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, MediaType), Diagnostic) {
   case yay.select_sugar(from: node, selector: "content") {
     Ok(yay.NodeMap(entries)) ->
@@ -1906,6 +2149,7 @@ fn parse_content_map(
                   use sr <- result.try(parse_schema_ref(
                     schema_node,
                     "content.schema",
+                    index,
                   ))
                   Ok(Some(sr))
                 }
@@ -1914,7 +2158,7 @@ fn parse_content_map(
             )
             let mt_example = value.extract_optional(value_node, "example")
             let mt_examples = value.extract_map(value_node, "examples")
-            use mt_encoding <- result.try(parse_encoding_map(value_node))
+            use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,
               media_type_name,
@@ -1936,6 +2180,7 @@ fn parse_content_map(
 /// Parse encoding map from a media type node.
 fn parse_encoding_map(
   node: yay.Node,
+  index: LocationIndex,
 ) -> Result(Dict(String, Encoding), Diagnostic) {
   case yay.select_sugar(from: node, selector: "encoding") {
     Ok(yay.NodeMap(entries)) ->
@@ -1952,7 +2197,7 @@ fn parse_encoding_map(
                 |> result.unwrap(None)
               {
                 Some(s) -> {
-                  use parsed <- result.try(parse_parameter_style(s))
+                  use parsed <- result.try(parse_parameter_style(s, index))
                   Ok(Some(parsed))
                 }
                 None -> Ok(None)
@@ -1975,7 +2220,10 @@ fn parse_encoding_map(
 }
 
 /// Parse headers map from a node.
-fn parse_headers_map(node: yay.Node) -> Result(Dict(String, Header), Diagnostic) {
+fn parse_headers_map(
+  node: yay.Node,
+  index: LocationIndex,
+) -> Result(Dict(String, Header), Diagnostic) {
   case yay.select_sugar(from: node, selector: "headers") {
     Ok(yay.NodeMap(entries)) ->
       list.try_fold(entries, dict.new(), fn(acc, entry) {
@@ -1995,6 +2243,7 @@ fn parse_headers_map(node: yay.Node) -> Result(Dict(String, Header), Diagnostic)
                   use sr <- result.try(parse_schema_ref(
                     schema_node,
                     "header." <> header_name <> ".schema",
+                    index,
                   ))
                   Ok(Some(sr))
                 }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -553,9 +553,7 @@ fn parse_parameters_list(
 ) -> Result(List(RefOr(Parameter(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "parameters") {
     Ok(yay.NodeSeq(items)) ->
-      list.try_map(items, fn(item) {
-        parse_parameter(item, components, index)
-      })
+      list.try_map(items, fn(item) { parse_parameter(item, components, index) })
     _ -> Ok([])
   }
 }
@@ -589,11 +587,7 @@ fn parse_parameter(
           diagnostic.missing_field(
             path: "parameter." <> name,
             field: "in",
-            loc: location_index.lookup_field(
-              index,
-              "parameter." <> name,
-              "in",
-            ),
+            loc: location_index.lookup_field(index, "parameter." <> name, "in"),
           )
         }),
       )
@@ -1062,11 +1056,7 @@ fn parse_parameters_map(
             case yay.extract_optional_string(value_node, "$ref") {
               Ok(Some(ref_str)) -> Ok(dict.insert(acc, name, Ref(ref_str)))
               _ -> {
-                use param <- result.try(parse_parameter(
-                  value_node,
-                  None,
-                  index,
-                ))
+                use param <- result.try(parse_parameter(value_node, None, index))
                 Ok(dict.insert(acc, name, param))
               }
             }
@@ -1546,11 +1536,7 @@ fn parse_discriminator(
       diagnostic.missing_field(
         path: "discriminator",
         field: "propertyName",
-        loc: location_index.lookup_field(
-          index,
-          "discriminator",
-          "propertyName",
-        ),
+        loc: location_index.lookup_field(index, "discriminator", "propertyName"),
       )
     }),
   )

--- a/src/oaspec/openapi/resolve.gleam
+++ b/src/oaspec/openapi/resolve.gleam
@@ -4,7 +4,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/set
 import gleam/string
-import oaspec/openapi/diagnostic.{type Diagnostic}
+import oaspec/openapi/diagnostic.{type Diagnostic, NoSourceLoc}
 import oaspec/openapi/spec.{
   type Callback, type Components, type OpenApiSpec, type Operation,
   type Parameter, type PathItem, type RefOr, type RequestBody, type Resolved,
@@ -158,6 +158,7 @@ fn resolve_alias(
         hint: Some(
           "Check that component $ref chains don't form a cycle. Each $ref must eventually point to a concrete definition.",
         ),
+        loc: NoSourceLoc,
       ))
     False -> {
       let new_seen = set.insert(seen, ref)
@@ -176,6 +177,7 @@ fn resolve_alias(
             hint: Some(
               "Verify the target component exists and the $ref path is spelled correctly.",
             ),
+            loc: NoSourceLoc,
           ))
       }
     }
@@ -210,6 +212,7 @@ fn validate_ref_kind(
         hint: Some(
           "Use the correct $ref prefix for the component type (e.g., #/components/schemas/ for schemas).",
         ),
+        loc: NoSourceLoc,
       ))
   }
 }
@@ -269,6 +272,7 @@ fn resolve_path_item_ref(
                 hint: Some(
                   "Verify the referenced component exists and the $ref path is spelled correctly.",
                 ),
+                loc: NoSourceLoc,
               ))
           }
         }
@@ -282,6 +286,7 @@ fn resolve_path_item_ref(
         hint: Some(
           "Verify the referenced component exists and the $ref path is spelled correctly.",
         ),
+        loc: NoSourceLoc,
       ))
     Error(_) ->
       Error(diagnostic.resolve_error(
@@ -292,6 +297,7 @@ fn resolve_path_item_ref(
         hint: Some(
           "Verify the referenced component exists and the $ref path is spelled correctly.",
         ),
+        loc: NoSourceLoc,
       ))
   }
 }
@@ -434,6 +440,7 @@ fn resolve_param_ref(
               <> ref_str
               <> " — target not found in components.parameters",
             hint: Some("Verify the parameter exists in components.parameters."),
+            loc: NoSourceLoc,
           ))
       }
     }
@@ -465,6 +472,7 @@ fn resolve_request_body_ref(
             hint: Some(
               "Verify the request body exists in components.requestBodies.",
             ),
+            loc: NoSourceLoc,
           ))
       }
     }
@@ -494,6 +502,7 @@ fn resolve_response_ref(
               <> ref_str
               <> " — target not found in components.responses",
             hint: Some("Verify the response exists in components.responses."),
+            loc: NoSourceLoc,
           ))
       }
     }

--- a/src/yaml_loc_ffi.erl
+++ b/src/yaml_loc_ffi.erl
@@ -1,0 +1,75 @@
+-module(yaml_loc_ffi).
+
+-export([build_location_index/1]).
+
+%% Build a location index from a YAML string.
+%% Returns a list of {BinaryPath, {Line, Column}} tuples that Gleam can
+%% convert into a Dict(String, SourceLoc).
+-spec build_location_index(binary()) -> {ok, list({binary(), {integer(), integer()}})} | {error, nil}.
+build_location_index(Content) ->
+    try
+        application:ensure_all_started(yamerl),
+        [Doc | _] = yamerl_constr:string(
+            binary_to_list(Content),
+            [{detailed_constr, true}, {keep_duplicate_keys, true}]
+        ),
+        {yamerl_doc, Root} = Doc,
+        Acc = walk_node(Root, <<>>, []),
+        {ok, Acc}
+    catch
+        _:_ -> {ok, []}
+    end.
+
+%% Walk a yamerl node tree and collect {Path, {Line, Col}} entries.
+-spec walk_node(tuple(), binary(), list()) -> list().
+walk_node(Node, Path, Acc) ->
+    Loc = extract_loc(Node),
+    Acc1 = [{Path, Loc} | Acc],
+    case Node of
+        {yamerl_map, _, _, _, Pairs} when is_list(Pairs) ->
+            walk_map_pairs(Pairs, Path, Acc1);
+        {yamerl_seq, _, _, _, Items, _Count} when is_list(Items) ->
+            walk_seq_items(Items, Path, 0, Acc1);
+        _ ->
+            Acc1
+    end.
+
+-spec walk_map_pairs(list(), binary(), list()) -> list().
+walk_map_pairs([], _ParentPath, Acc) ->
+    Acc;
+walk_map_pairs([{KeyNode, ValueNode} | Rest], ParentPath, Acc) ->
+    KeyStr = node_to_key(KeyNode),
+    ChildPath = case ParentPath of
+        <<>> -> KeyStr;
+        _ -> <<ParentPath/binary, ".", KeyStr/binary>>
+    end,
+    Acc1 = walk_node(ValueNode, ChildPath, Acc),
+    walk_map_pairs(Rest, ParentPath, Acc1).
+
+-spec walk_seq_items(list(), binary(), integer(), list()) -> list().
+walk_seq_items([], _ParentPath, _Idx, Acc) ->
+    Acc;
+walk_seq_items([Item | Rest], ParentPath, Idx, Acc) ->
+    IdxBin = integer_to_binary(Idx),
+    ChildPath = <<ParentPath/binary, "[", IdxBin/binary, "]">>,
+    Acc1 = walk_node(Item, ChildPath, Acc),
+    walk_seq_items(Rest, ParentPath, Idx + 1, Acc1).
+
+-spec extract_loc(tuple()) -> {integer(), integer()}.
+extract_loc(Node) ->
+    Pres = element(4, Node),
+    Line = proplists:get_value(line, Pres, 0),
+    Col = proplists:get_value(column, Pres, 0),
+    {Line, Col}.
+
+-spec node_to_key(tuple()) -> binary().
+node_to_key({yamerl_str, _, _, _, Text}) ->
+    unicode:characters_to_binary(Text);
+node_to_key({yamerl_int, _, _, _, Int}) ->
+    integer_to_binary(Int);
+node_to_key({yamerl_bool, _, _, _, true}) ->
+    <<"true">>;
+node_to_key({yamerl_bool, _, _, _, false}) ->
+    <<"false">>;
+node_to_key(_) ->
+    <<"_unknown_">>.

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -19,7 +19,8 @@ import oaspec/config
 import oaspec/generate
 import oaspec/openapi/capability_check
 import oaspec/openapi/dedup
-import oaspec/openapi/diagnostic.{Diagnostic}
+import oaspec/openapi/diagnostic.{Diagnostic, NoSourceLoc, SourceLoc}
+import oaspec/openapi/location_index
 import oaspec/openapi/hoist
 import oaspec/openapi/normalize
 import oaspec/openapi/parser
@@ -12208,4 +12209,97 @@ paths:
   // Should have server override comment
   string.contains(client_file.content, "Server override")
   |> should.be_true()
+}
+
+// ============================================================================
+// Source location tests (Issue #188)
+// ============================================================================
+
+pub fn location_index_build_extracts_locations_test() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+
+  // Root-level keys should have locations
+  let loc = location_index.lookup(index, "openapi")
+  case loc {
+    SourceLoc(line: _, column: _) -> should.be_true(True)
+    NoSourceLoc -> should.fail()
+  }
+}
+
+pub fn location_index_lookup_field_returns_source_loc_test() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+
+  let loc = location_index.lookup_field(index, "info", "title")
+  case loc {
+    SourceLoc(line: _, column: _) -> should.be_true(True)
+    NoSourceLoc -> should.fail()
+  }
+}
+
+pub fn location_index_lookup_missing_returns_no_source_loc_test() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+
+  let loc = location_index.lookup(index, "nonexistent.path")
+  loc |> should.equal(NoSourceLoc)
+}
+
+pub fn location_index_empty_returns_no_source_loc_test() {
+  let index = location_index.empty()
+  let loc = location_index.lookup(index, "openapi")
+  loc |> should.equal(NoSourceLoc)
+}
+
+pub fn missing_field_diagnostic_has_source_location_test() {
+  let yaml =
+    "openapi: \"3.0.0\"
+paths: {}
+"
+
+  case parser.parse_string(yaml) {
+    Error(Diagnostic(source_loc: loc, code: "missing_field", ..)) ->
+      case loc {
+        SourceLoc(line: _, column: _) -> should.be_true(True)
+        NoSourceLoc -> should.fail()
+      }
+    _ -> should.fail()
+  }
+}
+
+pub fn location_index_root_path_has_source_loc_test() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+
+  // Root path should have line 1 location
+  let loc = location_index.lookup(index, "")
+  case loc {
+    SourceLoc(line: 1, column: _) -> should.be_true(True)
+    _ -> should.fail()
+  }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -20,8 +20,8 @@ import oaspec/generate
 import oaspec/openapi/capability_check
 import oaspec/openapi/dedup
 import oaspec/openapi/diagnostic.{Diagnostic, NoSourceLoc, SourceLoc}
-import oaspec/openapi/location_index
 import oaspec/openapi/hoist
+import oaspec/openapi/location_index
 import oaspec/openapi/normalize
 import oaspec/openapi/parser
 import oaspec/openapi/provenance


### PR DESCRIPTION
## Summary

- Add a LocationIndex that maps YAML paths to line/column source locations, enabling parse and resolve diagnostics to report where errors occur
- Thread source locations through all missing_field, invalid_value, and resolve_error diagnostics
- Add 6 new tests verifying that the LocationIndex correctly extracts and reports source locations

## Changes

- **src/yaml_loc_ffi.erl**: New Erlang FFI that calls yamerl directly to extract line/column information from YAML nodes (yamerl preserves locations in its `pres` proplist, but the yay library discards them)
- **src/oaspec/openapi/location_index.gleam**: New `LocationIndex` opaque type with `build`, `lookup`, and `lookup_field` functions
- **src/oaspec/openapi/diagnostic.gleam**: Add `loc: SourceLoc` parameter to `missing_field`, `invalid_value`, and `resolve_error` constructors
- **src/oaspec/openapi/parser.gleam**: Thread `LocationIndex` through all internal parse functions (~40 function signatures); update ~32 diagnostic call sites with location lookups
- **src/oaspec/openapi/resolve.gleam**: Add `loc: NoSourceLoc` to all 9 resolve_error call sites (resolve phase will gain location support when LocationIndex is threaded through in a follow-up)
- **test/oaspec_test.gleam**: Add 6 new tests for LocationIndex build/lookup/empty and missing_field diagnostic source location
- **README.md**: Update unit test count (667 → 673)

## Design Decisions

- **LocationIndex approach**: Rather than replacing the yay Node type or modifying the yay dependency, we build a parallel path→location index by calling yamerl directly via FFI. This minimizes changes to existing yay.Node pattern matching while providing accurate locations for diagnostics
- **Double parse**: The YAML is parsed twice (once by yay for data, once by yamerl FFI for locations). This is negligible for typical OpenAPI spec sizes and avoids coupling to yay internals
- **Resolve phase uses NoSourceLoc**: The resolve phase does not yet receive LocationIndex — it will be threaded through in a follow-up. The diagnostic constructor signature change ensures the plumbing is ready
- **Path format**: The LocationIndex uses dotted paths (`info.title`, `paths./pets.get`) matching the parser's context string convention. Deep nested paths may not always match, so `lookup` gracefully falls back to `NoSourceLoc`

## Limitations

- Resolve-phase diagnostics still report `NoSourceLoc` (plumbing ready, threading deferred)
- Deep nested paths (parameters, responses) may not always match between the parser context and the location index due to different naming conventions

Closes #188