### PR TITLE
fix(codegen): resolve $ref schemas in response header type mapping

### DIFF
--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -276,12 +276,14 @@ fn build_response_header_records(
 }
 
 /// Convert a header schema to a Gleam type string.
+/// Handles both inline primitive schemas and `$ref` references (#294).
 fn header_schema_to_type(schema_opt: option.Option(schema.SchemaRef)) -> String {
   case schema_opt {
     Some(Inline(IntegerSchema(..))) -> "Int"
     Some(Inline(NumberSchema(..))) -> "Float"
     Some(Inline(BooleanSchema(..))) -> "Bool"
     Some(Inline(StringSchema(..))) -> "String"
+    Some(Reference(name:, ..)) -> "types." <> naming.schema_to_type_name(name)
     _ -> "String"
   }
 }


### PR DESCRIPTION
## Summary

Fix `header_schema_to_type` to handle `Reference(name:, ..)` by mapping to `types.<TypeName>` instead of falling through to the catch-all `String`.

## Changes

- Add `Some(Reference(name:, ..))` arm to `header_schema_to_type` in `ir_build.gleam`
- Uses existing `naming.schema_to_type_name` for consistent name conversion

Closes #294