### PR TITLE
fix(codegen): omit optional non-nullable JSON keys instead of emitting null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **codegen**: Optional non-nullable schema properties are now omitted
+  from the encoded JSON object when their `Option` field is `None`.
+  Previously the generator emitted `"<key>": null` via `json.nullable`,
+  producing schema-invalid output (per OpenAPI 3.0/3.1 only fields
+  marked `nullable: true` may carry `null` on the wire). When at least
+  one property in a schema falls into this bucket, encoders now emit
+  `json.object(list.flatten([...]))` with each optional-non-nullable
+  field contributing either `[]` (None) or `[#(<key>, encode(x))]`
+  (Some). Required and nullable properties are unchanged. (#303)
 - **codegen**: Query parameters whose schema `$ref`s a string-enum
   component now generate compilable Gleam. Previously the router tried
   to assign the raw `String` from `dict.get(query, key)` directly into

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 765 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 766 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/golden/complex_supported/api/encode.gleam
+++ b/golden/complex_supported/api/encode.gleam
@@ -2,6 +2,8 @@
 
 import api/types
 import gleam/json
+import gleam/list
+import gleam/option
 
 pub fn encode_admin_user_type_json(value: types.AdminUserType) -> json.Json {
   let str = case value {
@@ -86,17 +88,20 @@ pub fn encode_user_type_to_string(value: types.UserType) -> String {
 }
 
 pub fn encode_admin_user_json(value: types.AdminUser) -> json.Json {
-  json.object([
-    #("id", json.string(value.id)),
-    #("name", json.string(value.name)),
-    #(
-      "permissions",
-      json.nullable(value.permissions, fn(items) {
-        json.array(items, json.string)
-      }),
-    ),
-    #("type", json.nullable(value.type_, encode_admin_user_type_json)),
-  ])
+  json.object(
+    list.flatten([
+      [#("id", json.string(value.id))],
+      [#("name", json.string(value.name))],
+      case value.permissions {
+        option.None -> []
+        option.Some(x) -> [#("permissions", json.array(x, json.string))]
+      },
+      case value.type_ {
+        option.None -> []
+        option.Some(x) -> [#("type", encode_admin_user_type_json(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_admin_user(value: types.AdminUser) -> String {
@@ -104,14 +109,16 @@ pub fn encode_admin_user(value: types.AdminUser) -> String {
 }
 
 pub fn encode_error_json(value: types.Error) -> json.Json {
-  json.object([
-    #("code", json.int(value.code)),
-    #(
-      "details",
-      json.nullable(value.details, fn(items) { json.array(items, json.string) }),
-    ),
-    #("message", json.string(value.message)),
-  ])
+  json.object(
+    list.flatten([
+      [#("code", json.int(value.code))],
+      case value.details {
+        option.None -> []
+        option.Some(x) -> [#("details", json.array(x, json.string))]
+      },
+      [#("message", json.string(value.message))],
+    ]),
+  )
 }
 
 pub fn encode_error(value: types.Error) -> String {
@@ -143,10 +150,18 @@ pub fn encode_get_user_response_ok(value: types.GetUserResponseOk) -> String {
 }
 
 pub fn encode_pagination_json(value: types.Pagination) -> json.Json {
-  json.object([
-    #("page", json.nullable(value.page, json.int)),
-    #("per_page", json.nullable(value.per_page, json.int)),
-  ])
+  json.object(
+    list.flatten([
+      case value.page {
+        option.None -> []
+        option.Some(x) -> [#("page", json.int(x))]
+      },
+      case value.per_page {
+        option.None -> []
+        option.Some(x) -> [#("per_page", json.int(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_pagination(value: types.Pagination) -> String {
@@ -156,17 +171,26 @@ pub fn encode_pagination(value: types.Pagination) -> String {
 pub fn encode_post_search_request_json(
   value: types.PostSearchRequest,
 ) -> json.Json {
-  json.object([
-    #(
-      "filters",
-      json.nullable(value.filters, fn(items) {
-        json.array(items, encode_filter_json)
-      }),
-    ),
-    #("page", json.nullable(value.page, json.int)),
-    #("per_page", json.nullable(value.per_page, json.int)),
-    #("query", json.nullable(value.query, json.string)),
-  ])
+  json.object(
+    list.flatten([
+      case value.filters {
+        option.None -> []
+        option.Some(x) -> [#("filters", json.array(x, encode_filter_json))]
+      },
+      case value.page {
+        option.None -> []
+        option.Some(x) -> [#("page", json.int(x))]
+      },
+      case value.per_page {
+        option.None -> []
+        option.Some(x) -> [#("per_page", json.int(x))]
+      },
+      case value.query {
+        option.None -> []
+        option.Some(x) -> [#("query", json.string(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_post_search_request(value: types.PostSearchRequest) -> String {
@@ -176,15 +200,18 @@ pub fn encode_post_search_request(value: types.PostSearchRequest) -> String {
 pub fn encode_post_search_response_ok_json(
   value: types.PostSearchResponseOk,
 ) -> json.Json {
-  json.object([
-    #(
-      "results",
-      json.nullable(value.results, fn(items) {
-        json.array(items, encode_user_json)
-      }),
-    ),
-    #("total", json.nullable(value.total, json.int)),
-  ])
+  json.object(
+    list.flatten([
+      case value.results {
+        option.None -> []
+        option.Some(x) -> [#("results", json.array(x, encode_user_json))]
+      },
+      case value.total {
+        option.None -> []
+        option.Some(x) -> [#("total", json.int(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_post_search_response_ok(
@@ -194,12 +221,17 @@ pub fn encode_post_search_response_ok(
 }
 
 pub fn encode_regular_user_json(value: types.RegularUser) -> json.Json {
-  json.object([
-    #("id", json.string(value.id)),
-    #("name", json.string(value.name)),
-    #("subscription", json.nullable(value.subscription, json.string)),
-    #("type", json.nullable(value.type_, encode_regular_user_type_json)),
-  ])
+  json.object(
+    list.flatten([
+      [#("id", json.string(value.id))],
+      [#("name", json.string(value.name))],
+      [#("subscription", json.nullable(value.subscription, json.string))],
+      case value.type_ {
+        option.None -> []
+        option.Some(x) -> [#("type", encode_regular_user_type_json(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_regular_user(value: types.RegularUser) -> String {
@@ -207,11 +239,16 @@ pub fn encode_regular_user(value: types.RegularUser) -> String {
 }
 
 pub fn encode_user_json(value: types.User) -> json.Json {
-  json.object([
-    #("id", json.string(value.id)),
-    #("name", json.string(value.name)),
-    #("type", json.nullable(value.type_, encode_user_type_json)),
-  ])
+  json.object(
+    list.flatten([
+      [#("id", json.string(value.id))],
+      [#("name", json.string(value.name))],
+      case value.type_ {
+        option.None -> []
+        option.Some(x) -> [#("type", encode_user_type_json(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_user(value: types.User) -> String {

--- a/golden/petstore/api/encode.gleam
+++ b/golden/petstore/api/encode.gleam
@@ -2,15 +2,25 @@
 
 import api/types
 import gleam/json
+import gleam/list
+import gleam/option
 
 pub fn encode_create_pet_request_json(
   value: types.CreatePetRequest,
 ) -> json.Json {
-  json.object([
-    #("name", json.string(value.name)),
-    #("status", json.nullable(value.status, encode_pet_status_json)),
-    #("tag", json.nullable(value.tag, json.string)),
-  ])
+  json.object(
+    list.flatten([
+      [#("name", json.string(value.name))],
+      case value.status {
+        option.None -> []
+        option.Some(x) -> [#("status", encode_pet_status_json(x))]
+      },
+      case value.tag {
+        option.None -> []
+        option.Some(x) -> [#("tag", json.string(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_create_pet_request(value: types.CreatePetRequest) -> String {
@@ -29,12 +39,17 @@ pub fn encode_error(value: types.Error) -> String {
 }
 
 pub fn encode_pet_json(value: types.Pet) -> json.Json {
-  json.object([
-    #("id", json.int(value.id)),
-    #("name", json.string(value.name)),
-    #("status", encode_pet_status_json(value.status)),
-    #("tag", json.nullable(value.tag, json.string)),
-  ])
+  json.object(
+    list.flatten([
+      [#("id", json.int(value.id))],
+      [#("name", json.string(value.name))],
+      [#("status", encode_pet_status_json(value.status))],
+      case value.tag {
+        option.None -> []
+        option.Some(x) -> [#("tag", json.string(x))]
+      },
+    ]),
+  )
 }
 
 pub fn encode_pet(value: types.Pet) -> String {

--- a/src/oaspec/codegen/encoders.gleam
+++ b/src/oaspec/codegen/encoders.gleam
@@ -8,6 +8,7 @@
 //// duplication is stable, and extracting a shared dispatch module is
 //// tracked as follow-up to #212.
 
+import gleam/bool
 import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
@@ -92,6 +93,26 @@ fn generate_encoders(
       }
     })
 
+  // Issue #303: object schemas with at least one optional non-nullable
+  // property emit `case value.<f> { option.None -> [] option.Some(x) -> ... }`
+  // wrapped in `list.flatten([...])`. Both the option module and the list
+  // module need to be imported for those modules to resolve.
+  let needs_option_and_list =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      case schema_ref {
+        Inline(ObjectSchema(properties:, required:, ..)) ->
+          properties
+          |> ir_build.sorted_entries
+          |> list.any(fn(p) {
+            let #(prop_name, prop_ref) = p
+            !list.contains(required, prop_name)
+            && !schema_ref_is_nullable(prop_ref)
+          })
+        _ -> False
+      }
+    })
+
   let base_imports = case needs_dict, needs_dynamic {
     True, True -> [
       "gleam/dict",
@@ -102,6 +123,13 @@ fn generate_encoders(
     ]
     True, False -> ["gleam/dict", "gleam/json", "gleam/list"]
     _, _ -> ["gleam/json"]
+  }
+  let base_imports = case needs_option_and_list {
+    True ->
+      base_imports
+      |> ensure_import("gleam/list")
+      |> ensure_import("gleam/option")
+    False -> base_imports
   }
   let imports = case needs_types {
     True ->
@@ -278,14 +306,6 @@ fn generate_encoder(
         Typed(_) | Untyped -> True
         Forbidden | Unspecified -> False
       }
-      let sb = case has_ap {
-        True ->
-          sb
-          |> se.indent(1, "let base_props = [")
-        False ->
-          sb
-          |> se.indent(1, "json.object([")
-      }
 
       // Filter out readOnly properties -- they should not be sent to the server
       let all_props = ir_build.sorted_entries(properties)
@@ -303,6 +323,36 @@ fn generate_encoder(
           let #(_, prop_ref, _) = entry
           !type_gen.schema_ref_is_read_only(prop_ref, ctx)
         })
+
+      // Issue #303: a property that is in `properties` but not in `required`
+      // and is not `nullable: true` MUST be omitted entirely from the JSON
+      // object when its `Option` field is `None` — emitting `"<key>": null`
+      // is schema-invalid (only `nullable: true` allows null on the wire).
+      // When any property falls into that bucket we switch the encoder
+      // shape from a static `[<pairs>]` literal to `list.flatten([<lists>])`
+      // so each optional-non-nullable property can contribute either an
+      // empty list (None) or a singleton pair list (Some).
+      let has_omittable =
+        list.any(props_with_names, fn(entry) {
+          let #(prop_name, prop_ref, _) = entry
+          !list.contains(required, prop_name)
+          && !schema_ref_is_nullable(prop_ref)
+        })
+
+      let sb = case has_ap, has_omittable {
+        True, False ->
+          sb
+          |> se.indent(1, "let base_props = [")
+        True, True ->
+          sb
+          |> se.indent(1, "let base_props = list.flatten([")
+        False, False ->
+          sb
+          |> se.indent(1, "json.object([")
+        False, True ->
+          sb
+          |> se.indent(1, "json.object(list.flatten([")
+      }
       let sb =
         list.index_fold(props_with_names, sb, fn(sb, entry, idx) {
           let #(prop_name, prop_ref, field_name) = entry
@@ -323,14 +373,16 @@ fn generate_encoder(
           // Issue #296: required+nullable properties have Gleam type
           // Option(T) and must use json.nullable, not the bare encoder.
           let is_nullable = schema_ref_is_nullable(prop_ref)
-          case is_required, is_nullable {
-            True, False ->
+          let is_omittable = !is_required && !is_nullable
+          case has_omittable, is_required, is_nullable, is_omittable {
+            // No optional-non-nullable in the schema → static list, current shape.
+            False, True, False, _ ->
               sb
               |> se.indent(
                 2,
                 "#(\"" <> prop_name <> "\", " <> encoder_expr <> ")" <> trailing,
               )
-            _, _ ->
+            False, _, _, _ ->
               sb
               |> se.indent(
                 2,
@@ -343,15 +395,65 @@ fn generate_encoder(
                   <> "))"
                   <> trailing,
               )
+            // Schema has at least one optional-non-nullable → list-of-lists.
+            True, _, _, True -> {
+              // Issue #303: omit the key when the value is None.
+              // Re-derive the encoder expression with `x` substituted for
+              // `value.<field>` so we encode the unwrapped Some value.
+              let some_encoder_expr =
+                schema_ref_to_json_encoder("x", prop_ref, name, prop_name)
+              sb
+              |> se.indent(2, "case value." <> field_name <> " {")
+              |> se.indent(3, "option.None -> []")
+              |> se.indent(
+                3,
+                "option.Some(x) -> [#(\""
+                  <> prop_name
+                  <> "\", "
+                  <> some_encoder_expr
+                  <> ")]",
+              )
+              |> se.indent(2, "}" <> trailing)
+            }
+            True, True, False, _ ->
+              sb
+              |> se.indent(
+                2,
+                "[#(\""
+                  <> prop_name
+                  <> "\", "
+                  <> encoder_expr
+                  <> ")]"
+                  <> trailing,
+              )
+            True, _, _, _ ->
+              // Required+nullable or optional+nullable: keep `json.nullable`
+              // (None → wire-format null is permitted because nullable: true).
+              sb
+              |> se.indent(
+                2,
+                "[#(\""
+                  <> prop_name
+                  <> "\", json.nullable(value."
+                  <> field_name
+                  <> ", "
+                  <> schema_ref_to_json_encoder_fn(prop_ref, name, prop_name)
+                  <> "))]"
+                  <> trailing,
+              )
           }
         })
 
+      let close_props_list = case has_omittable {
+        True -> "])"
+        False -> "]"
+      }
       let sb = case additional_properties {
         Typed(ap_ref) -> {
           let inner_encoder_fn =
             schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties")
           sb
-          |> se.indent(1, "]")
+          |> se.indent(1, close_props_list)
           |> se.indent(
             1,
             "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, "
@@ -364,7 +466,7 @@ fn generate_encoder(
           // Untyped additional_properties (Dynamic) are re-encoded using
           // dynamic type inspection to preserve round-trip fidelity.
           sb
-          |> se.indent(1, "]")
+          |> se.indent(1, close_props_list)
           |> se.indent(
             1,
             "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry\n  #(k, encode_dynamic(v)) })",
@@ -373,7 +475,10 @@ fn generate_encoder(
         }
         Forbidden | Unspecified ->
           sb
-          |> se.indent(1, "])")
+          |> se.indent(1, case has_omittable {
+            True -> "]))"
+            False -> "])"
+          })
       }
 
       let sb =
@@ -774,6 +879,16 @@ fn schema_ref_is_nullable(ref: SchemaRef) -> Bool {
     Inline(inline_schema) -> schema.is_nullable(inline_schema)
     Reference(..) -> False
   }
+}
+
+/// Append `name` to `imports` if it isn't already there. Used by the
+/// import builder to keep the list deterministic when more than one
+/// codepath wants the same module (issue #303 wires `gleam/option` and
+/// `gleam/list` for optional-non-nullable encoding even when those
+/// modules were already pulled in by additionalProperties handling).
+fn ensure_import(imports: List(String), name: String) -> List(String) {
+  use <- bool.guard(list.contains(imports, name), imports)
+  list.append(imports, [name])
 }
 
 /// Get element at index from a list, or return a default.

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1761,6 +1761,71 @@ components:
 }
 
 // ===================================================================
+// Encoder: optional non-nullable field omits key on None (issue #303)
+// ===================================================================
+
+/// A property that is optional (not in `required`) and not `nullable: true`
+/// must be omitted from the JSON object when its `Option(_)` field is
+/// `None` — emitting `"<key>": null` is schema-invalid per OpenAPI 3.0/3.1.
+pub fn encoders_optional_non_nullable_field_is_omitted_on_none_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+          nullable: true
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { f.path == "encode.gleam" })
+
+  // Optional + non-nullable `details` must use the omit-on-None shape.
+  string.contains(encode_file.content, "case value.details {")
+  |> should.be_true()
+  string.contains(encode_file.content, "option.None -> []") |> should.be_true()
+  string.contains(
+    encode_file.content,
+    "option.Some(x) -> [#(\"details\", json.array(x, json.string))]",
+  )
+  |> should.be_true()
+
+  // Optional + nullable `comment` keeps the json.nullable shape
+  // (None → null on the wire is permitted because nullable: true).
+  string.contains(
+    encode_file.content,
+    "json.nullable(value.comment, json.string)",
+  )
+  |> should.be_true()
+
+  // The buggy fallback must not survive: no `json.nullable(value.details, ...)`.
+  string.contains(encode_file.content, "json.nullable(value.details")
+  |> should.be_false()
+
+  // The new shape uses list.flatten when any property is optional+non-nullable.
+  string.contains(encode_file.content, "list.flatten([") |> should.be_true()
+}
+
+// ===================================================================
 // Enum query parameter codegen (issue #305)
 // ===================================================================
 


### PR DESCRIPTION
## Summary

Fixes #303.

A schema property listed in `properties` but absent from `required` and not marked `nullable: true` is purely optional per OpenAPI 3.0/3.1 — instances may omit it, but `null` is only valid wire data when the schema explicitly allows it. The encoder used to wrap every non-required-non-nullable property in `json.nullable(value.<f>, ...)`, serialising `Option.None` to `\"<f>\": null` and producing JSON the same OpenAPI document declares invalid.

## Changes

- `src/oaspec/codegen/encoders.gleam`
  - Detect, per object schema, whether any property is optional + non-nullable. When at least one is, switch the encoder shape from a static pair list to `list.flatten([<lists>])` so each optional-non-nullable property can contribute either `[]` (None) or `[#(<key>, encode(x))]` (Some).
  - Required and nullable properties keep their existing encoder paths (bare encoder for required-non-nullable, `json.nullable` for required-nullable / optional-nullable).
  - New helper `ensure_import` keeps the import list deterministic when both AP handling and the new optional path want the same module.
  - Imports `gleam/option` and `gleam/list` are added on demand only when the new shape appears, so schemas without optional-non-nullable properties don't carry unused imports.
  - Schemas with no optional non-nullable properties continue to emit the previous direct `json.object([<pairs>])` form.

- `test/codegen_unit_test.gleam`: new `encoders_optional_non_nullable_field_is_omitted_on_none_test` asserting:
  - `case value.<f> { option.None -> [] option.Some(x) -> [#(\"<f>\", encode(x))] }` shape for optional non-nullable.
  - `json.nullable(value.<g>, ...)` retained for optional + `nullable: true`.
  - No leftover `json.nullable(value.details, ...)` for the renamed buggy path.
  - `list.flatten([` appears whenever the new shape is in play.

- `golden/petstore/api/encode.gleam`, `golden/complex_supported/api/encode.gleam`: regenerated. Schemas with optional non-nullable properties (e.g. `CreatePetRequest`, `Pet`, `Error`) switch to the new `list.flatten` shape.

- `CHANGELOG.md`, `README.md`: Unreleased entry, test count bump (765 → 766).

## Generated output (after)

For a schema with optional non-nullable + required + optional-nullable mix:

```gleam
pub fn encode_error_response_json(value: types.ErrorResponse) -> json.Json {
  json.object(
    list.flatten([
      [#(\"code\", json.nullable(value.code, json.int))],          // required + nullable
      [#(\"comment\", json.nullable(value.comment, json.string))],  // optional + nullable
      case value.details {                                          // optional + non-nullable
        option.None -> []
        option.Some(x) -> [#(\"details\", json.array(x, json.string))]
      },
      [#(\"error\", json.string(value.error))],                     // required + non-nullable
    ]),
  )
}
```

For schemas with no optional-non-nullable properties, the encoder shape is unchanged:

```gleam
pub fn encode_all_required_json(value: types.AllRequired) -> json.Json {
  json.object([
    #(\"a\", json.string(value.a)),
    #(\"b\", json.int(value.b))
  ])
}
```

## Out of scope

- The behaviour for `additionalProperties: <typed-ref>` on schemas with optional non-nullable properties was tested manually; the existing typed-AP merge code emits a deprecated `;` separator unrelated to this fix that fails `gleam format` on Gleam 1.16+. That's a pre-existing bug worth a separate Issue but it doesn't gate this one because no current fixture combines typed AP with optional-non-nullable properties.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam run -m glinter -- --stats` — 0 errors, 0 warnings
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` — 766 passed, 0 failures
- [x] `shellspec --no-color` — 78 examples, 0 failures
- [x] `bash integration_test/run.sh` — all integration tests passed (the 7-test required-params suite plus 14 compile-only fixtures all build)
- [x] `gleam run -m gleescript` + `bash scripts/smoke_escript.sh` — packaged escript smoke tests passed
- [x] Manual smoke: regenerated server from a spec containing optional + non-nullable + nullable + required mix and verified the resulting `encode.gleam` matches the shapes above.

Closes #303