### PR TITLE
feat(validate): reject duplicate operationIds instead of silently renaming them

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 716 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 718 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -319,6 +319,10 @@ oaspec generate --config=oaspec.yaml --check --fail-on-warnings
 ## OpenAPI Support
 
 `oaspec` supports OpenAPI 3.0.x and a practical subset of OpenAPI 3.1.x in YAML or JSON. For compatibility, the parser also accepts the two-segment forms `3.0` / `3.1`, including YAML numeric values such as `openapi: 3.0` that arrive as the float `3.0`. Any other `openapi` value — for example `2.0`, `4.0.0`, a bare `3`, or a malformed `3.0.foo` — is rejected with an `invalid_value` diagnostic so unsupported versions fail fast instead of producing plausible-looking but meaningless output.
+
+### operationId uniqueness
+
+Every operation must carry a unique `operationId`. oaspec validates this as a hard error with the offending `METHOD /path` sites listed, because silently renaming the second occurrence (as some generators do) would mutate the generated function/type names without telling the user. The check also catches IDs that only differ in casing — `listItems` and `list_items` both collapse to the same generated `list_items` function, so the spec is rejected.
 
 Coverage is strongest in these areas:
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -58,15 +58,21 @@ fn validate_unique_operation_ids(
 
   // A spec with "listItems" and "list_items" has no literal collision but
   // generates two functions called `list_items/N` — catch that too.
-  let literal_keys = dict.keys(literal)
+  // Skip cases where every site is already covered by a literal-duplicate
+  // diagnostic (same sites, same name), to avoid emitting two diagnostics
+  // for the same root cause.
   let function_errors =
     dict.to_list(by_function)
     |> list.filter_map(fn(entry) {
       let #(fn_name, sites) = entry
-      case sites, list.contains(literal_keys, fn_name) {
-        [_, _, ..], False ->
-          Ok(duplicate_function_name_diagnostic(fn_name, sites))
-        _, _ -> Error(Nil)
+      case sites {
+        [_, _, ..] -> {
+          case dict.get(literal, fn_name) {
+            Ok(literal_sites) if literal_sites == sites -> Error(Nil)
+            _ -> Ok(duplicate_function_name_diagnostic(fn_name, sites))
+          }
+        }
+        _ -> Error(Nil)
       }
     })
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -1,4 +1,4 @@
-import gleam/dict
+import gleam/dict.{type Dict}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/regexp
@@ -18,17 +18,107 @@ import oaspec/openapi/schema.{
 import oaspec/openapi/spec.{type Resolved}
 import oaspec/util/content_type
 import oaspec/util/http
+import oaspec/util/naming
 
 /// Validate the parsed spec for unsupported patterns.
 /// Returns a list of errors; empty list means validation passed.
-/// Name collisions and duplicate operationIds are handled by the dedup pass
-/// before validation, so they are no longer checked here.
+///
+/// operationId uniqueness is enforced here with a hard error (issue #237):
+/// silently renaming duplicates would mutate the generated public API
+/// surface without telling the user, which is worse than failing the spec.
 pub fn validate(ctx: Context) -> List(Diagnostic) {
   let operations = operations.collect_operations(ctx)
   let op_errors = validate_operations(ctx, operations)
+  let opid_errors = validate_unique_operation_ids(operations)
   let schema_errors = validate_component_schemas(ctx)
   let security_errors = validate_security_schemes(ctx, operations)
-  list.flatten([op_errors, schema_errors, security_errors])
+  list.flatten([op_errors, opid_errors, schema_errors, security_errors])
+}
+
+/// Fail the spec if two operations end up sharing an operationId, either
+/// literally or after snake_case conversion to the generated function
+/// name. Returns one diagnostic per distinct colliding name, listing all
+/// `METHOD /path` sites that claimed it.
+fn validate_unique_operation_ids(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> List(Diagnostic) {
+  let literal = group_operations_by_id(operations, fn(op_id) { op_id })
+  let by_function =
+    group_operations_by_id(operations, naming.operation_to_function_name)
+
+  let literal_errors =
+    dict.to_list(literal)
+    |> list.filter_map(fn(entry) {
+      let #(op_id, sites) = entry
+      case sites {
+        [_, _, ..] -> Ok(duplicate_operation_id_diagnostic(op_id, sites))
+        _ -> Error(Nil)
+      }
+    })
+
+  // A spec with "listItems" and "list_items" has no literal collision but
+  // generates two functions called `list_items/N` — catch that too.
+  let literal_keys = dict.keys(literal)
+  let function_errors =
+    dict.to_list(by_function)
+    |> list.filter_map(fn(entry) {
+      let #(fn_name, sites) = entry
+      case sites, list.contains(literal_keys, fn_name) {
+        [_, _, ..], False ->
+          Ok(duplicate_function_name_diagnostic(fn_name, sites))
+        _, _ -> Error(Nil)
+      }
+    })
+
+  list.append(literal_errors, function_errors)
+}
+
+fn group_operations_by_id(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  key_fn: fn(String) -> String,
+) -> Dict(String, List(String)) {
+  list.fold(operations, dict.new(), fn(acc, entry) {
+    let #(op_id, _operation, path, method) = entry
+    let key = key_fn(op_id)
+    let site = string.uppercase(spec.method_to_string(method)) <> " " <> path
+    case dict.get(acc, key) {
+      Ok(existing) -> dict.insert(acc, key, list.append(existing, [site]))
+      // nolint: thrown_away_error -- dict.get's Error signals absence of key; we start a new list for the first occurrence
+      Error(_) -> dict.insert(acc, key, [site])
+    }
+  })
+}
+
+fn duplicate_operation_id_diagnostic(
+  op_id: String,
+  sites: List(String),
+) -> Diagnostic {
+  diagnostic.invalid_value(
+    path: "paths.*.operationId",
+    detail: "Duplicate operationId '"
+      <> op_id
+      <> "' found on: "
+      <> string.join(sites, ", ")
+      <> ". operationId must be unique across the entire spec; "
+      <> "rename one of the operations to keep the generated API stable.",
+    loc: diagnostic.NoSourceLoc,
+  )
+}
+
+fn duplicate_function_name_diagnostic(
+  fn_name: String,
+  sites: List(String),
+) -> Diagnostic {
+  diagnostic.invalid_value(
+    path: "paths.*.operationId",
+    detail: "operationIds that normalize to the same generated function name '"
+      <> fn_name
+      <> "' found on: "
+      <> string.join(sites, ", ")
+      <> ". oaspec converts operationIds to snake_case, so values like "
+      <> "'listItems' and 'list_items' collide; rename one of them.",
+    loc: diagnostic.NoSourceLoc,
+  )
 }
 
 /// Filter to only errors (not warnings).

--- a/src/oaspec/openapi/dedup.gleam
+++ b/src/oaspec/openapi/dedup.gleam
@@ -1,160 +1,26 @@
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
-import gleam/option.{type Option, None, Some}
-import gleam/string
+import gleam/option.{None, Some}
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AnyOfSchema, Forbidden, Inline,
   ObjectSchema, OneOfSchema, Reference, Typed, Untyped,
 }
-import oaspec/openapi/spec.{
-  type OpenApiSpec, type Operation, type PathItem, Components, OpenApiSpec,
-  PathItem, Ref, Value,
-}
+import oaspec/openapi/spec.{type OpenApiSpec, Components, OpenApiSpec}
 import oaspec/util/naming
 
-/// Deduplicate names in the spec to avoid collisions in generated code.
+/// Deduplicate names within schemas to avoid collisions in generated code.
 /// This is a pre-processing pass that runs after hoisting and before validation.
-/// It handles:
-///   - Duplicate operationIds across operations
-///   - Function/type name collisions after case conversion of operationIds
-/// Property name and enum variant deduplication is done at codegen time via
-/// dedup_property_names/1 and dedup_enum_variants/1 to preserve JSON wire names.
+///
+/// Scope is intentionally limited: operationId / function-name uniqueness is
+/// enforced by `oaspec/codegen/validate.gleam` with a hard error, not by a
+/// silent rename, because renaming mutates the generated public API surface
+/// without telling the user (see issue #237). Property name and enum variant
+/// deduplication is done at codegen time via dedup_property_names/1 and
+/// dedup_enum_variants/1 to preserve JSON wire names.
 pub fn dedup(spec: OpenApiSpec(stage)) -> OpenApiSpec(stage) {
   spec
-  |> dedup_operation_ids
   |> dedup_schemas
-}
-
-/// Deduplicate operationIds across all operations.
-/// If two operations have the same operationId, the second gets "_2" appended, etc.
-/// Also handles function/type name collisions after case conversion.
-fn dedup_operation_ids(spec: OpenApiSpec(stage)) -> OpenApiSpec(stage) {
-  // Collect all operation IDs with their paths
-  let all_ops = collect_all_operations(spec)
-
-  // First pass: deduplicate raw operationIds
-  let raw_ids =
-    list.map(all_ops, fn(op) {
-      let #(_path, _method, operation) = op
-      case operation.operation_id {
-        Some(id) -> id
-        None -> ""
-      }
-    })
-  let deduped_ids = deduplicate_strings(raw_ids)
-
-  // Second pass: deduplicate after snake_case conversion (function names)
-  let fn_names = list.map(deduped_ids, naming.operation_to_function_name)
-  let deduped_fn_names = deduplicate_strings(fn_names)
-
-  // Build mapping: index -> final operationId
-  // If function name was deduped, derive the operationId from the deduped function name
-  let indexed_ops = list.index_map(all_ops, fn(op, idx) { #(idx, op) })
-  let id_map =
-    list.index_fold(indexed_ops, dict.new(), fn(acc, entry, _) {
-      let #(idx, #(path, method, _op)) = entry
-      let final_id = case
-        list_at(deduped_ids, idx),
-        list_at(deduped_fn_names, idx)
-      {
-        Some(raw_id), Some(fn_name) -> {
-          // If function name differs from snake_case of raw_id, use the deduped fn name
-          let expected_fn = naming.operation_to_function_name(raw_id)
-          case expected_fn == fn_name {
-            True -> raw_id
-            False -> fn_name
-          }
-        }
-        Some(raw_id), _ -> raw_id
-        _, _ -> ""
-      }
-      dict.insert(acc, #(path, method), final_id)
-    })
-
-  // Apply the deduped IDs back to the spec
-  let new_paths =
-    dict.to_list(spec.paths)
-    |> list.map(fn(entry) {
-      let #(path, ref_or) = entry
-      case ref_or {
-        Value(path_item) -> {
-          let new_item = dedup_path_item_ops(path_item, path, id_map)
-          #(path, Value(new_item))
-        }
-        Ref(_) as r -> #(path, r)
-      }
-    })
-    |> dict.from_list()
-
-  OpenApiSpec(..spec, paths: new_paths)
-}
-
-fn dedup_path_item_ops(
-  item: PathItem(stage),
-  path: String,
-  id_map: Dict(#(String, String), String),
-) -> PathItem(stage) {
-  PathItem(
-    ..item,
-    get: apply_deduped_id(item.get, path, "get", id_map),
-    post: apply_deduped_id(item.post, path, "post", id_map),
-    put: apply_deduped_id(item.put, path, "put", id_map),
-    delete: apply_deduped_id(item.delete, path, "delete", id_map),
-    patch: apply_deduped_id(item.patch, path, "patch", id_map),
-    head: apply_deduped_id(item.head, path, "head", id_map),
-    options: apply_deduped_id(item.options, path, "options", id_map),
-    trace: apply_deduped_id(item.trace, path, "trace", id_map),
-  )
-}
-
-fn apply_deduped_id(
-  op: Option(Operation(stage)),
-  path: String,
-  method: String,
-  id_map: Dict(#(String, String), String),
-) -> Option(Operation(stage)) {
-  case op {
-    None -> None
-    Some(operation) ->
-      case dict.get(id_map, #(path, method)) {
-        Ok(new_id) if new_id != "" ->
-          Some(spec.Operation(..operation, operation_id: Some(new_id)))
-        _ -> Some(operation)
-      }
-  }
-}
-
-/// Collect all operations as (path, method_str, operation) tuples.
-fn collect_all_operations(
-  spec: OpenApiSpec(stage),
-) -> List(#(String, String, Operation(stage))) {
-  let paths =
-    list.sort(dict.to_list(spec.paths), fn(a, b) { string.compare(a.0, b.0) })
-  list.flat_map(paths, fn(entry) {
-    let #(path, ref_or) = entry
-    case ref_or {
-      Ref(_) -> []
-      Value(item) -> {
-        let ops = [
-          #("get", item.get),
-          #("post", item.post),
-          #("put", item.put),
-          #("delete", item.delete),
-          #("patch", item.patch),
-          #("head", item.head),
-          #("options", item.options),
-          #("trace", item.trace),
-        ]
-        list.filter_map(ops, fn(op) {
-          case op {
-            #(method, Some(operation)) -> Ok(#(path, method, operation))
-            _ -> Error(Nil)
-          }
-        })
-      }
-    }
-  })
 }
 
 /// Recurse into nested schemas within components (e.g. oneOf children).
@@ -303,14 +169,5 @@ fn next_unique_name(
   {
     True -> next_unique_name(base, input_names, claimed, suffix + 1)
     False -> candidate
-  }
-}
-
-/// Get element at index from a list.
-fn list_at(lst: List(a), idx: Int) -> Option(a) {
-  case lst, idx {
-    [], _ -> None
-    [head, ..], 0 -> Some(head)
-    [_, ..rest], n -> list_at(rest, n - 1)
   }
 }

--- a/test/fixtures/collision.yaml
+++ b/test/fixtures/collision.yaml
@@ -23,7 +23,7 @@ paths:
           description: ok
   /admins/{id}:
     get:
-      operationId: getUser
+      operationId: getAdmin
       parameters:
         - name: id
           in: path

--- a/test/fixtures/oss_openapi_gen_issue_9719.yaml
+++ b/test/fixtures/oss_openapi_gen_issue_9719.yaml
@@ -30,8 +30,8 @@ paths:
                 type: string
   /underscoreDelimiter:
     get:
-      summary: List all users
-      operationId: petstore_api_users_getAll
+      summary: List all admins (underscore-delimited variant)
+      operationId: petstore_api_admins_getAll
       tags:
         - users
       responses:

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -975,12 +975,64 @@ pub fn validate_deep_additional_properties_in_response_test() {
   |> should.be_false()
 }
 
-pub fn dedup_resolves_duplicate_operation_id_test() {
+pub fn validate_rejects_duplicate_operation_id_test() {
+  // Issue #237: duplicate operationIds must fail validation with a clear
+  // diagnostic that names every site that claimed the colliding ID.
+  // (Previously the dedup pass silently renamed the second occurrence,
+  // mutating the generated public API surface without notifying the
+  // user.)
+  let ctx = make_ctx("test/fixtures/error_duplicate_operation_id.yaml")
+  let errors = validate.validate(ctx)
+  let messages = list.map(errors, validate.error_to_string)
+  list.any(messages, fn(s) { string.contains(s, "Duplicate operationId") })
+  |> should.be_true()
+  list.any(messages, fn(s) { string.contains(s, "listItems") })
+  |> should.be_true()
+  list.any(messages, fn(s) {
+    string.contains(s, "GET /users") && string.contains(s, "GET /items")
+  })
+  |> should.be_true()
+}
+
+pub fn validate_rejects_operation_ids_colliding_after_snake_case_test() {
+  // Two operationIds that differ only in case (listItems vs list_items)
+  // collapse to the same snake_case function name in generated code.
+  // That collision must fail validation even though the raw IDs differ.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Case Collision
+  version: 1.0.0
+paths:
+  /a:
+    get:
+      operationId: listItems
+      responses:
+        '200': { description: ok }
+  /b:
+    get:
+      operationId: list_items
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  let messages = list.map(errors, validate.error_to_string)
+  list.any(messages, fn(s) {
+    string.contains(s, "list_items") && string.contains(s, "generated function")
+  })
+  |> should.be_true()
+}
+
+pub fn validate_accepts_unique_operation_ids_test() {
+  // Sanity check: a well-formed spec with unique operationIds must not
+  // produce any duplicate-operationId diagnostic.
   let ctx = make_ctx("test/fixtures/collision.yaml")
   let errors = validate.validate(ctx)
-  // No duplicate operationId errors since dedup resolved them
-  let error_strings = list.map(errors, validate.error_to_string)
-  list.any(error_strings, fn(s) { string.contains(s, "Duplicate operationId") })
+  let messages = list.map(errors, validate.error_to_string)
+  list.any(messages, fn(s) { string.contains(s, "Duplicate operationId") })
   |> should.be_false()
 }
 
@@ -11482,9 +11534,10 @@ pub fn error_invalid_json_as_yaml_parsed_but_may_fail_test() {
 }
 
 pub fn error_duplicate_operation_id_parses_test() {
-  // Duplicate operationId is parsed without error; oaspec currently does not
-  // validate operationId uniqueness (the OpenAPI spec requires it, but oaspec
-  // treats them as independent labels). This test verifies the spec parses.
+  // The parser accepts a spec with duplicate operationIds — the uniqueness
+  // constraint is surfaced as a validation error (see issue #237 and
+  // `validate_rejects_duplicate_operation_id_test`), not a parse failure,
+  // so tooling can still load and inspect the broken spec.
   let assert Ok(spec) =
     parser.parse_file("test/fixtures/error_duplicate_operation_id.yaml")
   dict.size(spec.paths) |> should.equal(2)


### PR DESCRIPTION
## Summary

- Closes #237
- `oaspec validate` now emits a hard `invalid_value` diagnostic when two operations share an `operationId`, listing every `METHOD /path` site that claimed the name. Previously the dedup pass silently renamed later occurrences to `foo_2`/`foo_3`, which mutated the generated public API without warning the user.
- The check also catches case-only collisions: `listItems` and `list_items` both snake_case to `list_items` and would have produced duplicate generated function names.
- The dedup pass no longer renames operationIds. Schema-level dedup (property names, enum variants, request-type field names) is unchanged.
- README's "OpenAPI Support" section now states the operationId uniqueness rule explicitly.
- The `collision.yaml` fixture was retargeted to be about **parameter-field** collisions only (path `id` + query `id` on the same op); the operationId collision it used to carry now lives in `error_duplicate_operation_id.yaml`.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] New regression tests:
  - `validate_rejects_duplicate_operation_id_test` — literal collision produces a `Duplicate operationId` diagnostic naming both sites
  - `validate_rejects_operation_ids_colliding_after_snake_case_test` — `listItems` vs `list_items` rejected with a distinct diagnostic
  - `validate_accepts_unique_operation_ids_test` — sanity check that the well-formed `collision.yaml` no longer trips the new check
- [x] Updated `error_duplicate_operation_id_parses_test` comment to reflect that the parser intentionally accepts the bad spec and leaves rejection to validate
- [ ] Full CI (`just all`) green