### PR TITLE
feat(parser): detect cyclic external-ref graphs instead of recursing forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 723 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 223 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 725 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 228 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -96,7 +96,9 @@ diagnostic instead of producing broken output.
 - Schemas: `object`, primitives, arrays, enums, nullable, `allOf`,
   `oneOf`, `anyOf`, typed `additionalProperties`
 - Local `$ref` (and relative-file external `$ref`) across schemas,
-  parameters, request bodies, responses, and path items
+  parameters, request bodies, responses, and path items. External ref
+  graphs must be acyclic — cycles such as `A.yaml → B.yaml → A.yaml`
+  fail fast with a dedicated diagnostic that shows the visited chain.
 - Parameters: path, query, header, cookie, plus array styles (`form`,
   `pipeDelimited`, `spaceDelimited`) and objects via `deepObject`
 - Request bodies: `application/json`,

--- a/src/oaspec/openapi/external_loader.gleam
+++ b/src/oaspec/openapi/external_loader.gleam
@@ -36,9 +36,12 @@
 //// Out of scope (see issue #98 parent):
 ////   - alias chains longer than one hop inside the same file
 ////   - HTTP/HTTPS URLs
-////   - cyclic external refs (e.g., `A.yaml` → `B.yaml` → `A.yaml`)
-////     would loop forever; callers are expected to maintain acyclic
-////     file graphs.
+////
+//// Cyclic external refs (e.g., `A.yaml` → `B.yaml` → `A.yaml`) used
+//// to loop forever, but are now detected: `parser.parse_file`
+//// threads a visited-file stack through every recursive load and
+//// emits a dedicated `invalid_value` diagnostic that shows the cycle
+//// path instead of recursing indefinitely (issue #233).
 ////
 //// Name collisions — when an external ref would overwrite an existing local
 //// schema, or when two external refs pull in the same fragment name from

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -35,6 +35,22 @@ import yay
 /// merging their schemas. Nested or parameter/response external refs are
 /// left to downstream validation.
 pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  parse_file_internal(path, [])
