### PR TITLE
test(integration): add E2E tests that generated guards reject invalid data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 684 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 222 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 684 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -833,4 +833,344 @@ rm -rf "$KW_CLIENT_DIR"
 
 info "Reserved-keyword integration tests passed."
 
+# -------------------------------------------------------
+# Step 15: Exercise generated guards end-to-end against invalid input
+# -------------------------------------------------------
+# Compile the guard_constraints_api spec and call every emitted guard
+# function directly with both valid and invalid values. This protects
+# against regressions in guards.gleam that would otherwise only surface
+# when a user enables `validate: true` on a spec with constraints.
+info "Testing generated guards end-to-end (reject invalid data)..."
+
+GUARD_DIR="$SCRIPT_DIR/guard_constraints_test"
+rm -rf "$GUARD_DIR"
+mkdir -p "$GUARD_DIR/src" "$GUARD_DIR/test"
+
+cat > "$GUARD_DIR/oaspec-guard.yaml" << 'YAML_EOF'
+input: test/fixtures/guard_constraints_api.yaml
+output:
+  server: ./integration_test/guard_constraints_test/src/api
+package: api
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$GUARD_DIR/oaspec-guard.yaml" \
+  --mode=server
+
+# Replace panic stubs so server code compiles.
+cat > "$GUARD_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/request_types
+import api/response_types
+
+pub fn create_item(req: request_types.CreateItemRequest) -> response_types.CreateItemResponse {
+  let _ = req
+  response_types.CreateItemResponseCreated(req.body)
+}
+GLEAM_EOF
+
+cat > "$GUARD_DIR/gleam.toml" << 'TOML_EOF'
+name = "guard_constraints_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$GUARD_DIR/src/guard_constraints_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cat > "$GUARD_DIR/test/guard_constraints_test_test.gleam" << 'GLEAM_EOF'
+// E2E tests for generated guard functions. Each constraint family
+// (string length, string pattern, integer range, exclusive range,
+// multipleOf, float range, array length, array uniqueness, and the
+// composite schema validator) is exercised with both a valid and an
+// invalid value so a regression in any single branch fails this suite.
+
+import api/guards
+import api/types
+import gleam/dict
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// --- string length ---------------------------------------------------
+
+pub fn name_length_valid_test() {
+  guards.validate_item_name_length("acme")
+  |> should.equal(Ok("acme"))
+}
+
+pub fn name_length_too_short_test() {
+  guards.validate_item_name_length("ab")
+  |> should.be_error
+}
+
+pub fn name_length_too_long_test() {
+  guards.validate_item_name_length("xxxxxxxxxxxxxxxxxxxxxx")
+  |> should.be_error
+}
+
+// --- string pattern --------------------------------------------------
+
+pub fn slug_pattern_valid_test() {
+  guards.validate_item_slug_pattern("good_slug1")
+  |> should.equal(Ok("good_slug1"))
+}
+
+pub fn slug_pattern_invalid_test() {
+  guards.validate_item_slug_pattern("Bad Slug")
+  |> should.be_error
+}
+
+// --- integer range ---------------------------------------------------
+
+pub fn quantity_range_valid_test() {
+  guards.validate_item_quantity_range(50)
+  |> should.equal(Ok(50))
+}
+
+pub fn quantity_range_below_minimum_test() {
+  guards.validate_item_quantity_range(0)
+  |> should.be_error
+}
+
+pub fn quantity_range_above_maximum_test() {
+  guards.validate_item_quantity_range(1001)
+  |> should.be_error
+}
+
+// --- integer exclusive range ----------------------------------------
+
+pub fn price_exclusive_valid_test() {
+  guards.validate_item_price_exclusive_range(5000)
+  |> should.equal(Ok(5000))
+}
+
+pub fn price_exclusive_at_lower_bound_test() {
+  guards.validate_item_price_exclusive_range(0)
+  |> should.be_error
+}
+
+pub fn price_exclusive_at_upper_bound_test() {
+  guards.validate_item_price_exclusive_range(10_000)
+  |> should.be_error
+}
+
+// --- integer multipleOf ---------------------------------------------
+
+pub fn batch_size_multiple_of_valid_test() {
+  guards.validate_item_batch_size_multiple_of(25)
+  |> should.equal(Ok(25))
+}
+
+pub fn batch_size_multiple_of_invalid_test() {
+  guards.validate_item_batch_size_multiple_of(7)
+  |> should.be_error
+}
+
+// --- float range -----------------------------------------------------
+
+pub fn weight_range_valid_test() {
+  guards.validate_item_weight_range(50.0)
+  |> should.equal(Ok(50.0))
+}
+
+pub fn weight_range_below_minimum_test() {
+  guards.validate_item_weight_range(0.05)
+  |> should.be_error
+}
+
+pub fn weight_range_above_maximum_test() {
+  guards.validate_item_weight_range(100.0)
+  |> should.be_error
+}
+
+// --- array length ----------------------------------------------------
+
+pub fn tags_length_valid_test() {
+  guards.validate_item_tags_length(["a", "b"])
+  |> should.equal(Ok(["a", "b"]))
+}
+
+pub fn tags_length_empty_test() {
+  guards.validate_item_tags_length([])
+  |> should.be_error
+}
+
+pub fn tags_length_too_long_test() {
+  guards.validate_item_tags_length(["a", "b", "c", "d", "e", "f"])
+  |> should.be_error
+}
+
+// --- array uniqueness -----------------------------------------------
+
+pub fn tags_unique_valid_test() {
+  guards.validate_item_tags_unique(["a", "b"])
+  |> should.equal(Ok(["a", "b"]))
+}
+
+pub fn tags_unique_duplicate_test() {
+  guards.validate_item_tags_unique(["a", "a"])
+  |> should.be_error
+}
+
+// --- composite validator --------------------------------------------
+
+fn valid_item() -> types.Item {
+  types.Item(
+    name: "acme",
+    slug: Some("good_slug"),
+    quantity: 10,
+    price: Some(500),
+    weight: Some(5.0),
+    batch_size: Some(10),
+    tags: ["a", "b"],
+    additional_properties: dict.new(),
+  )
+}
+
+pub fn composite_valid_test() {
+  let item = valid_item()
+  guards.validate_item(item)
+  |> should.equal(Ok(item))
+}
+
+pub fn composite_collects_multiple_errors_test() {
+  let item =
+    types.Item(
+      name: "ab",
+      slug: Some("Bad"),
+      quantity: 0,
+      price: Some(0),
+      weight: Some(1000.0),
+      batch_size: Some(7),
+      tags: [],
+      additional_properties: dict.new(),
+    )
+  let result = guards.validate_item(item)
+  case result {
+    Error(errors) -> {
+      should.be_true(case errors {
+        [] -> False
+        _ -> True
+      })
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+// --- opt-in: default (validate omitted) does NOT embed guard calls --
+
+// Sanity: the omitted-validate router we compile for this step must
+// NOT carry `guards.validate_item(` in its body — that pattern only
+// appears when validate:true is set. We assert that by reading the
+// generated router.gleam below from run.sh, not from inside gleeunit.
+GLEAM_EOF
+
+cd "$GUARD_DIR"
+gleam deps download
+
+if gleam test 2>&1; then
+  info "PASS: Generated guards reject invalid data end-to-end."
+else
+  fail "Generated guard E2E tests failed."
+fi
+
+# Confirm the default (validate omitted => false) path does NOT emit
+# guard calls into router.gleam. This locks the opt-in semantics.
+if grep -q "guards.validate_item(" "$GUARD_DIR/src/api/router.gleam"; then
+  fail "Default router.gleam unexpectedly calls guards.validate_item — opt-in semantics broken."
+else
+  info "PASS: Default (validate unset) router.gleam does not embed guard calls."
+fi
+
+rm -rf "$GUARD_DIR"
+
+# -------------------------------------------------------
+# Step 16: Verify validate:true wires guard calls into generated code
+# -------------------------------------------------------
+info "Testing validate:true wiring (opt-in guard invocation)..."
+
+GUARD_V_DIR="$SCRIPT_DIR/guard_validate_on_test"
+rm -rf "$GUARD_V_DIR"
+mkdir -p "$GUARD_V_DIR/src"
+
+cat > "$GUARD_V_DIR/oaspec-guard-v.yaml" << 'YAML_EOF'
+input: test/fixtures/guard_constraints_api.yaml
+output:
+  server: ./integration_test/guard_validate_on_test/src/api
+package: api
+validate: true
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$GUARD_V_DIR/oaspec-guard-v.yaml" \
+  --mode=server
+
+cat > "$GUARD_V_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/request_types
+import api/response_types
+
+pub fn create_item(req: request_types.CreateItemRequest) -> response_types.CreateItemResponse {
+  let _ = req
+  response_types.CreateItemResponseCreated(req.body)
+}
+GLEAM_EOF
+
+cat > "$GUARD_V_DIR/gleam.toml" << 'TOML_EOF'
+name = "guard_validate_on_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$GUARD_V_DIR/src/guard_validate_on_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$GUARD_V_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors 2>&1; then
+  info "PASS: validate:true code compiles (warnings-as-errors)."
+else
+  fail "validate:true code failed to compile."
+fi
+
+if grep -q "guards.validate_item(" "$GUARD_V_DIR/src/api/router.gleam"; then
+  info "PASS: validate:true router.gleam embeds guards.validate_item."
+else
+  fail "validate:true router.gleam is missing expected guards.validate_item call."
+fi
+
+rm -rf "$GUARD_V_DIR"
+
+info "Guard constraint integration tests passed."
+
 info "All integration tests passed!"

--- a/test/fixtures/guard_constraints_api.yaml
+++ b/test/fixtures/guard_constraints_api.yaml
@@ -1,0 +1,65 @@
+openapi: "3.0.3"
+info:
+  title: Guard Constraints API
+  description: |
+    Fixture that concentrates constraint validation cases so the
+    integration test can exercise every guard-emitting family. Each
+    schema in components deliberately carries a distinct constraint
+    type so the generated guards.gleam has runtime-testable functions
+    for numeric, string, array, and object validators.
+  version: "1.0.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Item"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - name
+        - quantity
+        - tags
+      properties:
+        name:
+          type: string
+          minLength: 3
+          maxLength: 20
+        slug:
+          type: string
+          pattern: "^[a-z][a-z0-9_]*$"
+        quantity:
+          type: integer
+          minimum: 1
+          maximum: 1000
+        price:
+          type: integer
+          exclusiveMinimum: 0
+          exclusiveMaximum: 10000
+        weight:
+          type: number
+          minimum: 0.1
+          maximum: 99.9
+        batch_size:
+          type: integer
+          multipleOf: 5
+        tags:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 5
+          uniqueItems: true


### PR DESCRIPTION
## Summary

Closes #214.

Adds end-to-end tests that exercise every guard-emitting constraint family by calling the generated guard functions directly against both valid and invalid values. Also confirms the opt-in semantics of `validate: true` — that without it, the generated router does **not** wire guard calls, and with it, the router embeds the composite validator.

## Changes

- `test/fixtures/guard_constraints_api.yaml` — new fixture concentrating constraint cases (string length, string pattern, integer range, integer exclusive range, integer multipleOf, float range, array length, array uniqueItems, plus a composite schema that aggregates them).
- `integration_test/run.sh` — new Step 15 (E2E guard rejection) and Step 16 (opt-in wiring):
  - Step 15 generates server code with the default config (validate omitted → false), runs `gleam test` against a dedicated gleeunit suite that asserts each guard returns `Ok` on valid values and `Error` on invalid values, and greps `router.gleam` to confirm the composite guard is NOT embedded.
  - Step 16 regenerates with `validate: true` and asserts the same `router.gleam` now calls `guards.validate_item(...)` before invoking the handler.
- `README.md` — bump fixture count (222 → 223).

## Design Decisions

- **Calling guards directly instead of through an HTTP round-trip.** Issue #214 asks whether the emitted guard code does what it claims. Booting an HTTP server and sending bad payloads would test several layers at once and introduce flakiness; a direct gleeunit call of each `validate_item_<field>_<constraint>` function isolates the guard and fails precisely when that specific emitter regresses.
- **Separate Step for the opt-in check.** Step 16 only builds the validate:true variant and greps the emitted router, rather than re-running the full test suite. The goal is confirming the switch wires differently, not re-testing the guards themselves.
- **Composite-validator assertion uses a "non-empty errors" check rather than enumerating exact error messages.** The exact messages are an implementation detail of guards.gleam; asserting presence keeps the test resilient to wording tweaks while still catching a regression where validation silently passes.

## Limitations

- Does not cover `object.minProperties` / `object.maxProperties` / `object.required` / `object.additionalProperties` — those are either decode-time concerns or not currently exercised by an emitted guard function. If a future generator change adds guards for them, the fixture should grow matching schemas.
- The fixture is server-mode only. Client-mode guard emission shares the same generator path, but an explicit client-side test would require a separate Step and is out of scope for this issue.