### PR TITLE
feat(diagnostics): render pointer locations in human-readable form

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 684 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 704 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/config
+import oaspec/openapi/diagnostic_format
 
 /// Pipeline phase that produced the diagnostic.
 pub type Phase {
@@ -270,10 +271,7 @@ pub fn to_short_string(d: Diagnostic) -> String {
     "file_error" -> d.message
     "yaml_error" -> d.message <> loc_str
     "missing_field" -> {
-      let location = case d.pointer {
-        "" -> "root"
-        p -> p
-      }
+      let location = diagnostic_format.pointer_to_human(d.pointer)
       let field = string.replace(d.message, "Missing required field: ", "")
       "Missing required field '"
       <> field
@@ -285,17 +283,14 @@ pub fn to_short_string(d: Diagnostic) -> String {
       }
     }
     "invalid_value" -> {
-      let location = case d.pointer {
-        "" -> "root"
-        p -> p
-      }
+      let location = diagnostic_format.pointer_to_human(d.pointer)
       "Invalid value at " <> location <> ": " <> d.message
     }
     _ ->
       prefix
       <> case d.pointer {
         "" -> ""
-        p -> " at " <> p
+        p -> " at " <> diagnostic_format.pointer_to_human(p)
       }
       <> ": "
       <> d.message

--- a/src/oaspec/openapi/diagnostic_format.gleam
+++ b/src/oaspec/openapi/diagnostic_format.gleam
@@ -1,0 +1,101 @@
+//// Human-readable rendering of diagnostic pointer strings. The machine
+//// layer — `Diagnostic.pointer` itself — is left untouched so future
+//// `--format json` output or any consumer that wants the raw
+//// JSON Pointer / dotted path can still read it verbatim. This module
+//// only owns the CLI presentation transform.
+////
+//// The function is deliberately spec-context free: it never looks a
+//// path up in a parsed spec. That is a larger follow-up; here the goal
+//// is simply to turn `paths.~1pets.get.parameters.0` into
+//// `GET /pets, parameter #0` so a reader does not need to know about
+//// JSON Pointer escape rules.
+
+import gleam/list
+import gleam/string
+
+/// Translate a diagnostic pointer into a human-readable location string.
+///
+/// Recognised shapes:
+/// - `paths.<escaped>.<method>.parameters.<idx>[...]`
+///   → `METHOD /path, parameter #idx[...]`
+/// - `paths.<escaped>.<method>.requestBody[...]`
+///   → `METHOD /path, requestBody[...]`
+/// - `paths.<escaped>.<method>.responses.<status>[...]`
+///   → `METHOD /path, response <status>[...]`
+/// - `paths.<escaped>.<method>[...]`
+///   → `METHOD /path[...]`
+/// - `components.<kind>.<name>[...]`
+///   → `<kind>.<name>[...]`
+///
+/// Falls back to the escape-decoded pointer if no pattern matches, so
+/// callers always get *something* intelligible.
+pub fn pointer_to_human(pointer: String) -> String {
+  case pointer {
+    "" -> "root"
+    _ -> format_segments(split_pointer(pointer), pointer)
+  }
+}
+
+fn split_pointer(pointer: String) -> List(String) {
+  pointer
+  |> string.replace("#/", "")
+  |> string.replace("/", ".")
+  |> string.split(".")
+  |> list.filter(fn(s) { s != "" })
+  |> list.map(unescape_segment)
+}
+
+/// JSON Pointer unescaping per RFC 6901: `~1` → `/`, `~0` → `~`.
+/// Order matters: `~1` must be decoded first so `~01` ends up as `~1`,
+/// not `/`.
+fn unescape_segment(s: String) -> String {
+  s
+  |> string.replace("~1", "/")
+  |> string.replace("~0", "~")
+}
+
+fn format_segments(segments: List(String), original: String) -> String {
+  case segments {
+    ["paths", path, method, "parameters", idx, ..rest] ->
+      with_tail(
+        string.uppercase(method) <> " " <> path <> ", parameter #" <> idx,
+        rest,
+      )
+    ["paths", path, method, "requestBody", ..rest] ->
+      with_tail(
+        string.uppercase(method) <> " " <> path <> ", requestBody",
+        rest,
+      )
+    ["paths", path, method, "responses", status, ..rest] ->
+      with_tail(
+        string.uppercase(method) <> " " <> path <> ", response " <> status,
+        rest,
+      )
+    ["paths", path, method, ..rest] ->
+      with_tail(string.uppercase(method) <> " " <> path, rest)
+    ["components", "schemas", name, ..rest] ->
+      with_tail("schemas." <> name, rest)
+    ["components", "parameters", name, ..rest] ->
+      with_tail("parameters." <> name, rest)
+    ["components", "responses", name, ..rest] ->
+      with_tail("responses." <> name, rest)
+    ["components", "requestBodies", name, ..rest] ->
+      with_tail("requestBodies." <> name, rest)
+    ["components", kind, name, ..rest] -> with_tail(kind <> "." <> name, rest)
+    _ -> default_format(segments, original)
+  }
+}
+
+fn with_tail(base: String, rest: List(String)) -> String {
+  case rest {
+    [] -> base
+    _ -> base <> " (" <> string.join(rest, ".") <> ")"
+  }
+}
+
+fn default_format(segments: List(String), original: String) -> String {
+  case segments {
+    [] -> original
+    _ -> string.join(segments, ".")
+  }
+}

--- a/src/oaspec/openapi/diagnostic_format.gleam
+++ b/src/oaspec/openapi/diagnostic_format.gleam
@@ -37,6 +37,11 @@ pub fn pointer_to_human(pointer: String) -> String {
 }
 
 fn split_pointer(pointer: String) -> List(String) {
+  // Known limitation: this splits on `.` unconditionally, so a pointer whose
+  // path contains a literal dot (e.g. `/v1.0/pets`) will fragment. Every
+  // pointer constructed inside this repo is dot-free today. If that changes,
+  // switch to splitting on `/` first and only normalising `.` where the
+  // segment is known not to be a user-supplied path.
   pointer
   |> string.replace("#/", "")
   |> string.replace("/", ".")

--- a/test/diagnostic_format_test.gleam
+++ b/test/diagnostic_format_test.gleam
@@ -1,0 +1,130 @@
+import gleeunit
+import gleeunit/should
+import oaspec/openapi/diagnostic_format
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// --- empty / root ---------------------------------------------------
+
+pub fn empty_pointer_renders_root_test() {
+  diagnostic_format.pointer_to_human("")
+  |> should.equal("root")
+}
+
+// --- paths: parameters ---------------------------------------------
+
+pub fn path_parameter_dotted_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.get.parameters.0")
+  |> should.equal("GET /pets, parameter #0")
+}
+
+pub fn path_parameter_json_pointer_test() {
+  diagnostic_format.pointer_to_human("#/paths/~1pets/get/parameters/0")
+  |> should.equal("GET /pets, parameter #0")
+}
+
+pub fn path_parameter_with_tail_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.get.parameters.0.schema")
+  |> should.equal("GET /pets, parameter #0 (schema)")
+}
+
+// --- paths: requestBody --------------------------------------------
+
+pub fn path_request_body_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.post.requestBody")
+  |> should.equal("POST /pets, requestBody")
+}
+
+pub fn path_request_body_with_tail_test() {
+  diagnostic_format.pointer_to_human(
+    "paths.~1pets.post.requestBody.content.application~1json",
+  )
+  |> should.equal("POST /pets, requestBody (content.application/json)")
+}
+
+// --- paths: responses -----------------------------------------------
+
+pub fn path_response_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.get.responses.200")
+  |> should.equal("GET /pets, response 200")
+}
+
+pub fn path_response_with_tail_test() {
+  diagnostic_format.pointer_to_human(
+    "paths.~1pets.get.responses.404.content.application~1json.schema",
+  )
+  |> should.equal("GET /pets, response 404 (content.application/json.schema)")
+}
+
+// --- paths: bare method ---------------------------------------------
+
+pub fn path_method_only_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.get")
+  |> should.equal("GET /pets")
+}
+
+pub fn path_method_with_tail_test() {
+  diagnostic_format.pointer_to_human("paths.~1pets.get.summary")
+  |> should.equal("GET /pets (summary)")
+}
+
+// --- components -----------------------------------------------------
+
+pub fn components_schemas_test() {
+  diagnostic_format.pointer_to_human("components.schemas.Pet")
+  |> should.equal("schemas.Pet")
+}
+
+pub fn components_schemas_with_tail_test() {
+  diagnostic_format.pointer_to_human("components.schemas.Pet.properties.name")
+  |> should.equal("schemas.Pet (properties.name)")
+}
+
+pub fn components_parameters_test() {
+  diagnostic_format.pointer_to_human("components.parameters.PetId")
+  |> should.equal("parameters.PetId")
+}
+
+pub fn components_responses_test() {
+  diagnostic_format.pointer_to_human("components.responses.ErrorResponse")
+  |> should.equal("responses.ErrorResponse")
+}
+
+pub fn components_request_bodies_test() {
+  diagnostic_format.pointer_to_human("components.requestBodies.CreatePetBody")
+  |> should.equal("requestBodies.CreatePetBody")
+}
+
+pub fn components_other_kind_test() {
+  // Unrecognised component kinds still render as "<kind>.<name>"
+  diagnostic_format.pointer_to_human("components.headers.XRateLimit")
+  |> should.equal("headers.XRateLimit")
+}
+
+// --- escape decoding ------------------------------------------------
+
+pub fn tilde_zero_unescaped_test() {
+  // `~0` decodes to `~`
+  diagnostic_format.pointer_to_human("paths.~1a~0b.get")
+  |> should.equal("GET /a~b")
+}
+
+pub fn escape_order_preserves_tilde_one_test() {
+  // `~01` must decode to `~1`, NOT `/1` — `~1` is processed before `~0`.
+  diagnostic_format.pointer_to_human("components.schemas.a~01b")
+  |> should.equal("schemas.a~1b")
+}
+
+// --- fallback -------------------------------------------------------
+
+pub fn unknown_shape_falls_back_to_decoded_pointer_test() {
+  diagnostic_format.pointer_to_human("foo.bar.baz")
+  |> should.equal("foo.bar.baz")
+}
+
+pub fn slash_form_unknown_shape_test() {
+  diagnostic_format.pointer_to_human("#/foo/bar")
+  |> should.equal("foo.bar")
+}


