### PR TITLE
feat(codegen)!: thread spec-declared response headers onto the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **codegen (BREAKING)**: Spec-declared response headers now reach the
+  wire. When a response declares `headers:`, the generated
+  `response_types.<Op>Response<Status>` constructor grows a typed
+  headers slot (e.g. `ListPostsResponseOk(types.PostPage,
+  ListPostsResponseOkHeaders)`) so handlers must supply the values, and
+  the router's dispatch arm pattern-matches `(data, hdrs)` and merges
+  the typed values into `ServerResponse.headers` alongside the implicit
+  `content-type` tuple via `list.flatten([...])`. Required headers emit
+  `[#("Header-Name", value)]`; optional ones contribute `[]` when None.
+  Primitive non-string types (`Int`, `Float`, `Bool`) are stringified
+  via `int.to_string` / `float.to_string` / `bool.to_string` (with the
+  matching `gleam/<type>` import added automatically). The
+  `*Headers` types previously generated as dead code are now wired
+  through end-to-end. (#306)
 - **codegen (BREAKING)**: The generated `router.ServerResponse.body`
   field is now a `ResponseBody` sum type — `TextBody(String)`,
   `BytesBody(BitArray)`, or `EmptyBody` — instead of a fixed `String`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 770 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 772 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1587,4 +1587,171 @@ rm -rf "$BIN_DIR"
 
 info "Issue #304 binary response integration tests passed."
 
+# -------------------------------------------------------
+# Step 19: Issue #306 — typed response headers must reach the wire.
+# A spec declaring `responses.<code>.headers` is generated; the handler
+# returns body + a populated headers struct; the test asserts the
+# router emits both the implicit content-type tuple AND the spec-
+# declared header values (skipping None for optional headers).
+# -------------------------------------------------------
+info "Testing Issue #306 response header plumbing..."
+
+HDR_DIR="$SCRIPT_DIR/response_headers_test"
+rm -rf "$HDR_DIR"
+mkdir -p "$HDR_DIR/src/api" "$HDR_DIR/test"
+
+cat > "$HDR_DIR/response_headers.yaml" << 'YAML_EOF'
+openapi: "3.0.3"
+info:
+  title: Response Headers Test API
+  version: 1.0.0
+paths:
+  /v1/posts:
+    get:
+      operationId: listPosts
+      responses:
+        "200":
+          description: page of posts
+          headers:
+            Pagination-Cursor:
+              schema:
+                type: string
+            Pagination-Limit:
+              required: true
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+        "204":
+          description: no posts
+          headers:
+            X-Cache-Hit:
+              required: true
+              schema:
+                type: boolean
+YAML_EOF
+
+cat > "$HDR_DIR/oaspec-hdr.yaml" << 'YAML_EOF'
+input: ./integration_test/response_headers_test/response_headers.yaml
+output:
+  server: ./integration_test/response_headers_test/src/api
+package: api
+validate: false
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$HDR_DIR/oaspec-hdr.yaml" \
+  --mode=server
+
+cat > "$HDR_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/response_types
+import api/types
+import gleam/option.{Some}
+
+pub type State {
+  State
+}
+
+pub fn list_posts(state: State) -> response_types.ListPostsResponse {
+  let _ = state
+  response_types.ListPostsResponseOk(
+    types.ListPostsResponseOk(total: Some(2)),
+    response_types.ListPostsResponseOkHeaders(
+      pagination_cursor: Some("opaque-cursor"),
+      pagination_limit: 25,
+    ),
+  )
+}
+GLEAM_EOF
+
+cat > "$HDR_DIR/gleam.toml" << 'TOML_EOF'
+name = "response_headers_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$HDR_DIR/src/response_headers_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cat > "$HDR_DIR/test/response_headers_test_test.gleam" << 'GLEAM_EOF'
+// Issue #306 — a spec declaring response headers must wire those
+// values through `response_types.<Variant>(data, hdrs)` and onto the
+// `ServerResponse.headers` list. This test drives a handler that
+// returns body + headers and asserts the router lifts both onto the
+// wire alongside the implicit content-type tuple.
+
+import api/handlers
+import api/router
+import gleam/dict
+import gleam/list
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn declared_response_headers_reach_wire_test() {
+  let resp =
+    router.route(
+      handlers.State,
+      "GET",
+      ["v1", "posts"],
+      dict.new(),
+      dict.new(),
+      "",
+    )
+  resp.status |> should.equal(200)
+
+  // The spec-declared headers must appear in the returned headers
+  // list. Required Int (Pagination-Limit) is stringified; optional
+  // String (Pagination-Cursor) is present because the handler set
+  // Some(...). Order is whatever list.flatten produces — assert
+  // membership, not position.
+  list.contains(resp.headers, #("content-type", "application/json"))
+  |> should.be_true()
+  list.contains(resp.headers, #("Pagination-Cursor", "opaque-cursor"))
+  |> should.be_true()
+  list.contains(resp.headers, #("Pagination-Limit", "25"))
+  |> should.be_true()
+}
+GLEAM_EOF
+
+cd "$HDR_DIR"
+gleam deps download
+
+if gleam build; then
+  info "PASS: Response-headers test code compiles."
+else
+  fail "Response-headers test code failed to compile."
+fi
+
+if gleam test; then
+  info "PASS: Response-headers wire plumbing verified."
+else
+  fail "Response-headers integration tests failed."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$HDR_DIR"
+
+info "Issue #306 response header integration tests passed."
+
 info "All integration tests passed!"

--- a/src/oaspec/codegen/ir.gleam
+++ b/src/oaspec/codegen/ir.gleam
@@ -96,6 +96,16 @@ pub type Variant {
   VariantWithType(name: String, inner_type: String)
   /// Variant with no payload: `FooNone`
   VariantEmpty(name: String)
+  /// Response variant carrying a body and a typed headers record:
+  /// `FooBar(Bar, FooBarHeaders)` (issue #306).
+  VariantWithTypeAndHeaders(
+    name: String,
+    inner_type: String,
+    headers_type: String,
+  )
+  /// Response variant carrying only a typed headers record (no body):
+  /// `FooBar(FooBarHeaders)` (issue #306).
+  VariantWithHeaders(name: String, headers_type: String)
 }
 
 /// A typed record for response headers.

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -11,7 +11,8 @@ import oaspec/codegen/context.{type Context}
 import oaspec/codegen/import_analysis
 import oaspec/codegen/ir.{
   type Declaration, type Field, type Module, type Variant, EnumType, Field,
-  RecordType, TypeAlias, UnionType, VariantEmpty, VariantWithType,
+  RecordType, TypeAlias, UnionType, VariantEmpty, VariantWithHeaders,
+  VariantWithType, VariantWithTypeAndHeaders,
 }
 import oaspec/codegen/schema_dispatch
 import oaspec/codegen/schema_utils
@@ -368,17 +369,38 @@ fn response_variant(
 ) -> Variant {
   let variant_name = type_name <> http.status_code_suffix(status_code)
   let content_entries = sorted_entries(response.content)
+  // Issue #306: when the response declares headers, the variant carries
+  // an additional typed headers record so handlers can supply values
+  // and the router can serialise them onto the wire.
+  let headers_type_opt = case sorted_entries(response.headers) {
+    [] -> None
+    _ -> Some(variant_name <> "Headers")
+  }
   case content_entries {
-    [] -> VariantEmpty(name: variant_name)
-    [_, _, ..] -> VariantWithType(name: variant_name, inner_type: "String")
+    [] -> empty_variant_with_optional_headers(variant_name, headers_type_opt)
+    [_, _, ..] ->
+      typed_variant_with_optional_headers(
+        variant_name,
+        "String",
+        headers_type_opt,
+      )
     [#(media_type_name, media_type)] ->
       case content_type.from_string(media_type_name) {
         content_type.TextPlain
         | content_type.ApplicationXml
         | content_type.TextXml ->
           case media_type.schema {
-            Some(_) -> VariantWithType(name: variant_name, inner_type: "String")
-            None -> VariantEmpty(name: variant_name)
+            Some(_) ->
+              typed_variant_with_optional_headers(
+                variant_name,
+                "String",
+                headers_type_opt,
+              )
+            None ->
+              empty_variant_with_optional_headers(
+                variant_name,
+                headers_type_opt,
+              )
           }
         // Issue #304: binary response payloads ride a BitArray variant
         // so handlers can produce real bytes instead of forcing the
@@ -386,19 +408,64 @@ fn response_variant(
         content_type.ApplicationOctetStream ->
           case media_type.schema {
             Some(_) ->
-              VariantWithType(name: variant_name, inner_type: "BitArray")
-            None -> VariantEmpty(name: variant_name)
+              typed_variant_with_optional_headers(
+                variant_name,
+                "BitArray",
+                headers_type_opt,
+              )
+            None ->
+              empty_variant_with_optional_headers(
+                variant_name,
+                headers_type_opt,
+              )
           }
         _ ->
           case media_type.schema {
             Some(ref) -> {
               let suffix = "Response" <> http.status_code_suffix(status_code)
               let inner_type = schema_ref_to_type_qualified(ref, op_id, suffix)
-              VariantWithType(name: variant_name, inner_type: inner_type)
+              typed_variant_with_optional_headers(
+                variant_name,
+                inner_type,
+                headers_type_opt,
+              )
             }
-            None -> VariantEmpty(name: variant_name)
+            None ->
+              empty_variant_with_optional_headers(
+                variant_name,
+                headers_type_opt,
+              )
           }
       }
+  }
+}
+
+/// Pick the empty-body variant kind based on whether typed headers exist.
+fn empty_variant_with_optional_headers(
+  variant_name: String,
+  headers_type_opt: option.Option(String),
+) -> Variant {
+  case headers_type_opt {
+    Some(headers_type) ->
+      VariantWithHeaders(name: variant_name, headers_type: headers_type)
+    None -> VariantEmpty(name: variant_name)
+  }
+}
+
+/// Pick the body-bearing variant kind based on whether typed headers exist.
+fn typed_variant_with_optional_headers(
+  variant_name: String,
+  inner_type: String,
+  headers_type_opt: option.Option(String),
+) -> Variant {
+  case headers_type_opt {
+    Some(headers_type) ->
+      VariantWithTypeAndHeaders(
+        name: variant_name,
+        inner_type: inner_type,
+        headers_type: headers_type,
+      )
+    None -> VariantWithType(name: variant_name, inner_type: inner_type)
   }
 }
 

--- a/src/oaspec/codegen/ir_render.gleam
+++ b/src/oaspec/codegen/ir_render.gleam
@@ -6,7 +6,8 @@ import gleam/string
 import oaspec/codegen/context
 import oaspec/codegen/ir.{
   type Declaration, type Module, type TypeDef, EnumType, RecordType, TypeAlias,
-  UnionType, VariantEmpty, VariantWithType,
+  UnionType, VariantEmpty, VariantWithHeaders, VariantWithType,
+  VariantWithTypeAndHeaders,
 }
 import oaspec/util/string_extra as se
 
@@ -68,6 +69,14 @@ fn render_type_def(sb: se.StringBuilder, type_def: TypeDef) -> se.StringBuilder 
             VariantWithType(name: vname, inner_type:) ->
               sb |> se.indent(1, vname <> "(" <> inner_type <> ")")
             VariantEmpty(name: vname) -> sb |> se.indent(1, vname)
+            VariantWithTypeAndHeaders(name: vname, inner_type:, headers_type:) ->
+              sb
+              |> se.indent(
+                1,
+                vname <> "(" <> inner_type <> ", " <> headers_type <> ")",
+              )
+            VariantWithHeaders(name: vname, headers_type:) ->
+              sb |> se.indent(1, vname <> "(" <> headers_type <> ")")
           }
         })
       sb

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -342,6 +342,8 @@ fn generate_router(
         _ -> False
       }
     })
+    // Issue #306: integer response headers stringify via int.to_string.
+    || operations_have_response_header_of_type(operations, "Int")
 
   let needs_float =
     list.any(operations, fn(op) {
@@ -364,6 +366,13 @@ fn generate_router(
         _ -> False
       }
     })
+    // Issue #306: float response headers stringify via float.to_string.
+    || operations_have_response_header_of_type(operations, "Float")
+
+  // Issue #306: boolean response headers stringify via bool.to_string —
+  // generated routers had no prior need for `gleam/bool`, so this is a
+  // brand new import condition.
+  let needs_bool = operations_have_response_header_of_type(operations, "Bool")
 
   let needs_string =
     has_form_urlencoded_body
@@ -412,6 +421,9 @@ fn generate_router(
     || has_deep_object
     || has_form_urlencoded_body
     || has_multipart_body
+    // Issue #306: responses that declare headers materialise the
+    // ServerResponse `headers:` slot via `list.flatten([...])`.
+    || operations_have_response_headers(operations)
     || list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       list.any(operation.parameters, fn(ref_p) {
@@ -455,6 +467,10 @@ fn generate_router(
       || has_optional_form_urlencoded_fields
       || has_optional_multipart_fields
     })
+    // Issue #306: optional response headers pattern-match `Some(v) | None`,
+    // which needs `gleam/option` even on operations whose request side
+    // has no Option-typed parameters.
+    || operations_have_optional_response_header(operations)
 
   let needs_json =
     list.any(operations, fn(op) {
@@ -550,6 +566,10 @@ fn generate_router(
   }
   let std_imports = case needs_float {
     True -> list.append(std_imports, ["gleam/float"])
+    False -> std_imports
+  }
+  let std_imports = case needs_bool {
+    True -> list.append(std_imports, ["gleam/bool"])
     False -> std_imports
   }
   let std_imports = case needs_option {
@@ -1714,18 +1734,21 @@ fn generate_response_conversion(
                 response_type_name <> http.status_code_suffix(status_code)
               let status_int = http.status_code_to_int(status_code)
               let content_entries = dict.to_list(response.content)
+              let header_specs = sorted_header_specs(response.headers)
+              let has_headers = !list.is_empty(header_specs)
 
               case content_entries {
                 [] ->
                   // No content body variant
-                  sb
-                  |> se.indent(
-                    4,
-                    "response_types."
-                      <> variant_name
-                      <> " -> ServerResponse(status: "
-                      <> status_int
-                      <> ", body: EmptyBody, headers: [])",
+                  emit_response_arm(
+                    sb,
+                    variant_name,
+                    status_int,
+                    has_data: False,
+                    has_headers: has_headers,
+                    body_expr: "EmptyBody",
+                    content_type_header: None,
+                    header_specs: header_specs,
                   )
                 [#(media_type_name, media_type)] ->
                   case content_type.from_string(media_type_name) {
@@ -1734,29 +1757,29 @@ fn generate_response_conversion(
                         Some(_) -> {
                           let encode_fn =
                             get_encode_function(media_type.schema, ctx)
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> "(data) -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: TextBody(json.to_string("
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: True,
+                            has_headers: has_headers,
+                            body_expr: "TextBody(json.to_string("
                               <> encode_fn
-                              <> "(data))), headers: [#(\"content-type\", \""
-                              <> media_type_name
-                              <> "\")])",
+                              <> "(data)))",
+                            content_type_header: Some(media_type_name),
+                            header_specs: header_specs,
                           )
                         }
                         None ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> " -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: EmptyBody, headers: [])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: False,
+                            has_headers: has_headers,
+                            body_expr: "EmptyBody",
+                            content_type_header: None,
+                            header_specs: header_specs,
                           )
                       }
                     content_type.TextPlain
@@ -1764,26 +1787,26 @@ fn generate_response_conversion(
                     | content_type.TextXml ->
                       case media_type.schema {
                         Some(_) ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> "(data) -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: TextBody(data), headers: [#(\"content-type\", \""
-                              <> media_type_name
-                              <> "\")])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: True,
+                            has_headers: has_headers,
+                            body_expr: "TextBody(data)",
+                            content_type_header: Some(media_type_name),
+                            header_specs: header_specs,
                           )
                         None ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> " -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: EmptyBody, headers: [])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: False,
+                            has_headers: has_headers,
+                            body_expr: "EmptyBody",
+                            content_type_header: None,
+                            header_specs: header_specs,
                           )
                       }
                     content_type.ApplicationOctetStream ->
@@ -1793,26 +1816,26 @@ fn generate_response_conversion(
                       // variant carries `BitArray` (see ir_build).
                       case media_type.schema {
                         Some(_) ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> "(data) -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: BytesBody(data), headers: [#(\"content-type\", \""
-                              <> media_type_name
-                              <> "\")])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: True,
+                            has_headers: has_headers,
+                            body_expr: "BytesBody(data)",
+                            content_type_header: Some(media_type_name),
+                            header_specs: header_specs,
                           )
                         None ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> " -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: EmptyBody, headers: [])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: False,
+                            has_headers: has_headers,
+                            body_expr: "EmptyBody",
+                            content_type_header: None,
+                            header_specs: header_specs,
                           )
                       }
                     _ ->
@@ -1820,45 +1843,44 @@ fn generate_response_conversion(
                         Some(_) -> {
                           let encode_fn =
                             get_encode_function(media_type.schema, ctx)
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> "(data) -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: TextBody(json.to_string("
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: True,
+                            has_headers: has_headers,
+                            body_expr: "TextBody(json.to_string("
                               <> encode_fn
-                              <> "(data))), headers: [#(\"content-type\", \""
-                              <> media_type_name
-                              <> "\")])",
+                              <> "(data)))",
+                            content_type_header: Some(media_type_name),
+                            header_specs: header_specs,
                           )
                         }
                         None ->
-                          sb
-                          |> se.indent(
-                            4,
-                            "response_types."
-                              <> variant_name
-                              <> " -> ServerResponse(status: "
-                              <> status_int
-                              <> ", body: EmptyBody, headers: [])",
+                          emit_response_arm(
+                            sb,
+                            variant_name,
+                            status_int,
+                            has_data: False,
+                            has_headers: has_headers,
+                            body_expr: "EmptyBody",
+                            content_type_header: None,
+                            header_specs: header_specs,
                           )
                       }
                   }
                 // Multiple content types: variant wraps String.
                 // Use the first content type as default content-type header.
                 [#(first_media_type, _), _, ..] ->
-                  sb
-                  |> se.indent(
-                    4,
-                    "response_types."
-                      <> variant_name
-                      <> "(data) -> ServerResponse(status: "
-                      <> status_int
-                      <> ", body: TextBody(data), headers: [#(\"content-type\", \""
-                      <> first_media_type
-                      <> "\")])",
+                  emit_response_arm(
+                    sb,
+                    variant_name,
+                    status_int,
+                    has_data: True,
+                    has_headers: has_headers,
+                    body_expr: "TextBody(data)",
+                    content_type_header: Some(first_media_type),
+                    header_specs: header_specs,
                   )
               }
             }
@@ -1868,6 +1890,237 @@ fn generate_response_conversion(
 
       sb |> se.indent(3, "}")
     }
+  }
+}
+
+/// True if any response of any operation declares at least one header.
+fn operations_have_response_headers(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) -> !dict.is_empty(response.headers)
+        _ -> False
+      }
+    })
+  })
+}
+
+/// True if any response header field has the given Gleam type.
+/// Used to decide which primitive `gleam/<type>` import the generated
+/// router needs for header value stringification (issue #306).
+fn operations_have_response_header_of_type(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  type_name: String,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) ->
+          list.any(sorted_header_specs(response.headers), fn(spec) {
+            spec.field_type == type_name
+          })
+        _ -> False
+      }
+    })
+  })
+}
+
+/// True if any response header is optional. Optional headers emit
+/// `case hdrs.<field> { Some(v) -> ... None -> [] }` and need `gleam/option`.
+fn operations_have_optional_response_header(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) ->
+          list.any(sorted_header_specs(response.headers), fn(spec) {
+            !spec.required
+          })
+        _ -> False
+      }
+    })
+  })
+}
+
+/// Compact spec for a single declared response header, used to render
+/// the `headers:` slot of `ServerResponse` when issue #306 plumbing is
+/// active. The pair (header_name, field_name) keeps the wire-form name
+/// (e.g. "Pagination-Cursor") distinct from the Gleam record field
+/// (`pagination_cursor`); `field_type` decides how the value is
+/// stringified; `required` decides whether to emit a Some/None case.
+type HeaderSpec {
+  HeaderSpec(
+    header_name: String,
+    field_name: String,
+    field_type: String,
+    required: Bool,
+  )
+}
+
+fn sorted_header_specs(
+  headers: dict.Dict(String, spec.Header),
+) -> List(HeaderSpec) {
+  headers
+  |> dict.to_list
+  |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+  |> list.map(fn(entry) {
+    let #(header_name, header) = entry
+    let field_name = naming.to_snake_case(header_name)
+    let field_type = response_header_field_type(header.schema)
+    HeaderSpec(
+      header_name: header_name,
+      field_name: field_name,
+      field_type: field_type,
+      required: header.required,
+    )
+  })
+}
+
+/// Mirror of `header_schema_to_type` in ir_build — kept here so the
+/// router emission and the response_types record stay in sync without a
+/// cross-module dependency on the IR layer.
+fn response_header_field_type(
+  schema_opt: option.Option(schema.SchemaRef),
+) -> String {
+  case schema_opt {
+    Some(Inline(schema.IntegerSchema(..))) -> "Int"
+    Some(Inline(schema.NumberSchema(..))) -> "Float"
+    Some(Inline(schema.BooleanSchema(..))) -> "Bool"
+    Some(Inline(schema.StringSchema(..))) -> "String"
+    Some(Reference(name:, ..)) -> "types." <> naming.schema_to_type_name(name)
+    _ -> "String"
+  }
+}
+
+/// Emit one arm of the response dispatch `case` block.
+///
+/// Issue #306 introduces the headers plumbing: when `has_headers` is
+/// True the variant pattern grows an `hdrs` binding and the headers
+/// list is materialised via `list.flatten` so spec-declared response
+/// headers are appended to the implicit `content-type` tuple.
+fn emit_response_arm(
+  sb: se.StringBuilder,
+  variant_name: String,
+  status_int: String,
+  has_data has_data: Bool,
+  has_headers has_headers: Bool,
+  body_expr body_expr: String,
+  content_type_header content_type_header: option.Option(String),
+  header_specs header_specs: List(HeaderSpec),
+) -> se.StringBuilder {
+  let pattern_args = case has_data, has_headers {
+    True, True -> "(data, hdrs)"
+    True, False -> "(data)"
+    False, True -> "(hdrs)"
+    False, False -> ""
+  }
+  let headers_expr = headers_slot_expr(content_type_header, header_specs)
+  sb
+  |> se.indent(
+    4,
+    "response_types."
+      <> variant_name
+      <> pattern_args
+      <> " -> ServerResponse(status: "
+      <> status_int
+      <> ", body: "
+      <> body_expr
+      <> ", headers: "
+      <> headers_expr
+      <> ")",
+  )
+}
+
+/// Build the `headers:` argument for a `ServerResponse(...)` call.
+///
+/// - No content-type, no declared headers → `[]`
+/// - Content-type only → `[#("content-type", "<type>")]`
+/// - Declared headers (with or without content-type) → `list.flatten([...])`
+///   so optional headers can contribute `[]` and required ones a
+///   one-tuple list without repeated allocation. The fold keeps the
+///   spec-declared order (alphabetised by `sorted_header_specs`) so
+///   regenerated routers stay deterministic.
+fn headers_slot_expr(
+  content_type_header: option.Option(String),
+  header_specs: List(HeaderSpec),
+) -> String {
+  let content_type_chunk = case content_type_header {
+    Some(media_type_name) -> [
+      "[#(\"content-type\", \"" <> media_type_name <> "\")]",
+    ]
+    None -> []
+  }
+  let header_chunks =
+    list.map(header_specs, fn(spec) { header_chunk_expr(spec) })
+  case content_type_chunk, header_chunks {
+    [], [] -> "[]"
+    [single_chunk], [] -> single_chunk
+    _, _ ->
+      "list.flatten(["
+      <> string.join(content_type_chunk, ", ")
+      |> append_chunks(header_chunks)
+      <> "])"
+  }
+}
+
+fn append_chunks(prefix: String, header_chunks: List(String)) -> String {
+  case header_chunks {
+    [] -> prefix
+    _ ->
+      case prefix {
+        "" -> string.join(header_chunks, ", ")
+        _ -> prefix <> ", " <> string.join(header_chunks, ", ")
+      }
+  }
+}
+
+/// Render one declared response header into a chunk that contributes
+/// to the `headers:` `list.flatten` call.
+///
+/// Required: `[#("Pagination-Cursor", hdrs.pagination_cursor)]`
+/// Optional: `case hdrs.pagination_cursor { Some(v) -> [#(...)] None -> [] }`
+/// Non-string types are stringified via `int.to_string` /
+/// `float.to_string` / `bool.to_string` (the necessary imports are
+/// added by the import-analysis pass).
+fn header_chunk_expr(spec: HeaderSpec) -> String {
+  let render_value = fn(value_expr: String) -> String {
+    "[#(\""
+    <> spec.header_name
+    <> "\", "
+    <> stringify_header_value(spec.field_type, value_expr)
+    <> ")]"
+  }
+  case spec.required {
+    True -> render_value("hdrs." <> spec.field_name)
+    False ->
+      "case hdrs."
+      <> spec.field_name
+      <> " { Some(v) -> "
+      <> render_value("v")
+      <> " None -> [] }"
+  }
+}
+
+/// Convert a typed header value into a `String` for the wire. Header
+/// fields are limited to primitives (Int / Float / Bool / String) and
+/// `types.<X>` aliases (which the codegen treats as String-compatible
+/// — non-string aliases would fail to compile and signal the user
+/// that header value coercion is unsupported for that schema).
+fn stringify_header_value(field_type: String, value_expr: String) -> String {
+  case field_type {
+    "Int" -> "int.to_string(" <> value_expr <> ")"
+    "Float" -> "float.to_string(" <> value_expr <> ")"
+    "Bool" -> "bool.to_string(" <> value_expr <> ")"
+    _ -> value_expr
   }
 }
 

