### PR TITLE
fix(codegen): generate enum-from-string conversion for $ref enum query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **codegen**: Query parameters whose schema `$ref`s a string-enum
+  component now generate compilable Gleam. Previously the router tried
+  to assign the raw `String` from `dict.get(query, key)` directly into
+  the enum-typed field, producing a type mismatch. Optional enum query
+  params now emit an inline `String → Some(<Variant>) | None` match;
+  required ones get the same `Result`-based open/close scaffold as
+  numeric params (unknown values yield 400 Bad Request). (#305)
 - **codegen**: Discriminated `oneOf` decoders no longer surface a misleading
   inner-variant decode error when the discriminator value is unknown. The
   catch-all branch now short-circuits with a discriminator-specific

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 763 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 765 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -1092,10 +1092,11 @@ fn generate_safe_request_and_dispatch(
     })
 
   // Open numeric-parse cases for required query params (scalar int/float
-  // and explode=true int/float arrays). Bool / string don't need this.
+  // and explode=true int/float arrays, plus `$ref` to string-enum schemas
+  // per issue #305). Bool / string don't need this.
   let sb =
     list.fold(required_query_params, sb, fn(sb, p) {
-      query_required_open_parse_case(sb, p)
+      query_required_open_parse_case(sb, p, ctx)
     })
 
   // Open lookup cases for required header params.
