### PR TITLE
fix(config): drop _client suffix from default output in client-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 746 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 232 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 749 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 233 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 749 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 233 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 750 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 233 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -137,29 +137,6 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     |> result.unwrap(None)
     |> option.unwrap("api")
 
-  // Determine output base directory first, then derive server/client paths.
-  // Priority: output.server/client (explicit) > output.dir (base) > default "./gen"
-  //
-  // Both default paths land *inside* the base dir (Issue #248): the previous
-  // sibling `<dir>_client/<package>` derivation put client code where
-  // `gleam build` could not see it. The new layout is
-  //   server: <dir>/<package>
-  //   client: <dir>/<package>_client
-  // so a single `gleam build` rooted at <dir> sees both. Users who actually
-  // want server and client in separate Gleam projects keep setting
-  // output.server / output.client explicitly.
-  let output_dir =
-    extract_nested_string(root, "output", "dir")
-    |> option.unwrap("./gen")
-
-  let output_server =
-    extract_nested_string(root, "output", "server")
-    |> option.unwrap(output_dir <> "/" <> package)
-
-  let output_client =
-    extract_nested_string(root, "output", "client")
-    |> option.unwrap(output_dir <> "/" <> package <> "_client")
-
   use mode <- result.try(
     case yay.extract_optional_string(root, "mode") |> result.unwrap(None) {
       Some("server") -> Ok(Server)
@@ -173,6 +150,37 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
         ))
     },
   )
+
+  // Determine output base directory, then derive mode-aware server/client
+  // defaults. Priority: output.server/client (explicit) > output.dir (base)
+  // > default "./gen".
+  //
+  // The `_client` suffix is only needed in `Both` mode to disambiguate the
+  // two output trees inside a single `<dir>`. In client-only mode there is
+  // no server output to clash with, so the default client output is just
+  // `<dir>/<package>` and the generated `import <package>/...` lines
+  // resolve correctly (Issue #262).
+  //
+  // The unused field in single-mode configs (e.g. `output_server` in
+  // client-only mode) is set to a sensible-looking placeholder for
+  // diagnostics; it is never read by the writer or codegen.
+  let output_dir =
+    extract_nested_string(root, "output", "dir")
+    |> option.unwrap("./gen")
+
+  let server_default = output_dir <> "/" <> package
+  let client_default = case mode {
+    Client -> output_dir <> "/" <> package
+    Server | Both -> output_dir <> "/" <> package <> "_client"
+  }
+
+  let output_server =
+    extract_nested_string(root, "output", "server")
+    |> option.unwrap(server_default)
+
+  let output_client =
+    extract_nested_string(root, "output", "client")
+    |> option.unwrap(client_default)
 
   // When `validate:` is omitted, the default is mode-dependent (issue #268).
   // Server-mode codegen with `validate: false` lets schema-invalid input
@@ -215,17 +223,19 @@ pub fn with_validate(config: Config, validate: Bool) -> Config {
 }
 
 /// Apply output base directory override.
