### PR TITLE
fix(validate): detect Foo+FooList decode_*_list collision before codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A spec that defines both `Foo` and `FooList` component schemas
+  (or any `<Name>` + `<Name>List` pair) used to fail at `gleam build`
+  time with `Duplicate definition: decode_<name>_list` rather than
+  during validation. The synthetic list decoder for `Foo` and the
+  user-named decoder for `FooList` collided on the same identifier
+  in `decode.gleam`. The validator now detects the pair before
+  codegen and emits a spec-level diagnostic naming both schemas and
+  the offending identifier, with rename suggestions
+  (`<Name>Collection`, `<Name>Page`, `<Name>Items`). Specs that only
+  define one of the pair are unaffected. (#267)
 - A 2xx response whose schema is a top-level array of primitive items
   (`type: array, items: { type: string }` etc.) used to generate
   `body: json.to_string(json.string(data))` in the server router,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 742 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 743 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -32,7 +32,66 @@ pub fn validate(ctx: Context) -> List(Diagnostic) {
   let opid_errors = validate_unique_operation_ids(operations)
   let schema_errors = validate_component_schemas(ctx)
   let security_errors = validate_security_schemes(ctx, operations)
-  list.flatten([op_errors, opid_errors, schema_errors, security_errors])
+  let list_decoder_errors = validate_decode_list_collisions(ctx)
+  list.flatten([
+    op_errors,
+    opid_errors,
+    schema_errors,
+    security_errors,
+    list_decoder_errors,
+  ])
+}
+
+/// Detect `Foo` + `FooList` schema name pairs that would generate two
+/// `decode_foo_list` functions in `decode.gleam` and trip the gleam
+/// compiler's `Duplicate definition` check. The synthetic list decoder
+/// (`decode_<schema>_list` returning `List(<Schema>)`) is emitted for
+/// every component schema, so any user-named `<Schema>List` schema
+/// collides on the same identifier. Detected at validation time so the
+/// user gets a one-line spec-level diagnostic instead of a confusing
+/// post-codegen build failure. (#267)
+fn validate_decode_list_collisions(ctx: Context) -> List(Diagnostic) {
+  let schema_names = case context.spec(ctx).components {
+    Some(components) ->
+      dict.to_list(components.schemas) |> list.map(fn(entry) { entry.0 })
+    None -> []
+  }
+  list.filter_map(schema_names, fn(base_name) {
+    let collider_name = base_name <> "List"
+    case list.contains(schema_names, collider_name) {
+      False -> Error(Nil)
+      True -> {
+        let snake = naming.to_snake_case(base_name)
+        Ok(diagnostic.validation(
+          severity: SeverityError,
+          target: TargetBoth,
+          path: "components.schemas." <> collider_name,
+          detail: "Schema name '"
+            <> collider_name
+            <> "' would generate decode_"
+            <> snake
+            <> "_list, which collides with the synthetic list decoder for '"
+            <> base_name
+            <> "' (a JSON array of "
+            <> base_name
+            <> "). gleam build will fail with `Duplicate definition: decode_"
+            <> snake
+            <> "_list`.",
+          hint: Some(
+            "Rename one of the schemas. Example: rename '"
+            <> collider_name
+            <> "' to '"
+            <> base_name
+            <> "Collection', '"
+            <> base_name
+            <> "Page', or '"
+            <> base_name
+            <> "Items'.",
+          ),
+        ))
+      }
+    }
+  })
 }
 
 /// Fail the spec if two operations end up sharing an operationId, either

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13006,6 +13006,69 @@ paths:
                   type: string
 "
 
+/// Spec where two component schemas would collide on `decode_card_list`
+/// (Issue #267): `Card` synthesises a list decoder; `CardList` reuses the
+/// same identifier. The validator must surface this before codegen.
+const decode_list_collision_spec = "
+openapi: 3.0.3
+info:
+  title: Decode List Collision
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /cards:
+    get:
+      operationId: listCards
+      responses:
+        '200':
+          description: list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardList'
+components:
+  schemas:
+    Card:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+    CardList:
+      type: object
+      required: [cards]
+      properties:
+        cards:
+          type: array
+          items:
+            $ref: '#/components/schemas/Card'
+"
+
+pub fn validate_detects_decode_list_collision_test() {
+  let assert Ok(spec) = parser.parse_string(decode_list_collision_spec)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let errors = validate.validate(ctx)
+  let has_collision_error =
+    list.any(errors, fn(e) {
+      string.contains(diagnostic.to_string(e), "decode_card_list")
+      && string.contains(diagnostic.to_string(e), "CardList")
+    })
+  has_collision_error |> should.be_true()
+}
+
 pub fn top_level_array_response_uses_json_array_test() {
   let ctx = make_validate_ctx_from_yaml(top_level_array_spec)
   let files = server_gen.generate(ctx)


### PR DESCRIPTION
## Summary

A spec that defined both `Foo` and `FooList` component schemas (or any `<Name>` + `<Name>List` pair) compiled fine through oaspec, then failed at `gleam build` with the cryptic `Duplicate definition: decode_<name>_list`. The synthetic list decoder for `Foo` (`decode_foo_list` returning `List(Foo)`) and the user-named decoder for `FooList` (also `decode_foo_list`, returning `FooList`) collided on the same identifier in `decode.gleam`. This bug compounds with #266 because the natural workaround for that issue is to wrap a top-level array in a `<Name>List` object, which immediately trips this collision.

## Changes

- `src/oaspec/codegen/validate.gleam`: new `validate_decode_list_collisions(ctx)` function plugged into the `validate(ctx)` pipeline. Walks `components.schemas`, looks for any `<Name>` whose `<Name>List` partner also exists, and emits a `SeverityError` diagnostic with the colliding identifier (`decode_<name>_list`) and rename suggestions (`<Name>Collection`, `<Name>Page`, `<Name>Items`).
- `test/oaspec_test.gleam`: new `validate_detects_decode_list_collision_test` plus the `decode_list_collision_spec` YAML fixture (`Card` + `CardList` schemas) pinning that the diagnostic mentions both the collision identifier and the offending schema name.
- `CHANGELOG.md`: `## [Unreleased] / Fixed` entry.
- `README.md`: unit test count bumped to 743.

## Design Decisions

- **Validate, not rename.** The Issue lists three options: (1) change the synthetic suffix to `_array`, (2) auto-disambiguate one of the names, (3) detect and error. Option 1 silently breaks every existing caller of `decode_<name>_list`. Option 2 silently mutates the public API surface (one of the two functions gets a different name, and downstream callers don't know which). Option 3 keeps the contract explicit: the user names the schemas, oaspec generates predictable identifiers from those names, and any collision is reported up front so the user can choose the rename. This matches the existing `validate_unique_operation_ids` policy.
- **Detect at validation time, not codegen time.** A late detection (during `decoders.gleam` rendering) would surface as a generator-internal error far from where the user can act. The validator runs before codegen and emits diagnostics through the same pipeline as every other "spec rejected" error, so the failure mode and exit shape are familiar.
- **Diagnostic body names both schemas and the offending identifier.** The user reading the message sees `Schema name 'CardList' would generate decode_card_list, which collides with the synthetic list decoder for 'Card'`. They get the action ("rename one of these") and the location (which two schemas collide) without grepping the codebase.
- **Hint suggests three concrete renames** (`<Name>Collection`, `<Name>Page`, `<Name>Items`). All three are conventional REST collection names; offering more than one avoids "the docs told me to call it Collection, but Collection is the wrong domain word for my API".
- **Path field uses `components.schemas.<colliderName>`, not `<baseName>`.** The action lives on the *user-named* schema (`<Name>List`); the synthetic decoder for `<Name>` is what oaspec is allowed to generate. Pointing at the user-named one makes the rename target obvious.

## Limitations

- Only the `<Name>` + `<Name>List` pair is detected. Other suffix patterns that the codegen reuses for synthetic types (`<Name>Decoder`, `<Name>Encoder`, etc., if any get added in the future) would need their own check. The current naming convention keeps `_list` as the only synthetic-suffix risk for component-level decoder names.
- Operation-level `decode_<operation>_list_response_*` shapes are not checked here; those are scoped to the operation and don't collide with component schema decoders. If a future codegen change introduces a new synthetic-suffix family, this validator can be extended.
- The validator does not rewrite the spec or auto-rename. The user has to pick the new name themselves — intentional, since the right rename is domain-specific.

Closes #267