@@ -1248,8 +1249,9 @@ fn generate_safe_request_and_dispatch(
               decode_helpers.deep_object_required_expr(key, param, op_id, ctx)
             True, False ->
               decode_helpers.deep_object_optional_expr(key, param, op_id, ctx)
-            False, True -> decode_helpers.query_required_expr(raw_var, param)
-            False, False -> decode_helpers.query_optional_expr(key, param)
+            False, True ->
+              decode_helpers.query_required_expr(raw_var, param, ctx)
+            False, False -> decode_helpers.query_optional_expr(key, param, ctx)
           }
         }
         spec.InHeader -> {
@@ -1330,19 +1332,19 @@ fn generate_safe_request_and_dispatch(
   // `Error(_)` so all failure modes return 400.
   let sb =
     list.fold(required_cookie_params, sb, fn(sb, p) {
-      close_single_value_required_parse_case(sb, p)
+      close_single_value_required_parse_case(sb, p, ctx)
     })
   let sb =
     list.fold(required_cookie_params, sb, fn(sb, _p) { close_lookup_case(sb) })
   let sb =
     list.fold(required_header_params, sb, fn(sb, p) {
-      close_single_value_required_parse_case(sb, p)
+      close_single_value_required_parse_case(sb, p, ctx)
     })
   let sb =
     list.fold(required_header_params, sb, fn(sb, _p) { close_lookup_case(sb) })
   let sb =
     list.fold(required_query_params, sb, fn(sb, p) {
-      close_query_required_parse_case(sb, p)
+      close_query_required_parse_case(sb, p, ctx)
     })
   let sb =
     list.fold(required_query_params, sb, fn(sb, _p) { close_lookup_case(sb) })
@@ -1381,6 +1383,7 @@ fn query_param_explode_array(p: spec.Parameter(Resolved)) -> Bool {
 fn query_required_open_parse_case(
   sb: se.StringBuilder,
   p: spec.Parameter(Resolved),
+  ctx: Context,
 ) -> se.StringBuilder {
   let raw_var = naming.to_snake_case(p.name) <> "_raw"
   let delim = case p.style {
@@ -1415,6 +1418,27 @@ fn query_required_open_parse_case(
       |> se.indent(3, "case " <> parse_expr <> " {")
       |> se.indent(4, "Ok(" <> raw_var <> "_parsed_list) -> {")
     }
+    Some(ref) ->
+      // Issue #305: required `$ref` to a string-enum schema needs the
+      // same Result-based open/close scaffolding as int / float so an
+      // unknown enum value falls through to the `_ -> 400` arm in
+      // `close_single_value_required_parse_case` below.
+      case decode_helpers.schema_ref_string_enum(ref, ctx) {
+        Some(#(type_name, values)) ->
+          sb
+          |> se.indent(
+            3,
+            "case "
+              <> decode_helpers.enum_match_result_expr(
+              raw_var,
+              type_name,
+              values,
+            )
+              <> " {",
+          )
+          |> se.indent(4, "Ok(" <> raw_var <> "_parsed) -> {")
+        None -> sb
+      }
     _ -> sb
   }
 }
@@ -1455,7 +1479,17 @@ fn array_float_parse_expr(
 fn close_query_required_parse_case(
   sb: se.StringBuilder,
   p: spec.Parameter(Resolved),
+  ctx: Context,
 ) -> se.StringBuilder {
+  let close = fn(sb: se.StringBuilder) -> se.StringBuilder {
+    sb
+    |> se.indent(4, "}")
+    |> se.indent(
+      4,
+      "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+    )
+    |> se.indent(3, "}")
+  }
   case spec.parameter_schema(p) {
     Some(schema.Inline(schema.IntegerSchema(..)))
     | Some(schema.Inline(schema.NumberSchema(..)))
@@ -1466,14 +1500,15 @@ fn close_query_required_parse_case(
     | Some(schema.Inline(schema.ArraySchema(
         items: Inline(schema.NumberSchema(..)),
         ..,
-      ))) ->
-      sb
-      |> se.indent(4, "}")
-      |> se.indent(
-        4,
-        "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
-      )
-      |> se.indent(3, "}")
+      ))) -> close(sb)
+    Some(ref) ->
+      // Issue #305: matches the open emitted in
+      // `query_required_open_parse_case` for required `$ref` to string
+      // enum schemas.
+      case decode_helpers.schema_ref_string_enum(ref, ctx) {
+        Some(_) -> close(sb)
+        None -> sb
+      }
     _ -> sb
   }
 }
@@ -1527,7 +1562,17 @@ fn single_value_required_open_parse_case(
 fn close_single_value_required_parse_case(
   sb: se.StringBuilder,
   p: spec.Parameter(Resolved),
+  ctx: Context,
 ) -> se.StringBuilder {
+  let close = fn(sb: se.StringBuilder) -> se.StringBuilder {
+    sb
+    |> se.indent(4, "}")
+    |> se.indent(
+      4,
+      "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+    )
+    |> se.indent(3, "}")
+  }
   case spec.parameter_schema(p) {
     Some(schema.Inline(schema.IntegerSchema(..)))
     | Some(schema.Inline(schema.NumberSchema(..)))
@@ -1538,14 +1583,15 @@ fn close_single_value_required_parse_case(
     | Some(schema.Inline(schema.ArraySchema(
         items: Inline(schema.NumberSchema(..)),
         ..,
-      ))) ->
-      sb
-      |> se.indent(4, "}")
-      |> se.indent(
-        4,
-        "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
-      )
-      |> se.indent(3, "}")
+      ))) -> close(sb)
+    Some(ref) ->
+      // Issue #305: matches the open emitted in
+      // `query_required_open_parse_case` for required `$ref` to string
+      // enum schemas. Non-enum refs fall through unchanged.
+      case decode_helpers.schema_ref_string_enum(ref, ctx) {
+        Some(_) -> close(sb)
+        None -> sb
+      }
     _ -> sb
   }
 }

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -161,12 +161,14 @@ pub fn param_needs_result_unwrap(param: spec.Parameter(Resolved)) -> Bool {
 pub fn query_required_expr(
   bound_var: String,
   param: spec.Parameter(Resolved),
+  ctx: Context,
 ) -> String {
   query_required_expr_with_schema(
     bound_var,
     spec.parameter_schema(param),
     Some(operation_ir.effective_explode(param)),
     param.style,
+    ctx,
   )
 }
 
@@ -222,6 +224,7 @@ fn query_required_expr_with_schema(
   schema_ref: Option(SchemaRef),
   explode: Option(Bool),
   style: Option(spec.ParameterStyle),
+  ctx: Context,
 ) -> String {
   let delim = operation_ir.delimiter_for_style(style)
   case schema_ref {
@@ -263,7 +266,17 @@ fn query_required_expr_with_schema(
     Some(Inline(schema.NumberSchema(..))) -> bound_var <> "_parsed"
     Some(Inline(schema.BooleanSchema(..))) ->
       "{ let v = " <> bound_var <> " " <> bool_parse_expr <> " }"
-    _ -> bound_var
+    Some(ref) ->
+      case schema_ref_string_enum(ref, ctx) {
+        // Issue #305: required enum query params rely on the router-side
+        // open/close scaffolding (see `query_required_open_parse_case` /
+        // `close_single_value_required_parse_case` in server.gleam) to
+        // bind `<bound_var>_parsed` on a successful match and emit a 400
+        // on unknown values. The expression here is just the bound name.
+        Some(_) -> bound_var <> "_parsed"
+        None -> bound_var
+      }
+    None -> bound_var
   }
 }
 
@@ -271,13 +284,83 @@ fn query_required_expr_with_schema(
 pub fn query_optional_expr(
   key: String,
   param: spec.Parameter(Resolved),
+  ctx: Context,
 ) -> String {
   query_optional_expr_with_schema(
     key,
     spec.parameter_schema(param),
     Some(operation_ir.effective_explode(param)),
     param.style,
+    ctx,
   )
+}
+
+/// If `schema_ref` is a `$ref` to a string enum schema, return the
+/// generated Gleam type name and the list of enum values (in spec
+/// order). Used by query parameter codegen to emit a string→variant
+/// match for `$ref`-based enum query parameters (issue #305).
+pub fn schema_ref_string_enum(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Option(#(String, List(String))) {
+  case schema_ref {
+    Reference(name: ref_name, ..) ->
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+        Ok(schema.StringSchema(enum_values: values, ..)) ->
+          case values {
+            [_, ..] -> Some(#(naming.schema_to_type_name(ref_name), values))
+            [] -> None
+          }
+        _ -> None
+      }
+    _ -> None
+  }
+}
+
+/// Render the inline Gleam expression that converts a raw query-string
+/// `<bound_var>` into `Result(types.<TypeName><Variant>, Nil)`. Used by
+/// the required-enum query path (server.gleam opens a case on this
+/// expression; the Ok arm binds `<bound_var>_parsed`).
+pub fn enum_match_result_expr(
+  bound_var: String,
+  type_name: String,
+  values: List(String),
+) -> String {
+  let arms =
+    values
+    |> list.map(fn(v) {
+      "\""
+      <> v
+      <> "\" -> Ok(types."
+      <> type_name
+      <> naming.to_pascal_case(v)
+      <> ")"
+    })
+    |> string.join(" ")
+  "case " <> bound_var <> " { " <> arms <> " _ -> Error(Nil) }"
+}
+
+/// Render the inline Gleam expression that converts a raw query-string
+/// `<v_var>` into `Option(types.<TypeName><Variant>)` for an optional
+/// enum query parameter. Unknown values map to `None`, matching the
+/// permissive behaviour of Int / Float optional query handling.
+fn enum_match_option_expr(
+  v_var: String,
+  type_name: String,
+  values: List(String),
+) -> String {
+  let arms =
+    values
+    |> list.map(fn(v) {
+      "\""
+      <> v
+      <> "\" -> Some(types."
+      <> type_name
+      <> naming.to_pascal_case(v)
+      <> ")"
+    })
+    |> string.join(" ")
+  "case " <> v_var <> " { " <> arms <> " _ -> None }"
 }
 
 fn query_optional_expr_with_schema(
@@ -285,6 +368,7 @@ fn query_optional_expr_with_schema(
   schema_ref: Option(SchemaRef),
   explode: Option(Bool),
   style: Option(spec.ParameterStyle),
+  ctx: Context,
 ) -> String {
   let delim = operation_ir.delimiter_for_style(style)
   case schema_ref {
@@ -358,7 +442,25 @@ fn query_optional_expr_with_schema(
       <> "\") { Ok([v, ..]) -> Some("
       <> bool_parse_expr
       <> ") _ -> None }"
-    _ ->
+    Some(ref) ->
+      case schema_ref_string_enum(ref, ctx) {
+        Some(#(type_name, values)) -> {
+          // Issue #305: enum-typed query params need string→variant
+          // conversion. Unknown values fall through to None, matching
+          // the permissive handling of malformed Int / Float optional
+          // query params.
+          "case dict.get(query, \""
+          <> key
+          <> "\") { Ok([v, ..]) -> "
+          <> enum_match_option_expr("v", type_name, values)
+          <> " _ -> None }"
+        }
+        None ->
+          "case dict.get(query, \""
+          <> key
+          <> "\") { Ok([v, ..]) -> Some(v) _ -> None }"
+      }
+    None ->
       "case dict.get(query, \""
       <> key
       <> "\") { Ok([v, ..]) -> Some(v) _ -> None }"
@@ -470,6 +572,7 @@ fn deep_object_constructor_expr(
             Some(prop.schema_ref),
             Some(True),
             None,
+            ctx,
           )
       }
       prop.field_name <> ": " <> value_expr

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -348,32 +348,36 @@ pub fn server_request_decode_param_parse_expr_float_test() {
 // already-bound variable name (or a plain non-failing transform).
 
 pub fn server_request_decode_query_required_expr_int_returns_bound_var_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   let param = test_helpers.simple_param("page", True, test_helpers.int_schema())
-  let expr = server_request_decode.query_required_expr("page_raw", param)
+  let expr = server_request_decode.query_required_expr("page_raw", param, ctx)
   expr |> should.equal("page_raw_parsed")
   string.contains(expr, "let assert") |> should.be_false()
 }
 
 pub fn server_request_decode_query_required_expr_float_returns_bound_var_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   let param =
     test_helpers.simple_param("ratio", True, test_helpers.float_schema())
-  let expr = server_request_decode.query_required_expr("ratio_raw", param)
+  let expr = server_request_decode.query_required_expr("ratio_raw", param, ctx)
   expr |> should.equal("ratio_raw_parsed")
   string.contains(expr, "let assert") |> should.be_false()
 }
 
 pub fn server_request_decode_query_required_expr_string_returns_bound_var_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   let param =
     test_helpers.simple_param("name", True, test_helpers.string_schema())
-  let expr = server_request_decode.query_required_expr("name_raw", param)
+  let expr = server_request_decode.query_required_expr("name_raw", param, ctx)
   expr |> should.equal("name_raw")
   string.contains(expr, "let assert") |> should.be_false()
 }
 
 pub fn server_request_decode_query_required_expr_bool_has_no_let_assert_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   let param =
     test_helpers.simple_param("active", True, test_helpers.bool_schema())
-  let expr = server_request_decode.query_required_expr("active_raw", param)
+  let expr = server_request_decode.query_required_expr("active_raw", param, ctx)
   string.contains(expr, "let assert") |> should.be_false()
   string.contains(expr, "active_raw") |> should.be_true()
 }
@@ -1753,6 +1757,136 @@ components:
   let assert [client_file] = files
   // Should use JSON decode (not string passthrough)
   string.contains(client_file.content, "decode.decode_problem(resp.body)")
+  |> should.be_true()
+}
+
+// ===================================================================
+// Enum query parameter codegen (issue #305)
+// ===================================================================
+
+/// Optional `$ref` enum query parameter must emit a string→variant
+/// match returning Option(<EnumType>) — not a raw String.
+pub fn server_optional_enum_query_param_emits_inline_match_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - in: query
+          name: visibility
+          required: false
+          schema:
+            $ref: '#/components/schemas/Visibility'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Visibility:
+      type: string
+      enum: [public, unlisted, private]
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // Optional enum query: inline String→Variant match returns Option.
+  string.contains(
+    router_file.content,
+    "\"public\" -> Some(types.VisibilityPublic)",
+  )
+  |> should.be_true()
+  string.contains(
+    router_file.content,
+    "\"unlisted\" -> Some(types.VisibilityUnlisted)",
+  )
+  |> should.be_true()
+  string.contains(
+    router_file.content,
+    "\"private\" -> Some(types.VisibilityPrivate)",
+  )
+  |> should.be_true()
+  // Default arm produces None for unknown values.
+  string.contains(router_file.content, "_ -> None") |> should.be_true()
+  // The broken-default fallback must not survive: there is no remaining
+  // `Some(v)` that would assign a raw String into the enum slot.
+  string.contains(router_file.content, "Ok([v, ..]) -> Some(v)")
+  |> should.be_false()
+}
+
+/// Required `$ref` enum query parameter must emit the same Result
+/// scaffold as int / float (open `case`, bind `<raw>_parsed`, close
+/// `_ -> 400`) so unknown values fall through to a Bad Request.
+pub fn server_required_enum_query_param_emits_result_scaffold_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - in: query
+          name: priority
+          required: true
+          schema:
+            $ref: '#/components/schemas/Priority'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Priority:
+      type: string
+      enum: [low, medium, high]
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // Inline String→Result match for each variant.
+  string.contains(router_file.content, "\"low\" -> Ok(types.PriorityLow)")
+  |> should.be_true()
+  string.contains(router_file.content, "\"medium\" -> Ok(types.PriorityMedium)")
+  |> should.be_true()
+  string.contains(router_file.content, "\"high\" -> Ok(types.PriorityHigh)")
+  |> should.be_true()
+  // Result scaffold binds <raw>_parsed on Ok.
+  string.contains(router_file.content, "Ok(priority_raw_parsed) -> {")
+  |> should.be_true()
+  // The handler body uses the typed bound variable.
+  string.contains(router_file.content, "priority: priority_raw_parsed,")
+  |> should.be_true()
+  // Unknown values return 400.
+  string.contains(
+    router_file.content,
+    "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+  )
   |> should.be_true()
 }
 


### PR DESCRIPTION
## Summary

Fixes #305.

A query parameter whose schema `$ref`s a string-enum component used to make `gleam build` fail on the generated router with a type mismatch — the generated value was a raw `String` while the request type expected `Option(types.<Enum>)`. The body decode path handled enums correctly via `<enum>_decoder/0`; only the query-parameter codepath was missing the conversion.

## Changes

- `src/oaspec/codegen/server_request_decode.gleam`
  - New helper `schema_ref_string_enum/2`: resolves a `Reference` and returns `Some(#(type_name, enum_values))` iff it's a string-enum.
  - `query_optional_expr_with_schema/5` and `query_required_expr_with_schema/5` now take `ctx: Context` so they can call the resolver. New `Some(Reference(..))` branches:
    - **Optional** (issue's repro case): inline `case dict.get(query, key) { Ok([v, ..]) -> case v { "<value>" -> Some(types.<Enum><Variant>) ... _ -> None } _ -> None }`. Unknown values fall through to `None`, matching the permissive `Int` / `Float` optional handling.
    - **Required**: returns `<bound_var>_parsed` (mirrors the `int.parse` pattern). Server-side scaffolding emits `case <inline-string-match-Result> { Ok(<bound>_parsed) -> { ... } _ -> 400 }`.
  - New helper `enum_match_result_expr/3` renders the inline `case <bound> { ... _ -> Error(Nil) }` used by the required scaffold; `enum_match_option_expr/3` is the private equivalent for the optional path.

- `src/oaspec/codegen/server.gleam`
  - `query_required_open_parse_case`, `close_single_value_required_parse_case`, and `close_query_required_parse_case` now thread `ctx` through and add an enum branch that mirrors the int/float `Result`-based scaffold (open `case (case <raw> { ... }) { Ok(<raw>_parsed) -> {`, close `} _ -> ServerResponse(status: 400, ...)`).
  - Top-level `query_required_expr` / `query_optional_expr` callers updated to pass `ctx`.

- `test/codegen_unit_test.gleam`
  - Existing `query_required_expr_*` tests adjusted to pass `ctx`.
  - New `server_optional_enum_query_param_emits_inline_match_test` and `server_required_enum_query_param_emits_result_scaffold_test` assert the optional-inline-match + required-Result-scaffold shapes.

- `CHANGELOG.md`, `README.md`: Unreleased entry, test count bump (763 → 765).

## Generated output (after)

For an optional enum:
```gleam
visibility: case dict.get(query, "visibility") {
  Ok([v, ..]) -> case v {
    "public" -> Some(types.VisibilityPublic)
    "unlisted" -> Some(types.VisibilityUnlisted)
    "private" -> Some(types.VisibilityPrivate)
    _ -> None
  }
  _ -> None
},
```

For a required enum:
```gleam
case dict.get(query, "priority") {
  Ok([priority_raw, ..]) -> {
    case
      case priority_raw {
        "low" -> Ok(types.PriorityLow)
        "medium" -> Ok(types.PriorityMedium)
        "high" -> Ok(types.PriorityHigh)
        _ -> Error(Nil)
      }
    {
      Ok(priority_raw_parsed) -> {
        let request = request_types.ListPostsRequest(
          priority: priority_raw_parsed,
          ...
        )
        ...
      }
      _ -> ServerResponse(status: 400, body: "Bad Request", headers: [])
    }
  }
  _ -> ServerResponse(status: 400, body: "Bad Request", headers: [])
}
```

## Limitations / out of scope

- **Inline enums** (`type: string` + `enum: [...]` directly on the parameter, without a `$ref`) are not handled here. They generate operation-named anonymous types (e.g. `ListPostsVisibility`) whose construction needs a different codegen path; that's a separate follow-up.
- The required-position behaviour returns the existing generic `400 Bad Request` plain-text response on unknown enum values (matching the int / float pattern). A richer Problem-shaped 400 is the subject of #307.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam run -m glinter -- --stats` — 0 errors, 0 warnings
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` — 765 passed, 0 failures
- [x] `shellspec --no-color` — 78 examples, 0 failures
- [x] `bash integration_test/run.sh` — all integration tests passed
- [x] `gleam run -m gleescript` + `bash scripts/smoke_escript.sh` — packaged escript smoke tests passed
- [x] Manual smoke: regenerated server from a spec containing both an optional and a required enum query param; verified the resulting `router.gleam` matches the shapes above.

Closes #305