### PR TITLE
refactor(codegen): extract shared operation IR for parameter serialization rules

### DIFF
--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -3,6 +3,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context}
 import oaspec/codegen/ir_build
+import oaspec/codegen/operation_ir
 import oaspec/codegen/schema_dispatch
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{Inline, Reference}
@@ -810,24 +811,7 @@ pub fn is_exploded_array_param(
   }
   case is_array {
     False -> False
-    True -> effective_explode(param)
-  }
-}
-
-/// Per OpenAPI 3.x: explode defaults to true only for `form` (and
-/// `deepObject`); for all other styles — including simple, pipeDelimited,
-/// and spaceDelimited — the default is false. None style on a query
-/// parameter is equivalent to form.
-fn effective_explode(param: spec.Parameter(Resolved)) -> Bool {
-  case param.explode {
-    option.Some(v) -> v
-    option.None ->
-      case param.style {
-        option.Some(spec.FormStyle)
-        | option.Some(spec.DeepObjectStyle)
-        | option.None -> True
-        _ -> False
-      }
+    True -> operation_ir.effective_explode(param)
   }
 }
 
@@ -849,10 +833,11 @@ pub fn is_delimited_array_param(
   }
   // Use spec-default explode rules (false for pipe/space) so that omitting
   // `explode` yields the delimited path, matching OpenAPI semantics.
-  let is_non_exploded = !effective_explode(param)
+  let is_non_exploded = !operation_ir.effective_explode(param)
   case is_array, is_non_exploded, param.style {
-    True, True, option.Some(spec.PipeDelimitedStyle) -> option.Some("|")
-    True, True, option.Some(spec.SpaceDelimitedStyle) -> option.Some(" ")
+    True, True, option.Some(spec.PipeDelimitedStyle)
+    | True, True, option.Some(spec.SpaceDelimitedStyle)
+    -> option.Some(operation_ir.delimiter_for_style(param.style))
     _, _, _ -> option.None
   }
 }
@@ -987,15 +972,7 @@ pub fn is_deep_object_param(
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> Bool {
-  case param.payload {
-    ParameterSchema(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
-        Ok(schema.ObjectSchema(..)) -> True
-        _ -> False
-      }
-    ParameterSchema(Inline(schema.ObjectSchema(..))) -> True
-    _ -> False
-  }
+  operation_ir.is_deep_object_param(param, ctx)
 }
 
 /// Generate deepObject-style query parameters: key[prop]=value for each property.

--- a/src/oaspec/codegen/operation_ir.gleam
+++ b/src/oaspec/codegen/operation_ir.gleam
@@ -1,0 +1,52 @@
+import gleam/option.{type Option, None, Some}
+import oaspec/codegen/context.{type Context}
+import oaspec/openapi/resolver
+import oaspec/openapi/schema
+import oaspec/openapi/spec
+
+/// Compute the effective explode value for a parameter.
+/// OpenAPI 3.x default: true for form/deepObject style, false otherwise.
+/// When style is None (on a query parameter), the default is form → true.
+pub fn effective_explode(param: spec.Parameter(spec.Resolved)) -> Bool {
+  case param.explode {
+    Some(v) -> v
+    None ->
+      case param.style {
+        Some(spec.FormStyle) | Some(spec.DeepObjectStyle) | None -> True
+        _ -> False
+      }
+  }
+}
+
+/// Return the delimiter character for a parameter style.
+/// pipeDelimited → "|", spaceDelimited → " ", all others → ","
+pub fn delimiter_for_style(style: Option(spec.ParameterStyle)) -> String {
+  case style {
+    Some(spec.PipeDelimitedStyle) -> "|"
+    Some(spec.SpaceDelimitedStyle) -> " "
+    _ -> ","
+  }
+}
+
+/// Check if a parameter uses deepObject serialization.
+/// True when: in=query, style=deepObject, and schema is an ObjectSchema.
+pub fn is_deep_object_param(
+  param: spec.Parameter(spec.Resolved),
+  ctx: Context,
+) -> Bool {
+  case param.in_, param.style, spec.parameter_schema(param) {
+    spec.InQuery,
+      Some(spec.DeepObjectStyle),
+      Some(schema.Reference(..) as schema_ref)
+    ->
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+        Ok(schema.ObjectSchema(..)) -> True
+        _ -> False
+      }
+    spec.InQuery,
+      Some(spec.DeepObjectStyle),
+      Some(schema.Inline(schema.ObjectSchema(..)))
+    -> True
+    _, _, _ -> False
+  }
+}

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -4,6 +4,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/codegen/context.{type Context}
 import oaspec/codegen/ir_build
+import oaspec/codegen/operation_ir
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type AdditionalProperties, type SchemaRef, Forbidden, Inline, ObjectSchema,
@@ -17,16 +18,6 @@ import oaspec/util/naming
 /// Accepts "true"/"True"/"TRUE" etc. as True, everything else as False.
 /// This is compatible with Gleam's bool.to_string which produces "True"/"False".
 pub const bool_parse_expr = "case string.lowercase(v) { \"true\" -> True _ -> False }"
