### PR TITLE
feat(parser): preserve reusable callback refs and warn on parsed-not-used callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 718 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 722 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 722 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 723 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -246,6 +246,12 @@ pub fn registry() -> List(Capability) {
     Capability("tags", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("examples", "scope", ParsedNotUsed, "Parsed but no codegen"),
     Capability("links", "scope", ParsedNotUsed, "Parsed but no codegen"),
+    Capability(
+      "callbacks",
+      "scope",
+      ParsedNotUsed,
+      "Operation-level and components.callbacks are parsed and preserved (including `$ref` to `#/components/callbacks/...`) but no code is generated for callback endpoints",
+    ),
     Capability("xml", "scope", NotHandled, "XML annotations ignored"),
     // operation-level and path-level server overrides are supported as of #96
     // (generated clients resolve operation > path > top-level). They are no

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -411,10 +411,41 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
           ),
         ]
       }
-      list.flatten([header_w, example_w, link_w])
+      let callback_w = case dict.is_empty(components.callbacks) {
+        True -> []
+        False -> [
+          diagnostic.capability(
+            severity: SeverityWarning,
+            target: TargetBoth,
+            path: "components.callbacks",
+            detail: "Component callbacks are parsed and preserved but not used by code generation.",
+            hint: Some(
+              "Callback endpoints will not appear in generated code. No action needed unless you expected handler stubs for them.",
+            ),
+          ),
+        ]
+      }
+      list.flatten([header_w, example_w, link_w, callback_w])
     }
     None -> []
   }
+  let operation_callback_warnings =
+    list.filter_map(ops, fn(op) {
+      let #(op_id, operation, _path, _method) = op
+      case dict.is_empty(operation.callbacks) {
+        True -> Error(Nil)
+        False ->
+          Ok(diagnostic.capability(
+            severity: SeverityWarning,
+            target: TargetBoth,
+            path: op_id <> ".callbacks",
+            detail: "Operation-level callbacks are parsed and preserved but not used by code generation.",
+            hint: Some(
+              "The callback endpoints listed here will not appear in generated server/client code. No action needed unless you expected handler stubs.",
+            ),
+          ))
+      }
+    })
   list.flatten([
     webhook_warnings,
     response_warnings,
@@ -424,5 +455,6 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
     operation_server_warnings,
     path_server_warnings,
     component_warnings,
+    operation_callback_warnings,
   ])
 }

--- a/src/oaspec/openapi/external_loader.gleam
+++ b/src/oaspec/openapi/external_loader.gleam
@@ -1011,16 +1011,18 @@ fn rewrite_operation(
 /// Walk `operation.callbacks`: for each callback, rewrite every inline
 /// PathItem in its `entries` dict via the same `rewrite_path_item`
 /// helper used at the top level. `Ref` entries pointing at external
-/// PathItem objects pass through unchanged.
+/// PathItem objects pass through unchanged, and now so do top-level
+/// `Ref` callback entries (e.g. `myEvent: { $ref: '#/components/callbacks/foo' }`),
+/// which we keep as refs rather than inlining.
 fn rewrite_callback_map(
-  callbacks: dict.Dict(String, spec.Callback(Unresolved)),
+  callbacks: dict.Dict(String, spec.RefOr(spec.Callback(Unresolved))),
   base_dir: String,
   parse_file: fn(String) -> Result(OpenApiSpec(Unresolved), Diagnostic),
   imports: dict.Dict(String, #(String, SchemaRef)),
   original_local_names: List(String),
 ) -> Result(
   #(
-    dict.Dict(String, spec.Callback(Unresolved)),
+    dict.Dict(String, spec.RefOr(spec.Callback(Unresolved))),
     dict.Dict(String, #(String, SchemaRef)),
   ),
   Diagnostic,
@@ -1029,16 +1031,23 @@ fn rewrite_callback_map(
   use #(rewritten, new_imports) <- result.try(
     list.try_fold(entries, #([], imports), fn(acc, entry) {
       let #(collected, imports) = acc
-      let #(name, callback) = entry
-      use #(new_entries, new_imports) <- result.try(rewrite_callback_entries(
-        callback.entries,
-        base_dir,
-        parse_file,
-        imports,
-        original_local_names,
-      ))
-      let new_callback = spec.Callback(entries: new_entries)
-      Ok(#([#(name, new_callback), ..collected], new_imports))
+      let #(name, ref_or_callback) = entry
+      case ref_or_callback {
+        spec.Ref(_) as r -> Ok(#([#(name, r), ..collected], imports))
+        spec.Value(callback) -> {
+          use #(new_entries, new_imports) <- result.try(
+            rewrite_callback_entries(
+              callback.entries,
+              base_dir,
+              parse_file,
+              imports,
+              original_local_names,
+            ),
+          )
+          let new_callback = spec.Value(spec.Callback(entries: new_entries))
+          Ok(#([#(name, new_callback), ..collected], new_imports))
+        }
+      }
     }),
   )
   let new_callbacks =

--- a/src/oaspec/openapi/hoist.gleam
+++ b/src/oaspec/openapi/hoist.gleam
@@ -78,6 +78,7 @@ pub fn hoist(spec: OpenApiSpec(stage)) -> OpenApiSpec(stage) {
             headers: dict.new(),
             examples: dict.new(),
             links: dict.new(),
+            callbacks: dict.new(),
           ))
       }
   }