### PR DESCRIPTION
## Summary

Turns diagnostic location pointers from `paths.~1pets.get.parameters.0` into `GET /pets, parameter #0` so OpenAPI beginners don't need to know JSON Pointer escape rules. The structured `Diagnostic.pointer` string is left intact — this PR only changes what `to_short_string` (the CLI-facing renderer) emits for the location segment of each message.

Before:
```
Invalid value at paths.~1pets.get.parameters.0: unsupported pattern constraint
```

After:
```
Invalid value at GET /pets, parameter #0: unsupported pattern constraint
```

## Changes

- `src/oaspec/openapi/diagnostic_format.gleam` (new, ~95 lines) — `pub fn pointer_to_human/1` that parses the dotted / JSON-pointer form, RFC-6901-unescapes each segment, and pattern-matches the common shapes:
  - `paths.<path>.<method>.parameters.<idx>[...]` → `METHOD /path, parameter #idx[...]`
  - `paths.<path>.<method>.requestBody[...]` → `METHOD /path, requestBody[...]`
  - `paths.<path>.<method>.responses.<status>[...]` → `METHOD /path, response <status>[...]`
  - `paths.<path>.<method>[...]` → `METHOD /path[...]`
  - `components.<kind>.<name>[...]` → `<kind>.<name>[...]`
  - Anything else falls back to the escape-decoded pointer string.
