### PR TITLE
fix(cli): route diagnostic output to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI diagnostics now route to stderr (#251)**: error messages, warnings, and `--check` mismatch reports are written via `io.println_error` instead of `io.println`, and the top-level entry point uses `glint.execute` so glint's own usage/error text goes to stderr with exit code 1. Help text requested explicitly via `--help` still goes to stdout. Pipelines like `oaspec | jq` no longer receive diagnostic noise on stdin, and `2>&1` redirection produces the expected ordering.
+
 ## [0.17.0] - 2026-04-23
 
 This release tightens the OpenAPI 3.0/3.1 support boundary: every shape

--- a/src/oaspec.gleam
+++ b/src/oaspec.gleam
@@ -1,9 +1,22 @@
 import argv
+import gleam/io
 import glint
 import oaspec/cli
 
+@external(erlang, "erlang", "halt")
+fn halt(code: Int) -> Nil
+
 /// CLI entry point for the oaspec code generator.
+///
+/// Routes diagnostic output to stderr while keeping requested output (such as
+/// `--help` text) on stdout, following POSIX/CLIG conventions.
 pub fn main() -> Nil {
-  cli.app()
-  |> glint.run(argv.load().arguments)
+  case glint.execute(cli.app(), argv.load().arguments) {
+    Error(message) -> {
+      io.println_error(message)
+      halt(1)
+    }
+    Ok(glint.Help(text)) -> io.println(text)
+    Ok(glint.Out(_)) -> Nil
+  }
 }

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -188,14 +188,14 @@ package: api
 
   case simplifile.is_file(path) {
     Ok(True) -> {
-      io.println("Error: " <> path <> " already exists")
+      io.println_error("Error: " <> path <> " already exists")
       halt(1)
     }
     _ -> {
       case simplifile.write(path, template) {
         Ok(_) -> io.println("Created " <> path)
         Error(write_err) -> {
-          io.println(
+          io.println_error(
             "Error: failed to write "
             <> path
             <> ": "
@@ -242,8 +242,8 @@ fn run_generate(
   print_warnings(summary.warnings)
   case fail_on_warnings && summary.warnings != [] {
     True -> {
-      io.println("")
-      io.println("Error: warnings present and --fail-on-warnings is set.")
+      io.println_error("")
+      io.println_error("Error: warnings present and --fail-on-warnings is set.")
       halt(1)
     }
     False -> Nil
@@ -328,9 +328,9 @@ fn run_check(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
       io.println("All files up to date, check passed.")
     }
     _ -> {
-      io.println("")
-      list.each(all_issues, fn(d) { io.println("  " <> d) })
-      io.println(
+      io.println_error("")
+      list.each(all_issues, fn(d) { io.println_error("  " <> d) })
+      io.println_error(
         "\n"
         <> int.to_string(list.length(all_issues))
         <> " file(s) out of date. Run 'oaspec generate' to update.",
@@ -483,7 +483,7 @@ fn require(
   case result {
     Ok(value) -> continue(value)
     Error(err) -> {
-      io.println(to_message(err))
+      io.println_error(to_message(err))
       halt(1)
     }
   }
@@ -501,14 +501,15 @@ fn format_generate_error(err: generate.GenerateError) -> String {
   )
 }
 
-/// Print warnings if any exist.
+/// Print warnings if any exist. Warnings are diagnostics, so they go to stderr
+/// to keep stdout reserved for requested output.
 fn print_warnings(warnings: List(diagnostic.Diagnostic)) -> Nil {
   case warnings {
     [] -> Nil
     _ -> {
-      io.println("Warnings:")
+      io.println_error("Warnings:")
       list.each(warnings, fn(w) {
-        io.println("  - " <> diagnostic.to_short_string(w))
+        io.println_error("  - " <> diagnostic.to_short_string(w))
       })
     }
   }


### PR DESCRIPTION
## Summary

Diagnostic output from the `oaspec` CLI (errors, warnings, and `--check` mismatch reports) was being written to stdout instead of stderr, breaking POSIX/CLIG conventions and polluting pipelines like `oaspec | jq`. This PR routes every diagnostic site to stderr while keeping requested output (e.g. `--help` text, success messages) on stdout.

## Changes

- `src/oaspec.gleam`: switch the entry point from `glint.run` to `glint.execute` and pattern-match the result. `Error(message)` is printed via `io.println_error` and the process exits with code 1; `Ok(glint.Help(text))` is printed to stdout (help requested by the user is the requested output, not a diagnostic); `Ok(glint.Out(_))` produces no extra output because the subcommand has already printed its own.
- `src/oaspec/cli.gleam`: replace `io.println` with `io.println_error` at every diagnostic site — `init` already-exists / write-error, `--fail-on-warnings` rejection, `--check` mismatch report, the generic `require` error path, and `print_warnings`. Success messages (`Created <path>`, `All files up to date`, generation progress) keep using stdout.
- `CHANGELOG.md`: document the fix under the `Unreleased` section.

## Design Decisions

- **`glint.execute` over `glint.run`**: `glint.run` prints glint's own usage/error text to stdout internally, which is the original source of the misrouting reported in the Issue. `execute` returns a `Result` that the caller can route, which is the only way to keep glint's diagnostics off stdout without patching glint itself.
- **`--help` stays on stdout**: when the user asks for help explicitly, the help text *is* the requested output. Only diagnostic-mode help (printed because the invocation was invalid) needs to move to stderr, and that path now goes through the `Error(message)` branch.
- **`@external halt(1)`**: the existing pattern in `cli.gleam` already uses an Erlang `halt` FFI for non-zero exits; the entry point reuses the same approach for consistency.

Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic output (errors, warnings, check mismatches) now correctly routes to stderr instead of stdout, preventing interference with stdin in pipeline operations.
  * Improved error exit code handling for CLI operations.
  * Help text output remains routed to stdout as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->