### PR TITLE
fix(cli): suppress ANSI colours when not a TTY or NO_COLOR is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **CLI diagnostics now route to stderr (#251)**: error messages, warnings, and `--check` mismatch reports are written via `io.println_error` instead of `io.println`, and the top-level entry point uses `glint.execute` so glint's own usage/error text goes to stderr with exit code 1. Help text requested explicitly via `--help` still goes to stdout. Pipelines like `oaspec | jq` no longer receive diagnostic noise on stdin, and `2>&1` redirection produces the expected ordering.
+- **Suppress ANSI colour codes when stdout is not a TTY or `NO_COLOR` is set (#250)**: `pretty_help` was being applied unconditionally, so `oaspec --help > help.txt`, `oaspec --help | less`, and `NO_COLOR=1 oaspec --help` all leaked ANSI escape sequences into the captured output. `app()` now checks `io:getopts(standard_io)` for an interactive terminal and consults the `NO_COLOR` environment variable (per <https://no-color.org/>) before installing glint's pretty-help colours. The detection helpers live in `oaspec_ffi` next to the existing executable lookup helpers.
 
 ## [0.17.0] - 2026-04-23
 

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -15,6 +15,24 @@ Describe 'oaspec top-level help'
     The output should include 'generate'
     The output should include 'validate'
   End
+
+  Describe 'colour output'
+    # shellspec captures stdout via a pipe, so the CLI sees stdout as
+    # non-TTY. Both checks together cover the two suppression paths
+    # (TTY check and NO_COLOR honour).
+    It 'omits ANSI escape sequences when stdout is not a TTY'
+      When run oaspec_cli --help
+      The status should be success
+      The output should not include "$(printf '\033[')"
+    End
+
+    It 'omits ANSI escape sequences when NO_COLOR is set'
+      export NO_COLOR=1
+      When run oaspec_cli --help
+      The status should be success
+      The output should not include "$(printf '\033[')"
+    End
+  End
 End
 
 Describe 'oaspec generate'

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -15,6 +15,23 @@ import oaspec/openapi/diagnostic
 import oaspec/openapi/parser
 import simplifile
 
+@external(erlang, "oaspec_ffi", "is_stdout_tty")
+fn is_stdout_tty() -> Bool
+
+@external(erlang, "oaspec_ffi", "no_color_set")
+fn no_color_set() -> Bool
+
+/// Apply colour styling only when stdout is a terminal and NO_COLOR is unset,
+/// per <https://no-color.org/> and the CLIG "colorize when stdout is a TTY only"
+/// guideline. When either check fails, glint keeps its `pretty_help` as `None`
+/// and emits plain text.
+fn maybe_pretty_help(glint: glint.Glint(a)) -> glint.Glint(a) {
+  case is_stdout_tty(), no_color_set() {
+    True, False -> glint.pretty_help(glint, glint.default_pretty_help())
+    _, _ -> glint
+  }
+}
+
 /// Set up the CLI application.
 pub fn app() -> glint.Glint(Nil) {
   glint.new()
@@ -22,7 +39,7 @@ pub fn app() -> glint.Glint(Nil) {
   |> glint.global_help(
     "Generate Gleam code from OpenAPI 3.x specifications\n\nCommands:\n  init       Create a default oaspec.yaml config file\n  generate   Generate Gleam code from an OpenAPI spec\n  validate   Validate an OpenAPI spec without generating code\n\nRun 'oaspec <command> --help' for more information.",
   )
-  |> glint.pretty_help(glint.default_pretty_help())
+  |> maybe_pretty_help
   |> glint.add(at: ["init"], do: init_command())
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["validate"], do: validate_command())

--- a/src/oaspec_ffi.erl
+++ b/src/oaspec_ffi.erl
@@ -1,5 +1,5 @@
 -module(oaspec_ffi).
--export([find_executable/1, run_executable/2]).
+-export([find_executable/1, run_executable/2, is_stdout_tty/0, no_color_set/0]).
 
 %% Find an executable on PATH. Returns {ok, Path} or {error, nil}.
 -spec find_executable(binary()) -> {ok, binary()} | {error, nil}.
@@ -28,4 +28,29 @@ collect_exit(Port) ->
     after 60000 ->
         catch port_close(Port),
         1
+    end.
+
+%% Detect whether standard_io is connected to a terminal. io:getopts/1
+%% reports a `terminal' flag for interactive sessions; non-TTY (pipe,
+%% redirection, escript captured stdout) returns false or omits the key.
+-spec is_stdout_tty() -> boolean().
+is_stdout_tty() ->
+    case io:getopts(standard_io) of
+        {ok, Opts} ->
+            case lists:keyfind(terminal, 1, Opts) of
+                {terminal, true} -> true;
+                _ -> false
+            end;
+        _ -> false
+    end.
+
+%% Honor the NO_COLOR convention (https://no-color.org/): an unset or
+%% empty value means "do not opt out"; any non-empty value means "no
+%% color".
+-spec no_color_set() -> boolean().
+no_color_set() ->
+    case os:getenv("NO_COLOR") of
+        false -> false;
+        "" -> false;
+        _ -> true
     end.


### PR DESCRIPTION
## Summary

The `oaspec` CLI was emitting ANSI escape sequences in `--help` output unconditionally — even when stdout was redirected to a file or pipe, and even when `NO_COLOR=1` was set. This violates [no-color.org](https://no-color.org/) and the CLIG \"colorize when stdout is a TTY only\" guideline. This PR makes glint's pretty-help colours conditional on both checks.

## Changes

- `src/oaspec_ffi.erl`: add `is_stdout_tty/0` (consults `io:getopts(standard_io)` for the `terminal` flag) and `no_color_set/0` (treats unset and empty `NO_COLOR` as opt-in to colour, any other value as opt-out, per the no-color.org spec).
- `src/oaspec/cli.gleam`: replace the unconditional `glint.pretty_help(glint.default_pretty_help())` with a `maybe_pretty_help` helper that calls `pretty_help` only when stdout is a TTY *and* `NO_COLOR` is not set. When either check fails, glint keeps `pretty_help` as `None` and emits plain text.
- `spec/generate_spec.sh`: add two regression tests under `oaspec top-level help` confirming `--help` output contains no ESC byte (`\x1b`) when stdout is non-TTY (always true under shellspec) and when `NO_COLOR=1` is exported.
- `CHANGELOG.md`: document the fix in `Unreleased / Fixed`.

## Design Decisions

- **Skip `pretty_help` rather than call a hypothetical `no_pretty_help`**: glint's `pretty_help` field is `Option(PrettyHelp)`, defaulting to `None`. There is no `glint.no_pretty_help()` function; not calling `pretty_help` at all is the canonical \"plain text\" mode. The Issue's reference to `glint.no_pretty_help()` is not part of glint 1.x.
- **Erlang FFI in `oaspec_ffi.erl`**: TTY detection requires `io:getopts/1` and `NO_COLOR` requires `os:getenv/1`, neither of which has a direct Gleam stdlib equivalent for the boolean answer we want. Both helpers are tiny and live next to the existing executable lookup helpers — no new module is justified for two functions.
- **`NO_COLOR` semantics**: per <https://no-color.org/>, the variable is honoured when *present and non-empty*. An empty value (`NO_COLOR=`) is treated the same as unset, so users can override an environment-level `NO_COLOR=1` for a single invocation by exporting `NO_COLOR=` in a child shell.
- **Test reach**: under shellspec, stdout is always a pipe, so the TTY check returns false on its own. The `NO_COLOR=1` test verifies the second branch independently. Verifying the *colourised* path requires a real PTY, which would add disproportionate setup; manual smoke testing in a real terminal covers it.

Closes #250