### PR TITLE
fix(codegen): short-circuit unknown-discriminator branch with a clear error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen**: Discriminated `oneOf` decoders no longer surface a misleading
+  inner-variant decode error when the discriminator value is unknown. The
+  catch-all branch now short-circuits with a discriminator-specific
+  message (`<TypeName>: unknown discriminator '<value>' (expected
+  <valid|values>)`) before the first variant's decoder runs. (#308)
+
 ## [0.23.0] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 762 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 763 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/golden/complex_supported/api/decode.gleam
+++ b/golden/complex_supported/api/decode.gleam
@@ -174,6 +174,12 @@ pub fn get_user_response_ok_decoder() -> decode.Decoder(types.GetUserResponseOk)
       decode.success(types.GetUserResponseOkRegularUser(inner))
     }
     _ -> {
+      use _ <- decode.then(decode.failure(
+        Nil,
+        "GetUserResponseOk: unknown discriminator '"
+          <> disc_value
+          <> "' (expected AdminUser|RegularUser)",
+      ))
       use v <- decode.then(admin_user_decoder())
       decode.failure(types.GetUserResponseOkAdminUser(v), "GetUserResponseOk")
     }

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -925,9 +925,15 @@ fn generate_oneof_decoder(
               }
             })
 
-          // For unknown discriminator values, decode as the first variant
-          // then immediately fail. This avoids needing a placeholder value
-          // while maintaining the correct return type.
+          // For unknown discriminator values, fail immediately with a
+          // discriminator-specific error message. The second decode.then
+          // is unreachable at runtime — the leading decode.failure short-
+          // circuits decode.then, so the inner variant decoder is never
+          // invoked — but it's required at compile time to give the case
+          // branch the right Decoder(types.<TypeName>) type. Without this
+          // structure, an unknown discriminator whose body also fails to
+          // match the first variant would surface the *first variant's*
+          // decode error instead of the discriminator error (issue #308).
           let first_ref_decoder = case schemas {
             [Reference(name:, ..), ..] -> {
               let ref_name = name
@@ -944,9 +950,34 @@ fn generate_oneof_decoder(
             _ -> "types." <> type_name
           }
 
+          // Build the "expected" list mirroring the discriminator values
+          // each variant arm matches above. When the spec supplies an
+          // explicit `mapping`, those keys win; otherwise each variant
+          // falls back to its ref name (matching `get_discriminator_value`
+          // semantics on lines 1099-1119).
+          let valid_disc_values =
+            schemas
+            |> list.filter_map(fn(s_ref) {
+              case s_ref {
+                Reference(ref:, name:) ->
+                  Ok(get_discriminator_value(disc, ref, name))
+                _ -> Error(Nil)
+              }
+            })
+            |> list.sort(string.compare)
+            |> string.join("|")
+
           let sb =
             sb
             |> se.indent(2, "_ -> {")
+            |> se.indent(
+              3,
+              "use _ <- decode.then(decode.failure(Nil, \""
+                <> type_name
+                <> ": unknown discriminator '\" <> disc_value <> \"' (expected "
+                <> valid_disc_values
+                <> ")\"))",
+            )
             |> se.indent(3, "use v <- decode.then(" <> first_ref_decoder <> ")")
             |> se.indent(
               3,

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1755,3 +1755,73 @@ components:
   string.contains(client_file.content, "decode.decode_problem(resp.body)")
   |> should.be_true()
 }
+
+// ===================================================================
+// oneOf with discriminator: unknown-value fallback (issue #308)
+// ===================================================================
+
+/// The unknown-discriminator branch must surface a discriminator-specific
+/// error message FIRST, before any inner variant decoder runs. The fix
+/// uses `decode.then(decode.failure(Nil, ...), ...)` to short-circuit
+/// the chain so the inner decoder is never invoked at runtime.
+pub fn decoders_unknown_discriminator_short_circuits_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Shape:
+      oneOf:
+        - $ref: '#/components/schemas/Circle'
+        - $ref: '#/components/schemas/Square'
+      discriminator:
+        propertyName: kind
+        mapping:
+          circle: '#/components/schemas/Circle'
+          square: '#/components/schemas/Square'
+    Circle:
+      type: object
+      required: [kind, radius]
+      properties:
+        kind:
+          type: string
+          enum: [circle]
+        radius:
+          type: number
+    Square:
+      type: object
+      required: [kind, side]
+      properties:
+        kind:
+          type: string
+          enum: [square]
+        side:
+          type: number
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let assert Ok(decode_file) =
+    list.find(files, fn(f) { f.path == "decode.gleam" })
+
+  // The catch-all branch must lead with `decode.failure(Nil, ...)` so
+  // the inner variant decoder is never run on unknown discriminators.
+  string.contains(decode_file.content, "decode.failure(Nil,")
+  |> should.be_true()
+
+  // Error message must name the discriminator value at runtime and the
+  // valid alternatives at codegen time.
+  string.contains(decode_file.content, "unknown discriminator '")
+  |> should.be_true()
+  string.contains(decode_file.content, "<> disc_value <>")
+  |> should.be_true()
+  // Valid values are sorted alphabetically for deterministic output.
+  string.contains(decode_file.content, "(expected circle|square)")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Fixes #308.

The catch-all `_` branch of a generated discriminated `oneOf` decoder used to wrap the first variant's decoder with `decode.then` purely to obtain a placeholder value of the union type. When the discriminator was unknown **and** the body also failed to match the first variant's shape, `decode.then` propagated the inner decoder's error — surfacing a misleading `expected String at $.body` instead of the actual `unknown discriminator '<value>'` fault.

## Changes

- `src/oaspec/codegen/decoders.gleam`: rewrite the `_` branch in `generate_oneof_decoder` to lead with `decode.failure(Nil, ...)` and follow with the existing `decode.then(<inner_decoder>, ...)`. The leading `decode.failure` short-circuits the chain at runtime — the inner decoder is never executed — but the trailing `decode.then` remains for type inference (the case branch must produce a `Decoder(<UnionType>)`).
- Error message format mirrors the enum unknown-variant pattern and now embeds the offending discriminator value at runtime plus the alphabetised list of valid discriminator values (derived from `disc.mapping` keys, falling back to ref names where no mapping entry exists).
- `test/codegen_unit_test.gleam`: new `decoders_unknown_discriminator_short_circuits_test` asserting the generated content contains the new pattern and message.
- `golden/complex_supported/api/decode.gleam`: regenerated.
- `CHANGELOG.md`, `README.md`: Unreleased entry + test count bump (762 → 763).

## Generated output (before / after)

Before:

```gleam
_ -> {
  use v <- decode.then(circle_decoder())
  decode.failure(types.ShapeCircle(v), "Shape")
}
```

After:

```gleam
_ -> {
  use _ <- decode.then(decode.failure(
    Nil,
    "Shape: unknown discriminator '"
      <> disc_value
      <> "' (expected circle|rect|tri)",
  ))
  use v <- decode.then(circle_decoder())
  decode.failure(types.ShapeCircle(v), "Shape")
}
```

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam run -m glinter -- --stats`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` — 763 passed, 0 failures
- [x] `shellspec --no-color` — 78 examples, 0 failures
- [x] `bash integration_test/run.sh` — all integration tests passed
- [x] `gleam run -m gleescript` + `bash scripts/smoke_escript.sh` — packaged escript smoke tests passed
- [x] Manual smoke: regenerated server from `test/fixtures/complex_discriminator.yaml` and verified the new `_` branch shape in `shapes_api/decode.gleam`.

Closes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discriminated `oneOf` decoders now provide clearer error messages when encountering unknown discriminator values, displaying the actual value and expected alternatives instead of producing misleading variant decode errors.

* **Tests**
  * Added comprehensive test for unknown discriminator validation.

* **Documentation**
  * Updated changelog and test suite documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->