### PR TITLE
feat(parser): reject openapi versions outside the supported 3.0.x / 3.1.x range

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 713 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 716 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -318,7 +318,7 @@ oaspec generate --config=oaspec.yaml --check --fail-on-warnings
 
 ## OpenAPI Support
 
-`oaspec` supports OpenAPI 3.0.x and a practical subset of OpenAPI 3.1 in YAML or JSON. The parser rejects specs whose top-level `openapi` field is outside `3.0.x` / `3.1.x` (for example `2.0` or `4.0.0`) with a diagnostic, so unsupported versions fail fast instead of producing plausible-looking but meaningless output.
+`oaspec` supports OpenAPI 3.0.x and a practical subset of OpenAPI 3.1.x in YAML or JSON. For compatibility, the parser also accepts the two-segment forms `3.0` / `3.1`, including YAML numeric values such as `openapi: 3.0` that arrive as the float `3.0`. Any other `openapi` value — for example `2.0`, `4.0.0`, a bare `3`, or a malformed `3.0.foo` — is rejected with an `invalid_value` diagnostic so unsupported versions fail fast instead of producing plausible-looking but meaningless output.
 
 Coverage is strongest in these areas:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 707 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 713 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -318,7 +318,7 @@ oaspec generate --config=oaspec.yaml --check --fail-on-warnings
 
 ## OpenAPI Support
 
-`oaspec` supports OpenAPI 3.0.x and a practical subset of OpenAPI 3.1 in YAML or JSON.
+`oaspec` supports OpenAPI 3.0.x and a practical subset of OpenAPI 3.1 in YAML or JSON. The parser rejects specs whose top-level `openapi` field is outside `3.0.x` / `3.1.x` (for example `2.0` or `4.0.0`) with a diagnostic, so unsupported versions fail fast instead of producing plausible-looking but meaningless output.
 
 Coverage is strongest in these areas:
 

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -169,8 +169,15 @@ fn validate_openapi_version(
 
 fn is_supported_openapi_version(version: String) -> Bool {
   case string.split(version, ".") {
-    ["3", "0", _, ..] | ["3", "1", _, ..] -> True
-    // A two-segment "3.0" / "3.1" is tolerated: float-parsed YAML numbers
+    // Three-segment form: major.minor.patch. The patch must be a
+    // non-negative integer — `3.0.foo`, `3.0.-1`, and `3.0.0.1` must all
+    // fail so the "exact accepted range" guarantee holds.
+    ["3", "0", patch] | ["3", "1", patch] ->
+      case int.parse(patch) {
+        Ok(n) if n >= 0 -> True
+        _ -> False
+      }
+    // Two-segment "3.0" / "3.1" is tolerated: float-parsed YAML numbers
     // like `openapi: 3.0` arrive as "3.0" after normalization.
     ["3", "0"] | ["3", "1"] -> True
     _ -> False

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -114,6 +114,11 @@ fn parse_root(
     )),
   )
 
+  use _ <- result.try(validate_openapi_version(
+    openapi,
+    location_index.lookup_field(index, "", "openapi"),
+  ))
+
   use info <- result.try(parse_info(node, index))
 
   // Parse components FIRST so we can resolve $ref during path parsing.
@@ -142,6 +147,34 @@ fn parse_root(
     external_docs:,
     json_schema_dialect:,
   ))
