### PR TITLE
feat(capability): surface request-body encoding warnings for accurate support boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 676 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 220 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 677 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 221 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec
 

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -319,6 +319,37 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         }
       })
     })
+  let request_body_encoding_warnings =
+    list.flat_map(ops, fn(op) {
+      let #(op_id, operation, _path, _method) = op
+      case operation.request_body {
+        Some(Value(rb)) -> {
+          let base_path = op_id <> ".requestBody"
+          let content_entries = dict.to_list(rb.content)
+          list.flat_map(content_entries, fn(ce) {
+            let #(media_type_name, media_type) = ce
+            case dict.is_empty(media_type.encoding) {
+              True -> []
+              False -> [
+                diagnostic.capability(
+                  severity: SeverityWarning,
+                  target: TargetBoth,
+                  path: base_path
+                    <> ".content."
+                    <> media_type_name
+                    <> ".encoding",
+                  detail: "Request-body encoding is parsed but not used by code generation.",
+                  hint: Some(
+                    "Encoding settings (contentType, style, explode) will not affect generated code. No action needed.",
+                  ),
+                ),
+              ]
+            }
+          })
+        }
+        _ -> []
+      }
+    })
   let external_docs_warnings = case context.spec(ctx).external_docs {
     Some(_) -> [
       diagnostic.capability(
@@ -400,6 +431,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
   list.flatten([
     webhook_warnings,
     response_warnings,
+    request_body_encoding_warnings,
     external_docs_warnings,
     tag_warnings,
     operation_server_warnings,

--- a/test/fixtures/request_body_encoding.yaml
+++ b/test/fixtures/request_body_encoding.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  title: Request Body Encoding Test
+  version: "1.0.0"
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                photo:
+                  type: string
+                  format: binary
+            encoding:
+              photo:
+                contentType: image/png
+      responses:
+        "201":
+          description: Created

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -12349,3 +12349,30 @@ pub fn external_whole_object_response_ref_test() {
     spec.Ref(_) -> should.fail()
   }
 }
+
+// ============================================================================
+// Request-body encoding warning tests (Issue #191)
+// ============================================================================
+
+pub fn request_body_encoding_warning_is_surfaced_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/request_body_encoding.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/request_body_encoding.yaml",
+      output_server: "./gen/api",
+      output_client: "./gen_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let assert Ok(result) = generate.generate(spec, cfg)
+  let has_encoding_warning =
+    list.any(result.warnings, fn(w) {
+      string.contains(
+        diagnostic.to_string(w),
+        "Request-body encoding is parsed but not used",
+      )
+    })
+  has_encoding_warning |> should.be_true()
+}


### PR DESCRIPTION
## Summary

- Add capability warnings for request-body `MediaType.encoding` metadata, matching the existing response-side encoding warnings
- Add a test fixture and test that verifies encoding warnings are surfaced through the generation pipeline

## Changes

- **src/oaspec/openapi/capability_check.gleam**: Add `request_body_encoding_warnings` in `check_preserved()` that iterates operation request bodies and warns when `MediaType.encoding` is non-empty. Includes the warning in the final flattened list alongside existing response/webhook/component warnings
- **test/fixtures/request_body_encoding.yaml**: New fixture with a multipart/form-data request body that includes `encoding.photo.contentType: image/png`
- **test/oaspec_test.gleam**: New test `request_body_encoding_warning_is_surfaced_test` verifying the warning appears in `generate()` output
- **README.md**: Update test count (676→677) and fixture count (220→221)

## Design Decisions

- Followed the exact same pattern as the existing response-side encoding warnings (lines 293-310 in capability_check.gleam) for consistency
- The warning message explicitly names the three encoding fields (contentType, style, explode) that are parsed but not used, so users understand the boundary
- The `encoding` Capability registry entry remains at `ParsedNotUsed` level, which accurately reflects the current state — metadata is parsed and warned about, but not honored in codegen

Closes #191