--- a/src/oaspec/openapi/capability_check.gleam
+++ b/src/oaspec/openapi/capability_check.gleam
@@ -376,9 +376,14 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             severity: SeverityWarning,
             target: TargetBoth,
             path: "components.headers",
-            detail: "Component headers are parsed but not used by code generation.",
+            // Issue #306 wired response headers through to the
+            // generated router, so component headers `$ref`'d from a
+            // response.headers entry now reach the wire. Standalone
+            // component header definitions that aren't referenced by
+            // any response are still dropped on the floor.
+            detail: "Component headers are wired into generated code only when referenced from a response.headers entry; standalone definitions are not surfaced.",
             hint: Some(
-              "Component headers will not appear in generated code. No action needed.",
+              "If a component header should reach a client, reference it from the relevant response.headers entry.",
             ),
           ),
         ]

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -2221,6 +2221,164 @@ paths:
   |> should.be_true()
 }
 
+// ===================================================================
+// Response headers reach the wire (issue #306)
+// ===================================================================
+
+/// A response that declares typed `headers:` must:
+///   1. Grow the `response_types.<Variant>` constructor with the
+///      generated `*Headers` record so handlers can supply values.
+///   2. Pattern-match `Variant(data, hdrs)` in the router dispatcher.
+///   3. Materialise the spec-declared headers onto the wire alongside
+///      the implicit `content-type` tuple via `list.flatten([...])`.
+///
+/// Optional headers contribute a `case Some/None` chunk so they can
+/// be skipped at runtime; required Int headers are stringified via
+/// `int.to_string` (and the matching `gleam/int` import is added by
+/// the import-analysis pass).
+pub fn server_response_headers_reach_router_dispatch_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /v1/posts:
+    get:
+      operationId: listPosts
+      responses:
+        '200':
+          description: page of posts
+          headers:
+            Pagination-Cursor:
+              schema:
+                type: string
+            Pagination-Limit:
+              required: true
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let server_files = server_gen.generate(ctx)
+  let type_files = types_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(server_files, fn(f) { f.path == "router.gleam" })
+  let assert Ok(response_types_file) =
+    list.find(type_files, fn(f) { f.path == "response_types.gleam" })
+
+  // The response variant grows a headers slot — the handler can no
+  // longer construct it without supplying both body and headers.
+  string.contains(
+    response_types_file.content,
+    "ListPostsResponseOk(types.ListPostsResponseOk, ListPostsResponseOkHeaders)",
+  )
+  |> should.be_true()
+
+  // The dispatcher binds the headers via `(data, hdrs)` and merges
+  // the typed values with the implicit content-type tuple.
+  string.contains(router_file.content, "ListPostsResponseOk(data, hdrs) ->")
+  |> should.be_true()
+  string.contains(router_file.content, "list.flatten([") |> should.be_true()
+  string.contains(
+    router_file.content,
+    "[#(\"content-type\", \"application/json\")]",
+  )
+  |> should.be_true()
+
+  // Required Int header is emitted directly with int.to_string.
+  string.contains(
+    router_file.content,
+    "[#(\"Pagination-Limit\", int.to_string(hdrs.pagination_limit))]",
+  )
+  |> should.be_true()
+
+  // Optional String header is wrapped in a `case Some/None` chunk so
+  // None contributes the empty list (no header on the wire).
+  string.contains(router_file.content, "case hdrs.pagination_cursor {")
+  |> should.be_true()
+  string.contains(
+    router_file.content,
+    "Some(v) -> [#(\"Pagination-Cursor\", v)]",
+  )
+  |> should.be_true()
+  string.contains(router_file.content, "None -> []") |> should.be_true()
+
+  // Routers that emit response headers need `gleam/list` for flatten;
+  // this spec also needs `gleam/int` for the required Int header.
+  string.contains(router_file.content, "import gleam/list") |> should.be_true()
+  string.contains(router_file.content, "import gleam/int") |> should.be_true()
+}
+
+/// A no-content response (e.g. 204) that declares only headers must
+/// still dispatch via `Variant(hdrs)` — no body slot, but the typed
+/// header struct is required so the handler can supply values. The
+/// dispatcher emits `body: EmptyBody` and a `headers:` list built
+/// from the headers struct alone (no implicit content-type tuple).
+pub fn server_empty_response_with_headers_dispatches_via_headers_arg_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /v1/things:
+    delete:
+      operationId: deleteThing
+      responses:
+        '204':
+          description: deleted
+          headers:
+            X-Cache-Hit:
+              required: true
+              schema:
+                type: boolean
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let server_files = server_gen.generate(ctx)
+  let type_files = types_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(server_files, fn(f) { f.path == "router.gleam" })
+  let assert Ok(response_types_file) =
+    list.find(type_files, fn(f) { f.path == "response_types.gleam" })
+
+  // No-content variant grows a headers-only slot.
+  string.contains(
+    response_types_file.content,
+    "DeleteThingResponseNoContent(DeleteThingResponseNoContentHeaders)",
+  )
+  |> should.be_true()
+
+  // Dispatcher pattern-matches on `(hdrs)` (no `data` binding) and
+  // emits EmptyBody.
+  string.contains(router_file.content, "DeleteThingResponseNoContent(hdrs) ->")
+  |> should.be_true()
+  string.contains(router_file.content, "body: EmptyBody") |> should.be_true()
+
+  // Bool header is stringified via bool.to_string and gleam/bool is
+  // imported automatically.
+  string.contains(
+    router_file.content,
+    "[#(\"X-Cache-Hit\", bool.to_string(hdrs.x_cache_hit))]",
+  )
+  |> should.be_true()
+  string.contains(router_file.content, "import gleam/bool") |> should.be_true()
+}
+
 /// A response with no `content` block must dispatch to `EmptyBody`,
 /// preserving the previous "no body, just status" semantics without
 /// forcing handlers to invent a placeholder String.