+}
+
+/// Reject spec files whose `openapi` field is not in the supported 3.0.x /
+/// 3.1.x range. OpenAPI 3.x is what oaspec claims to generate from, so
+/// accepting 2.0 or 4.0.0 would let users feed specs that are either
+/// subtly or grossly incompatible with the generator.
+fn validate_openapi_version(
+  version: String,
+  loc: diagnostic.SourceLoc,
+) -> Result(Nil, Diagnostic) {
+  use <- bool.guard(is_supported_openapi_version(version), Ok(Nil))
+  Error(diagnostic.invalid_value(
+    path: "openapi",
+    detail: "Unsupported OpenAPI version: '"
+      <> version
+      <> "'. oaspec only supports OpenAPI 3.0.x and 3.1.x.",
+    loc: loc,
+  ))
+}
+
+fn is_supported_openapi_version(version: String) -> Bool {
+  case string.split(version, ".") {
+    ["3", "0", _, ..] | ["3", "1", _, ..] -> True
+    // A two-segment "3.0" / "3.1" is tolerated: float-parsed YAML numbers
+    // like `openapi: 3.0` arrive as "3.0" after normalization.
+    ["3", "0"] | ["3", "1"] -> True
+    _ -> False
+  }
 }
 
 /// Parse optional components section.

--- a/test/fixtures/oss_kin_openapi_callbacks.yaml
+++ b/test/fixtures/oss_kin_openapi_callbacks.yaml
@@ -1,4 +1,4 @@
-openapi: '3'
+openapi: '3.0.0'
 info:
   version: 0.0.1
   title: 'test'

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -227,10 +227,67 @@ paths: {}
   string.contains(detail, "4.0.0") |> should.be_true()
 }
 
