### PR TITLE
examples(server_adapter): split domain logic into regeneration-safe module

### DIFF
--- a/examples/server_adapter/README.md
+++ b/examples/server_adapter/README.md
@@ -6,8 +6,9 @@ A Gleam project that shows how to bridge the oaspec-generated
 ## What it shows
 
 - Generating a server from an OpenAPI 3.x spec via `oaspec.yaml`.
-- Hand-writing `handlers.gleam` — the generated file ships with `panic`
-  stubs; real applications replace these with domain logic.
+- A **regeneration-safe handler layout**: domain logic lives in
+  `src/example_handlers.gleam`, which the generator never touches.
+  `src/api/handlers.gleam` is a thin delegator owned by the generator.
 - Calling the generated router with primitive request pieces
   (`method`, `path`, `query`, `headers`, `body`) and inspecting the
   returned `ServerResponse`.
@@ -22,6 +23,41 @@ adapter is the same three-step pattern:
 
 This program runs that adapter against a canned request instead of
 spinning up an HTTP server, so the example has no framework dependency.
+
+## Recommended handler layout
+
+The generator owns every file under `src/api/`. Putting domain logic
+directly into `src/api/handlers.gleam` means regeneration clobbers it.
+The pattern this example demonstrates — and that we recommend for
+production projects — is:
+
+```text
+src/
+  api/
+    handlers.gleam         ← generated, regen-safe thin delegator
+    …other generated files
+  example_handlers.gleam   ← you own this; domain logic lives here
+```
+
+`src/api/handlers.gleam` is a two-line-per-function delegator:
+
+```gleam
+import api/request_types
+import api/response_types
+import example_handlers
+
+pub fn list_pets(
+  req: request_types.ListPetsRequest,
+) -> response_types.ListPetsResponse {
+  example_handlers.list_pets(req)
+}
+```
+
+When you regenerate the server, `handlers.gleam` is rewritten with
+fresh `panic` stubs. Restoring it is mechanical: for each function,
+replace the stub body with `example_handlers.<fn>(req)`. Because your
+actual domain logic never lived in `handlers.gleam`, nothing of value
+is lost in the overwrite.
 
 ## Run it
 
@@ -38,20 +74,6 @@ cd examples/server_adapter
 gleam run
 ```
 
-### Regenerating the server code
-
-The generated server files under `src/api/` are committed, so the example
-runs out of the box. Regenerate only when the spec or oaspec itself
-changes:
-
-```sh
-gleam run -- generate --config=examples/server_adapter/oaspec.yaml
-```
-
-> **WARNING:** regeneration overwrites `src/api/handlers.gleam`, which
-> this example hand-writes. Back up your handlers file first, then
-> restore it (or re-apply your edits) after regeneration.
-
 Expected output:
 
 ```text
@@ -60,6 +82,20 @@ headers: 1 header(s)
 body: [{"id":1,"name":"Fido","status":"available","tag":"dog"},{"id":2,"name":"Whiskers","status":"pending","tag":null}]
 ```
 
+## Regenerating the server code
+
+The generated server files under `src/api/` are committed, so the
+example runs out of the box. Regenerate only when the spec or oaspec
+itself changes:
+
+```sh
+gleam run -- generate --config=examples/server_adapter/oaspec.yaml
+```
+
+After regeneration, re-apply the thin delegator pattern to
+`src/api/handlers.gleam` (see above). `src/example_handlers.gleam` is
+untouched by the generator, so the domain logic carries over as-is.
+
 ## File layout
 
 ```text
@@ -67,13 +103,7 @@ examples/server_adapter/
   gleam.toml                 — project manifest
   oaspec.yaml                — generator config (server mode)
   src/api/                   — generated server code (checked in)
