### PR TITLE
feat(validate): emit dedicated diagnostic for openapi 3.1 $id-backed URL refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 725 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 228 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 726 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 228 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -343,7 +343,8 @@ These boundaries are generated from the capability registry in `src/oaspec/capab
 
 These are the most important limitations today:
 
-- The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`
+- The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`, `$id`
+- OpenAPI 3.1 `$id`-backed URL refs (e.g. `$ref: https://example.com/Box` paired with `$id: https://example.com/Box` inside `components.schemas`) are an explicit boundary: the parser accepts them, but validation rejects them with a dedicated URL-ref diagnostic. Rewrite to local `#/components/schemas/...` refs.
 - `xml` annotations are not handled by the parser
 - Some fields are parsed and preserved but not yet used by codegen: callbacks, webhooks, externalDocs, tags, examples, links, encoding
 - Operation-level and path-level server overrides are supported in generated clients (precedence: operation > path > top-level)

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -99,6 +99,12 @@ pub fn registry() -> List(Capability) {
     Capability("contentEncoding", "schema", Unsupported, "Not supported"),
     Capability("contentMediaType", "schema", Unsupported, "Not supported"),
     Capability("contentSchema", "schema", Unsupported, "Not supported"),
+    Capability(
+      "$id",
+      "schema",
+      Unsupported,
+      "OpenAPI 3.1 JSON Schema `$id`-backed URL refs are not resolved; use local `#/components/schemas/...` refs instead",
+    ),
     // Security
     Capability("apiKey", "security", Supported, "Header, query, cookie"),
     Capability("http", "security", Supported, "Bearer, basic, and digest auth"),

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -1027,6 +1027,14 @@ fn validate_component_schemas(ctx: Context) -> List(Diagnostic) {
 }
 
 /// Recursively validate a SchemaRef at any depth.
+/// Does this `$ref` value look like an absolute URL (http/https)? These
+/// are the shape that OpenAPI 3.1 `$id`-backed same-document refs take,
+/// and we surface them as a dedicated diagnostic separate from generic
+/// external `$ref` errors.
+fn is_url_style_ref(ref: String) -> Bool {
+  string.starts_with(ref, "http://") || string.starts_with(ref, "https://")
+}
+
 /// References are checked for resolvability against the spec's components.
 fn validate_schema_ref_recursive(
   path: String,
@@ -1038,17 +1046,32 @@ fn validate_schema_ref_recursive(
       // Detect external refs (not starting with #/) before resolution
       case string.starts_with(ref, "#/") {
         False -> [
-          diagnostic.validation(
-            severity: SeverityError,
-            target: TargetBoth,
-            path: path,
-            detail: "External $ref '"
-              <> ref
-              <> "' is not supported. Only local references (#/components/...) are supported.",
-            hint: Some(
-              "Inline the external schema or copy it into #/components/schemas/ and use a local $ref.",
-            ),
-          ),
+          case is_url_style_ref(ref) {
+            True ->
+              diagnostic.validation(
+                severity: SeverityError,
+                target: TargetBoth,
+                path: path,
+                detail: "URL-style $ref '"
+                  <> ref
+                  <> "' is not supported. oaspec does not resolve OpenAPI 3.1 / JSON Schema `$id`-backed identifiers — those refs are an explicit boundary.",
+                hint: Some(
+                  "Rewrite the schema to a local $ref (`#/components/schemas/...`) and drop the `$id` URL, or inline the schema at the use site.",
+                ),
+              )
+            False ->
+              diagnostic.validation(
+                severity: SeverityError,
+                target: TargetBoth,
+                path: path,
+                detail: "External $ref '"
+                  <> ref
+                  <> "' is not supported. Only local references (#/components/...) are supported.",
+                hint: Some(
+                  "Inline the external schema or copy it into #/components/schemas/ and use a local $ref.",
+                ),
+              )
+          },
         ]
         True ->
           case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -10332,6 +10332,30 @@ pub fn oss_openapi_dotnet_dollar_id_parses_test() {
   dict.size(spec.paths) |> should.equal(2)
 }
 
+/// Issue #234: URL-style `$ref` values (the shape OpenAPI 3.1
+/// `$id`-backed refs take) must fail validation with a dedicated
+/// URL-ref diagnostic, not a generic "external $ref" error. This keeps
+/// the advertised OpenAPI 3.1 boundary explicit and gives users an
+/// actionable hint.
+pub fn validate_rejects_id_backed_url_ref_with_dedicated_diagnostic_test() {
+  let ctx = make_ctx("test/fixtures/oss_openapi_dotnet_dollar_id.yaml")
+  let errors = validate.validate(ctx) |> validate.errors_only
+  let messages = list.map(errors, validate.error_to_string)
+  list.any(messages, fn(s) {
+    string.contains(s, "URL-style $ref")
+    && string.contains(s, "OpenAPI 3.1")
+    && string.contains(s, "$id")
+  })
+  |> should.be_true()
+  // A generic "External $ref ... is not supported" message must NOT be
+  // emitted for URL-style refs — that's the old gray-area behavior.
+  list.any(messages, fn(s) {
+    string.contains(s, "External $ref")
+    && string.contains(s, "https://foo.bar/Box")
+  })
+  |> should.be_false()
+}
+
 // ---------------------------------------------------------------------------
 // OSS: swagger-parser-java (Apache-2.0)
 // Test data derived from https://github.com/swagger-api/swagger-parser


### PR DESCRIPTION
## Summary

- Closes #234
- URL-style `$ref` values (e.g. `$ref: https://foo.bar/Box`), which is the shape OpenAPI 3.1 `$id`-backed same-document refs take, now produce a dedicated `URL-style $ref ... is not supported. oaspec does not resolve OpenAPI 3.1 / JSON Schema $id-backed identifiers — those refs are an explicit boundary` diagnostic instead of the generic "External \$ref" error. The hint tells the user to rewrite to a local ref or inline the schema.
- Capability registry gains a `$id / schema / Unsupported` entry and the README's keyword-rejection list includes it so the boundary is documented.
- README's "Current Boundaries" section now states the `$id` URL-ref boundary explicitly.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] New regression test `validate_rejects_id_backed_url_ref_with_dedicated_diagnostic_test` using the existing `oss_openapi_dotnet_dollar_id.yaml` fixture, asserting both the dedicated message is present and the generic "External \$ref" message is NOT used for URL-style refs.
- [ ] Full CI (`just all`) green