### PR TITLE
fix(codegen): dedup request-type parameter field names across locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 706 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 707 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 704 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 706 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/client.gleam
+++ b/src/oaspec/codegen/client.gleam
@@ -558,6 +558,7 @@ fn generate_client_function(
       }
     })
 
+  let field_names = client_request.build_param_field_names(operation)
   let path_params =
     list.filter(unwrapped_params, fn(p) {
       case p.in_ {
@@ -689,7 +690,7 @@ fn generate_client_function(
   let sb = sb |> se.indent(1, "let path = \"" <> path <> "\"")
   let sb =
     list.fold(path_params, sb, fn(sb, p) {
-      let param_name = naming.to_snake_case(p.name)
+      let param_name = client_request.field_name_for(field_names, p)
       let to_string_expr =
         client_request.param_to_string_expr(p, param_name, ctx)
       sb
@@ -710,7 +711,7 @@ fn generate_client_function(
       let sb = sb |> se.indent(1, "let query_parts = []")
       let sb =
         list.fold(query_params, sb, fn(sb, p) {
-          let param_name = naming.to_snake_case(p.name)
+          let param_name = client_request.field_name_for(field_names, p)
           // Check for deepObject style with object schema
           case p.style, client_request.is_deep_object_param(p, ctx) {
             Some(spec.DeepObjectStyle), True ->
@@ -893,7 +894,7 @@ fn generate_client_function(
   // Set header parameters
   let sb =
     list.fold(header_params, sb, fn(sb, p) {
-      let param_name = naming.to_snake_case(p.name)
+      let param_name = client_request.field_name_for(field_names, p)
       let header_name = string.lowercase(p.name)
       case p.required {
         True -> {
@@ -933,7 +934,7 @@ fn generate_client_function(
       let sb = sb |> se.indent(1, "let cookie_parts = []")
       let sb =
         list.fold(cookie_params, sb, fn(sb, p) {
-          let param_name = naming.to_snake_case(p.name)
+          let param_name = client_request.field_name_for(field_names, p)
           case p.required {
             True -> {
               let to_str =

--- a/src/oaspec/codegen/client_request.gleam
+++ b/src/oaspec/codegen/client_request.gleam
@@ -1,3 +1,4 @@
+import gleam/dict.{type Dict}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
@@ -5,11 +6,55 @@ import oaspec/codegen/context.{type Context}
 import oaspec/codegen/ir_build
 import oaspec/codegen/operation_ir
 import oaspec/codegen/schema_dispatch
+import oaspec/openapi/dedup
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec.{type Resolved, ParameterSchema, Value}
 import oaspec/util/naming
 import oaspec/util/string_extra as se
+
+/// Map from a parameter's `(wire name, location)` pair to its deduped Gleam
+/// field name within an operation. Used to keep type emission, server
+/// dispatch, and client builders in sync when two parameters in different
+/// locations would otherwise collide on the same snake_case field.
+pub type ParamFieldNames =
+  Dict(#(String, spec.ParameterIn), String)
+
+/// Build a `(name, in)` → deduped-field-name map for a single operation.
+/// The dedup order matches the spec's parameter order, so all codegen
+/// callers that use this map agree on the final field names.
+pub fn build_param_field_names(
+  operation: spec.Operation(Resolved),
+) -> ParamFieldNames {
+  let resolved =
+    list.filter_map(operation.parameters, fn(r) {
+      case r {
+        Value(p) -> Ok(p)
+        _ -> Error(Nil)
+      }
+    })
+  let deduped = dedup.dedup_param_field_names(resolved)
+  list.zip(resolved, deduped)
+  |> list.fold(dict.new(), fn(acc, pair) {
+    let #(param, name) = pair
+    dict.insert(acc, #(param.name, param.in_), name)
+  })
+}
+
+/// Look up the deduped field name for a parameter. The map is built from
+/// the same operation the caller iterates, so the lookup always hits —
+/// the fallback is just a safety net that keeps the output valid Gleam
+/// if a caller ever passes a mismatched map.
+pub fn field_name_for(
+  map: ParamFieldNames,
+  param: spec.Parameter(Resolved),
+) -> String {
+  case dict.get(map, #(param.name, param.in_)) {
+    Ok(name) -> name
+    // nolint: thrown_away_error -- dict.get's Error just means the map did not carry this parameter; fall back to raw snake_case so codegen still produces a valid (if un-deduped) identifier
+    Error(_) -> naming.to_snake_case(param.name)
+  }
+}
 
 /// Build the call-site argument list for the `_with_request` wrapper that
 /// unpacks a `request_types.*Request` record into the flat client function
@@ -36,8 +81,9 @@ pub fn build_request_object_call_args(
   case list.is_empty(all_params), has_body {
     True, False -> None
     _, _ -> {
+      let field_names = build_param_field_names(operation)
       let param_refs =
-        list.map(all_params, fn(p) { "req." <> naming.to_snake_case(p.name) })
+        list.map(all_params, fn(p) { "req." <> field_name_for(field_names, p) })
       case operation.request_body {
         Some(Value(rb)) -> {
           let content_entries = ir_build.sorted_entries(rb.content)
@@ -66,10 +112,11 @@ pub fn build_param_list(
     list.append(path_params, query_params)
     |> list.append(header_params)
     |> list.append(cookie_params)
+  let field_names = build_param_field_names(operation)
 
   let param_strs =
     list.map(all_params, fn(p) {
-      let param_name = naming.to_snake_case(p.name)
+      let param_name = field_name_for(field_names, p)
       let param_type = param_to_type(p, ctx)
       ", " <> param_name <> ": " <> param_type
     })

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -109,12 +109,18 @@ fn request_type_decl(
     True -> Error(Nil)
     False -> {
       let type_name = naming.schema_to_type_name(op_id) <> "Request"
-      let param_fields =
+      let resolved_params =
         list.filter_map(params, fn(ref_p) {
           case ref_p {
-            Value(param) -> Ok(request_param_field(param))
+            Value(param) -> Ok(param)
             _ -> Error(Nil)
           }
+        })
+      let deduped_names = dedup.dedup_param_field_names(resolved_params)
+      let param_fields =
+        list.map(list.zip(resolved_params, deduped_names), fn(pair) {
+          let #(param, field_name) = pair
+          request_param_field(param, field_name)
         })
       let body_field = case operation.request_body {
         Some(Value(rb)) -> [request_body_field(rb, op_id, ctx)]
@@ -131,8 +137,10 @@ fn request_type_decl(
   }
 }
 
-fn request_param_field(param: spec.Parameter(Resolved)) -> Field {
-  let field_name = naming.to_snake_case(param.name)
+fn request_param_field(
+  param: spec.Parameter(Resolved),
+  field_name: String,
+) -> Field {
   let field_type = case param.payload {
     spec.ParameterSchema(Inline(StringSchema(..))) -> "String"
     spec.ParameterSchema(Inline(IntegerSchema(..))) -> "Int"

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -8,6 +8,7 @@ import oaspec/codegen/guards
 import oaspec/codegen/import_analysis
 import oaspec/codegen/server_request_decode as decode_helpers
 import oaspec/config
+import oaspec/openapi/dedup
 import oaspec/openapi/operations
 import oaspec/openapi/schema.{Inline, Reference}
 import oaspec/openapi/spec.{type Resolved, Value}
@@ -898,6 +899,8 @@ fn generate_safe_request_and_dispatch(
         _ -> Error(Nil)
       }
     })
+  let deduped_field_names = dedup.dedup_param_field_names(params)
+  let params_with_field_names = list.zip(params, deduped_field_names)
 
   // Collect path params that need Result-based parsing (int, float)
   let path_params_needing_parse =
@@ -1019,8 +1022,8 @@ fn generate_safe_request_and_dispatch(
     |> se.indent(3, "let request = request_types." <> request_type_name <> "(")
 
   let sb =
-    list.fold(params, sb, fn(sb, param) {
-      let field_name = naming.to_snake_case(param.name)
+    list.fold(params_with_field_names, sb, fn(sb, entry) {
+      let #(param, field_name) = entry
       let trailing = ","
       let value_expr = case param.in_ {
         spec.InPath -> {

--- a/src/oaspec/openapi/dedup.gleam
+++ b/src/oaspec/openapi/dedup.gleam
@@ -236,6 +236,28 @@ pub fn dedup_property_names(prop_names: List(String)) -> List(String) {
   deduplicate_strings(snake_names)
 }
 
+/// Given the parameters of a single operation, return a parallel list of
+/// deduped snake_case Gleam field names. Parameters whose wire names map to
+/// the same snake_case field (e.g. `id` in path AND `id` in query) get the
+/// same `_2`/`_3` suffix treatment used for property names. The reserved
+/// label `body` is taken first so a parameter literally named `body` is
+/// renamed instead of clashing with the request type's body field.
+///
+/// The function is order-sensitive: the first occurrence keeps its base
+/// snake_case form, later occurrences get the suffix. Pass the parameters
+/// in the same order the spec lists them so type emission, server dispatch,
+/// and client builder agree on the final field name.
+pub fn dedup_param_field_names(
+  params: List(spec.Parameter(stage)),
+) -> List(String) {
+  let snake_names = list.map(params, fn(p) { naming.to_snake_case(p.name) })
+  let with_body_reserved = ["body", ..snake_names]
+  case deduplicate_strings(with_body_reserved) {
+    [_body, ..rest] -> rest
+    _ -> []
+  }
+}
+
 /// Given a list of original enum values (JSON wire values), return a list
 /// of deduped PascalCase Gleam variant suffixes. The returned list is
 /// parallel to the input.

--- a/src/oaspec/openapi/dedup.gleam
+++ b/src/oaspec/openapi/dedup.gleam
@@ -267,25 +267,34 @@ pub fn dedup_enum_variants(enum_values: List(String)) -> List(String) {
 }
 
 /// Deduplicate a list of strings by appending "_2", "_3", etc. for duplicates.
+/// The chosen suffix skips any name that already appears elsewhere in the
+/// input, so a later literal `foo_2` cannot collide with a generated
+/// `foo_2` produced from the second `foo`.
 fn deduplicate_strings(names: List(String)) -> List(String) {
   let #(result_rev, _) =
     list.fold(names, #([], dict.new()), fn(acc, name) {
-      let #(result, counts) = acc
-      case dict.get(counts, name) {
-        // nolint: thrown_away_error -- dict.get's Error signals absence of key; no diagnostic info to propagate
-        Error(_) -> {
-          let counts = dict.insert(counts, name, 1)
-          #([name, ..result], counts)
-        }
-        Ok(count) -> {
-          let new_count = count + 1
-          let unique_name = name <> "_" <> int.to_string(new_count)
-          let counts = dict.insert(counts, name, new_count)
-          #([unique_name, ..result], counts)
-        }
-      }
+      let #(result, used) = acc
+      let unique_name = next_unique_name(name, used, 1)
+      #([unique_name, ..result], dict.insert(used, unique_name, True))
     })
   list.reverse(result_rev)
+}
+
+/// Pick the first suffixed variant of `base` that is not already claimed.
+/// Suffix `1` means the raw name; higher suffixes append `_2`, `_3`, etc.
+fn next_unique_name(
+  base: String,
+  used: Dict(String, Bool),
+  suffix: Int,
+) -> String {
+  let candidate = case suffix {
+    1 -> base
+    n -> base <> "_" <> int.to_string(n)
+  }
+  case dict.has_key(used, candidate) {
+    True -> next_unique_name(base, used, suffix + 1)
+    False -> candidate
+  }
 }
 
 /// Get element at index from a list.

--- a/src/oaspec/openapi/dedup.gleam
+++ b/src/oaspec/openapi/dedup.gleam
@@ -268,31 +268,40 @@ pub fn dedup_enum_variants(enum_values: List(String)) -> List(String) {
 
 /// Deduplicate a list of strings by appending "_2", "_3", etc. for duplicates.
 /// The chosen suffix skips any name that already appears elsewhere in the
-/// input, so a later literal `foo_2` cannot collide with a generated
-/// `foo_2` produced from the second `foo`.
+/// input (so a later literal `foo_2` keeps its label and an earlier
+/// duplicate `foo` advances to `foo_3`) and any suffix this call has
+/// already handed out, so the output has no collisions in either
+/// direction.
 fn deduplicate_strings(names: List(String)) -> List(String) {
+  let input_names =
+    list.fold(names, dict.new(), fn(acc, name) { dict.insert(acc, name, True) })
   let #(result_rev, _) =
     list.fold(names, #([], dict.new()), fn(acc, name) {
-      let #(result, used) = acc
-      let unique_name = next_unique_name(name, used, 1)
-      #([unique_name, ..result], dict.insert(used, unique_name, True))
+      let #(result, claimed) = acc
+      case dict.has_key(claimed, name) {
+        False -> #([name, ..result], dict.insert(claimed, name, True))
+        True -> {
+          let unique_name = next_unique_name(name, input_names, claimed, 2)
+          #([unique_name, ..result], dict.insert(claimed, unique_name, True))
+        }
+      }
     })
   list.reverse(result_rev)
 }
 
-/// Pick the first suffixed variant of `base` that is not already claimed.
-/// Suffix `1` means the raw name; higher suffixes append `_2`, `_3`, etc.
+/// Pick the first `base_<n>` suffix that collides neither with another
+/// literal input name nor with a name this call has already minted.
 fn next_unique_name(
   base: String,
-  used: Dict(String, Bool),
+  input_names: Dict(String, Bool),
+  claimed: Dict(String, Bool),
   suffix: Int,
 ) -> String {
-  let candidate = case suffix {
-    1 -> base
-    n -> base <> "_" <> int.to_string(n)
-  }
-  case dict.has_key(used, candidate) {
-    True -> next_unique_name(base, used, suffix + 1)
+  let candidate = base <> "_" <> int.to_string(suffix)
+  case
+    dict.has_key(input_names, candidate) || dict.has_key(claimed, candidate)
+  {
+    True -> next_unique_name(base, input_names, claimed, suffix + 1)
     False -> candidate
   }
 }

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -839,20 +839,23 @@ pub fn dedup_resolves_request_param_field_name_collision_test() {
       string.contains(f.path, "request_types.gleam")
     })
 
-  // The record body must not have two fields sharing a label.
+  // The request record must not carry two fields sharing a label.
   string.contains(request_types_file.content, "id: String, id: Option")
   |> should.be_false()
-  string.contains(request_types_file.content, "id: String, id_2: Option")
-  |> should.be_true()
+  string.contains(request_types_file.content, "id: String, id: String")
+  |> should.be_false()
+  // The renamed second field must appear somewhere in the record.
+  string.contains(request_types_file.content, "id_2:") |> should.be_true()
 
-  // The server and client must agree with the renamed field, otherwise
-  // construction of the request record would fail to compile.
+  // The server must construct the renamed field. The raw (pre-format)
+  // output puts each field on its own line, so check the field assignment
+  // rather than a comma-separated fragment.
   let server_files = server_gen.generate(ctx)
   let assert Ok(router_file) =
     list.find(server_files, fn(f) { string.contains(f.path, "router.gleam") })
-  string.contains(router_file.content, "id: id, id_2:")
-  |> should.be_true()
+  string.contains(router_file.content, "id_2:") |> should.be_true()
 
+  // The client's _with_request wrapper unpacks the renamed field.
   let client_files = client_gen.generate(ctx)
   let assert Ok(client_file) =
     list.find(client_files, fn(f) { string.contains(f.path, "client.gleam") })

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -827,6 +827,79 @@ pub fn dedup_resolves_duplicate_operation_id_test() {
   |> should.be_false()
 }
 
+pub fn dedup_resolves_request_param_field_name_collision_test() {
+  // Regression for issue #236: two parameters that collapse to the same
+  // snake_case field name (e.g. path `id` and query `id` on the same op)
+  // must be renamed so the generated request type compiles.
+  let ctx = make_ctx("test/fixtures/collision.yaml")
+
+  let type_files = types.generate(ctx)
+  let assert Ok(request_types_file) =
+    list.find(type_files, fn(f) {
+      string.contains(f.path, "request_types.gleam")
+    })
+
+  // The record body must not have two fields sharing a label.
+  string.contains(request_types_file.content, "id: String, id: Option")
+  |> should.be_false()
+  string.contains(request_types_file.content, "id: String, id_2: Option")
+  |> should.be_true()
+
+  // The server and client must agree with the renamed field, otherwise
+  // construction of the request record would fail to compile.
+  let server_files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(server_files, fn(f) { string.contains(f.path, "router.gleam") })
+  string.contains(router_file.content, "id: id, id_2:")
+  |> should.be_true()
+
+  let client_files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(client_files, fn(f) { string.contains(f.path, "client.gleam") })
+  string.contains(client_file.content, "req.id_2") |> should.be_true()
+}
+
+pub fn dedup_param_field_names_reserves_body_label_test() {
+  // A parameter literally named `body` must not collide with the
+  // request type's `body` field (used for request bodies).
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Body Collision
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      operationId: createItem
+      parameters:
+        - name: body
+          in: query
+          required: false
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, properties: { name: { type: string } } }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+
+  let type_files = types.generate(ctx)
+  let assert Ok(request_types_file) =
+    list.find(type_files, fn(f) {
+      string.contains(f.path, "request_types.gleam")
+    })
+
+  // Exactly one `body: ` field (the request body). The `body` query
+  // parameter must have been renamed to `body_2`.
+  string.contains(request_types_file.content, "body_2: Option(String)")
+  |> should.be_true()
+}
+
 pub fn validate_accepts_typed_additional_properties_test() {
   let yaml =
     "

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -903,6 +903,54 @@ paths:
   |> should.be_true()
 }
 
+pub fn dedup_param_field_names_skips_existing_suffix_test() {
+  // Regression: when a later parameter literally matches a suffix the
+  // deduper would otherwise generate (e.g. wire names `body`, `body`,
+  // `body_2`), the deduper must pick the next free suffix (`body_3`)
+  // rather than minting a second `body_2`.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Suffix Collision
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      operationId: createItem
+      parameters:
+        - name: body
+          in: query
+          required: false
+          schema: { type: string }
+        - name: body_2
+          in: header
+          required: false
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, properties: { name: { type: string } } }
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+
+  let type_files = types.generate(ctx)
+  let assert Ok(request_types_file) =
+    list.find(type_files, fn(f) {
+      string.contains(f.path, "request_types.gleam")
+    })
+
+  // The reserved `body` (request body) is kept, the query `body` is
+  // renamed to `body_3` (since `body_2` is already a real wire name),
+  // and the header `body_2` keeps its original label.
+  string.contains(request_types_file.content, "body_3:") |> should.be_true()
+  string.contains(request_types_file.content, "body_2:") |> should.be_true()
+}
+
 pub fn validate_accepts_typed_additional_properties_test() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

- Closes #236
- Parameters that collapse to the same `snake_case` field inside a single operation (e.g. path `id` and query `id`) now get the `_2`/`_3` suffix treatment already used for property and operationId collisions. Declarations, router construction, and client builder now all agree on the renamed field.
- Reserves the `body` label in the dedup pass so a parameter literally named `body` does not collide with the request type's body field.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] New regression tests in `test/oaspec_test.gleam`:
  - `dedup_resolves_request_param_field_name_collision_test`
  - `dedup_param_field_names_reserves_body_label_test`
- [ ] Full CI (`just all`) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter naming collisions in generated API client and server code. When multiple parameters normalize to the same field name, the code generator now automatically renames them with numeric suffixes to ensure unique, valid identifiers in request objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->