--- a/src/oaspec/openapi/normalize.gleam
+++ b/src/oaspec/openapi/normalize.gleam
@@ -125,8 +125,11 @@ fn normalize_operation(op: Operation(stage)) -> Operation(stage) {
         Value(r) -> Value(normalize_response(r))
       }
     }),
-    callbacks: dict.map_values(op.callbacks, fn(_k, cb) {
-      normalize_callback(cb)
+    callbacks: dict.map_values(op.callbacks, fn(_k, ref_or) {
+      case ref_or {
+        Ref(r) -> Ref(r)
+        Value(cb) -> Value(normalize_callback(cb))
+      }
     }),
   )
 }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1026,6 +1026,10 @@ fn parse_components(
   use headers <- result.try(parse_headers_map(components_node, index))
   let examples = value.extract_map(components_node, "examples")
   use links <- result.try(parse_links_map(components_node))
+  use callbacks <- result.try(parse_components_callbacks_map(
+    components_node,
+    index,
+  ))
 
   Ok(Components(
     schemas:,
@@ -1037,7 +1041,46 @@ fn parse_components(
     headers:,
     examples:,
     links:,
+    callbacks:,
   ))
+}
+
+/// Parse `components.callbacks`: each entry is a named reusable callback
+/// object. Returns an empty dict if the section is missing. `$ref` values
+/// are preserved so chains like `components.callbacks.foo.$ref: ...`
+/// stay as references.
+fn parse_components_callbacks_map(
+  components_node: yay.Node,
+  index: LocationIndex,
+) -> Result(Dict(String, RefOr(Callback(Unresolved))), Diagnostic) {
+  case yay.select_sugar(from: components_node, selector: "callbacks") {
+    Ok(yay.NodeMap(entries)) -> {
+      list.try_fold(entries, dict.new(), fn(acc, entry) {
+        let #(key_node, value_node) = entry
+        case key_node {
+          yay.NodeStr(name) -> {
+            case
+              yay.extract_optional_string(value_node, "$ref")
+              |> result.unwrap(None)
+            {
+              Some(ref_str) -> Ok(dict.insert(acc, name, Ref(ref_str)))
+              None -> {
+                use callback <- result.try(parse_callback_object(
+                  value_node,
+                  "components.callbacks." <> name,
+                  None,
+                  index,
+                ))
+                Ok(dict.insert(acc, name, Value(callback)))
+              }
+            }
+          }
+          _ -> Ok(acc)
+        }
+      })
+    }
+    _ -> Ok(dict.new())
+  }
 }
 
 /// Parse the schemas map from components.
@@ -1476,26 +1519,39 @@ fn parse_security_requirement_object(
 
 /// Parse callbacks from an operation node.
 /// Returns an empty dict if no callbacks are present.
-/// Propagates parse errors instead of silently dropping invalid callbacks.
+/// Each entry is a `RefOr(Callback)`: a top-level `$ref` pointing at
+/// `#/components/callbacks/foo` is preserved as-is (so the reusable
+/// callback reference survives into the resolved AST), while inline
+/// definitions are parsed into their URL-expression→PathItem shape.
 fn parse_callbacks(
   node: yay.Node,
   context: String,
   components: Option(Components(Unresolved)),
   index: LocationIndex,
-) -> Result(dict.Dict(String, Callback(Unresolved)), Diagnostic) {
+) -> Result(dict.Dict(String, RefOr(Callback(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "callbacks") {
     Ok(yay.NodeMap(entries)) -> {
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
           yay.NodeStr(callback_name) -> {
-            use callback <- result.try(parse_callback_object(
-              value_node,
-              context,
-              components,
-              index,
-            ))
-            Ok(dict.insert(acc, callback_name, callback))
+            // A top-level `$ref` here means the operation is pointing
+            // at a reusable callback object — keep it as Ref.
+            case
+              yay.extract_optional_string(value_node, "$ref")
+              |> result.unwrap(None)
+            {
+              Some(ref_str) -> Ok(dict.insert(acc, callback_name, Ref(ref_str)))
+              None -> {
+                use callback <- result.try(parse_callback_object(
+                  value_node,
+                  context,
+                  components,
+                  index,
+                ))
+                Ok(dict.insert(acc, callback_name, Value(callback)))
+              }
+            }
           }
           _ -> Ok(acc)
         }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1059,12 +1059,9 @@ fn parse_components_callbacks_map(
         let #(key_node, value_node) = entry
         case key_node {
           yay.NodeStr(name) -> {
-            case
-              yay.extract_optional_string(value_node, "$ref")
-              |> result.unwrap(None)
-            {
-              Some(ref_str) -> Ok(dict.insert(acc, name, Ref(ref_str)))
-              None -> {
+            case yay.extract_optional_string(value_node, "$ref") {
+              Ok(Some(ref_str)) -> Ok(dict.insert(acc, name, Ref(ref_str)))
+              Ok(None) -> {
                 use callback <- result.try(parse_callback_object(
                   value_node,
                   "components.callbacks." <> name,
@@ -1073,6 +1070,16 @@ fn parse_components_callbacks_map(
                 ))
                 Ok(dict.insert(acc, name, Value(callback)))
               }
+              Error(_) ->
+                Error(diagnostic.invalid_value(
+                  path: "components.callbacks." <> name <> ".$ref",
+                  detail: "`$ref` under a reusable callback must be a string pointing at '#/components/callbacks/...'.",
+                  loc: location_index.lookup_field(
+                    index,
+                    "components.callbacks." <> name,
+                    "$ref",
+                  ),
+                ))
             }
           }
           _ -> Ok(acc)
@@ -1537,12 +1544,10 @@ fn parse_callbacks(
           yay.NodeStr(callback_name) -> {
             // A top-level `$ref` here means the operation is pointing
             // at a reusable callback object — keep it as Ref.
-            case
-              yay.extract_optional_string(value_node, "$ref")
-              |> result.unwrap(None)
-            {
-              Some(ref_str) -> Ok(dict.insert(acc, callback_name, Ref(ref_str)))
-              None -> {
+            case yay.extract_optional_string(value_node, "$ref") {
+              Ok(Some(ref_str)) ->
+                Ok(dict.insert(acc, callback_name, Ref(ref_str)))
+              Ok(None) -> {
                 use callback <- result.try(parse_callback_object(
                   value_node,
                   context,
@@ -1551,6 +1556,16 @@ fn parse_callbacks(
                 ))
                 Ok(dict.insert(acc, callback_name, Value(callback)))
               }
+              Error(_) ->
+                Error(diagnostic.invalid_value(
+                  path: context <> ".callbacks." <> callback_name <> ".$ref",
+                  detail: "`$ref` under a callback entry must be a string pointing at '#/components/callbacks/...'.",
+                  loc: location_index.lookup_field(
+                    index,
+                    context <> ".callbacks." <> callback_name,
+                    "$ref",
+                  ),
+                ))
             }
           }
           _ -> Ok(acc)

--- a/src/oaspec/openapi/resolve.gleam
+++ b/src/oaspec/openapi/resolve.gleam
@@ -394,10 +394,11 @@ fn resolve_inline_operation(
   )
 }
 
-/// Resolve a `RefOr(Callback)`: top-level `$ref` entries are validated
-/// against `components.callbacks` and kept as `Ref` so downstream
-/// passes can recognise reusable-callback references; inline `Value`
-/// entries have their URL→PathItem entries recursively resolved.
+/// Resolve a `RefOr(Callback)`: top-level `$ref` entries are walked
+/// through `components.callbacks` — aliases (`Foo -> Ref(Bar)`) are
+/// allowed up to a small bound, but the chain must eventually land on
+/// a concrete `Value(Callback)`. Cycles, dangling targets, and
+/// non-callback refs become a single `invalid_value` diagnostic.
 fn resolve_callback_ref(
   ref_or: RefOr(Callback(stage)),
   path: String,
@@ -405,26 +406,53 @@ fn resolve_callback_ref(
 ) -> Result(RefOr(Callback(stage)), List(Diagnostic)) {
   case ref_or {
     Ref(ref_str) ->
-      validate_ref_kind(ref_str, "#/components/callbacks/", "paths." <> path)
-      |> result.try(fn(ref_name) {
-        case dict.get(components.callbacks, ref_name) {
-          Ok(_) -> Ok(Ref(ref_str))
-          Error(_) ->
-            Error(diagnostic.invalid_value(
-              path: "paths." <> path <> ".callbacks",
-              detail: "Callback $ref '"
-                <> ref_str
-                <> "' does not resolve to an entry in components.callbacks.",
-              loc: diagnostic.NoSourceLoc,
-            ))
-        }
-      })
+      follow_callback_ref_chain(ref_str, path, components, [])
+      |> result.map(fn(_) { Ref(ref_str) })
       |> result.map_error(fn(e) { [e] })
     Value(cb) ->
       case resolve_inline_callback(cb, path, components) {
         Ok(resolved) -> Ok(Value(resolved))
         Error(errs) -> Error(errs)
       }
+  }
+}
+
+/// Walk a callback `$ref` chain until it lands on `Value(Callback)`,
+/// refusing cycles and nonsensical targets. `seen` is the list of ref
+/// strings we have already visited on this chain.
+fn follow_callback_ref_chain(
+  ref_str: String,
+  path: String,
+  components: Components(stage),
+  seen: List(String),
+) -> Result(Nil, Diagnostic) {
+  use <- bool.guard(
+    list.contains(seen, ref_str),
+    Error(diagnostic.invalid_value(
+      path: "paths." <> path <> ".callbacks",
+      detail: "Callback $ref chain is cyclic; visited: "
+        <> string.join(list.reverse([ref_str, ..seen]), " -> ")
+        <> ".",
+      loc: diagnostic.NoSourceLoc,
+    )),
+  )
+  use ref_name <- result.try(validate_ref_kind(
+    ref_str,
+    "#/components/callbacks/",
+    "paths." <> path,
+  ))
+  case dict.get(components.callbacks, ref_name) {
+    Ok(Value(_)) -> Ok(Nil)
+    Ok(Ref(next_ref)) ->
+      follow_callback_ref_chain(next_ref, path, components, [ref_str, ..seen])
+    Error(_) ->
+      Error(diagnostic.invalid_value(
+        path: "paths." <> path <> ".callbacks",
+        detail: "Callback $ref '"
+          <> ref_str
+          <> "' does not resolve to an entry in components.callbacks.",
+        loc: diagnostic.NoSourceLoc,
+      ))
   }
 }
 

--- a/src/oaspec/openapi/resolve.gleam
+++ b/src/oaspec/openapi/resolve.gleam
@@ -42,6 +42,7 @@ fn resolve_internal(
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   case spec.components {
     None -> {
@@ -378,8 +379,8 @@ fn resolve_inline_operation(
     }),
   )
   use callbacks <- result.try(
-    try_map_values(op.callbacks, fn(_name, cb) {
-      resolve_inline_callback(cb, path, components)
+    try_map_values(op.callbacks, fn(_name, ref_or_cb) {
+      resolve_callback_ref(ref_or_cb, path, components)
     }),
   )
   Ok(
@@ -391,6 +392,40 @@ fn resolve_inline_operation(
       callbacks: callbacks,
     ),
   )
+}
+
+/// Resolve a `RefOr(Callback)`: top-level `$ref` entries are validated
+/// against `components.callbacks` and kept as `Ref` so downstream
+/// passes can recognise reusable-callback references; inline `Value`
+/// entries have their URL→PathItem entries recursively resolved.
+fn resolve_callback_ref(
+  ref_or: RefOr(Callback(stage)),
+  path: String,
+  components: Components(stage),
+) -> Result(RefOr(Callback(stage)), List(Diagnostic)) {
+  case ref_or {
+    Ref(ref_str) ->
+      validate_ref_kind(ref_str, "#/components/callbacks/", "paths." <> path)
+      |> result.try(fn(ref_name) {
+        case dict.get(components.callbacks, ref_name) {
+          Ok(_) -> Ok(Ref(ref_str))
+          Error(_) ->
+            Error(diagnostic.invalid_value(
+              path: "paths." <> path <> ".callbacks",
+              detail: "Callback $ref '"
+                <> ref_str
+                <> "' does not resolve to an entry in components.callbacks.",
+              loc: diagnostic.NoSourceLoc,
+            ))
+        }
+      })
+      |> result.map_error(fn(e) { [e] })
+    Value(cb) ->
+      case resolve_inline_callback(cb, path, components) {
+        Ok(resolved) -> Ok(Value(resolved))
+        Error(errs) -> Error(errs)
+      }
+  }
 }
 
 /// Resolve inline refs within a callback.

--- a/src/oaspec/openapi/spec.gleam
+++ b/src/oaspec/openapi/spec.gleam
@@ -137,6 +137,7 @@ pub type Components(stage) {
     headers: Dict(String, Header),
     examples: Dict(String, JsonValue),
     links: Dict(String, Link),
+    callbacks: Dict(String, RefOr(Callback(stage))),
   )
 }
 
@@ -227,7 +228,7 @@ pub type Operation(stage) {
     responses: Dict(http.HttpStatusCode, RefOr(Response(stage))),
     deprecated: Bool,
     security: Option(List(SecurityRequirement)),
-    callbacks: Dict(String, Callback(stage)),
+    callbacks: Dict(String, RefOr(Callback(stage))),
     servers: List(Server),
     external_docs: Option(ExternalDoc),
   )

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -915,6 +915,7 @@ fn make_security_ctx(
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(

--- a/test/golden_test.gleam
+++ b/test/golden_test.gleam
@@ -197,6 +197,7 @@ pub fn resolve_circular_component_alias_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(
@@ -248,6 +249,7 @@ pub fn resolve_unresolved_ref_target_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(
@@ -299,6 +301,7 @@ pub fn resolve_wrong_kind_ref_in_parameter_position_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let operation =
     spec.Operation(
@@ -379,6 +382,7 @@ pub fn resolve_wrong_kind_ref_in_request_body_position_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let operation =
     spec.Operation(
@@ -458,6 +462,7 @@ pub fn resolve_unresolved_inline_response_ref_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let operation =
     spec.Operation(
@@ -543,6 +548,7 @@ pub fn resolve_unresolved_path_item_ref_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(
@@ -593,6 +599,7 @@ pub fn resolve_wrong_kind_path_item_ref_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(
@@ -648,6 +655,7 @@ pub fn resolve_three_way_circular_alias_error_test() {
       headers: dict.new(),
       examples: dict.new(),
       links: dict.new(),
+      callbacks: dict.new(),
     )
   let test_spec =
     spec.OpenApiSpec(

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -10396,12 +10396,51 @@ components:
   }
 }
 
+/// Issue #232: a cyclic callback $ref chain
+/// (components.callbacks.A -> B -> A) must be detected at resolve time
+/// instead of being accepted as "exists in components".
+pub fn validate_rejects_cyclic_callback_ref_chain_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Cyclic Callback Ref
+  version: 1.0.0
+paths:
+  /register:
+    post:
+      operationId: subscribe
+      responses:
+        '200': { description: ok }
+      callbacks:
+        myEvent:
+          $ref: '#/components/callbacks/A'
+components:
+  callbacks:
+    A:
+      $ref: '#/components/callbacks/B'
+    B:
+      $ref: '#/components/callbacks/A'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  case resolve.resolve(spec) {
+    Error(errors) -> {
+      let messages = list.map(errors, validate.error_to_string)
+      list.any(messages, fn(s) { string.contains(s, "cyclic") })
+      |> should.be_true()
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
 /// Issue #232: both operation-level and components.callbacks must emit
-/// `ParsedNotUsed` capability warnings so users are not misled into
-/// thinking callbacks are code-generated.
+/// `ParsedNotUsed` capability warnings (not errors) so users are not
+/// misled into thinking callbacks are code-generated.
 pub fn capability_check_warns_on_callbacks_test() {
   let ctx = make_ctx("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
-  let warnings = capability_check.check_preserved(ctx)
+  let warnings =
+    capability_check.check_preserved(ctx)
+    |> validate.warnings_only
   let messages = list.map(warnings, validate.error_to_string)
   list.any(messages, fn(s) {
     string.contains(s, "Operation-level callbacks")

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3424,7 +3424,7 @@ paths:
   let subscribe_path = dict.get(spec.paths, "/subscribe")
   let assert Ok(spec.Value(path_item)) = subscribe_path
   let assert Some(post_op) = path_item.post
-  let assert Ok(callback) = dict.get(post_op.callbacks, "onEvent")
+  let assert Ok(spec.Value(callback)) = dict.get(post_op.callbacks, "onEvent")
   // Callback entries dict must have 2 URL expressions
   let entries = dict.to_list(callback.entries)
   list.length(entries) |> should.equal(2)
@@ -3857,7 +3857,8 @@ pub fn external_ref_in_callback_path_item_test() {
   // schema ref is rewritten to local form.
   let assert Ok(spec.Value(path_item)) = dict.get(loaded.paths, "/subscribe")
   let assert Some(post_op) = path_item.post
-  let assert Ok(callback) = dict.get(post_op.callbacks, "widgetEvent")
+  let assert Ok(spec.Value(callback)) =
+    dict.get(post_op.callbacks, "widgetEvent")
   let assert Ok(spec.Value(cb_path_item)) =
     dict.get(callback.entries, "{$request.body#/callbackUrl}")
   let assert Some(cb_post) = cb_path_item.post
@@ -10328,6 +10329,90 @@ pub fn oss_swagger_parser_java_callback_ref_parses_test() {
     parser.parse_file("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
   spec.info.title |> should.equal("Callback with ref Example")
   dict.size(spec.paths) |> should.equal(1)
+}
+
+/// Issue #232: operation-level `{ myEvent: { $ref: '#/components/callbacks/foo' } }`
+/// must be preserved as a `Ref(...)` entry on `operation.callbacks`, not
+/// flattened into the inline URL-expression shape.
+pub fn parse_preserves_operation_level_callback_ref_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
+  let assert Ok(spec.Value(path_item)) = dict.get(spec.paths, "/register")
+  let assert Some(post_op) = path_item.post
+  let assert Ok(entry) = dict.get(post_op.callbacks, "myEvent")
+  case entry {
+    spec.Ref(ref_str) ->
+      ref_str |> should.equal("#/components/callbacks/callbackEvent")
+    spec.Value(_) -> should.fail()
+  }
+}
+
+/// Issue #232: `components.callbacks` entries must be parsed losslessly
+/// into the reusable-components AST so downstream passes can see them.
+pub fn parse_populates_components_callbacks_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
+  let assert Some(components) = spec.components
+  dict.size(components.callbacks) |> should.equal(1)
+  let assert Ok(spec.Value(callback)) =
+    dict.get(components.callbacks, "callbackEvent")
+  dict.has_key(callback.entries, "{$request.body#/callbackUrl}")
+  |> should.be_true()
+}
+
+/// Issue #232: a callback `$ref` that does not resolve to an entry in
+/// `components.callbacks` must produce a validation error — otherwise
+/// users get silent nothingness for a clearly broken spec.
+pub fn validate_rejects_callback_ref_with_missing_target_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Dangling Callback Ref
+  version: 1.0.0
+paths:
+  /register:
+    post:
+      operationId: subscribe
+      responses:
+        '200': { description: ok }
+      callbacks:
+        myEvent:
+          $ref: '#/components/callbacks/doesNotExist'
+components:
+  callbacks: {}
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  case resolve.resolve(spec) {
+    Error(errors) -> {
+      let messages = list.map(errors, validate.error_to_string)
+      list.any(messages, fn(s) {
+        string.contains(s, "doesNotExist")
+        && string.contains(s, "components.callbacks")
+      })
+      |> should.be_true()
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+/// Issue #232: both operation-level and components.callbacks must emit
+/// `ParsedNotUsed` capability warnings so users are not misled into
+/// thinking callbacks are code-generated.
+pub fn capability_check_warns_on_callbacks_test() {
+  let ctx = make_ctx("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
+  let warnings = capability_check.check_preserved(ctx)
+  let messages = list.map(warnings, validate.error_to_string)
+  list.any(messages, fn(s) {
+    string.contains(s, "Operation-level callbacks")
+    && string.contains(s, "parsed and preserved")
+  })
+  |> should.be_true()
+  list.any(messages, fn(s) {
+    string.contains(s, "Component callbacks")
+    && string.contains(s, "parsed and preserved")
+  })
+  |> should.be_true()
 }
 
 /// swagger-parser-java issue1433: schema without explicit type field.


### PR DESCRIPTION
## Summary

- Closes #232
- `Components` now carries a `callbacks: Dict(String, RefOr(Callback(stage)))` field and the parser fills it from `components.callbacks`, so reusable callback definitions survive into the AST.
- `Operation.callbacks` changed from `Dict(String, Callback(stage))` to `Dict(String, RefOr(Callback(stage)))`. An operation-level `{ myEvent: { \$ref: '#/components/callbacks/foo' } }` is now preserved as `Ref(...)` instead of being silently reinterpreted as an inline URL-expression map.
- `resolve` validates callback refs against `components.callbacks` and emits a dedicated `invalid_value` diagnostic when the target is missing.
- `capability_check` emits `Warning` for non-empty operation-level and component-level callbacks, so `validate` on callback-heavy specs no longer prints a bare `Validation passed.`
- Capability registry gains a `callbacks / scope / ParsedNotUsed` entry (the `Current Boundaries` drift test already mentions the name).
- `normalize` / `external_loader` updated to walk the new `RefOr` shape and leave `Ref` entries alone.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] 4 new regression tests:
  - `parse_preserves_operation_level_callback_ref_test`
  - `parse_populates_components_callbacks_test`
  - `validate_rejects_callback_ref_with_missing_target_test`
  - `capability_check_warns_on_callbacks_test`
- [x] Manual validate run on `oss_swagger_parser_java_callback_ref.yaml` now prints the two expected `components.callbacks` / operation-level warnings instead of a bare success line
- [ ] Full CI (`just all`) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and preserving OpenAPI callback definitions from specification files.

* **Tests**
  * Expanded test coverage to 722 tests, including new validation scenarios for callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->