### PR TITLE
docs(readme): add one-minute scope qualifier above Quickstart (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,46 @@ pub fn list_pets(req: request_types.ListPetsRequest)
 }
 ```
 
+## Is oaspec right for your spec?
+
+A one-minute check before you paste in your OpenAPI document — if your
+spec stays inside the green list below, `oaspec` will generate code; if
+it relies on anything in the red list, generation stops with a clear
+diagnostic instead of producing broken output.
+
+**Generates code for:**
+
+- Schemas: `object`, primitives, arrays, enums, nullable, `allOf`,
+  `oneOf`, `anyOf`, typed `additionalProperties`
+- Local `$ref` (and relative-file external `$ref`) across schemas,
+  parameters, request bodies, responses, and path items
+- Parameters: path, query, header, cookie, plus array styles (`form`,
+  `pipeDelimited`, `spaceDelimited`) and objects via `deepObject`
+- Request bodies: `application/json`,
+  `application/x-www-form-urlencoded`, `multipart/form-data`
+- Typed response variants, typed response headers, and `$ref` /
+  `default` responses
+- Security: `apiKey`, HTTP (bearer/basic/digest), OAuth2, OpenID Connect
+  (bearer token attachment)
+
+**Stops with a diagnostic for:**
+
+- JSON Schema 2020 keywords: `$defs`, `prefixItems`, `if/then/else`,
+  `dependentSchemas`, `not`, `unevaluatedProperties` /
+  `unevaluatedItems`, `contentEncoding` / `contentMediaType` /
+  `contentSchema`
+- XML request/response bodies with structural decoding, `xml`
+  annotations, and `mutualTLS` security
+
+**Parsed but not yet turned into code:** callbacks, webhooks,
+`externalDocs`, tags, examples, links, `encoding` metadata.
+
+See [Current Boundaries](#current-boundaries) for the full list,
+including server-mode restrictions and normalization rules. The
+boundaries are kept in sync with the capability registry at
+[`src/oaspec/capability.gleam`](src/oaspec/capability.gleam) by a
+drift-detection test.
+
 ## Quickstart
 
 ### Install from GitHub release (Linux / macOS)


### PR DESCRIPTION
## Summary

The \"Current Boundaries\" table lived below Quickstart and the example
sections, so a user pasting in their own spec could burn minutes before
discovering an unsupported feature. That optimized the README for
happy-path users and punished anyone whose spec was one keyword away
from being generatable.

## Changes

- Add a new \"Is oaspec right for your spec?\" section between the
  \"What you get\" block and Quickstart (README line 78).
- Organize it as three short lists: **Generates code for**, **Stops
  with a diagnostic for**, **Parsed but not yet turned into code** —
  so a reader can self-qualify in under a minute.
- Link down to the existing Current Boundaries and capability.gleam so
  the short section does not duplicate the authoritative source of
  truth.

## Design Decisions

- Kept the detailed Current Boundaries section unchanged; this new
  section is a qualifier, not a replacement. The drift-detection test
  still pins the table content to the capability registry.
- Did not introduce a cross-check test for the short qualifier itself.
  Issue explicitly says \"keep the detailed table in its existing
  location\" and the qualifier is intentionally narrative rather than
  a second source of truth.
- Linked to capability.gleam so curious readers can see the registry
  without leaving the repo.

Closes #205