### PR TITLE
feat(validate): accept application/octet-stream in request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 750 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 233 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 751 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 234 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/capability.gleam
+++ b/src/oaspec/capability.gleam
@@ -174,6 +174,12 @@ pub fn registry() -> List(Capability) {
     ),
     Capability("multipart/form-data", "request", Supported, "Multipart upload"),
     Capability(
+      "application/octet-stream",
+      "request",
+      Supported,
+      "Binary upload (raw bytes; passes through as the body parameter without JSON decoding)",
+    ),
+    Capability(
       "+json/+xml suffix",
       "content-type",
       Supported,

--- a/src/oaspec/codegen/validate.gleam
+++ b/src/oaspec/codegen/validate.gleam
@@ -670,9 +670,9 @@ fn validate_request_body(
             path: op_id <> ".requestBody",
             detail: "Content type '"
               <> media_type
-              <> "' is not supported. Supported request content types: application/json (and +json suffix types), multipart/form-data, application/x-www-form-urlencoded.",
+              <> "' is not supported. Supported request content types: application/json (and +json suffix types), multipart/form-data, application/x-www-form-urlencoded, application/octet-stream.",
             hint: Some(
-              "Use application/json (or a +json suffix type like application/problem+json), multipart/form-data, or application/x-www-form-urlencoded.",
+              "Use application/json (or a +json suffix type like application/problem+json), multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream.",
             ),
           ),
         ]
@@ -880,6 +880,7 @@ fn validate_server_request_body_content_types(
           key != "application/json"
           && key != "application/x-www-form-urlencoded"
           && key != "multipart/form-data"
+          && key != "application/octet-stream"
           && content_type.is_supported_request(content_type.from_string(key))
         })
       list.map(non_json_but_supported, fn(media_type) {
@@ -891,7 +892,7 @@ fn validate_server_request_body_content_types(
             <> media_type
             <> "' is not supported for server code generation. Server router only supports application/json request bodies with typed decoding.",
           hint: Some(
-            "Use application/json for typed server request bodies, or multipart/form-data and application/x-www-form-urlencoded for form data.",
+            "Use application/json for typed server request bodies, or multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream for non-JSON payloads.",
           ),
         )
       })

--- a/test/fixtures/request_octet_stream.yaml
+++ b/test/fixtures/request_octet_stream.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: Binary Upload API
+  version: 1.0.0
+paths:
+  /blobs:
+    post:
+      operationId: putBlob
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "201":
+          description: stored
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PutResult"
+components:
+  schemas:
+    PutResult:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -653,6 +653,41 @@ paths:
   |> should.be_true()
 }
 
+// Issue #265: application/octet-stream must be accepted as a request body
+// content type so callers can describe binary upload endpoints (S3
+// PutObject-style, image upload, log shipping, etc.).
+pub fn validate_accepts_octet_stream_request_body_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /blobs:
+    post:
+      operationId: putBlob
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema: { type: string, format: binary }
+      responses:
+        '201': { description: stored }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  // No content-type-related diagnostic should mention application/octet-stream
+  // as unsupported.
+  let error_strings = list.map(errors, validate.error_to_string)
+  list.any(error_strings, fn(s) {
+    string.contains(s, "application/octet-stream")
+    && string.contains(s, "is not supported")
+  })
+  |> should.be_false()
+}
+
 pub fn dedup_resolves_property_name_collision_test() {
   let yaml =
     "
@@ -4312,6 +4347,7 @@ pub fn capability_registry_covers_content_type_request_helpers_test() {
     "application/json",
     "application/x-www-form-urlencoded",
     "multipart/form-data",
+    "application/octet-stream",
   ]
   let registry_request_names =
     capability.registry()


### PR DESCRIPTION
## Summary

Accept `application/octet-stream` as a request-body content type so
binary-upload endpoints (S3 PutObject, image upload, PDF upload, log
shipping, sensor data) can be described in OpenAPI specs and run
through codegen. Previously the validator rejected the spec outright
with `Content type 'application/octet-stream' is not supported`.

## Changes

- `src/oaspec/capability.gleam`
  - Added `Capability("application/octet-stream", "request", Supported,
    "Binary upload (raw bytes; passes through as the body parameter
    without JSON decoding)")` to the registry. This makes
    `content_type.is_supported_request(ApplicationOctetStream)` return
    `True`, which is the gate the validator's `validate_request_body`
    function uses.
- `src/oaspec/codegen/validate.gleam`
  - Updated the unsupported-content-type error message to mention
    `application/octet-stream` in the list of supported request types.
  - Updated the server-side allow-list in
    `validate_non_json_request_body_unsupported_for_server` so
    octet-stream isn't rejected by the secondary "server router only
    supports JSON typed bodies" check. Octet-stream now passes both
    the general request-body validator and the server-mode validator.
  - Refreshed the hint text accordingly.
- `test/fixtures/request_octet_stream.yaml` (new)
  - Mirrors the fixture from #265: a `POST /blobs` operation with an
    `application/octet-stream` request body and a JSON response.
- `test/oaspec_test.gleam`
  - `validate_accepts_octet_stream_request_body_test` — feeds the
    issue's spec through the validator and asserts no diagnostic
    contains `"application/octet-stream … is not supported"`.
  - Updated `capability_registry_covers_content_type_request_helpers_test`
    to include `application/octet-stream` in the drift-guard list
    (keeps the registry as the source of truth).
- `README.md`
  - Bumped test/fixture counts (751 / 234) to keep `check_sync.sh`
    green.

## Design Decisions

- **Pure registry + validator change, no codegen body-type change.**
  The minimal fix that addresses the user's reported pain ("Spec
  rejected; codegen does not run") is to let validation pass. The
  codegen path falls through to the existing fall-through in
  `generate_body_decode_expr` (the `_ -> "body"` arm), which passes
  the body parameter through as `String`. On Erlang `String` is a
  binary so the bytes survive intact; on the JavaScript target
  binary content can still be lossy if the body contains
  non-UTF-8 byte sequences.
- **`BitArray` body type is intentionally out of scope.** The issue
  requests `BitArray`-typed bodies for codegen. That requires
  threading the body type through every consumer (router, handler
  signatures, client request emission) and is a deeper architectural
  change than what the immediate user pain justifies. With this PR,
  `application/octet-stream` specs generate valid Gleam code on
  Erlang. A follow-up issue should track moving the body type to
  `BitArray` for proper binary handling on both targets.
- **Mirrored the existing pattern from #261 (response side).** The
  issue points out that `application/x-ndjson` was added to the
  *response* allow-list as an alias to `TextPlain`. The request-side
  fix here uses the same shape: registry entry + validator allow-list
  update + drift test.
- **No new content-type variant.** `ApplicationOctetStream` already
  exists in the `ContentType` enum; only the registry entry and the
  validator paths needed updating.

## Limitations

- **Body parameter type is still `String`.** As described above, the
  full `BitArray` support is out of scope for this PR. Callers using
  the Erlang target are byte-safe; callers using the JavaScript
  target with binary payloads should track the follow-up issue or
  use `multipart/form-data` for now.
- **Spec-level validation accepts; codegen content is unchanged.**
  The codegen does not yet emit dedicated octet-stream encode/decode
  helpers. Callers receive the raw body bytes via the existing body
  parameter and are expected to pass them through to whatever
  storage layer accepts them.
- **Multi-content operations** that mix octet-stream with another
  content type are not specially handled — the existing precedence
  rules (JSON wins when present) apply.

Closes #265
