### PR TITLE
feat(cli): list subcommands in top-level --help output (#206)

### DIFF
--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -4,6 +4,19 @@
 # Integration tests for oaspec code generation.
 # Uses a single generation run for file/content checks to keep tests fast.
 
+Describe 'oaspec top-level help'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'lists available subcommands when called with --help'
+    When run oaspec_cli --help
+    The status should be success
+    The output should include 'Commands:'
+    The output should include 'init'
+    The output should include 'generate'
+    The output should include 'validate'
+  End
+End
+
 Describe 'oaspec generate'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -19,6 +19,12 @@ export TEST_OUTPUT_DIR
 TEST_OUTPUT_DIR_CLIENT="${PROJECT_ROOT}/test_output_client"
 export TEST_OUTPUT_DIR_CLIENT
 
+# Helper: run the oaspec CLI with raw arguments (no subcommand injected).
+# Used for top-level assertions like `oaspec --help`.
+oaspec_cli() {
+  cd "$PROJECT_ROOT" && gleam run -- "$@" 2>&1
+}
+
 # Helper: run oaspec generate command
 generate() {
   cd "$PROJECT_ROOT" && gleam run -- generate "$@" 2>&1

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -19,7 +19,9 @@ import simplifile
 pub fn app() -> glint.Glint(Nil) {
   glint.new()
   |> glint.with_name("oaspec")
-  |> glint.global_help("Generate Gleam code from OpenAPI 3.x specifications")
+  |> glint.global_help(
+    "Generate Gleam code from OpenAPI 3.x specifications\n\nCommands:\n  init       Create a default oaspec.yaml config file\n  generate   Generate Gleam code from an OpenAPI spec\n  validate   Validate an OpenAPI spec without generating code\n\nRun 'oaspec <command> --help' for more information.",
+  )
   |> glint.pretty_help(glint.default_pretty_help())
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["validate"], do: validate_command())

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -23,9 +23,9 @@ pub fn app() -> glint.Glint(Nil) {
     "Generate Gleam code from OpenAPI 3.x specifications\n\nCommands:\n  init       Create a default oaspec.yaml config file\n  generate   Generate Gleam code from an OpenAPI spec\n  validate   Validate an OpenAPI spec without generating code\n\nRun 'oaspec <command> --help' for more information.",
   )
   |> glint.pretty_help(glint.default_pretty_help())
+  |> glint.add(at: ["init"], do: init_command())
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["validate"], do: validate_command())
-  |> glint.add(at: ["init"], do: init_command())
 }
 
 /// The generate command definition.


### PR DESCRIPTION
## Summary

Running \`oaspec\` or \`oaspec --help\` only showed the bare tagline.
A new user who didn't already know that \`init\`, \`generate\`, and
\`validate\` exist had no way to discover them from the CLI itself and
had to return to the README.

## Changes

- Expand the \`glint.global_help\` text in \`src/oaspec/cli.gleam\` into a
  command index that names each subcommand and points readers at
  \`oaspec <command> --help\` for details.
- Add a \`Describe 'oaspec top-level help'\` block to
  \`spec/generate_spec.sh\` that asserts \`oaspec --help\` lists every
  subcommand.
- Add an \`oaspec_cli\` helper to \`spec/spec_helper.sh\` so ShellSpec
  tests can run the CLI with raw arguments (no subcommand injected).

## Design Decisions

- Kept the existing \`glint.pretty_help(glint.default_pretty_help())\`
  stage so glint still renders its auto-generated USAGE / SUBCOMMANDS
  sections below our index. The index adds context; the auto output
  still provides the precise invocation syntax.
- The help text lives as a single string literal (rather than multiple
  \`<>\` concatenations) to satisfy glinter's
  \`unnecessary_string_concatenation\` rule.
- Listed commands in the same order as they are registered so the
  output stays predictable for ShellSpec.

Closes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved `oaspec --help` output to explicitly list available commands (init, generate, validate) with guidance on accessing command-specific help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->