-pub fn parse_rejects_bare_openapi_3_test() {
+pub fn parse_rejects_openapi_3_2_0_test() {
+  // An as-yet-unreleased 3.2 must not sneak through a "starts with 3"
+  // check. oaspec only supports 3.0.x and 3.1.x.
   let yaml =
     "
-openapi: \"3\"
+openapi: 3.2.0
+info:
+  title: Future Minor API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+  let assert Error(Diagnostic(
+    code: "invalid_value",
+    pointer: "openapi",
+    message: detail,
+    ..,
+  )) = result
+  string.contains(detail, "Unsupported OpenAPI version") |> should.be_true()
+  string.contains(detail, "3.2.0") |> should.be_true()
+}
+
+pub fn parse_rejects_malformed_patch_segment_test() {
+  // A non-numeric patch must be rejected — if we let `3.0.foo` through,
+  // the "exact accepted range" promise stops being exact.
+  let yaml =
+    "
+openapi: 3.0.foo
+info:
+  title: Garbage Patch API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+  let assert Error(Diagnostic(code: "invalid_value", ..)) = result
+}
+
+pub fn parse_rejects_openapi_with_extra_segment_test() {
+  // More than three segments is not a valid SemVer-ish form.
+  let yaml =
+    "
+openapi: 3.0.0.1
+info:
+  title: Over-Segmented API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+  let assert Error(Diagnostic(code: "invalid_value", ..)) = result
+}
+
+pub fn parse_rejects_bare_openapi_3_test() {
+  // YAML-integer `openapi: 3` should also be rejected (the parser
+  // stringifies it to "3"), since oaspec cannot infer whether this is
+  // 3.0.x or 3.1.x.
+  let yaml =
+    "
+openapi: 3
 info:
   title: Ambiguous API
   version: 1.0.0

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -282,12 +282,14 @@ paths: {}
 }
 
 pub fn parse_rejects_bare_openapi_3_test() {
-  // YAML-integer `openapi: 3` should also be rejected (the parser
-  // stringifies it to "3"), since oaspec cannot infer whether this is
-  // 3.0.x or 3.1.x.
+  // A bare quoted `"3"` cannot tell us whether the spec was authored
+  // against 3.0.x or 3.1.x, so it is rejected. (An unquoted `openapi: 3`
+  // is parsed as a YAML integer, coerced to the float 3.0, and
+  // normalized to the string "3.0" — which is an explicitly accepted
+  // two-segment form, so that case does NOT error.)
   let yaml =
     "
-openapi: 3
+openapi: \"3\"
 info:
   title: Ambiguous API
   version: 1.0.0
@@ -295,6 +297,7 @@ paths: {}
 "
   let result = parser.parse_string(yaml)
   should.be_error(result)
+  let assert Error(Diagnostic(code: "invalid_value", ..)) = result
 }
 
 pub fn parse_accepts_openapi_3_0_3_test() {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -186,6 +186,103 @@ pub fn parse_file_not_found_test() {
   should.be_error(result)
 }
 
+// --- OpenAPI version gate (issue #235) ---
+//
+// oaspec advertises itself as an OpenAPI 3.x parser/generator. Feeding it a
+// spec with a version it cannot actually support (Swagger 2.0, a future
+// 4.x, or a bare "3") would produce plausible-looking but meaningless
+// output, so the parser rejects anything outside 3.0.x / 3.1.x up front.
+
+pub fn parse_rejects_openapi_2_0_test() {
+  let yaml =
+    "
+openapi: 2.0
+info:
+  title: Wrong API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+  let assert Error(Diagnostic(code: "invalid_value", message: detail, ..)) =
+    result
+  string.contains(detail, "Unsupported OpenAPI version") |> should.be_true()
+  string.contains(detail, "2.0") |> should.be_true()
+}
+
+pub fn parse_rejects_openapi_4_0_0_test() {
+  let yaml =
+    "
+openapi: 4.0.0
+info:
+  title: Future API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+  let assert Error(Diagnostic(code: "invalid_value", message: detail, ..)) =
+    result
+  string.contains(detail, "Unsupported OpenAPI version") |> should.be_true()
+  string.contains(detail, "4.0.0") |> should.be_true()
+}
+
+pub fn parse_rejects_bare_openapi_3_test() {
+  let yaml =
+    "
+openapi: \"3\"
+info:
+  title: Ambiguous API
+  version: 1.0.0
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  should.be_error(result)
+}
+
+pub fn parse_accepts_openapi_3_0_3_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  spec.openapi |> should.equal("3.0.3")
+}
+
+pub fn parse_accepts_openapi_3_1_0_test() {
+  let yaml =
+    "
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  spec.openapi |> should.equal("3.1.0")
+}
+
+pub fn parse_accepts_openapi_3_0_from_yaml_float_test() {
+  // YAML numbers like `openapi: 3.0` arrive as the float 3.0 and get
+  // normalized to the string "3.0". That two-segment form must still
+  // parse so existing specs that rely on YAML float semantics keep
+  // working.
+  let yaml =
+    "
+openapi: 3.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  spec.openapi |> should.equal("3.0")
+}
+
 pub fn parse_secure_api_has_security_schemes_test() {
   let assert Ok(spec) = parser.parse_file("test/fixtures/secure_api.yaml")
   let assert Some(components) = spec.components


### PR DESCRIPTION
## Summary

- Closes #235
- The parser now validates the root `openapi` field and rejects specs whose version is not in the supported 3.0.x / 3.1.x range with a dedicated `invalid_value` diagnostic. Swagger 2.0 and any future 4.x now fail fast with a clear message instead of silently passing `validate`.
- Two-segment forms like `openapi: 3.0` (which arrive from YAML float parsing) stay accepted so existing specs that rely on YAML float semantics keep working.
- README's "OpenAPI Support" section now documents the exact accepted range.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] 6 new regression tests in `test/oaspec_test.gleam`:
  - `parse_rejects_openapi_2_0_test`
  - `parse_rejects_openapi_4_0_0_test`
  - `parse_rejects_bare_openapi_3_test`
  - `parse_accepts_openapi_3_0_3_test`
  - `parse_accepts_openapi_3_1_0_test`
  - `parse_accepts_openapi_3_0_from_yaml_float_test`
- [x] Updated the `oss_kin_openapi_callbacks.yaml` fixture from the bare `openapi: '3'` to `'3.0.0'`
- [ ] Full CI (`just all`) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser now enforces strict OpenAPI specification version validation, rejecting unsupported versions outside the 3.0.x and 3.1.x ranges with diagnostic error messages.

* **Tests**
  * Added regression tests confirming version validation for both supported and unsupported OpenAPI specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->