### PR TITLE
fix(config)!: default validate to true for server-producing modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (default)**: when `validate:` is omitted from
+  `oaspec.yaml`, the default is now mode-dependent rather than always
+  `false`: `mode: server` and `mode: both` default to `true`, while
+  `mode: client` defaults to `false`. Previously the silent default
+  was `false` for every mode, which let schema-invalid input
+  (`minimum`, `maximum`, `pattern`, `minLength`, `maxLength`
+  violations) flow straight into user handlers — security-adjacent
+  because handlers can do real work (SRS / scoring algorithms,
+  length-bounded fields with downstream compute, pattern-bounded
+  fields used for SQL parameter generation, etc.) on input they
+  assumed was constraint-checked. Server-side codegen is now
+  fail-closed by default. Explicit `validate: true` / `validate:
+  false` keeps overriding regardless of mode. Migration: if you
+  generated server code and relied on the no-validation default,
+  add `validate: false` explicitly to opt out, or remove handler
+  code that handled out-of-range input. The CLI flag
+  `--validate=true` (which only adds, never removes, validation)
+  is unchanged. (#268)
+
 ### Added
 
 - `application/x-ndjson` (newline-delimited JSON) is now accepted as

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 743 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 229 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 746 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 232 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -201,7 +201,7 @@ Generated server code is written to `<dir>/<package>` and generated client code 
 | `input` | yes | - | Path to an OpenAPI 3.x spec in YAML or JSON |
 | `package` | no | `api` | Gleam module namespace prefix |
 | `mode` | no | `both` | `server`, `client`, or `both` |
-| `validate` | no | `false` | Enable guard validation in generated server/client code |
+| `validate` | no | mode-dependent (`true` for `server` / `both`, `false` for `client`) | Enable guard validation in generated server/client code |
 | `output.dir` | no | `./gen` | Base output directory |
 | `output.server` | no | `<dir>/<package>` | Server output path |
 | `output.client` | no | `<dir>/<package>_client` | Client output path |

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -850,6 +850,11 @@ input: test/fixtures/guard_constraints_api.yaml
 output:
   server: ./integration_test/guard_constraints_test/src/api
 package: api
+# validate is explicit because issue #268 changed the default for
+# server-producing modes from `false` to `true`. This step intentionally
+# exercises the opt-out path so the grep below for the absence of
+# `guards.validate_item(` keeps verifying the off-state semantics.
+validate: false
 YAML_EOF
 
 cd "$PROJECT_ROOT"

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -208,11 +208,15 @@ package: api
 # Generation mode: server, client, or both (default: both).
 # mode: both
 
-# Enable guard validation in generated server/client code (default: false).
-# When enabled, generated routers validate request bodies against schema
-# constraints and return 422 on failure. Generated clients validate
-# request bodies before sending.
-# validate: false
+# Enable guard validation in generated server/client code.
+# Default: true for mode: server / both (fail-closed: server handlers
+# should not receive schema-invalid input by default), false for
+# mode: client (clients pre-validating before sending is nice but
+# optional). When enabled, generated routers validate request bodies
+# against schema constraints and return 422 on failure. Generated
+# clients validate request bodies before sending. Set explicitly to
+# override the mode-dependent default.
+# validate: true
 
 # Output settings (optional).
 # output:

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -174,12 +174,25 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     },
   )
 
