### PR TITLE
fix(cli): hint to add gleam_regexp when generated code uses pattern validation (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Generated record fields no longer split letter+digit identifiers, so
+  `rev_b58`, `sha256`, `port_8080`, `iso8601`, etc. survive codegen
+  unchanged instead of becoming `rev_b_58` / `sha_256` / `port_8_080`.
+  Matches the convention sqlode landed on in nao1215/sqlode#480; the
+  digit→letter direction (`256sha` → `256_sha`) still splits because
+  that asymmetry is the standard reading. (#283)
+
+### Added
+
+- `oaspec generate` now prints a `Note:` line at the end of generation
+  reminding the user to `gleam add gleam_regexp` when the generated
+  code imports `gleam/regexp` for pattern validation. Without the
+  direct dep, `gleam build` warns about the transitive import (and a
+  future Gleam release turns this into a hard error). The hint is only
+  printed when at least one generated file actually imports
+  `gleam/regexp`. (#284)
+
 ## [0.21.0] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 762 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 234 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 762 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -100,6 +100,25 @@ Describe 'oaspec generate'
     End
   End
 
+  Describe 'pattern constraint dependency hint (Issue #284)'
+    It 'prints a Note about gleam_regexp when generated code uses pattern validation'
+      clean_test_output
+      When run generate --config=test/fixtures/oaspec_guards_pattern.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      The output should include 'gleam/regexp for pattern validation'
+      The output should include "gleam add gleam_regexp"
+    End
+
+    It 'does not print the Note when no patterns are present'
+      clean_test_output
+      When run generate --config=test/fixtures/oaspec.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      The output should not include 'gleam_regexp'
+    End
+  End
+
   # -------------------------------------------------------------------
   # File existence checks (generate once, check many)
   # -------------------------------------------------------------------

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -314,6 +314,32 @@ fn write_files(files: List(context.GeneratedFile), cfg: config.Config) -> Nil {
   io.println(
     "Successfully generated " <> int.to_string(list.length(written)) <> " files",
   )
+  print_dep_hints(files)
+}
+
+/// Issue #284: when the generated code imports a Gleam stdlib module
+/// whose package is not a direct dep of the consumer's project (today,
+/// only `gleam/regexp` for pattern validation), `gleam build` warns
+/// about the transitive import and a future Gleam release turns this
+/// into a hard error. Print an actionable hint so the user adds the
+/// missing dep — we deliberately do not rewrite the consumer's
+/// `gleam.toml` because modifying user-managed config invisibly is
+/// surprising.
+fn print_dep_hints(files: List(context.GeneratedFile)) -> Nil {
+  let needs_regexp =
+    list.any(files, fn(f) { string.contains(f.content, "import gleam/regexp") })
+  case needs_regexp {
+    True -> {
+      io.println("")
+      io.println(
+        "Note: generated code imports gleam/regexp for pattern validation.",
+      )
+      io.println(
+        "      Run 'gleam add gleam_regexp' in your project before 'gleam build'.",
+      )
+    }
+    False -> Nil
+  }
 }
 
 /// Check that generated code matches existing files on disk.

--- a/test/fixtures/oaspec_guards_pattern.yaml
+++ b/test/fixtures/oaspec_guards_pattern.yaml
@@ -1,0 +1,6 @@
+input: test/fixtures/guard_constraints_api.yaml
+output:
+  server: ./test_output/api
+  client: ./test_output_client/api
+package: api
+validate: true


### PR DESCRIPTION
## Summary

Fixes #284. When `oaspec generate` produces a `guards.gleam` that imports `gleam/regexp` (used for `pattern:` constraint validation), the consumer's `gleam.toml` typically does NOT have `gleam_regexp` as a direct dependency. `gleam build` warns about the transitive import, and a future Gleam release will turn this into a hard error.

This PR adds a Note line at the end of generation that points the user at the fix:

```
Note: generated code imports gleam/regexp for pattern validation.
      Run 'gleam add gleam_regexp' in your project before 'gleam build'.
```

The line is only printed when at least one generated file actually imports `gleam/regexp`, so specs without `pattern:` constraints (the common case) see no extra noise.

## Why a hint, not auto-modify gleam.toml?

The Issue listed three options, in order of preference:

1. **Auto-modify the consumer's `gleam.toml`** — Best on paper, but writing into a user-managed config file invisibly is surprising and would also need to handle: existing version constraints on `gleam_regexp`, lock file regeneration, and rollback on partial failure. Out of scope for a 0.x.
2. **Print a hint at the end of generation** — Implemented here. Actionable, deterministic, and only fires when relevant.
3. **README quickstart note** — Easy to miss; the hint covers it.

If the auto-modification path is later wanted, the hint can stay as a fallback for non-write modes.

## Changes

- `src/oaspec/cli.gleam`: new `print_dep_hints/1` helper called at the end of `write_files/2`. It scans every `GeneratedFile.content` for `import gleam/regexp` and prints the Note when any match.
- `test/fixtures/oaspec_guards_pattern.yaml`: new config fixture pointing at the existing `guard_constraints_api.yaml` (which already exercises `pattern:` constraints) with `validate: true`.
- `spec/generate_spec.sh`: two new shellspec cases under `pattern constraint dependency hint (Issue #284)`:
  - asserts the hint fires when patterns are present,
  - asserts the hint does NOT fire on the petstore fixture (no patterns).
- `README.md`: bump test fixture count to 235 to reflect the new fixture.
- `CHANGELOG.md`: `[Unreleased]` entries for #283 (already merged) and #284 (this PR).

## Test plan

- [x] `gleam build --warnings-as-errors`
- [x] `gleam test --target erlang` — 762 passed
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter -- --stats` — 0 errors, 0 warnings
- [x] `shellspec spec/generate_spec.sh` — 71 examples, 0 failures (includes the two new cases)
- [x] `bash scripts/check_sync.sh` — versions and counts in sync

Closes #284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now emits a helpful reminder to add the `gleam_regexp` dependency when generated code requires it for pattern validation.

* **Bug Fixes**
  * Code generator now correctly preserves record field identifiers containing mixed letters and digits.

* **Tests**
  * Added integration tests validating the dependency reminder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->