### PR TITLE
feat(normalize): reject non-string const and multi-type schemas with constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 726 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 228 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 729 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -343,8 +343,9 @@ These boundaries are generated from the capability registry in `src/oaspec/capab
 
 These are the most important limitations today:
 
-- The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`, `$id`
+- The following keywords are detected and rejected: `$defs`, `prefixItems`, `if/then/else`, `dependentSchemas`, `not`, `unevaluatedProperties`, `unevaluatedItems`, `contentEncoding`, `contentMediaType`, `contentSchema`, `mutualTLS`, `$id`, `const (non-string)`, `type: [T1, T2] with type-specific constraints`
 - OpenAPI 3.1 `$id`-backed URL refs (e.g. `$ref: https://example.com/Box` paired with `$id: https://example.com/Box` inside `components.schemas`) are an explicit boundary: the parser accepts them, but validation rejects them with a dedicated URL-ref diagnostic. Rewrite to local `#/components/schemas/...` refs.
+- `const` is only supported on string schemas (lowered to a single-value enum). Non-string `const` (bool, int, number, object, array, null) and multi-type schemas that carry type-specific constraints (`pattern`, `minLength`, `minimum`, etc.) are rejected explicitly during `generate` / `validate` so semantic loss never slips into generated code.
 - `xml` annotations are not handled by the parser
 - Some fields are parsed and preserved but not yet used by codegen: callbacks, webhooks, externalDocs, tags, examples, links, encoding
 - Operation-level and path-level server overrides are supported in generated clients (precedence: operation > path > top-level)

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -105,6 +105,18 @@ pub fn registry() -> List(Capability) {
       Unsupported,
       "OpenAPI 3.1 JSON Schema `$id`-backed URL refs are not resolved; use local `#/components/schemas/...` refs instead",
     ),
+    Capability(
+      "const (non-string)",
+      "schema",
+      Unsupported,
+      "Only string `const` is lowered to a single-value enum; non-string `const` (bool, int, number, object, array, null) cannot be represented in generated code",
+    ),
+    Capability(
+      "type: [T1, T2] with type-specific constraints",
+      "schema",
+      Unsupported,
+      "Multi-type schemas are rewritten to `oneOf`, which would silently drop type-specific constraints (pattern, minLength, minimum, etc.). Split the schema into separate variants or drop the constraints",
+    ),
     // Security
     Capability("apiKey", "security", Supported, "Header, query, cookie"),
     Capability("http", "security", Supported, "Bearer, basic, and digest auth"),