+}
+
+/// Internal parse entry that threads the `visited` stack through every
+/// external-ref recursion so `A.yaml -> B.yaml -> A.yaml` cycles fail
+/// fast with a dedicated diagnostic instead of spinning forever.
+fn parse_file_internal(
+  path: String,
+  visited: List(String),
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  let canonical = canonicalize_ref_path(path)
+  use <- bool.guard(
+    list.contains(visited, canonical),
+    Error(cyclic_external_ref_diagnostic(canonical, visited)),
+  )
+
   use content <- result.try(
     simplifile.read(path)
     |> result.map_error(fn(err) {
@@ -49,10 +65,41 @@ pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
   )
 
   use spec <- result.try(parse_string(content))
+  let new_visited = [canonical, ..visited]
   external_loader.resolve_external_component_refs(
     spec,
     external_loader.base_dir_of(path),
-    parse_file,
+    fn(sub_path) { parse_file_internal(sub_path, new_visited) },
+  )
+}
+
+/// Normalize a path string for cycle detection. This is not a full
+/// canonicalization (no symlink resolution, no realpath call); it just
+/// collapses the `./` and duplicate-slash noise that `filepath.join`
+/// can leave behind so the same file reached via two equivalent
+/// relative paths compares equal.
+fn canonicalize_ref_path(path: String) -> String {
+  let segments =
+    path
+    |> string.split("/")
+    |> list.filter(fn(seg) { seg != "" && seg != "." })
+  case string.starts_with(path, "/") {
+    True -> "/" <> string.join(segments, "/")
+    False -> string.join(segments, "/")
+  }
+}
+
+fn cyclic_external_ref_diagnostic(
+  current: String,
+  visited: List(String),
+) -> Diagnostic {
+  let chain = list.reverse([current, ..visited])
+  diagnostic.invalid_value(
+    path: "external_ref",
+    detail: "Cyclic external $ref graph detected: "
+      <> string.join(chain, " -> ")
+      <> ". oaspec requires external ref graphs to be acyclic.",
+    loc: NoSourceLoc,
   )
 }
 

--- a/test/fixtures/external_ref_cycle_a.yaml
+++ b/test/fixtures/external_ref_cycle_a.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: External Ref Cycle A
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FromA:
+      $ref: "./external_ref_cycle_b.yaml#/components/schemas/FromB"

--- a/test/fixtures/external_ref_cycle_b.yaml
+++ b/test/fixtures/external_ref_cycle_b.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: External Ref Cycle B
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FromB:
+      $ref: "./external_ref_cycle_a.yaml#/components/schemas/FromA"

--- a/test/fixtures/external_ref_cycle_deep_a.yaml
+++ b/test/fixtures/external_ref_cycle_deep_a.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: External Ref Cycle Deep A
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Root:
+      $ref: "./external_ref_cycle_deep_b.yaml#/components/schemas/Bridge"

--- a/test/fixtures/external_ref_cycle_deep_b.yaml
+++ b/test/fixtures/external_ref_cycle_deep_b.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: External Ref Cycle Deep B
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Bridge:
+      $ref: "./external_ref_cycle_deep_c.yaml#/components/schemas/Leaf"

--- a/test/fixtures/external_ref_cycle_deep_c.yaml
+++ b/test/fixtures/external_ref_cycle_deep_c.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: External Ref Cycle Deep C
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Leaf:
+      $ref: "./external_ref_cycle_deep_a.yaml#/components/schemas/Root"

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3717,6 +3717,30 @@ pub fn external_ref_collision_across_files_rejected_test() {
   string.contains(msg, "already imported") |> should.be_true()
 }
 
+pub fn external_ref_two_file_cycle_rejected_test() {
+  // Issue #233: A.yaml -> B.yaml -> A.yaml used to loop forever. The
+  // loader must now detect the cycle, stop walking, and emit a
+  // diagnostic listing the visited files.
+  let result = parser.parse_file("test/fixtures/external_ref_cycle_a.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "Cyclic external $ref") |> should.be_true()
+  string.contains(msg, "external_ref_cycle_a.yaml") |> should.be_true()
+  string.contains(msg, "external_ref_cycle_b.yaml") |> should.be_true()
+}
+
+pub fn external_ref_three_file_cycle_rejected_test() {
+  // Issue #233: A -> B -> C -> A cycles must also be caught, not just
+  // direct two-file back-references.
+  let result = parser.parse_file("test/fixtures/external_ref_cycle_deep_a.yaml")
+  let assert Error(err) = result
+  let msg = parser.parse_error_to_string(err)
+  string.contains(msg, "Cyclic external $ref") |> should.be_true()
+  string.contains(msg, "external_ref_cycle_deep_a.yaml") |> should.be_true()
+  string.contains(msg, "external_ref_cycle_deep_b.yaml") |> should.be_true()
+  string.contains(msg, "external_ref_cycle_deep_c.yaml") |> should.be_true()
+}
+
 pub fn external_ref_nested_collision_with_local_schema_rejected_test() {
   // Main spec defines a local `Widget` AND an Envelope.payload property
   // that imports a *different* `Widget` from a sibling file. Silently


### PR DESCRIPTION
## Summary

- Closes #233
- \`parser.parse_file\` now threads a visited-file stack through every recursive external-ref load (top-level schemas, nested property / array / composition refs, parameters, request bodies, responses, callbacks). Re-entering a file that is already on the stack returns an \`invalid_value\` diagnostic that shows the full \`A → B → A\` chain instead of looping forever.
- External loader's module-level comment now points to the detection path rather than listing cycles as out-of-scope.
- README's capability list mentions the boundary so users know cyclic graphs are explicitly rejected.

## Test plan

- [x] \`gleam format --check src/ test/\`
- [x] \`gleam check\`
- [x] \`gleam build --warnings-as-errors\`
- [x] \`gleam run -m glinter -- --stats\` (0 errors)
- [x] 2 new fixtures covering both shapes:
  - \`external_ref_cycle_a.yaml\` ↔ \`external_ref_cycle_b.yaml\` (two-file cycle)
  - \`external_ref_cycle_deep_{a,b,c}.yaml\` (A → B → C → A chain)
- [x] 2 new regression tests:
  - \`external_ref_two_file_cycle_rejected_test\`
  - \`external_ref_three_file_cycle_rejected_test\`
- [ ] Full CI (\`just all\`) green