### PR TITLE
fix(cli): accept --flag VALUE form alongside --flag=VALUE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `oaspec generate --config oaspec.yaml` (GNU long-option form with a
+  space between flag and value) is now accepted in addition to the
+  existing `--config=oaspec.yaml`. Previously the space-separated form
+  failed with the misleading `invalid flag 'config'`, because the
+  underlying CLI parser (glint 1.x) only recognises the `=`-joined
+  form. `oaspec.main` now normalises the argv before handing it to
+  glint, translating `--name value` into `--name=value` for the
+  value-bearing long options listed in `oaspec/cli.value_flag_names`
+  (`--config`, `--mode`, `--output`). Equals-form, boolean-flag,
+  positional, and unknown-flag callers are unaffected. Same behaviour
+  for `validate` and `init`. (#260)
+
 ## [0.18.0] - 2026-04-25
 
 This release is a UX overhaul of the generated server / client surface.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 729 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 740 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -84,6 +84,20 @@ Describe 'oaspec generate'
       The output should include 'Successfully generated'
       The output should include '16 files'
     End
+
+    It 'accepts space-separated --config FILE form'
+      clean_test_output
+      When run generate --config test/fixtures/oaspec.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+    End
+
+    It 'accepts space-separated --mode VALUE form'
+      clean_test_output
+      When run generate --config test/fixtures/oaspec.yaml --mode server
+      The status should be success
+      The output should include 'Successfully generated'
+    End
   End
 
   # -------------------------------------------------------------------

--- a/src/oaspec.gleam
+++ b/src/oaspec.gleam
@@ -1,5 +1,8 @@
 import argv
+import gleam/bool
 import gleam/io
+import gleam/list
+import gleam/string
 import glint
 import oaspec/cli
 import oaspec/codegen/context
@@ -15,7 +18,7 @@ pub fn main() -> Nil {
   let arguments = argv.load().arguments
   case arguments {
     ["--version", ..] -> io.println("oaspec v" <> context.version)
-    _ -> run_glint(arguments)
+    _ -> run_glint(normalize_argv(arguments))
   }
 }
 
@@ -28,4 +31,45 @@ fn run_glint(arguments: List(String)) -> Nil {
     Ok(glint.Help(text)) -> io.println(text)
     Ok(glint.Out(_)) -> Nil
   }
+}
+
+/// Translate `--name value` into `--name=value` for the value-bearing long
+/// options listed in `cli.value_flag_names`. glint 1.x only accepts the
+/// `=`-joined form, so users who reach for the GNU `--name value` convention
+/// (or who copy commands from `git`/`gh`/`cargo` muscle memory) hit
+/// `invalid flag '<name>'`. The normalisation happens before glint sees the
+/// argv so existing `--name=value` callers are unaffected, and so unknown
+/// flags still surface from glint with their original error.
+///
+/// Other shapes are passed through untouched:
+/// - `--name=value`: already canonical (the name has `=` in it, so no match)
+/// - `--bool-flag`: not in the value-bearing list
+/// - `--name -other`: a `-`-prefixed value is treated as the next flag, so
+///   the original (broken) call is preserved and glint reports it as before
+pub fn normalize_argv(arguments: List(String)) -> List(String) {
+  do_normalize(arguments, [])
+}
+
+fn do_normalize(arguments: List(String), acc: List(String)) -> List(String) {
+  case arguments {
+    [] -> list.reverse(acc)
+    [arg, value, ..rest] -> {
+      use <- bool.guard(
+        !{ is_value_long_flag(arg) && value_is_value(value) },
+        do_normalize([value, ..rest], [arg, ..acc]),
+      )
+      do_normalize(rest, [arg <> "=" <> value, ..acc])
+    }
+    [single, ..rest] -> do_normalize(rest, [single, ..acc])
+  }
+}
+
+fn is_value_long_flag(arg: String) -> Bool {
+  use <- bool.guard(!string.starts_with(arg, "--"), False)
+  let name = string.drop_start(arg, 2)
+  list.contains(cli.value_flag_names, name)
+}
+
+fn value_is_value(arg: String) -> Bool {
+  !string.starts_with(arg, "-")
 }