### PR DESCRIPTION
## Summary

Fixes Issue #306. Generated routers were silently dropping every
spec-declared response header on the floor: oaspec produced a
`*Headers` type for each response that declared `headers:`, but
neither the response constructor nor the router carried the values
through. The result was that handler authors had no way to surface
those headers, and the OpenAPI contract was being violated without
any compile-time signal.

This PR plumbs response headers end-to-end:

1. **Response variant constructors** — when a response declares
   `headers:`, the variant grows a typed headers slot. So
   `ListPostsResponseOk(types.PostPage)` becomes
   `ListPostsResponseOk(types.PostPage, ListPostsResponseOkHeaders)`,
   and a no-content variant like `DeleteThingResponseNoContent`
   becomes `DeleteThingResponseNoContent(DeleteThingResponseNoContentHeaders)`.
   Handlers can no longer construct the variant without supplying
   header values — silent breakage at the spec layer turns into a
   compile error at the handler layer.

2. **Router dispatch** — the dispatcher pattern-matches the new
   shape (`(data, hdrs)`, `(hdrs)`) and materialises the
   `ServerResponse.headers` slot via `list.flatten([...])`. Required
   headers emit `[#("Header-Name", value)]`; optional ones contribute
   `[]` on `None`. Non-string primitive types (`Int`, `Float`,
   `Bool`) are stringified via `int.to_string` / `float.to_string` /
   `bool.to_string` — and the matching `gleam/<type>` import is added
   to the router automatically by the import-analysis pass.

