### PR TITLE
docs(config): document oaspec.yaml path resolution rules (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,55 @@ Generated server code is written to `<dir>/<package>`. Generated client code is 
 | `output.server` | no | `<dir>/<package>` | Server output path |
 | `output.client` | no | `<dir>_client/<package>` | Client output path |
 
+### Configuration paths
+
+All path-valued fields — `input`, `output.dir`, `output.server`,
+`output.client` — are resolved **relative to the current working
+directory** when oaspec runs, not the directory the config file lives
+in.
+
+A config at the repo root that refers to a sibling spec works with no
+prefix:
+
+```text
+myproject/
+├── oaspec.yaml   # input: openapi.yaml
+└── openapi.yaml
+```
+
+```sh
+cd myproject
+oaspec generate --config=oaspec.yaml   # resolves ./openapi.yaml
+```
+
+If the config lives in a subdirectory, its `input` must be reachable
+from where the command is run, so either use a path relative to that
+CWD or keep invoking oaspec from the config's own directory:
+
+```text
+myproject/
+├── api/
+│   ├── oaspec.yaml    # input: openapi.yaml
+│   └── openapi.yaml
+└── (other code)
+```
+
+```sh
+cd myproject/api
+oaspec generate --config=oaspec.yaml   # resolves ./openapi.yaml
+
+# or, from the repo root:
+oaspec generate --config=api/oaspec.yaml   # needs input: api/openapi.yaml
+```
+
+Output directories (`output.dir`, `output.server`, `output.client`)
+are created automatically if they do not exist; existing files in the
+target directories are overwritten by the newly generated code.
+
+If the input spec or the config file itself cannot be opened, oaspec
+exits with a `Config file not found` / `parse_file` diagnostic that
+includes the path it attempted to read.
+
 ### CLI commands
 
 | Command | Description |

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -256,7 +256,10 @@ fn basename(path: String) -> String {
 /// Convert config error to a human-readable string.
 pub fn error_to_string(error: ConfigError) -> String {
   case error {
-    FileNotFound(path:) -> "Config file not found: " <> path
+    FileNotFound(path:) ->
+      "Config file not found: "
+      <> path
+      <> " (paths resolve relative to the current working directory)"
     FileReadError(path:, detail:) ->
       "Error reading config file " <> path <> ": " <> detail
     ParseError(detail:) -> "Config parse error: " <> detail


### PR DESCRIPTION
## Summary

The README showed config snippets like \`input: openapi.yaml\` and
\`output.dir: ./gen\` without saying what these paths are relative to.
A user placing the spec in a subdirectory hit a \"Config file not
found\" error that didn't explain where oaspec actually looked.

## Changes

- Add a \"Configuration paths\" subsection to the README Configuration
  section that spells out the CWD-relative resolution rule, shows two
  concrete layouts (config at repo root vs. config in a subdirectory),
  and notes that output directories are created automatically while
  existing files in them are overwritten.
- Enrich \`config.FileNotFound\`'s \`error_to_string\` output with the
  same CWD hint so the diagnostic itself answers \"where did you look?\"
  when a user runs \`oaspec generate --config=...\` from the wrong
  directory.

## Design Decisions

- Documented the current behavior (CWD-relative) rather than changing
  it. A move to \"paths relative to the config file's directory\" is a
  larger design change and would belong in its own issue.
- Kept the error-message change minimal: one extra clause in the
  existing \`FileNotFound\` branch. Considered adding a resolved
  absolute path, but that would require a new FS helper and the CWD
  hint plus the original path is enough to unblock a confused user.
- Unit test \`config_not_found_test\` matches on the \`FileNotFound\`
  variant, not on the error string, so the message change does not
  affect tests.

Closes #207