### PR TITLE
fix(server): emit json.array for top-level array responses with primitive items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A 2xx response whose schema is a top-level array of primitive items
+  (`type: array, items: { type: string }` etc.) used to generate
+  `body: json.to_string(json.string(data))` in the server router,
+  which fails to type-check because `data: List(String)` is fed into
+  the scalar `json.string` encoder. The codegen now emits
+  `fn(items) { json.array(items, json.<primitive>) }` for inline
+  primitive-item arrays (`string` / `integer` / `number` / `boolean`)
+  and falls back to `json.array(items, json.string)` for inline
+  non-primitive items rather than the previous `json.string`
+  fallback that produced uncompilable code. Top-level array of `$ref`
+  items already worked through the existing `Reference` branch and
+  is unaffected. (#266)
 - `oaspec generate --config oaspec.yaml` (GNU long-option form with a
   space between flag and value) is now accepted in addition to the
   existing `--config=oaspec.yaml`. Previously the space-separated form

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 741 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 742 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -1434,7 +1434,22 @@ fn get_encode_function(
           "fn(items) { json.array(items, encode.encode_"
           <> naming.to_snake_case(name)
           <> "_json) }"
-        _ -> "json.string"
+        Inline(schema.StringSchema(..)) ->
+          "fn(items) { json.array(items, json.string) }"
+        Inline(schema.IntegerSchema(..)) ->
+          "fn(items) { json.array(items, json.int) }"
+        Inline(schema.NumberSchema(..)) ->
+          "fn(items) { json.array(items, json.float) }"
+        Inline(schema.BooleanSchema(..)) ->
+          "fn(items) { json.array(items, json.bool) }"
+        // Inline non-primitive items (e.g. nested ArraySchema, anonymous
+        // ObjectSchema) at the top level of a response are not yet hoisted
+        // into reusable encoders. Falling back to the previous "json.string"
+        // shape would emit code that fails to compile against List(_); emit a
+        // homogeneous String array instead so the call still type-checks even
+        // when the items are not actually strings. Once such schemas get a
+        // hoist + per-item encoder, replace this branch.
+        _ -> "fn(items) { json.array(items, json.string) }"
       }
     }
     Some(Inline(schema.StringSchema(..))) -> "json.string"

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -12980,3 +12980,44 @@ pub fn request_body_encoding_warning_is_surfaced_test() {
     })
   has_encoding_warning |> should.be_true()
 }
+
+/// Spec where the 200 response is a top-level array of primitive items.
+/// (Issue #266: previously emitted `json.string(data)` which fails to type-check
+/// against `List(String)`.)
+const top_level_array_spec = "
+openapi: 3.0.3
+info:
+  title: Top Level Array
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /blobs:
+    get:
+      operationId: listBlobs
+      responses:
+        '200':
+          description: list of blob ids
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+"
+
+pub fn top_level_array_response_uses_json_array_test() {
+  let ctx = make_validate_ctx_from_yaml(top_level_array_spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // Should wrap the List in json.array, not pass it to json.string directly.
+  string.contains(router_file.content, "json.array(items, json.string)")
+  |> should.be_true()
+
+  // Should NOT emit the buggy json.string(data) shape from the report
+  // (where `data: List(String)` is fed directly into the scalar encoder).
+  string.contains(router_file.content, "json.string(data)")
+  |> should.be_false()
+}


### PR DESCRIPTION
## Summary

A 2xx response whose schema was a top-level array of primitive items (`type: array, items: { type: string }`) caused the generated server router to emit `body: json.to_string(json.string(data))`. That call fails to type-check because `data: List(String)` is fed into the scalar `json.string` encoder. Top-level array of `$ref` items already worked (it took a different `Reference` branch); only inline-primitive-item top-level arrays were broken.

## Changes

- `src/oaspec/codegen/server.gleam`: `get_encode_function` now matches each primitive variant in the inline `ArraySchema(items: ...)` branch and emits `fn(items) { json.array(items, json.<primitive>) }` for `string` / `integer` / `number` / `boolean` items. The default branch for inline non-primitive items (e.g. nested arrays, anonymous objects that are not yet hoisted) now falls back to a homogeneous `json.array(items, json.string)` shape rather than the previous `json.string` literal, so the call still type-checks against `List(_)` even when the items are not actually strings.
- `test/oaspec_test.gleam`: new `top_level_array_response_uses_json_array_test` plus the YAML fixture `top_level_array_spec`. Pins both directions of the regression: the bug shape `json.string(data)` must NOT appear, and the fixed shape `json.array(items, json.string)` must appear.
- `CHANGELOG.md`: `## [Unreleased] / Fixed` entry describing the failure mode and the new emission.
- `README.md`: unit test count bumped to 742.

## Design Decisions

- **Fix `get_encode_function`, not the call-site template.** The bug is in the encoder-name selection: every call-site that uses `get_encode_function` benefits, including the `[#(_, _), _, ..]` multi-content-type passthrough and the matching `ApplicationJson` branch. Patching only the router template would leave the same hole in any other site that calls `get_encode_function` for a top-level inline array.
- **Inline primitive items are exhaustively enumerated.** All four primitive `Schema` variants (`StringSchema`, `IntegerSchema`, `NumberSchema`, `BooleanSchema`) get explicit `json.<primitive>` mappings. This matches how the existing object-nested-array path handles primitives (via `encode.gleam`), so the runtime types line up between top-level and nested cases.
- **Fallback chosen for type-check safety, not correctness.** The `_ -> "fn(items) { json.array(items, json.string) }"` clause is reachable for inline `ArraySchema(items: ArraySchema(..))`, inline anonymous `ObjectSchema(..)` items, and a few other shapes the hoist pass leaves inline. None of these will produce semantically correct JSON for non-string item types, but the result *compiles*, which is a strict improvement over the previous `json.string` fallback that produced uncompilable code. A comment in the source flags this as a follow-up: hoisting these item shapes into reusable encoders and emitting the right `encode.encode_*_json` call is the proper fix and is tracked separately.
- **Deferred: the `[#(_, _), _, ..]` multi-content-type branch.** The same code path (router response dispatch) handles responses with multiple content types differently — it always emits `body: data, headers: [content-type: <first>]` assuming `data` is already a `String`. That assumes the response variant wraps `String`, which is what `ir_build.response_variant` produces (`VariantWithType(_, "String")`). No bug there for the current reproduction.

## Limitations

- Only inline `ArraySchema` items are addressed. Top-level array of `$ref` items already worked through the existing `Reference` branch and is not changed.
- The fallback `fn(items) { json.array(items, json.string) }` for inline non-primitive items (e.g. `type: array, items: { type: array, items: { type: integer } }`) compiles but produces wrong output (treats the inner list as a string). Marked as a follow-up in the source comment; the proper fix is hoisting these item schemas. Out of scope for this Issue, which targets the specific compile-failure regression for primitive-item top-level arrays.
- The shellspec layer is not touched. The unit test exercises the codegen directly, which is faster and more localised; integration coverage will arrive automatically once the petstore fixture grows a top-level array endpoint.

Closes #266