3. **Capability warning** — the diagnostic emitted when a spec
   declares `components.headers` was misleading after this change
   ("parsed but not used by code generation"). It now says component
   headers are wired into generated code only when referenced from a
   `response.headers` entry; standalone definitions remain unused.

## Changes

- `src/oaspec/codegen/ir.gleam`: extended `Variant` with two new
  variants — `VariantWithTypeAndHeaders` (body + headers) and
  `VariantWithHeaders` (headers-only) — so the response IR can carry
  the typed headers record name alongside the body type.
- `src/oaspec/codegen/ir_render.gleam`: render the two new variants
  as `Foo(Bar, FooHeaders)` and `Foo(FooHeaders)`.
- `src/oaspec/codegen/ir_build.gleam`: `response_variant` detects
  declared headers and picks the appropriate variant kind.
- `src/oaspec/codegen/server.gleam`:
  - Refactored `generate_response_conversion` to dispatch through a
    single `emit_response_arm` helper instead of repeating the
    `ServerResponse(...)` template across each content-type branch.
  - Added `headers_slot_expr` / `header_chunk_expr` helpers that
    build the `headers:` argument from spec-declared headers,
    handling required vs optional and primitive stringification.
  - Added import-analysis predicates (`operations_have_response_headers`,
    `operations_have_response_header_of_type`,
    `operations_have_optional_response_header`) so `gleam/list`,
    `gleam/int`, `gleam/float`, `gleam/bool`, and `gleam/option`
    are imported when (and only when) needed.