--- a/src/oaspec/openapi/normalize.gleam
+++ b/src/oaspec/openapi/normalize.gleam
@@ -184,10 +184,11 @@ fn normalize_schema_ref(ref: SchemaRef) -> SchemaRef {
 }
 
 fn normalize_schema(schema_obj: SchemaObject) -> SchemaObject {
-  // 1. const_value -> single-value enum (string const only)
-  // Non-string const (bool, int, float, object, array, null) is preserved
-  // as-is in metadata — codegen doesn't support const for these types yet,
-  // and capability_check will warn about it.
+  // 1. const_value -> single-value enum (string const only).
+  // Non-string const (bool, int, float, object, array, null) cannot be
+  // represented as a Gleam enum, so flag it as unsupported. Previously
+  // the const was silently dropped and codegen emitted a bare
+  // `pub type BoolConst = Bool` that lost the const restriction (#238).
   let schema_obj = case schema_obj {
     StringSchema(metadata: meta, ..) ->
       case meta.const_value {
@@ -199,30 +200,46 @@ fn normalize_schema(schema_obj: SchemaObject) -> SchemaObject {
           )
         _ -> schema_obj
       }
-    _ -> schema_obj
+    _ ->
+      case schema.get_metadata(schema_obj).const_value {
+        Some(_) -> mark_unsupported(schema_obj, "const (non-string)")
+        None -> schema_obj
+      }
   }
 
-  // 2. raw_type with multiple types -> oneOf
+  // 2. raw_type with multiple types -> oneOf. If the primary schema
+  // carried type-specific constraints (pattern, minLength, minimum,
+  // enum, etc.) the `make_typed_schema` rewrite would silently drop
+  // them when it builds bare variants, so flag it instead (#238).
   let schema_obj = case schema.get_metadata(schema_obj).raw_type {
     Some(types) ->
       case list.length(types) > 1 {
         True -> {
           let meta = schema.get_metadata(schema_obj)
-          let type_schemas =
-            list.map(types, fn(t) {
-              Inline(make_typed_schema(
-                t,
-                SchemaMetadata(
-                  ..schema.default_metadata(),
-                  nullable: meta.nullable,
-                ),
-              ))
-            })
-          OneOfSchema(
-            metadata: SchemaMetadata(..meta, raw_type: None),
-            schemas: type_schemas,
-            discriminator: None,
-          )
+          case has_type_specific_constraints(schema_obj) {
+            True ->
+              mark_unsupported(
+                schema_obj,
+                "type: [T1, T2] with type-specific constraints",
+              )
+            False -> {
+              let type_schemas =
+                list.map(types, fn(t) {
+                  Inline(make_typed_schema(
+                    t,
+                    SchemaMetadata(
+                      ..schema.default_metadata(),
+                      nullable: meta.nullable,
+                    ),
+                  ))
+                })
+              OneOfSchema(
+                metadata: SchemaMetadata(..meta, raw_type: None),
+                schemas: type_schemas,
+                discriminator: None,
+              )
+            }
+          }
         }
         False -> schema_obj
       }
@@ -231,6 +248,65 @@ fn normalize_schema(schema_obj: SchemaObject) -> SchemaObject {
 
   // 3. Recurse into sub-schemas
   normalize_schema_children(schema_obj)
+}
+
+/// Add `keyword` to the schema's `unsupported_keywords` list so the
+/// downstream capability_check rejects the schema with a targeted error
+/// instead of silently dropping the constraint.
+fn mark_unsupported(schema_obj: SchemaObject, keyword: String) -> SchemaObject {
+  let meta = schema.get_metadata(schema_obj)
+  let new_meta =
+    SchemaMetadata(..meta, unsupported_keywords: [
+      keyword,
+      ..meta.unsupported_keywords
+    ])
+  schema.set_metadata(schema_obj, new_meta)
+}
+
+/// Does this primitive-typed schema carry any constraint that the
+/// multi-type `oneOf` rewrite would drop? Only type-specific constraints
+/// count — generic metadata like `nullable` or `description` is already
+/// preserved by the rewrite.
+fn has_type_specific_constraints(schema_obj: SchemaObject) -> Bool {
+  case schema_obj {
+    StringSchema(format:, enum_values:, min_length:, max_length:, pattern:, ..) ->
+      option.is_some(format)
+      || enum_values != []
+      || option.is_some(min_length)
+      || option.is_some(max_length)
+      || option.is_some(pattern)
+    IntegerSchema(
+      format:,
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      option.is_some(format)
+      || option.is_some(minimum)
+      || option.is_some(maximum)
+      || option.is_some(exclusive_minimum)
+      || option.is_some(exclusive_maximum)
+      || option.is_some(multiple_of)
+    NumberSchema(
+      format:,
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      option.is_some(format)
+      || option.is_some(minimum)
+      || option.is_some(maximum)
+      || option.is_some(exclusive_minimum)
+      || option.is_some(exclusive_maximum)
+      || option.is_some(multiple_of)
+    _ -> False
+  }
 }
 
 fn make_typed_schema(type_str: String, metadata: SchemaMetadata) -> SchemaObject {

--- a/src/oaspec/openapi/schema.gleam
+++ b/src/oaspec/openapi/schema.gleam
@@ -202,7 +202,7 @@ pub fn get_provenance(schema: SchemaObject) -> OriginKind {
 }
 
 /// Replace the metadata on a schema object.
-fn set_metadata(schema: SchemaObject, meta: SchemaMetadata) -> SchemaObject {
+pub fn set_metadata(schema: SchemaObject, meta: SchemaMetadata) -> SchemaObject {
   case schema {
     StringSchema(format:, enum_values:, min_length:, max_length:, pattern:, ..) ->
       StringSchema(

--- a/test/fixtures/normalize_multi_type_with_constraints.yaml
+++ b/test/fixtures/normalize_multi_type_with_constraints.yaml
@@ -1,0 +1,14 @@
+openapi: "3.1.0"
+info:
+  title: Normalize Multi-Type With Constraints Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    LossyFlexibleId:
+      type:
+        - string
+        - integer
+      minLength: 3
+      maxLength: 64
+      pattern: "^[a-z0-9_-]+$"

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -11119,6 +11119,86 @@ pub fn normalize_preserves_non_string_const_test() {
   int_meta.const_value |> should.equal(Some(value.JsonInt(42)))
 }
 
+/// Issue #238: a non-string `const` cannot be represented as a Gleam
+/// enum, so normalize now marks the schema as carrying the unsupported
+/// keyword `const (non-string)` instead of silently dropping the
+/// restriction at codegen. capability_check must reject with a
+/// targeted diagnostic.
+pub fn normalize_flags_non_string_const_as_unsupported_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/normalize_const_types.yaml")
+  let normalized = normalize.normalize(spec)
+  let assert Some(components) = normalized.components
+  let assert Ok(schema.Inline(bool_schema)) =
+    dict.get(components.schemas, "BoolConst")
+  list.contains(
+    schema.get_metadata(bool_schema).unsupported_keywords,
+    "const (non-string)",
+  )
+  |> should.be_true()
+  let assert Ok(schema.Inline(int_schema)) =
+    dict.get(components.schemas, "IntConst")
+  list.contains(
+    schema.get_metadata(int_schema).unsupported_keywords,
+    "const (non-string)",
+  )
+  |> should.be_true()
+}
+
+/// Issue #238: non-string `const` must surface as a capability_check
+/// error during generate, not succeed silently.
+pub fn generate_rejects_non_string_const_test() {
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/normalize_const_types.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/normalize_const_types.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  case generate.generate(spec, cfg) {
+    Error(generate.ValidationErrors(errors:)) -> {
+      let messages = list.map(errors, validate.error_to_string)
+      list.any(messages, fn(s) { string.contains(s, "const (non-string)") })
+      |> should.be_true()
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+/// Issue #238: a multi-type schema with type-specific constraints
+/// (here: `minLength`, `maxLength`, `pattern` on a `type: [string,
+/// integer]`) cannot be losslessly rewritten to oneOf, so normalize
+/// must flag it and capability_check must reject it.
+pub fn generate_rejects_multi_type_with_constraints_test() {
+  let assert Ok(spec) =
+    parser.parse_file(
+      "test/fixtures/normalize_multi_type_with_constraints.yaml",
+    )
+  let cfg =
+    config.new(
+      input: "test/fixtures/normalize_multi_type_with_constraints.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  case generate.generate(spec, cfg) {
+    Error(generate.ValidationErrors(errors:)) -> {
+      let messages = list.map(errors, validate.error_to_string)
+      list.any(messages, fn(s) {
+        string.contains(s, "type: [T1, T2] with type-specific constraints")
+      })
+      |> should.be_true()
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
 /// type: [string, integer] is normalized to oneOf by normalize pass.
 pub fn normalize_multi_type_to_oneof_test() {
   let assert Ok(spec) =


### PR DESCRIPTION
## Summary

- Closes #238
- Non-string `const` (bool, int, number, object, array, null) is now flagged by \`normalize\` with a new \`const (non-string)\` entry in \`unsupported_keywords\` so \`capability_check\` rejects it with a targeted diagnostic. Previously the const was silently dropped and codegen emitted a bare \`pub type BoolConst = Bool\` that lost the const restriction.
- Multi-type schemas (\`type: [T1, T2]\`) that also carry type-specific constraints (e.g. \`pattern\`, \`minLength\`, \`minimum\`) are now flagged with \`type: [T1, T2] with type-specific constraints\` — the old rewrite would have built bare \`oneOf\` variants that dropped those constraints.
- Unconstrained multi-type schemas are unchanged: they still normalize to \`oneOf\` exactly as before.
- Capability registry + README keyword-rejection list + "Current Boundaries" block all state the new explicit rejections.

## Test plan

- [x] \`gleam format --check src/ test/\`
- [x] \`gleam check\`
- [x] \`gleam build --warnings-as-errors\`
- [x] \`gleam run -m glinter -- --stats\` (0 errors)
- [x] New regression tests:
  - \`normalize_flags_non_string_const_as_unsupported_test\` — AST-level assertion that BoolConst / IntConst carry \`const (non-string)\` in \`unsupported_keywords\` after normalize
  - \`generate_rejects_non_string_const_test\` — end-to-end \`generate\` fails with the targeted message
  - \`generate_rejects_multi_type_with_constraints_test\` — e2e \`generate\` on the new fixture fails with the multi-type constraint message
- [x] New fixture \`normalize_multi_type_with_constraints.yaml\` covers the constrained multi-type case
- [x] Existing \`normalize_multi_type_to_oneof_test\` / \`normalize_preserves_non_string_const_test\` still pass (unchanged behavior for the old cases)
- [ ] Full CI (\`just all\`) green