### PR TITLE
fix(codegen): emit RFC 7807 Problem JSON for router error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **codegen**: Generated routers now respond with RFC 7807-shaped
+  `application/problem+json` JSON for every error path (request body
+  decode failure, path/query/header parameter parse failure, missing
+  required parameter, unmatched route) instead of the previous plain
+  `Bad Request` / `Not Found` text without a `Content-Type` header.
+  Status codes are unchanged. Bodies follow the form
+  `{"type":"about:blank","title":"<reason>"}`. (#307)
 - **codegen**: Optional non-nullable schema properties are now omitted
   from the encoded JSON object when their `Option` field is `None`.
   Previously the generator emitted `"<key>": null` via `json.nullable`,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 766 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 767 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/golden/complex_supported/api/router.gleam
+++ b/golden/complex_supported/api/router.gleam
@@ -60,27 +60,43 @@ pub fn route(
                         _ ->
                           ServerResponse(
                             status: 400,
-                            body: "Bad Request",
-                            headers: [],
+                            body: "{\"type\":\"about:blank\",\"title\":\"missing or invalid parameter\"}",
+                            headers: [
+                              #("content-type", "application/problem+json"),
+                            ],
                           )
                       }
                     }
                     _ ->
                       ServerResponse(
                         status: 400,
-                        body: "Bad Request",
-                        headers: [],
+                        body: "{\"type\":\"about:blank\",\"title\":\"missing or invalid parameter\"}",
+                        headers: [#("content-type", "application/problem+json")],
                       )
                   }
                 }
                 _ ->
-                  ServerResponse(status: 400, body: "Bad Request", headers: [])
+                  ServerResponse(
+                    status: 400,
+                    body: "{\"type\":\"about:blank\",\"title\":\"invalid query parameter\"}",
+                    headers: [#("content-type", "application/problem+json")],
+                  )
               }
             }
-            _ -> ServerResponse(status: 400, body: "Bad Request", headers: [])
+            _ ->
+              ServerResponse(
+                status: 400,
+                body: "{\"type\":\"about:blank\",\"title\":\"missing or invalid parameter\"}",
+                headers: [#("content-type", "application/problem+json")],
+              )
           }
         }
-        _ -> ServerResponse(status: 400, body: "Bad Request", headers: [])
+        _ ->
+          ServerResponse(
+            status: 400,
+            body: "{\"type\":\"about:blank\",\"title\":\"missing or invalid parameter\"}",
+            headers: [#("content-type", "application/problem+json")],
+          )
       }
     }
     "POST", ["search"] -> {
@@ -141,7 +157,12 @@ pub fn route(
           ServerResponse(status: 200, body: "", headers: [])
       }
     }
-    _, _ -> ServerResponse(status: 404, body: "Not Found", headers: [])
+    _, _ ->
+      ServerResponse(
+        status: 404,
+        body: "{\"type\":\"about:blank\",\"title\":\"not found\"}",
+        headers: [#("content-type", "application/problem+json")],
+      )
   }
 }
 

--- a/golden/petstore/api/router.gleam
+++ b/golden/petstore/api/router.gleam
@@ -95,7 +95,11 @@ pub fn route(
           }
         }
         Error(_) ->
-          ServerResponse(status: 400, body: "Bad Request", headers: [])
+          ServerResponse(
+            status: 400,
+            body: "{\"type\":\"about:blank\",\"title\":\"invalid request body\"}",
+            headers: [#("content-type", "application/problem+json")],
+          )
       }
     }
     "GET", ["pets", pet_id] -> {
@@ -117,7 +121,11 @@ pub fn route(
           }
         }
         Error(_) ->
-          ServerResponse(status: 400, body: "Bad Request", headers: [])
+          ServerResponse(
+            status: 400,
+            body: "{\"type\":\"about:blank\",\"title\":\"invalid path parameter\"}",
+            headers: [#("content-type", "application/problem+json")],
+          )
       }
     }
     "DELETE", ["pets", pet_id] -> {
@@ -135,9 +143,18 @@ pub fn route(
           }
         }
         Error(_) ->
-          ServerResponse(status: 400, body: "Bad Request", headers: [])
+          ServerResponse(
+            status: 400,
+            body: "{\"type\":\"about:blank\",\"title\":\"invalid path parameter\"}",
+            headers: [#("content-type", "application/problem+json")],
+          )
       }
     }