- `src/oaspec/openapi/capability_check.gleam`: clarified the
  `components.headers` warning so it reflects post-#306 reality.
- `test/codegen_unit_test.gleam`: two new tests cover the body+headers
  dispatch (with optional + required header fields, content-type
  merge, and import injection) and the headers-only no-content
  dispatch (Bool stringification + `gleam/bool` import).
- `integration_test/run.sh`: new Step 19 generates a small
  pagination spec, runs a handler that returns body + populated
  `*Headers`, and asserts the wire-side `ServerResponse.headers`
  list contains all declared header tuples alongside the implicit
  content-type tuple.
- `CHANGELOG.md`: documented as a breaking change under `### Changed`.
- `README.md`: bumped unit test count (770 → 772).

## Design Decisions

- **Two new variant kinds vs. an `Option` field on existing variants**.
  `VariantWithType` and `VariantEmpty` are also used by discriminated
  `oneOf` decoders (`ir_build.gleam:703,862`) which have nothing to
  do with response headers. Adding an `Option(String) headers_type`
  field there would have leaked response-only state into an unrelated
  IR concept and forced every existing call site to be touched. The
  new variants are response-only and additive.
- **Variant pattern choices**. Rather than introducing a marker
  argument or an option-typed field on `ServerResponse`, the headers
  ride alongside the body in the variant constructor. This mirrors
  how the request side already works (the request struct carries
  every parameter as a typed field, not as a side-channel) and gives
  handlers a single record to construct.
- **`list.flatten` over `list.append` chains**. With multiple
  optional headers, `list.append` chains nest awkwardly; `list.flatten`
  keeps the per-header chunks readable and easy to extend. The
  implicit content-type tuple is just one chunk among the rest.
- **Primitive coercion only**. Non-primitive `types.<X>` header
  schemas (e.g. a `$ref` to a string type alias) are passed through
  as `String` directly. If the alias resolves to a non-String type
  the generated router will fail to compile and surface the
  limitation explicitly to the user — preferable to a hidden
  silent-cast.

## Test Plan

- [x] `gleam test` — 772 passes (2 new unit tests for #306).
- [x] `bash integration_test/run.sh` — Step 19 confirms a real
  handler-supplied `Pagination-Cursor` / `Pagination-Limit` /
  `content-type` triple appears in `ServerResponse.headers` after
  the router runs.
- [x] `gleam format` — clean.
- [x] `gleam run -m glinter` — 0 errors / 0 warnings.
- [x] `bash scripts/check_sync.sh` — versions/counts in sync.
- [x] `bash scripts/check_readme_examples.sh` — README snippets
  compile.
- [x] Existing golden fixtures unchanged (no spec declares response
  headers, so the dispatcher emission is byte-identical).

Closes #306
