### PR TITLE
fix(codegen): panic on unsupported inline complex schemas instead of emitting decode.string

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -85,6 +85,9 @@ unwrap_used = "error"
 "src/oaspec/capability.gleam" = ["label_possible"]
 "src/oaspec/formatter.gleam" = ["label_possible"]
 "src/oaspec/generate.gleam" = ["label_possible", "deep_nesting"]
-"src/oaspec/codegen/*.gleam" = ["label_possible", "deep_nesting"]
+# schema_dispatch.gleam uses panic for unsupported inline complex schemas
+# (object/allOf/oneOf/anyOf) in decoder/encoder dispatch — these patterns
+# must fail fast instead of silently generating broken code (#290).
+"src/oaspec/codegen/*.gleam" = ["label_possible", "deep_nesting", "avoid_panic"]
 "src/oaspec/openapi/*.gleam" = ["label_possible", "deep_nesting"]
 "src/oaspec/util/*.gleam" = ["label_possible", "deep_nesting"]

--- a/src/oaspec/codegen/schema_dispatch.gleam
+++ b/src/oaspec/codegen/schema_dispatch.gleam
@@ -95,6 +95,12 @@ pub fn schema_ref_to_string_expr(
 
 /// Map a schema ref to its decoder expression (for inline primitives)
 /// or decoder function name (for references).
+///
+/// Inline complex schemas (object, allOf, oneOf, anyOf) are not
+/// supported here — they must be defined under `components/schemas`
+/// and referenced via `$ref`. The catch-all panics so unsupported
+/// patterns fail fast instead of silently generating broken code
+/// (#290).
 pub fn decoder_expr(ref: SchemaRef) -> String {
   case ref {
     Inline(StringSchema(..)) -> "decode.string"
@@ -102,7 +108,13 @@ pub fn decoder_expr(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "decode.float"
     Inline(BooleanSchema(..)) -> "decode.bool"
     Reference(name:, ..) -> naming.to_snake_case(name) <> "_decoder()"
-    Inline(_) -> "decode.string"
+    Inline(schema) ->
+      panic as {
+        "oaspec: inline "
+        <> schema_kind(schema)
+        <> " schema is not supported in decoder_expr. "
+        <> "Move the schema to components/schemas and use a $ref instead."
+      }
   }
 }
 
@@ -115,7 +127,13 @@ pub fn json_encoder_expr(ref: SchemaRef, value: String) -> String {
     Inline(BooleanSchema(..)) -> "json.bool(" <> value <> ")"
     Reference(name:, ..) ->
       "encode_" <> naming.to_snake_case(name) <> "_json(" <> value <> ")"
-    Inline(_) -> "json.string(" <> value <> ")"
+    Inline(schema) ->
+      panic as {
+        "oaspec: inline "
+        <> schema_kind(schema)
+        <> " schema is not supported in json_encoder_expr. "
+        <> "Move the schema to components/schemas and use a $ref instead."
+      }
   }
 }
 
@@ -127,7 +145,13 @@ pub fn json_encoder_fn(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "json.float"
     Inline(BooleanSchema(..)) -> "json.bool"
     Reference(name:, ..) -> "encode_" <> naming.to_snake_case(name) <> "_json"
-    Inline(_) -> "json.string"
+    Inline(schema) ->
+      panic as {
+        "oaspec: inline "
+        <> schema_kind(schema)
+        <> " schema is not supported in json_encoder_fn. "
+        <> "Move the schema to components/schemas and use a $ref instead."
+      }
   }
 }
 
@@ -147,7 +171,28 @@ pub fn to_string_fn(ref: SchemaRef, spec: OpenApiSpec(Resolved)) -> String {
         Error(_) -> "fn(x) { x }"
       }
     }
-    Inline(_) -> "fn(x) { x }"
+    Inline(schema) ->
+      panic as {
+        "oaspec: inline "
+        <> schema_kind(schema)
+        <> " schema is not supported in to_string_fn. "
+        <> "Move the schema to components/schemas and use a $ref instead."
+      }
+  }
+}
+
+/// Human-readable name for a schema variant (for error messages).
+fn schema_kind(schema: SchemaObject) -> String {
+  case schema {
+    StringSchema(..) -> "string"
+    IntegerSchema(..) -> "integer"
+    NumberSchema(..) -> "number"
+    BooleanSchema(..) -> "boolean"
+    ArraySchema(..) -> "array"
+    ObjectSchema(..) -> "object"
+    AllOfSchema(..) -> "allOf"
+    OneOfSchema(..) -> "oneOf"
+    AnyOfSchema(..) -> "anyOf"
   }
 }
 


### PR DESCRIPTION
## Summary

Replace the silent `Inline(_) -> "decode.string"` catch-all branches with explicit panics that name the unsupported schema kind and suggest using a `$ref`.

## Changes

- `decoder_expr`: catch-all now panics with "inline object/allOf/oneOf/anyOf schema is not supported — use a $ref"
- `json_encoder_expr`: same treatment
- `json_encoder_fn`: same treatment
- `to_string_fn`: same treatment
- Add `schema_kind` helper for human-readable schema variant names in error messages

## Design Decisions

- Panic (fail fast) rather than returning a diagnostic, because these functions return `String` and sit deep in the codegen pipeline where threading a `Result` would require significant refactoring
- The panic message includes the schema kind and a clear remediation ("Move the schema to components/schemas and use a $ref instead")
- `schema_base_type` is intentionally left unchanged — it maps to Gleam type names and is used in broader contexts; its Object/AllOf/OneOf/AnyOf → "String" mapping may need a different fix

Closes #290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for schema configuration. Invalid inline schemas now trigger informative error messages that guide users to properly structure their schemas by placing them in `components/schemas` and using `$ref` references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->