### PR TITLE
feat(cli): add --version flag and version subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`--version` flag and `version` subcommand (#252)**: both `oaspec --version` and `oaspec version` now print `oaspec v<X.Y.Z>` (sourced from `context.version`) and exit 0. The flag is intercepted by `main()` before glint is invoked so it does not need to be wired through every subcommand; the subcommand is registered through glint so it appears in `--help` and supports `oaspec version --help`. Both forms answer the "what version of oaspec wrote this generated code?" question without requiring users to inspect package metadata.
+
 ### Fixed
 
 - **CLI diagnostics now route to stderr (#251)**: error messages, warnings, and `--check` mismatch reports are written via `io.println_error` instead of `io.println`, and the top-level entry point uses `glint.execute` so glint's own usage/error text goes to stderr with exit code 1. Help text requested explicitly via `--help` still goes to stdout. Pipelines like `oaspec | jq` no longer receive diagnostic noise on stdin, and `2>&1` redirection produces the expected ordering.

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -14,6 +14,7 @@ Describe 'oaspec top-level help'
     The output should include 'init'
     The output should include 'generate'
     The output should include 'validate'
+    The output should include 'version'
   End
 
   Describe 'colour output'
@@ -32,6 +33,22 @@ Describe 'oaspec top-level help'
       The status should be success
       The output should not include "$(printf '\033[')"
     End
+  End
+End
+
+Describe 'oaspec version'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'prints the version when invoked as --version'
+    When run oaspec_cli --version
+    The status should be success
+    The output should include 'oaspec v'
+  End
+
+  It 'prints the version when invoked as the version subcommand'
+    When run oaspec_cli version
+    The status should be success
+    The output should include 'oaspec v'
   End
 End
 

--- a/src/oaspec.gleam
+++ b/src/oaspec.gleam
@@ -2,6 +2,7 @@ import argv
 import gleam/io
 import glint
 import oaspec/cli
+import oaspec/codegen/context
 
 @external(erlang, "erlang", "halt")
 fn halt(code: Int) -> Nil
@@ -11,7 +12,15 @@ fn halt(code: Int) -> Nil
 /// Routes diagnostic output to stderr while keeping requested output (such as
 /// `--help` text) on stdout, following POSIX/CLIG conventions.
 pub fn main() -> Nil {
-  case glint.execute(cli.app(), argv.load().arguments) {
+  let arguments = argv.load().arguments
+  case arguments {
+    ["--version", ..] -> io.println("oaspec v" <> context.version)
+    _ -> run_glint(arguments)
+  }
+}
+
+fn run_glint(arguments: List(String)) -> Nil {
+  case glint.execute(cli.app(), arguments) {
     Error(message) -> {
       io.println_error(message)
       halt(1)

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -37,12 +37,22 @@ pub fn app() -> glint.Glint(Nil) {
   glint.new()
   |> glint.with_name("oaspec")
   |> glint.global_help(
-    "Generate Gleam code from OpenAPI 3.x specifications\n\nCommands:\n  init       Create a default oaspec.yaml config file\n  generate   Generate Gleam code from an OpenAPI spec\n  validate   Validate an OpenAPI spec without generating code\n\nRun 'oaspec <command> --help' for more information.",
+    "Generate Gleam code from OpenAPI 3.x specifications\n\nCommands:\n  init       Create a default oaspec.yaml config file\n  generate   Generate Gleam code from an OpenAPI spec\n  validate   Validate an OpenAPI spec without generating code\n  version    Print the oaspec version and exit\n\nRun 'oaspec <command> --help' for more information.\nUse 'oaspec --version' for a flag-style version check.",
   )
   |> maybe_pretty_help
   |> glint.add(at: ["init"], do: init_command())
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["validate"], do: validate_command())
+  |> glint.add(at: ["version"], do: version_command())
+}
+
+/// The version command definition.
+fn version_command() -> glint.Command(Nil) {
+  glint.command_help("Print the oaspec version and exit", fn() {
+    glint.command(fn(_named_args, _args, _flags) {
+      io.println("oaspec v" <> context.version)
+    })
+  })
 }
 
 /// The generate command definition.


### PR DESCRIPTION
## Summary

`oaspec` had neither a `--version` flag nor a `version` subcommand, so users could not check their installed version short of inspecting Hex package metadata. Generated code carries an `oaspec v<X.Y.Z>` marker, which makes \"what version of oaspec wrote this code?\" a load-bearing question. This PR adds both forms, mirroring the convention already used by the sibling `sqlode` project.

## Changes

- `src/oaspec.gleam`: `main()` now reads `argv.load().arguments` once, branches on `[\"--version\", ..]` to print `oaspec v<X.Y.Z>` and exit 0, and otherwise dispatches to a new `run_glint` helper that holds the existing glint.execute path.
- `src/oaspec/cli.gleam`: new `version_command()` registered via `glint.add(at: [\"version\"], ...)`. The top-level `global_help` text now lists `version` alongside the other subcommands and points users at `oaspec --version` for a flag-style check.
- `spec/generate_spec.sh`: new `Describe 'oaspec version'` block with two regression tests covering both invocation forms, plus a check that the existing top-level help lists `version`.
- `CHANGELOG.md`: document the new entry under `Unreleased / Added`.

## Design Decisions

- **`--version` is intercepted in `main`, not registered as a glint flag**: glint doesn't have a built-in `--version` and forcing it through every subcommand's flag set would be noisy. Treating `--version` as a flag-shaped query that short-circuits before glint runs is the simplest path; it also means `oaspec --version` works in any position glint would otherwise reject.
- **`version` subcommand is registered through glint**: this keeps `oaspec --help` listing it consistently with the other subcommands and gives users `oaspec version --help` for free.
- **Version source: existing `context.version` constant**: there's already a single source of truth at `oaspec/codegen/context.gleam:5`, used by every generated-file header and the `run_generate` banner. Reusing it keeps `oaspec --version`, `oaspec version`, and the generated code's `oaspec v<X.Y.Z>` marker locked together so they cannot drift.
- **No `-v` short flag**: `-v` is more commonly an alias for `verbose` in CLI conventions, and the Issue only requested `--version`. Reserving `-v` for a future verbose flag avoids a backwards-incompatible surprise.

Closes #252