+  // When `validate:` is omitted, the default is mode-dependent (issue #268).
+  // Server-mode codegen with `validate: false` lets schema-invalid input
+  // (`minimum`, `maximum`, `pattern`, `minLength`, `maxLength` violations)
+  // through to user handlers — security-adjacent and surprising. The
+  // generator emits the guard functions either way; the only knob is whether
+  // the router calls them. So fail-closed by default for any mode that
+  // produces a server (`Server` and `Both`), and keep `False` only for the
+  // pure-client case where pre-validating before send is nice but optional.
+  // Explicit `validate: true` / `validate: false` continues to override.
   use validate <- result.try(
     case yay.select_sugar(from: root, selector: "validate") {
       Ok(yay.NodeBool(True)) | Ok(yay.NodeStr("true")) -> Ok(True)
       Ok(yay.NodeBool(False)) | Ok(yay.NodeStr("false")) -> Ok(False)
-      // nolint: thrown_away_error -- missing optional 'validate' key defaults to False
-      Error(_) -> Ok(False)
+      // nolint: thrown_away_error -- missing optional 'validate' key defaults to mode-dependent value
+      Error(_) ->
+        case mode {
+          Server | Both -> Ok(True)
+          Client -> Ok(False)
+        }
       Ok(_) ->
         Error(InvalidValue(
           field: "validate",

--- a/test/fixtures/oaspec_validate_default_both.yaml
+++ b/test/fixtures/oaspec_validate_default_both.yaml
@@ -1,0 +1,6 @@
+input: test/fixtures/petstore.yaml
+output:
+  server: ./test_output/api
+  client: ./test_output_client/api
+package: api
+mode: both

--- a/test/fixtures/oaspec_validate_default_client.yaml
+++ b/test/fixtures/oaspec_validate_default_client.yaml
@@ -1,0 +1,6 @@
+input: test/fixtures/petstore.yaml
+output:
+  server: ./test_output/api
+  client: ./test_output_client/api
+package: api
+mode: client

--- a/test/fixtures/oaspec_validate_default_server.yaml
+++ b/test/fixtures/oaspec_validate_default_server.yaml
@@ -1,0 +1,6 @@
+input: test/fixtures/petstore.yaml
+output:
+  server: ./test_output/api
+  client: ./test_output_client/api
+package: api
+mode: server

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -117,6 +117,28 @@ pub fn parse_mode_test() {
   config.parse_mode("invalid") |> should.be_error()
 }
 
+// Issue #268: when `validate:` is omitted, the default depends on `mode:`.
+// Server / Both default to True (fail-closed: server handlers should not
+// receive schema-invalid input by default). Client defaults to False.
+
+pub fn config_validate_default_server_test() {
+  let assert Ok(cfg) =
+    config.load("test/fixtures/oaspec_validate_default_server.yaml")
+  config.validate(cfg) |> should.be_true()
+}
+
+pub fn config_validate_default_client_test() {
+  let assert Ok(cfg) =
+    config.load("test/fixtures/oaspec_validate_default_client.yaml")
+  config.validate(cfg) |> should.be_false()
+}
+
+pub fn config_validate_default_both_test() {
+  let assert Ok(cfg) =
+    config.load("test/fixtures/oaspec_validate_default_both.yaml")
+  config.validate(cfg) |> should.be_true()
+}
+
 pub fn config_package_dir_mismatch_test() {
   let cfg =
     config.new(
@@ -12573,13 +12595,16 @@ pub fn config_validate_field_test() {
   Nil
 }
 
-/// Config load should default validate to False when not specified.
-pub fn config_validate_default_false_test() {
+/// Config load: when `validate:` is omitted and `mode:` is also omitted,
+/// `mode` defaults to `Both`, which yields `validate: true` (issue #268,
+/// fail-closed for any mode that produces a server). Explicit overrides
+/// still win — covered by `config_validate_default_client_test`.
+pub fn config_validate_default_when_omitted_test() {
   let yaml_content = "input: test.yaml\npackage: api\n"
   let temp_path = "/tmp/oaspec_validate_default_test.yaml"
   let assert Ok(Nil) = simplifile.write(temp_path, yaml_content)
   let assert Ok(cfg) = config.load(temp_path)
-  config.validate(cfg) |> should.be_false()
+  config.validate(cfg) |> should.be_true()
   let _ = simplifile.delete(temp_path)
   Nil
 }


### PR DESCRIPTION
## Summary

When `validate:` is omitted from `oaspec.yaml`, the previous default was always `false`. That meant a generated server router *did not* call the `guards.validate_*` functions even when the spec declared `minimum`, `maximum`, `pattern`, `minLength`, `maxLength` constraints — schema-invalid input flowed straight into user handlers. This is security-adjacent (handlers can do real work — SRS / scoring algorithms, length-bounded fields with downstream compute, pattern-bounded fields used for SQL parameter generation — on input they assumed was constraint-checked) and contradicts the README claim that oaspec "Refuses to emit broken code on unsupported spec patterns".

This change makes the default mode-dependent and fail-closed for any mode that produces a server: `Server` and `Both` default to `true`, `Client` defaults to `false`. Explicit `validate: true` / `validate: false` in the YAML keeps overriding regardless of mode.

## Changes

- `src/oaspec/config.gleam`: the `validate:` extraction in `load()` now branches on `mode` when the YAML key is omitted (was: hard-coded `Ok(False)`).
- `test/fixtures/oaspec_validate_default_{server,client,both}.yaml` (new, 3 fixtures): minimal YAMLs that omit `validate:` and only set `mode:` to one of the three values. Used by the new tests below.
- `test/oaspec_test.gleam`: 3 new tests `config_validate_default_{server,client,both}_test` pin the new mode-dependent default. Existing `config_validate_default_false_test` is renamed to `config_validate_default_when_omitted_test` and its assertion flips from `should.be_false` to `should.be_true` (now covers the `mode: both` default path; the YAML in that test omits `mode:`, which itself defaults to `Both`, so the validate-default chain resolves to `true`).
- `src/oaspec/cli.gleam`: the `init` command's generated `oaspec.yaml` template comment now describes the new default behaviour and shows `# validate: true` as the suggested explicit setting.
- `integration_test/run.sh`: the `guard_constraints_test` step (which intentionally exercises the validate-off path to assert that guard calls are NOT embedded) now sets `validate: false` explicitly in its temp YAML, plus a comment explaining why. Without this, the new default would flip the test's expectation. The `guard_validate_on_test` step (which already sets `validate: true`) is unchanged.
- `CHANGELOG.md`: `## [Unreleased] / Changed` entry tagged `**BREAKING (default)**` with the migration recipe.
- `README.md`: config-table row for `validate` now shows the mode-dependent default; unit test count bumped to 746; fixture count bumped to 232.

## Design Decisions

- **Fail-closed by default for server-producing modes.** The ergonomics are clear: the user wrote `minimum: 0, maximum: 5` to declare a contract, and the server should enforce it without the user having to remember a flag. The cost of the breaking change is small (one explicit line of YAML for the few users that wanted the no-validation default) and the safety win is substantial. This matches the spirit of `Refuses to emit broken code on unsupported spec patterns` from the README.
- **Mode-dependent rather than blanket `true`.** Pure-client codegen has no security pressure for default-on validation (the network sits between the validator and the receiver, so the server validates anyway). Forcing `validate: true` on `mode: client` would generate guard code the user did not ask for and may cause client-side rejections that the server would have accepted. Keeping `Client` at `false` preserves the principle of minimum surprise for the client-only path.
- **`Both` defaults to `true`, not "both apply separately".** The Issue suggests "both apply" semantics, which would require splitting the single `validate` flag into `server_validate` / `client_validate`. That is a larger API change and would invalidate every existing `with_validate(cfg, b)` call site. Defaulting `Both` to `true` is the conservative read: any mode that emits a server should default to validating server-side input. Users who want only client-side validation should set `mode: client` explicitly anyway.
- **Migration left to the user, not auto-rewritten.** The CLI does not warn-and-rewrite config files: a Changed (Breaking) entry in CHANGELOG plus an explicit `# validate: true` line in the `init` template is enough to make the new default discoverable. Auto-rewriting `oaspec.yaml` would mutate user-tracked files silently, which is worse than the explicit migration step.
- **Integration test made explicit instead of hard-coding the old default.** The integration step that asserts "default router does NOT call guards" used to lean on `validate omitted ⇒ false`. With the new default, that step would fail unless its YAML pins `validate: false`. Pinning makes the test's intent (exercise the opt-out path) clear in the YAML itself — which is what a real user opting out would do — instead of relying on a brittle implicit default.

## Limitations

- Existing users who relied on `validate omitted ⇒ false` will see their generated router suddenly call `guards.validate_*`. The migration is one line: add `validate: false` to `oaspec.yaml`. The Changed entry in CHANGELOG calls this out.
- `--validate` CLI flag default is unchanged. The flag adds validation when set (`True`) and falls through to the config value when unset (`False`). Reversing that flag's default would also be a breaking change; deferred until needed because the config-side default is the one that matters for "the safe default" ergonomics.
- The `Both` mode still uses a single `validate` flag for both server and client codegen. Users who want server-only validation should switch to `mode: server` (which is what the new default rewards).
- Behaviour is keyed on `mode` at config-load time. CLI `--mode=server` overrides the mode AFTER `validate` has been resolved, so `--mode=server` on a YAML with `mode: client` (no explicit validate) inherits the client default of `false`. If users want server-mode + validate-on, they should set `mode: server` in YAML or pass `--validate` (CLI flag). This is consistent with how `with_mode` overrides flow today and avoids re-running the validate-default logic mid-pipeline.

Closes #268
