### PR TITLE
fix(naming): keep letter+digit identifiers attached (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 759 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 234 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 762 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 234 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/util/naming.gleam
+++ b/src/oaspec/util/naming.gleam
@@ -17,9 +17,31 @@ type Regexes {
 fn compile_regexes() -> Regexes {
   // nolint: assert_ok_pattern -- regex literal cannot fail
   let assert Ok(word_separator) = regexp.from_string("[_\\-\\s./]+")
+  // Word-split rule for camelCase / PascalCase / mixed input. The four
+  // alternatives, in priority order:
+  //
+  //   1. `[A-Z]+(?=[A-Z][a-z])` — split before the trailing capital of
+  //      an ALLCAPS run that's followed by a lower run (XMLParser →
+  //      XML, Parser).
+  //   2. `[A-Z]?[a-z]+[0-9]*` — a lower-cased word with an optional
+  //      leading capital and an OPTIONAL trailing digit run (sha256 →
+  //      sha256, getV2 → getV2's "v2" piece). The trailing-digit
+  //      attachment (Issue #283) keeps `rev_b58` / `sha256` / `utf8` /
+  //      `base64` / `oauth2` / `md5` as a single word in generated
+  //      Gleam, matching the convention sqlode landed on in #480 and
+  //      avoiding the `rev_b_58` / `sha_256` shapes that read like a
+  //      division.
+  //   3. `[A-Z]+[0-9]*` — an ALLCAPS word with the same optional
+  //      trailing digit run (USER, ID2, UUID).
+  //   4. `[0-9]+` — a leading or otherwise-unattached digit run
+  //      (256sha → "256", "sha"). Only digits not absorbed by the
+  //      preceding letter run land here; this preserves the
+  //      digit→letter split (the standard convention is asymmetric).
   // nolint: assert_ok_pattern -- regex literal cannot fail
   let assert Ok(camel_case) =
-    regexp.from_string("([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)")
+    regexp.from_string(
+      "([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+[0-9]*|[A-Z]+[0-9]*|[0-9]+)",
+    )
   // nolint: assert_ok_pattern -- regex literal cannot fail
   let assert Ok(underscore_before_caps) =
     regexp.from_string("([a-z0-9])([A-Z])")

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -46,6 +46,34 @@ pub fn naming_to_snake_case_non_keyword_unaffected_test() {
   |> should.equal("list_pets")
 }
 
+// Issue #283: letter+digit identifiers stay together in generated
+// Gleam, matching the convention sqlode landed on in nao1215/sqlode#480.
+// `rev_b58` keeps its trailing digits attached to the preceding letter
+// run; the digit→letter direction (`256sha`) still splits because the
+// rule is asymmetric.
+pub fn naming_to_snake_case_keeps_letter_digit_suffix_attached_test() {
+  naming.to_snake_case("rev_b58") |> should.equal("rev_b58")
+  naming.to_snake_case("sha256") |> should.equal("sha256")
+  naming.to_snake_case("utf8") |> should.equal("utf8")
+  naming.to_snake_case("base64") |> should.equal("base64")
+  naming.to_snake_case("oauth2") |> should.equal("oauth2")
+  naming.to_snake_case("md5") |> should.equal("md5")
+  naming.to_snake_case("ipv4") |> should.equal("ipv4")
+  naming.to_snake_case("port_8080") |> should.equal("port_8080")
+  naming.to_snake_case("iso8601") |> should.equal("iso8601")
+}
+
+pub fn naming_to_snake_case_pascal_with_letter_digit_suffix_test() {
+  naming.to_snake_case("Sha256Hash") |> should.equal("sha256_hash")
+  naming.to_snake_case("GetV2Author") |> should.equal("get_v2_author")
+  naming.to_snake_case("OAuth2Token") |> should.equal("o_auth2_token")
+}
+
+pub fn naming_to_snake_case_digit_letter_still_splits_test() {
+  // Digit→letter remains a split point — only letter→digit is glued.
+  naming.to_snake_case("256sha") |> should.equal("256_sha")
+}
+
 // naming.operation_to_function_name tests
 // ===================================================================
 


### PR DESCRIPTION
## Summary

Fixes #283. The camelCase/PascalCase tokenizer in `oaspec/util/naming` previously split letter+digit identifiers, turning `rev_b58` into `rev_b_58`, `sha256` into `sha_256`, and so on. JSON wire format kept the original name, so generated handlers and clients carried three names for one concept.

This change updates the regex so a trailing digit run stays attached to the preceding letter run, matching the convention sqlode landed on in nao1215/sqlode#480. The digit→letter direction (`256sha` → `256_sha`) still splits, since that asymmetry is the standard reading.

## Changes

- `src/oaspec/util/naming.gleam`: regex alternatives for `[A-Z]?[a-z]+` and `[A-Z]+` now allow an optional trailing `[0-9]*` cluster.
- `test/naming_test.gleam`: three new tests covering the snake-case / PascalCase / digit-letter cases.

## Examples

| Input | Before | After |
|------|--------|-------|
| `rev_b58` | `rev_b_58` | `rev_b58` |
| `sha256` | `sha_256` | `sha256` |
| `port_8080` | `port_8_080` | `port_8080` |
| `Sha256Hash` | `sha_256_hash` | `sha256_hash` |
| `256sha` | `256_sha` | `256_sha` (unchanged) |

## Test plan

- [x] `gleam test --target erlang` — 762 passed
- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam run -m glinter -- --stats` — 0 errors, 0 warnings
- [x] `gleam build --warnings-as-errors`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of names containing digits following letters (e.g., `sha256`, `rev_b58`) to keep digit suffixes attached during case conversion.

* **Tests**
  * Added test coverage for letter-digit boundary behavior in naming conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->