-
-/// Delimiter literal for splitting non-exploded array query values.
-/// Percent decoding is assumed to have already happened upstream (wisp/mist).
-fn split_delimiter_literal(style: Option(spec.ParameterStyle)) -> String {
-  case style {
-    Some(spec.PipeDelimitedStyle) -> "|"
-    Some(spec.SpaceDelimitedStyle) -> " "
-    _ -> ","
-  }
-}
 
 pub type DeepObjectProperty {
   DeepObjectProperty(
@@ -154,7 +145,7 @@ pub fn query_required_expr(
   query_required_expr_with_schema(
     key,
     spec.parameter_schema(param),
-    Some(effective_explode_for_query(param)),
+    Some(operation_ir.effective_explode(param)),
     param.style,
   )
 }
@@ -165,7 +156,7 @@ pub fn query_required_expr_with_schema(
   explode: Option(Bool),
   style: Option(spec.ParameterStyle),
 ) -> String {
-  let delim = split_delimiter_literal(style)
+  let delim = operation_ir.delimiter_for_style(style)
   let base = "{ let assert Ok([v, ..]) = dict.get(query, \"" <> key <> "\") v }"
   case schema_ref {
     Some(Inline(schema.ArraySchema(items: Inline(schema.StringSchema(..)), ..))) ->
@@ -250,22 +241,9 @@ pub fn query_optional_expr(
   query_optional_expr_with_schema(
     key,
     spec.parameter_schema(param),
-    Some(effective_explode_for_query(param)),
+    Some(operation_ir.effective_explode(param)),
     param.style,
   )
-}
-
-/// Per OpenAPI 3.x: explode defaults to true only for `form` (and
-/// `deepObject`); for all other styles the default is false.
-fn effective_explode_for_query(param: spec.Parameter(Resolved)) -> Bool {
-  case param.explode {
-    Some(v) -> v
-    None ->
-      case param.style {
-        Some(spec.FormStyle) | Some(spec.DeepObjectStyle) | None -> True
-        _ -> False
-      }
-  }
 }
 
 pub fn query_optional_expr_with_schema(
@@ -274,7 +252,7 @@ pub fn query_optional_expr_with_schema(
   explode: Option(Bool),
   style: Option(spec.ParameterStyle),
 ) -> String {
-  let delim = split_delimiter_literal(style)
+  let delim = operation_ir.delimiter_for_style(style)
   case schema_ref {
     Some(Inline(schema.ArraySchema(items: Inline(schema.StringSchema(..)), ..))) ->
       case explode {
@@ -357,16 +335,7 @@ pub fn is_deep_object_param(
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> Bool {
-  case param.in_, param.style, spec.parameter_schema(param) {
-    spec.InQuery, Some(spec.DeepObjectStyle), Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
-        Ok(ObjectSchema(..)) -> True
-        _ -> False
-      }
-    spec.InQuery, Some(spec.DeepObjectStyle), Some(Inline(ObjectSchema(..))) ->
-      True
-    _, _, _ -> False
-  }
+  operation_ir.is_deep_object_param(param, ctx)
 }
 
 fn deep_object_properties(

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -608,7 +608,7 @@ pub fn client_request_is_deep_object_param_object_test() {
       spec.InQuery,
       True,
       spec.ParameterSchema(schema.Inline(obj)),
-      None,
+      Some(spec.DeepObjectStyle),
       None,
       False,
     )


### PR DESCRIPTION
## Summary

- Introduce a shared `operation_ir` module that captures parameter transport semantics (explode defaults, delimiter selection, deepObject detection) in one place
- Both client and server generators now consume the same analyzed parameter rules instead of re-deriving behavior independently

## Changes

- **src/oaspec/codegen/operation_ir.gleam** (NEW): Shared module with three functions:
  - `effective_explode(param)` — compute effective explode value per OpenAPI 3.x defaults
  - `delimiter_for_style(style)` — map parameter style to delimiter character
  - `is_deep_object_param(param, ctx)` — detect deepObject serialization (query + deepObject style + ObjectSchema)
- **src/oaspec/codegen/client_request.gleam**: Remove duplicated `effective_explode()` and `is_deep_object_param()`, replace with `operation_ir.*` calls
- **src/oaspec/codegen/server_request_decode.gleam**: Remove duplicated `effective_explode_for_query()`, `split_delimiter_literal()`, and `is_deep_object_param()`, replace with `operation_ir.*` calls
- **test/codegen_unit_test.gleam**: Update test to use shared `operation_ir.is_deep_object_param()` which requires `in_=InQuery` and `style=Some(DeepObjectStyle)`

## Design Decisions

- Extracted the three most clearly duplicated logic patterns as an initial slice — explode defaults, delimiter selection, and deepObject detection were identical or near-identical across both generators
- The shared module uses the server-side's stricter `is_deep_object_param` logic (requires `in_=InQuery` and `style=DeepObjectStyle`) since the client-side version was unnecessarily permissive
- Kept the module focused on semantic rules rather than string rendering to satisfy the "IR carries semantics, not render-ready strings" criterion
- Future slices (schema-to-expression mapping, form body field processing) can be added to this module incrementally

Closes #190