### PR TITLE
feat(content-type): accept application/x-ndjson as response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `application/x-ndjson` (newline-delimited JSON) is now accepted as
+  a response content type. NDJSON is widely deployed for streaming
+  JSON Lines responses (Elasticsearch bulk API, Loki, OpenAI
+  streaming endpoints, log shippers) and the previous "unsupported
+  response content type" rejection blocked any spec that used it.
+  For codegen purposes the body is a `String` and no per-line
+  decoding happens at the SDK layer, so the implementation aliases
+  to the existing `text/plain` branch in `content_type.from_string`.
+  The original `application/x-ndjson` string is still embedded
+  verbatim into the generated server's `Content-Type` response
+  header (the codegen pulls the media-type name from the spec, not
+  from the alias). Same behaviour applies to validate-only runs
+  via `oaspec validate`. (#261)
+
 ### Fixed
 
 - `oaspec generate --config oaspec.yaml` (GNU long-option form with a

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 740 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 741 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -183,6 +183,12 @@ pub fn registry() -> List(Capability) {
     Capability("application/json", "response", Supported, "JSON responses"),
     Capability("text/plain", "response", Supported, "Text passthrough"),
     Capability(
+      "application/x-ndjson",
+      "response",
+      Supported,
+      "NDJSON streaming, treated as text passthrough",
+    ),
+    Capability(
       "application/octet-stream",
       "response",
       Supported,

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -994,9 +994,9 @@ fn validate_responses(
             path: path,
             detail: "Response content type '"
               <> media_type_name
-              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/octet-stream, application/xml (and +xml suffix types), text/xml.",
+              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/x-ndjson, application/octet-stream, application/xml (and +xml suffix types), text/xml.",
             hint: Some(
-              "Use application/json (or a +json suffix type), text/plain, application/octet-stream, application/xml (or a +xml suffix type), or text/xml.",
+              "Use application/json (or a +json suffix type), text/plain, application/x-ndjson, application/octet-stream, application/xml (or a +xml suffix type), or text/xml.",
             ),
           ),
         ]

--- a/src/oaspec/util/content_type.gleam
+++ b/src/oaspec/util/content_type.gleam
@@ -21,6 +21,15 @@ pub fn from_string(content_type: String) -> ContentType {
   case content_type {
     "application/json" -> ApplicationJson
     "text/plain" -> TextPlain
+    // application/x-ndjson (newline-delimited JSON) is widely deployed for
+    // streaming JSON Lines responses (Elasticsearch bulk, Loki, OpenAI
+    // streaming, log shippers). For codegen purposes the body is a `String`
+    // and no per-line decoding happens at the SDK layer, so it aliases to
+    // TextPlain. The original "application/x-ndjson" string is still embedded
+    // verbatim into the generated server's `Content-Type` response header
+    // because the codegen pulls the media-type name from the spec, not from
+    // `to_string`.
+    "application/x-ndjson" -> TextPlain
     "multipart/form-data" -> MultipartFormData
     "application/x-www-form-urlencoded" -> FormUrlEncoded
     "application/octet-stream" -> ApplicationOctetStream

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -1788,6 +1788,17 @@ pub fn content_type_from_string_test() {
 
   content_type.from_string("application/octet-stream")
   |> should.equal(content_type.ApplicationOctetStream)
+
+  // application/x-ndjson aliases to TextPlain (issue #261)
+  content_type.from_string("application/x-ndjson")
+  |> should.equal(content_type.TextPlain)
+}
+
+pub fn content_type_x_ndjson_is_supported_response_test() {
+  content_type.is_supported_response(content_type.from_string(
+    "application/x-ndjson",
+  ))
+  |> should.be_true()
 }
 
 pub fn content_type_to_string_test() {


### PR DESCRIPTION
## Summary

`application/x-ndjson` (newline-delimited JSON streaming) was rejected by the response content-type allow-list. NDJSON is widely deployed (Elasticsearch bulk, Loki, OpenAI streaming, log shippers) and the rejection forced spec authors to either downgrade to `text/plain` or fork oaspec. This change adds it to the allow-list with `text/plain`-equivalent codegen semantics — the body is a `String`, no per-line decoding happens at the SDK layer, and the accurate `application/x-ndjson` Content-Type still goes out on the wire.

## Changes

- `src/oaspec/util/content_type.gleam`: `from_string` now maps `"application/x-ndjson"` to the existing `TextPlain` variant. No new `ContentType` variant is introduced.
- `src/oaspec/capability.gleam`: `application/x-ndjson` added to the response capability registry next to `application/json` and `text/plain`, so the capability surface stays accurate.
- `src/oaspec/codegen/validate.gleam`: the "unsupported response content type" diagnostic and its hint both now list `application/x-ndjson` as supported.
- `test/oaspec_test.gleam`: 2 new tests pinning `from_string("application/x-ndjson") == TextPlain` and `is_supported_response(...) == True`.
- `CHANGELOG.md`: `## [Unreleased] / Added` entry.
- `README.md`: unit test count bumped to 741.

## Design Decisions

- **Alias to `TextPlain` rather than introduce `ApplicationXNdjson`.** A new `ContentType` variant would force a `case` arm in `ir_build.gleam`, `client_response.gleam`, and `server.gleam` (every site that already routes `TextPlain | ApplicationXml | TextXml | ApplicationOctetStream` through the "string body" path). The aliasing approach is one line of code and zero codegen-site churn, with no observable behaviour difference: the SDK layer treats both as `String`, and the generated server's `Content-Type` header pulls the media-type name from the spec (`media_type_name`) not from `content_type.to_string`, so the wire-side header is still correct.
- **`Capability` registry entry kept even though the lookup keys on `to_string`.** `is_supported_response` does the registry lookup via `to_string(ct)`, which for an aliased `application/x-ndjson` returns `"text/plain"` (matching the `text/plain` registry entry). The new `application/x-ndjson` registry entry therefore documents the supported MIME without driving the lookup. Future capability-table generation (e.g. README scrapers) gets the right answer.
- **No new boundary-case test for non-NDJSON `application/x-*` types.** The aliasing is keyed on the exact string `"application/x-ndjson"`, so other `application/x-*` MIMEs continue to fall through to `UnsupportedContentType` and fail validation as before. The existing `unsupported response content-type` test path covers that regression.
- **Diagnostic message edits keep the same word ordering.** The hint preserves the order `application/json, text/plain, application/x-ndjson, application/octet-stream, …` so users grep-for / muscle-memory the original message can find the new addition without rebuilding their mental model.

## Limitations

- Only `application/x-ndjson` is added. The Issue mentions `application/jsonl`, `application/x-jsonlines`, `application/json-seq` as related candidates; those are deferred until there is a concrete spec asking for them, since each is a separate one-line addition that can be made on demand and overcommitting risks endorsing legacy/non-canonical names.
- Request-body NDJSON (clients sending NDJSON to the server) is not addressed — the registry entry is `category: "response"`. If a future spec uses NDJSON in a `requestBody`, that will need its own `request` capability entry plus a request-body allow-list update. Out of scope for this fix because the Issue is response-side.

Closes #261