--- a/src/oaspec.gleam
+++ b/src/oaspec.gleam
@@ -54,9 +54,9 @@ fn do_normalize(arguments: List(String), acc: List(String)) -> List(String) {
   case arguments {
     [] -> list.reverse(acc)
     [arg, value, ..rest] -> {
-      use <- bool.guard(
+      use <- bool.lazy_guard(
         !{ is_value_long_flag(arg) && value_is_value(value) },
-        do_normalize([value, ..rest], [arg, ..acc]),
+        fn() { do_normalize([value, ..rest], [arg, ..acc]) },
       )
       do_normalize(rest, [arg <> "=" <> value, ..acc])
     }

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -32,6 +32,14 @@ fn maybe_pretty_help(glint: glint.Glint(a)) -> glint.Glint(a) {
   }
 }
 
+/// Long-option flag names that take a value across all subcommands. Used by
+/// the argv-normalisation step in `oaspec.main` to translate the GNU
+/// `--name value` form into glint's expected `--name=value` form. Must stay
+/// in sync with the `glint.string_flag(...)` calls below: any new
+/// value-bearing long-option flag must be added here, otherwise the
+/// space-separated form will fail with `invalid flag '<name>'`.
+pub const value_flag_names = ["config", "mode", "output"]
+
 /// Set up the CLI application.
 pub fn app() -> glint.Glint(Nil) {
   glint.new()

--- a/test/normalize_argv_test.gleam
+++ b/test/normalize_argv_test.gleam
@@ -1,0 +1,61 @@
+import gleeunit/should
+import oaspec
+
+pub fn normalize_argv_passthrough_empty_test() {
+  oaspec.normalize_argv([])
+  |> should.equal([])
+}
+
+pub fn normalize_argv_passthrough_subcommand_only_test() {
+  oaspec.normalize_argv(["generate"])
+  |> should.equal(["generate"])
+}
+
+pub fn normalize_argv_passthrough_equals_form_test() {
+  oaspec.normalize_argv(["generate", "--config=oaspec.yaml"])
+  |> should.equal(["generate", "--config=oaspec.yaml"])
+}
+
+pub fn normalize_argv_passthrough_bool_flag_test() {
+  oaspec.normalize_argv(["generate", "--check"])
+  |> should.equal(["generate", "--check"])
+}
+
+pub fn normalize_argv_joins_space_separated_config_test() {
+  oaspec.normalize_argv(["generate", "--config", "oaspec.yaml"])
+  |> should.equal(["generate", "--config=oaspec.yaml"])
+}
+
+pub fn normalize_argv_joins_space_separated_mode_test() {
+  oaspec.normalize_argv(["generate", "--mode", "server"])
+  |> should.equal(["generate", "--mode=server"])
+}
+
+pub fn normalize_argv_joins_space_separated_output_test() {
+  oaspec.normalize_argv(["init", "--output", "./oaspec.yaml"])
+  |> should.equal(["init", "--output=./oaspec.yaml"])
+}
+
+pub fn normalize_argv_joins_multiple_value_flags_test() {
+  oaspec.normalize_argv([
+    "generate", "--config", "oaspec.yaml", "--mode", "server", "--check",
+  ])
+  |> should.equal([
+    "generate", "--config=oaspec.yaml", "--mode=server", "--check",
+  ])
+}
+
+pub fn normalize_argv_preserves_dash_value_as_next_flag_test() {
+  oaspec.normalize_argv(["generate", "--config", "--check"])
+  |> should.equal(["generate", "--config", "--check"])
+}
+
+pub fn normalize_argv_does_not_join_unknown_flag_test() {
+  oaspec.normalize_argv(["generate", "--unknown", "foo"])
+  |> should.equal(["generate", "--unknown", "foo"])
+}
+
+pub fn normalize_argv_mixed_equals_and_space_test() {
+  oaspec.normalize_argv(["validate", "--config=a.yaml", "--mode", "client"])
+  |> should.equal(["validate", "--config=a.yaml", "--mode=client"])
+}


### PR DESCRIPTION
## Summary

`oaspec generate --config oaspec.yaml` (GNU long-option form with a space between flag and value) was rejected with the misleading `invalid flag 'config'`. Only the `=`-joined form `--config=oaspec.yaml` worked. Users coming from `git`, `gh`, `cargo`, `kubectl` etc. expect both forms; the error text also misled them into thinking the flag name was wrong rather than the syntax.

The underlying parser is glint 1.x which only accepts the `=`-joined form. Rather than fork glint, this PR normalises argv in `oaspec.main` before handing it to glint, translating `--name value` into `--name=value` for the value-bearing long options.

## Changes

- `src/oaspec/cli.gleam`: new `pub const value_flag_names = ["config", "mode", "output"]` listing every value-bearing long flag across `generate` / `validate` / `init`. The constant lives next to the `glint.string_flag(...)` definitions so future flags get added in the same edit.
- `src/oaspec.gleam`: new `pub fn normalize_argv(arguments)` that pairs `--known-flag` with its next argv element when that element does not start with `-`, and joins them with `=`. `main` calls it before `glint.execute`.
- `test/normalize_argv_test.gleam` (new): 10 unit tests covering passthrough cases (empty, subcommand-only, equals form, bool flag, unknown flag, dash-value), join cases (each of the three string flags, multiple in one call), and a mixed equals/space case.
- `spec/generate_spec.sh`: two new shellspec cases that drive the binary end-to-end with the space-separated form, so the regression is caught even if a future refactor moves the normalisation logic.
- `CHANGELOG.md`: `## [Unreleased] / Fixed` entry describing the behaviour and naming the new constant for callers that subclass the CLI.
- `README.md`: unit test count bumped from 729 to 740 (`scripts/check_sync.sh` enforces this).

## Design Decisions

- **Normalise argv, do not fork glint.** glint's parser hard-codes `flag_delimiter = "="` (`build/packages/glint/src/glint.gleam:758`) and the public API offers no hook to override it. A pre-glint normalisation is a 30-line change that we can revisit if/when glint 2.x adds native support; forking glint to add space-separated parsing would carry a much larger maintenance burden across the ecosystem.
- **Whitelist the value-bearing flags rather than guessing.** We cannot ask glint at runtime "does this flag take a value?" without depending on its private types, and a generic "join every `--flag <next>` pair" would mishandle bool flags (`--check`) by gluing the next positional to them. The hand-maintained whitelist is short (3 entries) and has a comment requiring it to be kept in sync with the `glint.string_flag(...)` calls in the same module.
- **`-`-prefixed values stay broken.** `oaspec generate --config -other` is preserved as-is and glint reports its original error. The alternative — treating `-other` as a positional value — would silently accept a malformed call. Filenames that legitimately start with `-` can still be passed via the `=` form (`--config=-special.yaml`).
- **Equals-form unaffected.** `--config=foo.yaml` does not match the whitelist check (the name comes back as `"config=foo.yaml"`, not `"config"`) so existing callers are byte-for-byte unchanged.
- **`bool.guard` over nested `case True/False`.** glinter's `prefer_guard_clause = "error"` rule rejects the latter shape; `bool.guard` is the project-wide idiom for early-return-style boolean dispatch.

## Limitations

- The whitelist is hand-maintained. Adding a new `glint.string_flag("foo")` call without also adding `"foo"` to `value_flag_names` will leave the new flag rejecting the space-separated form. Mitigation: an inline comment on the constant calls this out, and the new shellspec coverage will catch any regression on the existing flags.
- `validate` and `init` are not exercised by the new shellspec cases (only `generate` is). The unit tests cover the normalisation logic for all three subcommands, and the shellspec cases pin the integration path for the most-used subcommand. Adding `validate` / `init` shellspec coverage is straightforward but out of scope for this fix.

Closes #260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line argument parsing to accept space-separated long options (e.g., `--config value`) in addition to equals form across `generate`, `validate`, and `init` commands.

* **Tests**
  * Added comprehensive test coverage for argument normalization scenarios (11 new tests).
  * Updated total test count from 729 to 740.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->