### PR TITLE
docs(examples): link petstore_client README to the shipped server_adapter (#211)

### DIFF
--- a/examples/petstore_client/README.md
+++ b/examples/petstore_client/README.md
@@ -51,5 +51,10 @@ examples/petstore_client/
   src/petstore_client_example.gleam  — the program you run
 ```
 
-More examples (`server_adapter`, `security_client`) will follow in
-subsequent PRs per Issue #26.
+## Related examples
+
+- [`examples/server_adapter`](../server_adapter/) — a framework-free runnable
+  example that bridges the generated `router.route/5` to a canned
+  request/response pair. Run it with `just example-server-adapter`.
+
+A `security_client` example is still to come; see Issue #26.


### PR DESCRIPTION
## Summary

The petstore_client README still said the \`server_adapter\` and
\`security_client\` examples \"will follow in subsequent PRs per Issue #26,\"
but \`examples/server_adapter/\` has shipped since v0.13.0. A new user
reading the example first would think the server-side example doesn't
exist and might look elsewhere.

## Changes

- Replace the stale \"will follow\" line with a \"Related examples\"
  subsection that links directly to \`../server_adapter/\` and mentions the
  \`just example-server-adapter\` recipe.
- Keep a short note that the \`security_client\` example is still to come,
  so that outstanding item doesn't silently disappear.

## Design Decisions

- Linked with a relative path (\`../server_adapter/\`) so the reference
  stays working when the README is read from GitHub or locally.
- Kept Issue #26 as the tracking reference rather than inventing a new
  tracking issue for \`security_client\`.

Closes #211