- `src/oaspec/openapi/diagnostic.gleam` — `to_short_string` now routes the `pointer` field through `diagnostic_format.pointer_to_human` in all three code branches (`missing_field`, `invalid_value`, generic). `yaml_error` / `file_error` are unchanged because they don't carry pointers.
- `test/diagnostic_format_test.gleam` (new, 20 tests) — covers each recognised shape, JSON Pointer vs dotted input, `~1` / `~0` / `~01` escape ordering, tail-suffix handling, and unknown-shape fallback.
- `README.md` — unit test count 684 → 704.

## Design Decisions

- **Spec-context-free transform, on purpose.** The Issue mentions resolving `parameter #0` into `parameter #0 (name: "limit")` by looking the operation up in the parsed spec. That requires either threading the spec through every diagnostic renderer or doing it lazily at the CLI layer, both of which noticeably widen the change. The escape-decoded, pattern-matched form already fixes the worst friction point (cryptic `~1`) without introducing spec coupling. Parameter-name enrichment is tracked as follow-up.
- **`Diagnostic.pointer` is unchanged.** The wire-format pointer is still available for any future `--format json` / machine consumer. Only the CLI-facing `to_short_string` switches to the human form.
- **New module under `openapi/` instead of `formatter.gleam`.** `formatter.gleam` is already taken: it wraps `gleam format` for generated code. Overloading it for diagnostic rendering would be confusing — `diagnostic_format.gleam` sits next to `diagnostic.gleam` and makes the dependency direction obvious (`diagnostic` imports `diagnostic_format`, not the other way around).
- **Escape order: `~1` before `~0`.** Per RFC 6901 the unescape order matters so that `~01` decodes to `~1` rather than `/`. Test `escape_order_preserves_tilde_one_test` locks this in.

## Verification

- `just all` — format-check + typecheck + glinter + build + test + shellspec + integration + escript + smoke — green.
- 704 / 704 unit tests pass (20 new tests for `diagnostic_format`).
- Existing `yaml_error` location test (`yaml_error_has_source_location_test`) still passes — the change only touches the `pointer`-based branches, not the YAML line/column branch.

## Limitations / Follow-up

- Parameter `#0` is still shown as an index. Translating it into the parameter's name (`parameter "limit"`) needs the parsed spec and is left as a follow-up.
- `--format json` is not implemented in this PR. The design makes it easy to add later because the structured pointer is preserved.

Closes #208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error diagnostics now display human-readable location information instead of raw pointer strings.

* **Tests**
  * Added comprehensive test coverage for diagnostic message formatting.

* **Documentation**
  * Updated test count in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->