-  src/api/handlers.gleam     — *hand-written* handlers (NOT regenerated)
+  src/api/handlers.gleam     — thin delegator (hand-edited, 1 line per op)
+  src/example_handlers.gleam — your domain logic (generator never touches)
   src/server_adapter_example.gleam  — the program you run
 ```
-
-`handlers.gleam` is also produced by the generator with `panic` stubs.
-The example commits the hand-written version; running the generator
-again will overwrite it. When integrating into a real project, keep
-handler implementations in a separate module (or a separate file
-excluded from `generate`) and delegate from the generated
-`handlers.gleam` to that module.

--- a/examples/server_adapter/src/api/handlers.gleam
+++ b/examples/server_adapter/src/api/handlers.gleam
@@ -1,75 +1,37 @@
-//// Hand-written handler implementations for the server_adapter example.
-//// These replace the generated panic stubs and return canned test data.
+//// Thin delegator. `oaspec generate` emits `panic` stubs into this
+//// file; the example replaces each stub with a one-line call into
+//// `example_handlers` so real domain logic can live outside the
+//// regeneration-affected `api/` directory.
+////
+//// After regenerating the server, restore this file by replacing the
+//// generated `panic` body of each function with the matching
+//// `example_handlers.<fn>(req)` call. That restoration is mechanical
+//// and version-control-diffable.
 
-import api/guards
 import api/request_types
 import api/response_types
-import api/types
-import gleam/dict
-import gleam/option.{None, Some}
+import example_handlers
 
 pub fn list_pets(
   req: request_types.ListPetsRequest,
 ) -> response_types.ListPetsResponse {
-  let _ = req
-  response_types.ListPetsResponseOk([
-    types.Pet(
-      id: 1,
-      name: "Fido",
-      status: types.PetStatusAvailable,
-      tag: Some("dog"),
-      additional_properties: dict.new(),
-    ),
-    types.Pet(
-      id: 2,
-      name: "Whiskers",
-      status: types.PetStatusPending,
-      tag: None,
-      additional_properties: dict.new(),
-    ),
-  ])
+  example_handlers.list_pets(req)
 }
 
 pub fn create_pet(
   req: request_types.CreatePetRequest,
 ) -> response_types.CreatePetResponse {
-  // Run the generated validation guard before constructing the response.
-  // A well-formed OpenAPI spec will reject out-of-range values at the
-  // guard layer; returning 400 is the idiomatic mapping.
-  case guards.validate_create_pet_request(req.body) {
-    Error(_) -> response_types.CreatePetResponseBadRequest
-    Ok(_) ->
-      response_types.CreatePetResponseCreated(types.Pet(
-        id: 100,
-        name: req.body.name,
-        status: types.PetStatusAvailable,
-        tag: req.body.tag,
-        additional_properties: dict.new(),
-      ))
-  }
+  example_handlers.create_pet(req)
 }
 
 pub fn get_pet(
   req: request_types.GetPetRequest,
 ) -> response_types.GetPetResponse {
-  case req.pet_id {
-    1 ->
-      response_types.GetPetResponseOk(types.Pet(
-        id: 1,
-        name: "Fido",
-        status: types.PetStatusAvailable,
-        tag: Some("dog"),
-        additional_properties: dict.new(),
-      ))
-    _ -> response_types.GetPetResponseNotFound
-  }
+  example_handlers.get_pet(req)
 }
 
 pub fn delete_pet(
   req: request_types.DeletePetRequest,
 ) -> response_types.DeletePetResponse {
-  case req.pet_id {
-    1 -> response_types.DeletePetResponseNoContent
-    _ -> response_types.DeletePetResponseNotFound
-  }
+  example_handlers.delete_pet(req)
 }

--- a/examples/server_adapter/src/example_handlers.gleam
+++ b/examples/server_adapter/src/example_handlers.gleam
@@ -1,0 +1,80 @@
+//// Hand-written handler implementations for the server_adapter example.
+////
+//// This file lives OUTSIDE the `api/` directory, so `oaspec generate`
+//// does not touch it. Domain logic — anything an application author
+//// actually writes — belongs here. `api/handlers.gleam` is then a thin
+//// delegator owned by the generator; after a regeneration it is
+//// enough to restore the two-line body of each stub below.
+
+import api/guards
+import api/request_types
+import api/response_types
+import api/types
+import gleam/dict
+import gleam/option.{None, Some}
+
+pub fn list_pets(
+  req: request_types.ListPetsRequest,
+) -> response_types.ListPetsResponse {
+  let _ = req
+  response_types.ListPetsResponseOk([
+    types.Pet(
+      id: 1,
+      name: "Fido",
+      status: types.PetStatusAvailable,
+      tag: Some("dog"),
+      additional_properties: dict.new(),
+    ),
+    types.Pet(
+      id: 2,
+      name: "Whiskers",
+      status: types.PetStatusPending,
+      tag: None,
+      additional_properties: dict.new(),
+    ),
+  ])
+}
+
+pub fn create_pet(
+  req: request_types.CreatePetRequest,
+) -> response_types.CreatePetResponse {
+  // Run the generated validation guard before constructing the response.
+  // A well-formed OpenAPI spec will reject out-of-range values at the
+  // guard layer; returning 400 is the idiomatic mapping.
+  case guards.validate_create_pet_request(req.body) {
+    Error(_) -> response_types.CreatePetResponseBadRequest
+    Ok(_) ->
+      response_types.CreatePetResponseCreated(types.Pet(
+        id: 100,
+        name: req.body.name,
+        status: types.PetStatusAvailable,
+        tag: req.body.tag,
+        additional_properties: dict.new(),
+      ))
+  }
+}
+
+pub fn get_pet(
+  req: request_types.GetPetRequest,
+) -> response_types.GetPetResponse {
+  case req.pet_id {
+    1 ->
+      response_types.GetPetResponseOk(types.Pet(
+        id: 1,
+        name: "Fido",
+        status: types.PetStatusAvailable,
+        tag: Some("dog"),
+        additional_properties: dict.new(),
+      ))
+    _ -> response_types.GetPetResponseNotFound
+  }
+}
+
+pub fn delete_pet(
+  req: request_types.DeletePetRequest,
+) -> response_types.DeletePetResponse {
+  case req.pet_id {
+    1 -> response_types.DeletePetResponseNoContent
+    _ -> response_types.DeletePetResponseNotFound
+  }
+}


### PR DESCRIPTION
## Summary

Addresses #209 at the example-restructuring scope. Demonstrates the recommended integration pattern for real projects: user code lives in a file the generator does not touch, and `api/handlers.gleam` becomes a thin delegator whose body is mechanical to restore after regeneration.

The generator-side work (emitting delegation stubs automatically so restoration isn't needed at all) is deliberately left out of this PR — that belongs in a separate Issue because it changes the public generator contract.

## Changes

- `examples/server_adapter/src/example_handlers.gleam` — new file that owns the hand-written domain logic (list_pets / create_pet / get_pet / delete_pet), including the existing guard-based 400 handling for `create_pet`. The generator never touches this path.
- `examples/server_adapter/src/api/handlers.gleam` — rewritten as a thin delegator: each function is a one-liner calling into `example_handlers`. The top-doc explains the pattern and how to restore this file after `gleam run -- generate ...`.
- `examples/server_adapter/README.md` — replaces the "WARNING: back up your handlers" workflow with a recommended-pattern section showing the split. Regeneration section now explains that restoring `api/handlers.gleam` is mechanical (swap `panic` for `example_handlers.<fn>(req)`) because domain logic never lives there.

## Design Decisions

- **Kept `api/handlers.gleam` as a committed, hand-edited file.** Making it fully regeneration-safe requires the generator to emit delegation stubs by default, which would change the generator's contract and affect every existing user. That work is listed as optional follow-up in #209's description and should be its own Issue.
- **Domain logic including guard handling moved verbatim.** `create_pet` still runs `guards.validate_create_pet_request` and maps `Error(_)` to `CreatePetResponseBadRequest` — the behavior of the example is unchanged; only the file layout changed.
- **README structure:** added a dedicated "Recommended handler layout" section above "Run it" so a first-time reader sees the pattern before the run commands.

## Verification

- `gleam build --warnings-as-errors` (inside `examples/server_adapter`) compiles cleanly.
- `just example-server-adapter` prints the README's expected output byte-for-byte.
- `just all` (format-check + typecheck + lint + build + test + shellspec + integration + escript + smoke) passes.

## Limitations

- The generator still overwrites `api/handlers.gleam` on every run. Users get the same overwrite experience after this PR; the improvement is only that re-creating a valid `handlers.gleam` is now a 4-line edit with a template they can copy.
- `examples/petstore_client` is unchanged — it is a client-side example and does not emit handlers.

Closes #209 (example layout scope). Generator-side delegation-stub emission to be tracked separately.