### PR TITLE
docs(readme): add Why oaspec? value prop and comparison (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
 - Backed by 677 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 221 test fixtures (including 94 OSS-derived edge-case specs)
 
-## Why oaspec
+## Why oaspec?
+
+**oaspec is the OpenAPI code generator built for Gleam.** Generated code
+is regular Gleam: no templates, no runtime magic, type-safe end to end.
+
+|                                                           | `oaspec` | Generic multi-language generators (e.g. openapi-generator) | Single-language generators for other targets (e.g. oapi-codegen for Go) |
+|-----------------------------------------------------------|:--------:|:----------------------------------------------------------:|:----------------------------------------------------------------------:|
+| First-class Gleam output                                  |    Yes   |                             No                             |                                   No                                   |
+| Idiomatic types, decoders, encoders, and request/response records |    Yes   |                 Templated, not always idiomatic            |                           Language-specific                           |
+| Refuses to emit broken code on unsupported spec patterns  |    Yes   |                          Sometimes                         |                                Partial                                 |
 
 - Built for Gleam: the generated code is shaped like normal Gleam modules, not generic templates awkwardly translated from another ecosystem.
 - Focused on practical OpenAPI: coverage is strongest around the features teams actually ship with, not just toy Petstore specs.


### PR DESCRIPTION
## Summary

The README's first screen emphasized internal metrics (test counts,
fixture counts) over a one-line answer to \"why choose oaspec over
openapi-generator / oapi-codegen for a Gleam project?\" That made the
value proposition invisible above the fold for anyone landing from a
\`gleam openapi generator\` search.

## Changes

- Rename the existing \"Why oaspec\" heading to \"Why oaspec?\" so the
  question and the answer line up.
- Lead with a one-line positioning statement: \"oaspec is the OpenAPI
  code generator built for Gleam. Generated code is regular Gleam: no
  templates, no runtime magic, type-safe end to end.\"
- Add a three-row comparison table against two concrete competitor
  categories (generic multi-language generators and single-language
  generators for other targets) covering first-class Gleam output,
  idiomaticity, and strict-on-unsupported behavior.
- Keep the existing three bullet points for readers who want the
  longer version.

## Design Decisions

- Compared against competitor *categories* rather than naming one
  project per cell so the claims stay factual (\"Generic multi-language
  generators\" is an objective grouping; claiming a specific feature
  about one named project invites drift and nitpicks).
- Kept the section strictly above \"What you get\" and Quickstart so
  the positioning is visible in the first screen, matching Issue #204.
- Did not drop the existing bullet list — the table says \"what\", the
  bullets say \"why\" in the author's voice, and both are short.

Closes #204