-/// Derives server/client paths as <dir>/<package> and <dir>/<package>_client.
-/// Issue #248: the client default used to be a sibling `<dir>_client/<package>`,
-/// which left the generated client code outside any Gleam src/ root. The new
-/// layout keeps both paths under <dir> so a single `gleam build` sees both.
+/// Derives server/client paths as <dir>/<package> and <dir>/<package>_client
+/// in `Both` mode. In client-only mode the client path drops the suffix
+/// (Issue #262) so generated `import <package>/...` lines resolve.
 pub fn with_output(config: Config, output: Option(String)) -> Config {
   case output {
     Some(dir) ->
       Config(
         ..config,
         output_server: dir <> "/" <> config.package,
-        output_client: dir <> "/" <> config.package <> "_client",
+        output_client: case config.mode {
+          Client -> dir <> "/" <> config.package
+          Server | Both -> dir <> "/" <> config.package <> "_client"
+        },
       )
     None -> config
   }

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -226,6 +226,10 @@ pub fn with_validate(config: Config, validate: Bool) -> Config {
 /// Derives server/client paths as <dir>/<package> and <dir>/<package>_client
 /// in `Both` mode. In client-only mode the client path drops the suffix
 /// (Issue #262) so generated `import <package>/...` lines resolve.
+///
+/// The suffix decision reads `config.mode` at call time, so apply
+/// `with_mode/2` before `with_output/2` if both overrides are needed —
+/// otherwise the client path will reflect the previous mode's default.
 pub fn with_output(config: Config, output: Option(String)) -> Config {
   case output {
     Some(dir) ->
@@ -267,6 +271,22 @@ pub fn validate_output_package_match(config: Config) -> Result(Nil, ConfigError)
       }
     Client -> Ok(Nil)
   }
+  |> result.try(fn(_) {
+    // Both-mode safety: server and client must not write to the same
+    // directory or one would overwrite the other (Issue #262 follow-up).
+    case config.mode {
+      Both ->
+        case config.output_server == config.output_client {
+          False -> Ok(Nil)
+          True ->
+            Error(InvalidValue(
+              field: "output.client",
+              detail: "In `Both` mode, output.server and output.client must differ. Set them explicitly, or use `mode: client` / `mode: server` to opt out of dual emission.",
+            ))
+        }
+      Server | Client -> Ok(Nil)
+    }
+  })
   |> result.try(fn(_) {
     case config.mode {
       Client | Both -> {

--- a/test/fixtures/oaspec_client_default_path.yaml
+++ b/test/fixtures/oaspec_client_default_path.yaml
@@ -1,0 +1,5 @@
+input: test/fixtures/petstore.yaml
+output:
+  dir: ./gen
+package: api
+mode: client

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -133,6 +133,46 @@ pub fn config_validate_default_client_test() {
   config.validate(cfg) |> should.be_false()
 }
 
+// Issue #262: in client-only mode the default `output.client` must drop
+// the `_client` suffix so generated `import <package>/...` lines resolve
+// against the directory layout. In `Both` mode the suffix is still applied
+// (server and client need distinct basenames inside the same `<dir>`).
+
+pub fn config_client_only_default_drops_client_suffix_test() {
+  let assert Ok(cfg) =
+    config.load("test/fixtures/oaspec_client_default_path.yaml")
+  config.output_client(cfg) |> should.equal("./gen/api")
+}
+
+pub fn config_with_output_client_only_drops_suffix_test() {
+  let cfg =
+    config.new(
+      input: "test/fixtures/petstore.yaml",
+      output_server: "./old/api",
+      output_client: "./old/api_client",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let updated = config.with_output(cfg, Some("./new"))
+  config.output_client(updated) |> should.equal("./new/api")
+}
+
+pub fn config_with_output_both_keeps_suffix_test() {
+  let cfg =
+    config.new(
+      input: "test/fixtures/petstore.yaml",
+      output_server: "./old/api",
+      output_client: "./old/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: True,
+    )
+  let updated = config.with_output(cfg, Some("./new"))
+  config.output_server(updated) |> should.equal("./new/api")
+  config.output_client(updated) |> should.equal("./new/api_client")
+}
+
 pub fn config_validate_default_both_test() {
   let assert Ok(cfg) =
     config.load("test/fixtures/oaspec_validate_default_both.yaml")

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -155,6 +155,7 @@ pub fn config_with_output_client_only_drops_suffix_test() {
       validate: False,
     )
   let updated = config.with_output(cfg, Some("./new"))
+  config.output_server(updated) |> should.equal("./new/api")
   config.output_client(updated) |> should.equal("./new/api")
 }
 
@@ -171,6 +172,27 @@ pub fn config_with_output_both_keeps_suffix_test() {
   let updated = config.with_output(cfg, Some("./new"))
   config.output_server(updated) |> should.equal("./new/api")
   config.output_client(updated) |> should.equal("./new/api_client")
+}
+
+pub fn config_validate_rejects_both_mode_with_same_paths_test() {
+  // Guards the with_mode-after-load edge case: a Client-mode config
+  // upgraded to Both must not silently overwrite the server directory
+  // with client content. validate_output_package_match catches the
+  // collision.
+  let cfg =
+    config.new(
+      input: "test/fixtures/petstore.yaml",
+      output_server: "./gen/api",
+      output_client: "./gen/api",
+      package: "api",
+      mode: config.Both,
+      validate: True,
+    )
+  case config.validate_output_package_match(cfg) {
+    Error(config.InvalidValue(field: "output.client", detail: _)) ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
 }
 
 pub fn config_validate_default_both_test() {


### PR DESCRIPTION
## Summary

In client-only mode (`mode: client`) the default `output.client` path now
drops the `_client` suffix, so generated files land in
`<output.dir>/<package>/` instead of `<output.dir>/<package>_client/`.
This matches the `import <package>/...` lines the codegen still emits,
fixing the `Unknown module` build error described in #262.

In `Both` mode the suffix is preserved so server and client trees can
coexist inside a single `<dir>` with distinct basenames (the prior fix
from #248).

## Changes

- `src/oaspec/config.gleam`
  - Reordered `load_from_root` to parse `mode` *before* deriving the
    default output paths so the defaults can branch on mode.
  - Default `output.client` is now mode-aware:
    - `Client` mode → `<dir>/<package>` (no `_client` suffix)
    - `Server` / `Both` mode → `<dir>/<package>_client` (unchanged)
  - `with_output/2` mirrors the same mode-aware logic so CLI overrides
    behave identically to YAML defaults.
  - Refreshed the inline comment block to document the mode-aware
    behavior and reference #262.
- `test/fixtures/oaspec_client_default_path.yaml` (new)
  - Minimal client-only config with `output: { dir: ./gen }` and no
    explicit `output.client`. Exercises the new default-derivation
    path.
- `test/oaspec_test.gleam`
  - `config_client_only_default_drops_client_suffix_test` —
    loads the new fixture and asserts
    `output_client(cfg) == "./gen/api"` (was `"./gen/api_client"`
    before this fix).
  - `config_with_output_client_only_drops_suffix_test` — exercises the
    `with_output/2` CLI override path with mode `Client`.
  - `config_with_output_both_keeps_suffix_test` — regression guard that
    `Both` mode still gets `<dir>/<package>` and
    `<dir>/<package>_client` (preserving the #248 layout).
- `README.md`
  - Bumped the test-count line from 746 / 232 fixtures to 749 / 233 to
    reflect the new tests and fixture (keeps `check_sync.sh` green).

## Design Decisions

- **Mode-aware defaults beat unconditional rewrites.** Two alternatives
  the issue mentions:
  1. Drop the suffix unconditionally — would collide with the server
     output in `Both` mode (both would try to write to
     `<dir>/<package>/`).
  2. Keep the suffix and rewrite imports in shared files — requires
     the codegen to emit two different versions of every shared file
     (one with `<package>/...` imports, one with `<package>_client/...`),
     a much larger architectural change.
  Mode-aware defaults solve the reported bug for the `Client` case
  without disturbing `Both`-mode users who already rely on the
  suffix to keep server and client distinct inside `<dir>`.
- **`output_server` in client-only mode keeps a sensible-looking
  placeholder** (`<dir>/<package>`) but is never read by the writer
  or codegen — `writer.output_dirs/1` only returns server paths in
  `Server`/`Both` mode. Setting it to anything more elaborate would
  add noise without behavior change.
- **`with_output/2` mirrors the load path.** The CLI's `--output`
  flag flows through `with_output`; if it didn't apply the same
  mode-aware suffix logic, the YAML and CLI behaviors would diverge
  and surprise users.
- **Existing validation in `validate_output_package_match`** already
  accepts both `<package>` and `<package>_client` basenames for
  client outputs, so no validation changes are needed.

## Limitations

- This PR addresses only the client-only-mode default-path bug. Users
  who explicitly set `output.client: ./src/api_client` (or otherwise
  end up with the suffix) and run in `Client` mode still hit the
  original `Unknown module` error — the codegen would need a second
  fix to rewrite imports inside shared files when written to a
  suffix-using client directory. That's the harder Option B from the
  issue and is left as future work.
- The mode-aware default in `with_output/2` is determined from the
  current `config.mode` at the time of the call. If a user invokes
  `with_output` *before* `with_mode` (or otherwise in an unusual
  order), they may get the suffix when they expected the
  client-only behavior. CLI flow constructs the config with mode
  set first, so this only affects programmatic API consumers.

Closes #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output paths now adjust intelligently based on generation mode: Client mode excludes the "_client" suffix, while Server and Both modes retain it.

* **Tests**
  * Added three new configuration tests to verify path behavior across generation modes.

* **Documentation**
  * Updated test coverage statistics in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->