-    _, _ -> ServerResponse(status: 404, body: "Not Found", headers: [])
+    _, _ ->
+      ServerResponse(
+        status: 404,
+        body: "{\"type\":\"about:blank\",\"title\":\"not found\"}",
+        headers: [#("content-type", "application/problem+json")],
+      )
   }
 }

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1364,7 +1364,11 @@ pub fn missing_required_string_query_returns_400_test() {
   let query = dict.from_list([#("limit", ["10"])])
   let resp = router.route(handlers.State, "GET", ["search"], query, full_headers(), "")
   resp.status |> should.equal(400)
-  resp.body |> should.equal("Bad Request")
+  // Issue #307: 400 responses are now RFC 7807-shaped Problem JSON.
+  resp.body
+  |> should.equal("{\"type\":\"about:blank\",\"title\":\"missing or invalid parameter\"}")
+  resp.headers
+  |> should.equal([#("content-type", "application/problem+json")])
 }
 
 pub fn missing_required_integer_query_returns_400_test() {

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -1,5 +1,6 @@
 import gleam/bool
 import gleam/dict
+import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
@@ -924,10 +925,7 @@ fn generate_router(
 
   let sb =
     sb
-    |> se.indent(
-      2,
-      "_, _ -> ServerResponse(status: 404, body: \"Not Found\", headers: [])",
-    )
+    |> se.indent(2, "_, _ -> " <> problem_response_expr(404, "not found"))
     |> se.indent(1, "}")
     |> se.line("}")
     |> se.blank_line()
@@ -1319,7 +1317,7 @@ fn generate_safe_request_and_dispatch(
       |> se.indent(4, "}")
       |> se.indent(
         4,
-        "Error(_) -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+        "Error(_) -> " <> problem_response_expr(400, "invalid request body"),
       )
       |> se.indent(3, "}")
     False -> sb
@@ -1354,7 +1352,7 @@ fn generate_safe_request_and_dispatch(
     |> se.indent(4, "}")
     |> se.indent(
       4,
-      "Error(_) -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+      "Error(_) -> " <> problem_response_expr(400, "invalid path parameter"),
     )
     |> se.indent(3, "}")
   })
@@ -1486,7 +1484,7 @@ fn close_query_required_parse_case(
     |> se.indent(4, "}")
     |> se.indent(
       4,
-      "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+      "_ -> " <> problem_response_expr(400, "invalid query parameter"),
     )
     |> se.indent(3, "}")
   }
@@ -1569,7 +1567,7 @@ fn close_single_value_required_parse_case(
     |> se.indent(4, "}")
     |> se.indent(
       4,
-      "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+      "_ -> " <> problem_response_expr(400, "invalid header or cookie"),
     )
     |> se.indent(3, "}")
   }
@@ -1596,6 +1594,30 @@ fn close_single_value_required_parse_case(
   }
 }
 
+/// Build the Gleam source expression for a `ServerResponse` carrying an
+/// RFC 7807-shaped `application/problem+json` body. Used by every
+/// router-side error-emit site so clients receive a structured JSON
+/// response instead of plain `Bad Request` / `Not Found` text — a
+/// schema-conformant default for specs that declare 4xx responses with
+/// `application/problem+json` content (issue #307).
+///
+/// The body is emitted as a literal JSON string at codegen time —
+/// stable, allocation-free, and safe to embed because `detail` is a
+/// short codegen-controlled phrase (no user input is interpolated).
+/// Specs that need a different Problem encoding can still override at
+/// the framework adapter layer.
+fn problem_response_expr(status: Int, detail: String) -> String {
+  let body =
+    "\"{\\\"type\\\":\\\"about:blank\\\",\\\"title\\\":\\\""
+    <> detail
+    <> "\\\"}\""
+  "ServerResponse(status: "
+  <> int.to_string(status)
+  <> ", body: "
+  <> body
+  <> ", headers: [#(\"content-type\", \"application/problem+json\")])"
+}
+
 /// Close a required-param lookup case (`case dict.get(...) { Ok(...) -> { ... }`).
 /// The catch-all `_ ->` arm covers both `Error(_)` and `Ok([])` (empty list)
 /// for query params, plus the bare `Error(_)` for header/cookie lookups.
@@ -1604,7 +1626,7 @@ fn close_lookup_case(sb: se.StringBuilder) -> se.StringBuilder {
   |> se.indent(4, "}")
   |> se.indent(
     4,
-    "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+    "_ -> " <> problem_response_expr(400, "missing or invalid parameter"),
   )
   |> se.indent(3, "}")
 }

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1947,12 +1947,85 @@ components:
   // The handler body uses the typed bound variable.
   string.contains(router_file.content, "priority: priority_raw_parsed,")
   |> should.be_true()
-  // Unknown values return 400.
+  // Unknown values return 400 with an RFC 7807-shaped Problem JSON body
+  // (issue #307 — replaced the previous plain-text "Bad Request").
+  string.contains(router_file.content, "status: 400") |> should.be_true()
   string.contains(
     router_file.content,
-    "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+    "\"{\\\"type\\\":\\\"about:blank\\\",\\\"title\\\":\\\"invalid query parameter\\\"}\"",
   )
   |> should.be_true()
+  string.contains(
+    router_file.content,
+    "[#(\"content-type\", \"application/problem+json\")]",
+  )
+  |> should.be_true()
+}
+
+// ===================================================================
+// Router error responses use Problem JSON (issue #307)
+// ===================================================================
+
+/// Body decode failures, path/query/header parameter parse failures, and
+/// unmatched routes must emit `application/problem+json` with an RFC 7807
+/// shape rather than plain `Bad Request` / `Not Found` text.
+pub fn server_error_paths_emit_problem_json_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // The decode-fail branch emits a Problem JSON body, not plain text.
+  string.contains(router_file.content, "\"Bad Request\"") |> should.be_false()
+  string.contains(router_file.content, "\"Not Found\"") |> should.be_false()
+  string.contains(
+    router_file.content,
+    "[#(\"content-type\", \"application/problem+json\")]",
+  )
+  |> should.be_true()
+  // Body decode failure carries the spec-relevant title.
+  string.contains(
+    router_file.content,
+    "\\\"title\\\":\\\"invalid request body\\\"",
+  )
+  |> should.be_true()
+  // The unmatched-route catch-all uses the same Problem shape.
+  string.contains(router_file.content, "\\\"title\\\":\\\"not found\\\"")
+  |> should.be_true()
+  // Status codes are intact.
+  string.contains(router_file.content, "status: 400") |> should.be_true()
+  string.contains(router_file.content, "status: 404") |> should.be_true()
 }
 
 // ===================================================================

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -8379,9 +8379,12 @@ paths:
   |> should.be_true()
   string.contains(content, "x_enabled: case dict.get(headers, \"x-enabled\") {")
   |> should.be_true()
+  // Issue #307: failure paths emit RFC 7807 Problem JSON, not plain text.
+  string.contains(content, "status: 400") |> should.be_true()
+  string.contains(content, "\"Bad Request\"") |> should.be_false()
   string.contains(
     content,
-    "_ -> ServerResponse(status: 400, body: \"Bad Request\", headers: [])",
+    "[#(\"content-type\", \"application/problem+json\")]",
   )
   |> should.be_true()
 }


### PR DESCRIPTION
## Summary

Fixes #307.

The generated router used to return plain `Bad Request` and `Not Found` text bodies for every error path with no `Content-Type` header. Specs that declared 4xx responses as `application/problem+json` (a common choice) saw their contract silently broken — strict clients reject the response on shape, and schema-driven multi-language pipelines reject it on validation.

## Changes

- `src/oaspec/codegen/server.gleam`
  - New helper `problem_response_expr(status, detail)` that returns a `ServerResponse(...)` Gleam expression whose body is a literal RFC 7807-shaped JSON string and whose Content-Type is `application/problem+json`.
  - Replaced every error emit site with the helper:
    - body decode failure → `\"invalid request body\"`
    - path parameter parse failure → `\"invalid path parameter\"`
    - query parameter parse failure → `\"invalid query parameter\"`
    - header / cookie parameter parse failure → `\"invalid header or cookie\"`
    - missing required parameter (lookup catch-all) → `\"missing or invalid parameter\"`
    - unmatched route catch-all (404) → `\"not found\"`
  - Added `import gleam/int` for the helper.

- Tests:
  - `test/codegen_unit_test.gleam`: enum-query-param test re-asserted on the new shape; new `server_error_paths_emit_problem_json_test` covers body decode and unmatched-route paths.
  - `test/oaspec_test.gleam`: scalar-query-and-header test re-asserted on the new shape.
  - `integration_test/run.sh`: required-param 400 test now compares the full Problem JSON body and the Content-Type header.
  - `golden/petstore/api/router.gleam`, `golden/complex_supported/api/router.gleam`: regenerated.

- `CHANGELOG.md`, `README.md`: Unreleased entry, test count bump (766 → 767).

## Generated output (after)

For the body decode-fail branch:

```gleam
Error(_) ->
  ServerResponse(
    status: 400,
    body: \"{\\\"type\\\":\\\"about:blank\\\",\\\"title\\\":\\\"invalid request body\\\"}\",
    headers: [#(\"content-type\", \"application/problem+json\")],
  )
```

For the unmatched route catch-all:

```gleam
_, _ ->
  ServerResponse(
    status: 404,
    body: \"{\\\"type\\\":\\\"about:blank\\\",\\\"title\\\":\\\"not found\\\"}\",
    headers: [#(\"content-type\", \"application/problem+json\")],
  )
```

Status codes are unchanged.

## Out of scope

- The 422 `Error(errors)` branch produced by `guards.validation_failure_to_json` already emits `application/json` with a structured array of validation failures. It predates the spec's declared 400 contract and would benefit from a richer Problem-with-errors output, but folding that into this PR would mean rewriting the guard validator output type. Left for a follow-up.
- The body interpolates a fixed phrase (no user input). Specs with a non-standard Problem schema can override at the framework adapter layer or by writing their own catch-all middleware.

## Test plan

- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam run -m glinter -- --stats` — 0 errors, 0 warnings
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` — 767 passed, 0 failures
- [x] `shellspec --no-color` — 78 examples, 0 failures
- [x] `bash integration_test/run.sh` — all integration tests passed (the required-param 400 test now compares the full Problem JSON body)
- [x] `gleam run -m gleescript` + `bash scripts/smoke_escript.sh` — packaged escript smoke tests passed
- [x] Manual smoke: regenerated server from a spec with a `POST` body and verified the resulting `router.gleam` matches the shapes above.

Closes #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now return structured JSON (`application/problem+json`) instead of plain text for invalid requests and missing routes, with consistent formatting across all error scenarios.

* **Documentation**
  * Updated CHANGELOG and test coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->