### PR TITLE
fix(codegen)!: elide single-value enum discriminators as constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **codegen (BREAKING)**: A required, inline `type: string, enum:
+  [<single-value>]` property is now treated as a constant. The generated
+  Gleam record drops the field, no tautological one-variant `*Kind` enum
+  is emitted, the encoder inlines `json.string("<value>")` without
+  reading a record field, and the decoder validates the wire value
+  matches and discards it. Optional single-value enums (the
+  `Some(theOnlyVariant) | None` case) are unchanged because the
+  presence/absence distinction is still meaningful. Multi-value enums,
+  `$ref`'d enum components, and standalone enum schemas are also
+  unchanged. Constructors that previously had to restate
+  `kind: TextPostRequestKindText` lose that argument; spec violations
+  on the wire (`kind: "media"` where only `kind: "text"` is legal) now
+  surface as decode errors instead of silently passing through. (#309)
 - **codegen (BREAKING)**: Spec-declared response headers now reach the
   wire. When a response declares `headers:`, the generated
   `response_types.<Op>Response<Status>` constructor grows a typed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 772 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 776 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1754,4 +1754,155 @@ rm -rf "$HDR_DIR"
 
 info "Issue #306 response header integration tests passed."
 
+# -------------------------------------------------------
+# Step 20: Issue #309 — required, inline single-value string-enum
+# properties are constants and must be elided from the generated
+# record. The encoder still emits the constant on the wire, the
+# decoder validates it. This step generates a spec with a `kind:
+# enum: [text]` discriminator-shaped property, drives an encode →
+# decode round-trip, and verifies a wire mismatch fails decoding.
+# -------------------------------------------------------
+info "Testing Issue #309 single-value enum elision..."
+
+CONST_DIR="$SCRIPT_DIR/constant_property_test"
+rm -rf "$CONST_DIR"
+mkdir -p "$CONST_DIR/src/api" "$CONST_DIR/test"
+
+cat > "$CONST_DIR/constant_property.yaml" << 'YAML_EOF'
+openapi: "3.0.3"
+info:
+  title: Constant Property Test API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TextPostRequest:
+      type: object
+      required: [kind, body]
+      properties:
+        kind:
+          type: string
+          enum: [text]
+        body:
+          type: string
+YAML_EOF
+
+cat > "$CONST_DIR/oaspec-const.yaml" << 'YAML_EOF'
+input: ./integration_test/constant_property_test/constant_property.yaml
+output:
+  client: ./integration_test/constant_property_test/src/api
+package: api
+validate: false
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$CONST_DIR/oaspec-const.yaml" \
+  --mode=client
+
+cat > "$CONST_DIR/gleam.toml" << 'TOML_EOF'
+name = "constant_property_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+gleam_http = ">= 4.0.0 and < 5.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$CONST_DIR/src/constant_property_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cat > "$CONST_DIR/test/constant_property_test_test.gleam" << 'GLEAM_EOF'
+// Issue #309 — a required inline single-value string-enum property
+// is fully determined by the schema, so the generated record drops
+// the field and the codec emits / validates the constant on the
+// wire. The handler-facing surface stops needing a tautological
+// `kind: TextPostRequestKindText` argument at every call site.
+
+import api/decode as api_decode
+import api/encode as api_encode
+import api/types
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn record_constructor_takes_no_kind_argument_test() {
+  // The generated record only exposes the meaningful field. If the
+  // codegen regressed and re-introduced a `kind:` argument, this
+  // module would fail to compile.
+  let req = types.TextPostRequest(body: "hello")
+  req.body |> should.equal("hello")
+}
+
+pub fn encoder_emits_kind_constant_test() {
+  let req = types.TextPostRequest(body: "hello")
+  let json = api_encode.encode_text_post_request(req)
+  // The wire still carries `"kind":"text"` even though the record
+  // has no `kind` field — the encoder inlines the constant at
+  // codegen time.
+  case json {
+    "{\"body\":\"hello\",\"kind\":\"text\"}" -> Nil
+    "{\"kind\":\"text\",\"body\":\"hello\"}" -> Nil
+    other -> {
+      should.equal(other, "{\"body\":\"hello\",\"kind\":\"text\"}")
+      Nil
+    }
+  }
+}
+
+pub fn decoder_round_trips_valid_kind_test() {
+  let assert Ok(decoded) =
+    api_decode.decode_text_post_request(
+      "{\"kind\":\"text\",\"body\":\"hello\"}",
+    )
+  decoded.body |> should.equal("hello")
+}
+
+pub fn decoder_rejects_wire_mismatch_test() {
+  // A wire payload claiming a different discriminator value must
+  // fail — silent acceptance would defeat the purpose of the
+  // single-value enum constraint.
+  let result =
+    api_decode.decode_text_post_request(
+      "{\"kind\":\"media\",\"body\":\"hello\"}",
+    )
+  case result {
+    Ok(_) -> should.fail()
+    Error(_) -> Nil
+  }
+}
+GLEAM_EOF
+
+cd "$CONST_DIR"
+gleam deps download
+
+if gleam build; then
+  info "PASS: Constant-property test code compiles."
+else
+  fail "Constant-property test code failed to compile."
+fi
+
+if gleam test; then
+  info "PASS: Constant-property elision verified."
+else
+  fail "Constant-property integration tests failed."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$CONST_DIR"
+
+info "Issue #309 constant-property integration tests passed."
+
 info "All integration tests passed!"

--- a/src/oaspec/codegen/decoders.gleam
+++ b/src/oaspec/codegen/decoders.gleam
@@ -6,6 +6,7 @@ import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
+import oaspec/codegen/schema_utils
 import oaspec/codegen/types as type_gen
 import oaspec/config
 import oaspec/openapi/dedup
@@ -240,24 +241,36 @@ fn generate_inline_enum_decoders(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> se.StringBuilder {
-  let props = case schema_ref {
-    Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
-    Inline(AllOfSchema(schemas:, ..)) ->
-      ir_build.sorted_entries(
-        allof_merge.merge_allof_schemas(schemas, ctx).properties,
-      )
-    _ -> []
+  let #(props, required) = case schema_ref {
+    Inline(ObjectSchema(properties:, required:, ..)) -> #(
+      ir_build.sorted_entries(properties),
+      required,
+    )
+    Inline(AllOfSchema(schemas:, ..)) -> {
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
+      #(ir_build.sorted_entries(merged.properties), merged.required)
+    }
+    _ -> #([], [])
   }
   list.fold(props, sb, fn(sb, entry) {
     let #(prop_name, prop_ref) = entry
-    case prop_ref {
-      Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
-        let enum_name =
-          naming.schema_to_type_name(parent_name)
-          <> naming.schema_to_type_name(prop_name)
-        generate_decoder(sb, enum_name, prop_ref, ctx)
-      }
-      _ -> sb
+    // Issue #309: a required inline single-value string-enum has no
+    // corresponding type in `types.gleam` (the IR pass elided it), so
+    // emitting a decoder for it would produce orphan code that
+    // references a missing type. Skip it; the constant value is
+    // validated inline by the parent object decoder instead.
+    case schema_utils.constant_property_value(prop_ref, prop_name, required) {
+      Some(_) -> sb
+      None ->
+        case prop_ref {
+          Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
+            let enum_name =
+              naming.schema_to_type_name(parent_name)
+              <> naming.schema_to_type_name(prop_name)
+            generate_decoder(sb, enum_name, prop_ref, ctx)
+          }
+          _ -> sb
+        }
     }
   })
 }
@@ -449,46 +462,59 @@ fn generate_object_decoder(
         False -> field_decoder
       }
 
-      case is_required {
-        True ->
+      // Issue #309: a required, inline single-value string-enum
+      // property is elided from the generated record. The decoder
+      // must still observe the wire value and reject mismatches —
+      // otherwise a spec violation would silently slip through. The
+      // emitted decoder reads the field as a string, validates it
+      // against the codegen-time constant via `decode.then`, and
+      // discards the value (the record has no slot for it).
+      case schema_utils.constant_property_value(prop_ref, prop_name, required) {
+        Some(constant_value) ->
           sb
-          |> se.indent(
-            1,
-            "use "
-              <> field_name
-              <> " <- decode.field(\""
-              <> prop_name
-              <> "\", "
-              <> effective_decoder
-              <> ")",
-          )
-        False ->
-          case is_nullable_schema {
+          |> emit_constant_field_decoder(prop_name, constant_value)
+        None ->
+          case is_required {
             True ->
-              // Type is Option(T), default is None
               sb
               |> se.indent(
                 1,
                 "use "
                   <> field_name
-                  <> " <- decode.optional_field(\""
+                  <> " <- decode.field(\""
                   <> prop_name
-                  <> "\", option.None, "
+                  <> "\", "
                   <> effective_decoder
                   <> ")",
               )
             False ->
-              sb
-              |> se.indent(
-                1,
-                "use "
-                  <> field_name
-                  <> " <- decode.optional_field(\""
-                  <> prop_name
-                  <> "\", option.None, decode.optional("
-                  <> field_decoder
-                  <> "))",
-              )
+              case is_nullable_schema {
+                True ->
+                  // Type is Option(T), default is None
+                  sb
+                  |> se.indent(
+                    1,
+                    "use "
+                      <> field_name
+                      <> " <- decode.optional_field(\""
+                      <> prop_name
+                      <> "\", option.None, "
+                      <> effective_decoder
+                      <> ")",
+                  )
+                False ->
+                  sb
+                  |> se.indent(
+                    1,
+                    "use "
+                      <> field_name
+                      <> " <- decode.optional_field(\""
+                      <> prop_name
+                      <> "\", option.None, decode.optional("
+                      <> field_decoder
+                      <> "))",
+                  )
+              }
           }
       }
     })
@@ -566,9 +592,24 @@ fn generate_object_decoder(
 
   let param_names =
     list.index_map(props, fn(entry, idx) {
-      let #(prop_name, _) = entry
+      let #(prop_name, prop_ref) = entry
       let field_name =
         list_at_or(deduped_names, idx, naming.to_snake_case(prop_name))
+      #(prop_name, prop_ref, field_name)
+    })
+    // Issue #309: constant properties are elided from the record, so
+    // their decoder consumed-and-discarded the wire value above. They
+    // must NOT appear in the success constructor's argument list.
+    |> list.filter(fn(entry) {
+      let #(prop_name, prop_ref, _) = entry
+      option.is_none(schema_utils.constant_property_value(
+        prop_ref,
+        prop_name,
+        required,
+      ))
+    })
+    |> list.map(fn(entry) {
+      let #(_, _, field_name) = entry
       field_name <> ": " <> field_name
     })
 
@@ -1191,4 +1232,50 @@ fn maybe_doc_comment(
     Some(desc) -> sb |> se.doc_comment(desc)
     None -> sb
   }
+}
+
+/// Emit the decoder snippet for a constant (issue #309) field.
+///
+/// The wire value is required and fully determined at codegen time
+/// (an inline `enum: [<single>]`). The decoder reads it as a string
+/// and chains a `decode.then` that fails fast on any other value.
+/// `_` discards the binding because the surrounding record has no
+/// slot for the field. Failing on mismatch keeps the discriminator
+/// contract honest — silently accepting `kind: "media"` where only
+/// `kind: "text"` is legal would defeat the purpose of the enum.
+fn emit_constant_field_decoder(
+  sb: se.StringBuilder,
+  prop_name: String,
+  constant_value: String,
+) -> se.StringBuilder {
+  let escaped = escape_for_string_literal(constant_value)
+  sb
+  |> se.indent(
+    1,
+    "use _ <- decode.field(\""
+      <> prop_name
+      <> "\", decode.then(decode.string, fn(constant_value) {",
+  )
+  |> se.indent(2, "case constant_value {")
+  |> se.indent(3, "\"" <> escaped <> "\" -> decode.success(Nil)")
+  |> se.indent(
+    3,
+    "other -> decode.failure(Nil, \"expected "
+      <> prop_name
+      <> "=\\\""
+      <> escaped
+      <> "\\\", got \\\"\" <> other <> \"\\\"\")",
+  )
+  |> se.indent(2, "}")
+  |> se.indent(1, "}))")
+}
+
+/// Escape a spec-derived string so it can be safely interpolated
+/// inside a generated Gleam string literal. Mirrors the helper in
+/// `encoders.gleam` — extracted here to keep the decoder module
+/// self-contained for issue #309.
+fn escape_for_string_literal(value: String) -> String {
+  value
+  |> string.replace(each: "\\", with: "\\\\")
+  |> string.replace(each: "\"", with: "\\\"")
 }

--- a/src/oaspec/codegen/encoders.gleam
+++ b/src/oaspec/codegen/encoders.gleam
@@ -17,6 +17,7 @@ import oaspec/codegen/allof_merge
 import oaspec/codegen/context.{type Context, type GeneratedFile, GeneratedFile}
 import oaspec/codegen/ir_build
 import oaspec/codegen/schema_dispatch
+import oaspec/codegen/schema_utils
 import oaspec/codegen/types as type_gen
 import oaspec/config
 import oaspec/openapi/dedup
@@ -207,24 +208,35 @@ fn generate_inline_enum_encoders(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> se.StringBuilder {
-  let props = case schema_ref {
-    Inline(ObjectSchema(properties:, ..)) -> ir_build.sorted_entries(properties)
-    Inline(AllOfSchema(schemas:, ..)) ->
-      ir_build.sorted_entries(
-        allof_merge.merge_allof_schemas(schemas, ctx).properties,
-      )
-    _ -> []
+  let #(props, required) = case schema_ref {
+    Inline(ObjectSchema(properties:, required:, ..)) -> #(
+      ir_build.sorted_entries(properties),
+      required,
+    )
+    Inline(AllOfSchema(schemas:, ..)) -> {
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
+      #(ir_build.sorted_entries(merged.properties), merged.required)
+    }
+    _ -> #([], [])
   }
   list.fold(props, sb, fn(sb, entry) {
     let #(prop_name, prop_ref) = entry
-    case prop_ref {
-      Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
-        let enum_name =
-          naming.schema_to_type_name(parent_name)
-          <> naming.schema_to_type_name(prop_name)
-        generate_encoder(sb, enum_name, prop_ref, ctx)
-      }
-      _ -> sb
+    // Issue #309: a required inline single-value string-enum has no
+    // matching type in `types.gleam`, so generating an encoder for it
+    // would reference a non-existent type. Skip it; the parent
+    // object's encoder inlines the constant `json.string("...")`.
+    case schema_utils.constant_property_value(prop_ref, prop_name, required) {
+      Some(_) -> sb
+      None ->
+        case prop_ref {
+          Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
+            let enum_name =
+              naming.schema_to_type_name(parent_name)
+              <> naming.schema_to_type_name(prop_name)
+            generate_encoder(sb, enum_name, prop_ref, ctx)
+          }
+          _ -> sb
+        }
     }
   })
 }
@@ -362,13 +374,28 @@ fn generate_encoder(
             False -> ","
           }
 
-          let encoder_expr =
-            schema_ref_to_json_encoder(
-              "value." <> field_name,
-              prop_ref,
-              name,
-              prop_name,
-            )
+          // Issue #309: a required inline single-value string-enum
+          // property is elided from the generated record; the wire
+          // value is fixed at codegen time. Inline `json.string(...)`
+          // here so the encoder never tries to read a field that does
+          // not exist on the Gleam record. The downstream `case`
+          // branches still pick the right tuple/list-of-lists shape
+          // because the property is required and non-nullable.
+          let encoder_expr = case
+            schema_utils.constant_property_value(prop_ref, prop_name, required)
+          {
+            Some(constant_value) ->
+              "json.string(\""
+              <> escape_for_string_literal(constant_value)
+              <> "\")"
+            None ->
+              schema_ref_to_json_encoder(
+                "value." <> field_name,
+                prop_ref,
+                name,
+                prop_name,
+              )
+          }
 
           // Issue #296: required+nullable properties have Gleam type
           // Option(T) and must use json.nullable, not the bare encoder.
@@ -889,6 +916,17 @@ fn schema_ref_is_nullable(ref: SchemaRef) -> Bool {
 fn ensure_import(imports: List(String), name: String) -> List(String) {
   use <- bool.guard(list.contains(imports, name), imports)
   list.append(imports, [name])
+}
+
+/// Escape a spec-derived string so it can be safely interpolated
+/// inside a generated Gleam string literal (e.g. `json.string("...")`).
+/// Constant property values from issue #309 land here — practical
+/// values are simple identifiers (`text`, `media`, …) but a spec
+/// could in principle declare an enum value containing `"` or `\`.
+fn escape_for_string_literal(value: String) -> String {
+  value
+  |> string.replace(each: "\\", with: "\\\\")
+  |> string.replace(each: "\"", with: "\\\"")
 }
 
 /// Get element at index from a list, or return a default.

--- a/src/oaspec/codegen/ir_build.gleam
+++ b/src/oaspec/codegen/ir_build.gleam
@@ -614,11 +614,16 @@ fn inline_enums_for_schema(
   ctx: Context,
 ) -> List(Declaration) {
   case schema_ref {
-    Inline(ObjectSchema(properties:, ..)) ->
-      inline_enums_from_properties(parent_name, properties, ctx)
+    Inline(ObjectSchema(properties:, required:, ..)) ->
+      inline_enums_from_properties(parent_name, properties, required, ctx)
     Inline(AllOfSchema(schemas:, ..)) -> {
       let merged = allof_merge.merge_allof_schemas(schemas, ctx)
-      inline_enums_from_properties(parent_name, merged.properties, ctx)
+      inline_enums_from_properties(
+        parent_name,
+        merged.properties,
+        merged.required,
+        ctx,
+      )
     }
     _ -> []
   }
@@ -627,29 +632,41 @@ fn inline_enums_for_schema(
 fn inline_enums_from_properties(
   parent_name: String,
   properties: dict.Dict(String, SchemaRef),
+  required: List(String),
   _ctx: Context,
 ) -> List(Declaration) {
   let entries = sorted_entries(properties)
   list.filter_map(entries, fn(entry) {
     let #(prop_name, prop_ref) = entry
-    case prop_ref {
-      Inline(StringSchema(metadata:, enum_values:, ..)) if enum_values != [] -> {
-        let type_name =
-          naming.schema_to_type_name(parent_name)
-          <> naming.schema_to_type_name(prop_name)
-        let deduped_variants = dedup.dedup_enum_variants(enum_values)
-        let variants =
-          list.zip(enum_values, deduped_variants)
-          |> list.map(fn(pair) {
-            let #(_, variant_suffix) = pair
-            naming.schema_to_type_name(type_name) <> variant_suffix
-          })
-        Ok(ir.declaration(
-          doc: metadata.description,
-          type_def: EnumType(name: type_name, variants: variants),
-        ))
-      }
-      _ -> Error(Nil)
+    // Issue #309: a required property whose schema is an inline
+    // string-enum with exactly one allowed value is fully determined
+    // — the dispatching union variant or the single legal wire value
+    // already carries the choice. Skip emitting a tautological
+    // one-variant `*Kind` enum for it.
+    case schema_utils.constant_property_value(prop_ref, prop_name, required) {
+      Some(_) -> Error(Nil)
+      None ->
+        case prop_ref {
+          Inline(StringSchema(metadata:, enum_values:, ..))
+            if enum_values != []
+          -> {
+            let type_name =
+              naming.schema_to_type_name(parent_name)
+              <> naming.schema_to_type_name(prop_name)
+            let deduped_variants = dedup.dedup_enum_variants(enum_values)
+            let variants =
+              list.zip(enum_values, deduped_variants)
+              |> list.map(fn(pair) {
+                let #(_, variant_suffix) = pair
+                naming.schema_to_type_name(type_name) <> variant_suffix
+              })
+            Ok(ir.declaration(
+              doc: metadata.description,
+              type_def: EnumType(name: type_name, variants: variants),
+            ))
+          }
+          _ -> Error(Nil)
+        }
     }
   })
 }
@@ -686,7 +703,21 @@ fn schema_type_decls(
 ) -> List(Declaration) {
   case schema {
     ObjectSchema(metadata:, properties:, required:, additional_properties:, ..) -> {
-      let props = sorted_entries(properties)
+      // Issue #309: drop constant properties (required, inline,
+      // single-value string enums) from the generated record. The
+      // value is fixed at codegen time, so encoder emits the literal
+      // and decoder validates it — keeping the field would force
+      // every constructor call to restate `kind: KindOnly`.
+      let props =
+        sorted_entries(properties)
+        |> list.filter(fn(entry) {
+          let #(prop_name, prop_ref) = entry
+          option.is_none(schema_utils.constant_property_value(
+            prop_ref,
+            prop_name,
+            required,
+          ))
+        })
       let deduped_names =
         dedup.dedup_property_names(list.map(props, fn(e) { e.0 }))
 

--- a/src/oaspec/codegen/schema_utils.gleam
+++ b/src/oaspec/codegen/schema_utils.gleam
@@ -3,11 +3,12 @@
 /// to mirror these helpers from types.gleam.
 import gleam/dict
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import oaspec/codegen/context.{type Context}
 import oaspec/openapi/resolver
 import oaspec/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, Inline, ObjectSchema,
-  Reference, Typed, Untyped,
+  Reference, StringSchema, Typed, Untyped,
 }
 
 /// Check if a schema has typed or untyped additionalProperties that would need Dict.
@@ -73,6 +74,30 @@ pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
         Error(_) -> False
       }
     _ -> False
+  }
+}
+
+/// Issue #309: detect a property that is fully determined by the
+/// schema — an inline string-enum with exactly one allowed value that
+/// the parent schema lists as required. Such a property is a constant
+/// marker on the wire (e.g. a `kind: type: string, enum: [text]`
+/// discriminator on a oneOf variant): the only legal value is known
+/// at codegen time, so the generated record drops the field, the
+/// encoder emits the constant, and the decoder validates it.
+///
+/// Returns `Some(value)` for an elidable constant property; `None`
+/// otherwise (including `$ref`s, multi-value enums, optional
+/// properties, and non-string schemas — those keep their current
+/// record-field shape).
+pub fn constant_property_value(
+  prop_ref: SchemaRef,
+  prop_name: String,
+  required: List(String),
+) -> Option(String) {
+  case list.contains(required, prop_name), prop_ref {
+    True, Inline(StringSchema(enum_values: [single_value], ..)) ->
+      Some(single_value)
+    _, _ -> None
   }
 }
 

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -2420,3 +2420,183 @@ paths:
   string.contains(router_file.content, "status: 204, body: \"\"")
   |> should.be_false()
 }
+
+// ===================================================================
+// Single-value enum properties are elided as constants (issue #309)
+// ===================================================================
+
+/// A required, inline `type: string, enum: [<single-value>]` property
+/// must be treated as a constant — fully determined by the schema.
+/// The generated record drops the field, no tautological `*Kind`
+/// enum is emitted, the encoder inlines `json.string("<value>")`
+/// without reading a record field, and the decoder validates the
+/// wire value matches and discards it.
+pub fn types_constant_property_is_elided_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TextPostRequest:
+      type: object
+      required: [kind, body]
+      properties:
+        kind:
+          type: string
+          enum: [text]
+        body:
+          type: string
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let type_files = types_gen.generate(ctx)
+  let assert Ok(types_file) =
+    list.find(type_files, fn(f) { f.path == "types.gleam" })
+
+  // The record drops the constant `kind` field.
+  string.contains(types_file.content, "TextPostRequest(body: String)")
+  |> should.be_true()
+  // The tautological `*Kind` enum is not emitted.
+  string.contains(types_file.content, "TextPostRequestKind")
+  |> should.be_false()
+  // No constructor for the absent enum either.
+  string.contains(types_file.content, "TextPostRequestKindText")
+  |> should.be_false()
+}
+
+pub fn encoders_constant_property_emits_literal_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TextPostRequest:
+      type: object
+      required: [kind, body]
+      properties:
+        kind:
+          type: string
+          enum: [text]
+        body:
+          type: string
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let encoder_files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(encoder_files, fn(f) { f.path == "encode.gleam" })
+
+  // The encoder emits the constant inline — no `value.kind` access.
+  string.contains(encode_file.content, "json.string(\"text\")")
+  |> should.be_true()
+  string.contains(encode_file.content, "value.kind") |> should.be_false()
+  // The record's body field is still accessed normally.
+  string.contains(encode_file.content, "value.body") |> should.be_true()
+  // No orphan `encode_text_post_request_kind` function survives — the
+  // matching `*Kind` type was elided so emitting an encoder for it
+  // would produce a reference to a non-existent type.
+  string.contains(encode_file.content, "encode_text_post_request_kind")
+  |> should.be_false()
+}
+
+pub fn decoders_constant_property_validates_and_discards_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TextPostRequest:
+      type: object
+      required: [kind, body]
+      properties:
+        kind:
+          type: string
+          enum: [text]
+        body:
+          type: string
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let decoder_files = decoders.generate(ctx)
+  let assert Ok(decode_file) =
+    list.find(decoder_files, fn(f) { f.path == "decode.gleam" })
+
+  // The decoder reads and validates the constant, discarding via `_`.
+  string.contains(decode_file.content, "use _ <- decode.field(\"kind\",")
+  |> should.be_true()
+  // Validation is via decode.then on a string decoder — we accept the
+  // single legal value and fail otherwise so spec violations surface
+  // as decode errors rather than silently passing through.
+  string.contains(decode_file.content, "decode.then(decode.string,")
+  |> should.be_true()
+  string.contains(decode_file.content, "\"text\" -> decode.success(Nil)")
+  |> should.be_true()
+  string.contains(decode_file.content, "expected kind=\\\"text\\\"")
+  |> should.be_true()
+  // The success constructor must NOT pass `kind:` — the record has
+  // no slot for it.
+  string.contains(decode_file.content, "kind: kind") |> should.be_false()
+  // The matching record constructor still receives `body`.
+  string.contains(decode_file.content, "body: body") |> should.be_true()
+  // No orphan `text_post_request_kind_decoder` survives — the
+  // matching `*Kind` type was elided.
+  string.contains(decode_file.content, "text_post_request_kind_decoder")
+  |> should.be_false()
+}
+
+/// Optional single-value enum properties are NOT elided. The
+/// difference between `None` and `Some(theOnlyVariant)` is still
+/// meaningful (presence vs. absence on the wire), so the field
+/// stays as `Option(<Kind>)` and the `*Kind` enum is still emitted.
+pub fn types_optional_single_value_enum_is_kept_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Note:
+      type: object
+      required: [body]
+      properties:
+        kind:
+          type: string
+          enum: [text]
+        body:
+          type: string
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let type_files = types_gen.generate(ctx)
+  let assert Ok(types_file) =
+    list.find(type_files, fn(f) { f.path == "types.gleam" })
+
+  // Optional means the field is `Option(NoteKind)` and the enum is
+  // still emitted.
+  string.contains(types_file.content, "kind: Option(NoteKind)")
+  |> should.be_true()
+  string.contains(types_file.content, "NoteKindText") |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Fixes Issue #309. When a oneOf variant (or any object schema)
declares a property like:

```yaml
TextPostRequest:
  type: object
  required: [kind, body]
  properties:
    kind:
      type: string
      enum: [text]   # exactly one allowed value
    body:
      type: string
```

oaspec used to emit a tautological one-variant Gleam enum
(`pub type TextPostRequestKind { TextPostRequestKindText }`) and
force every constructor of `TextPostRequest` to pass
`kind: TextPostRequestKindText` — fully determined noise that
multiplies at every handler / test fixture / client call site for a
six-variant union.

This PR treats such properties as constants:

- The generated record drops the field
  (`TextPostRequest(body: String)` instead of
  `TextPostRequest(body: String, kind: TextPostRequestKind)`).
- The matching `*Kind` enum type is not emitted.
- The encoder inlines `[#("kind", json.string("text"))]` so the
  wire format is unchanged.
- The decoder reads the field, validates it equals the
  codegen-time constant via `decode.then`, and discards the value
  via `_`. A wire mismatch (`kind: "media"` where only `kind: "text"`
  is legal) now surfaces as a decode error instead of silently
  passing through.

## Scope

- **Required** properties only. Optional single-value enums (`Some
  (theOnlyVariant)` vs. `None`) carry meaningful presence/absence
  information — they keep their current `Option(<Kind>)` shape.
- **Inline** schemas only. A `$ref` to a top-level component enum
  (`PostKind` defined under `components.schemas`) is left alone
  because the component is an independent type that may be
  referenced from multiple places.
- **String** schemas only. Other primitive enums (`type: integer,
  enum: [42]`) are not touched.

## Changes

- `src/oaspec/codegen/schema_utils.gleam`: new
  `constant_property_value(prop_ref, prop_name, required)` helper
  returns `Some(value)` when a property is elidable. All four
  affected codegen modules call into this single source of truth.
- `src/oaspec/codegen/ir_build.gleam`:
  - `inline_enums_from_properties` skips the `*Kind` declaration
    for constant properties (and now threads the parent's
    `required` list through both ObjectSchema and AllOfSchema
    cases).
  - `schema_type_decls` ObjectSchema branch filters constant
    properties before computing the record's field list.
- `src/oaspec/codegen/encoders.gleam`:
  - The per-property emission loop replaces the encoder expression
    with `json.string("<constant>")` for constant properties, so
    the encoder never tries to read a record field that does not
    exist.
  - `generate_inline_enum_encoders` skips constants (matching the
    type elision in ir_build).
  - New `escape_for_string_literal` helper protects against spec
    enum values containing `"` or `\`.
- `src/oaspec/codegen/decoders.gleam`:
  - The per-property emission loop emits a `decode.then` chain that
    validates the constant and discards via `_`.
  - The success constructor's `param_names` list filters out
    constant properties so the record constructor receives only
    the surviving fields.
  - `generate_inline_enum_decoders` skips constants (so no orphan
    decoder references the elided type).
  - New `emit_constant_field_decoder` and
    `escape_for_string_literal` helpers.
- `test/codegen_unit_test.gleam`: four new tests cover the type
  elision, encoder inlining, decoder validate-and-discard, and the
  optional-stays-untouched negative case.
- `integration_test/run.sh`: new Step 20 generates a spec with a
  constant property, runs an encode → decode round-trip, and
  asserts that a wire payload claiming a different discriminator
  value fails decoding.
- `CHANGELOG.md`: documented as a breaking change under
  `### Changed`.
- `README.md`: bumped unit test count (772 → 776).

## Design Decisions

- **One detection helper, four call sites.** Filtering at the IR
  layer alone wouldn't work — the encoder still needs to KNOW about
  the constant to emit the literal on the wire, and the decoder
  needs to validate it. So the helper lives in `schema_utils` and
  every codegen module that iterates object properties (types,
  encoder, decoder, inline-enum passes) consults it.
- **Decoder validates rather than ignores.** A spec that declares
  `kind: enum: [text]` is asserting that the only legal wire value
  is `"text"`. Silently accepting `kind: "media"` would defeat the
  purpose of the constraint and mask real bugs; the
  `decode.failure` arm makes the violation explicit.
- **Inline-only, required-only.** Limiting the elision keeps the
  surface area predictable: optional and `$ref`-typed enums retain
  their current shape, so user-facing handler call sites only see
  the change for the exact pattern the issue describes.
- **No special-casing for oneOf discriminators.** The codegen
  doesn't need to know whether the parent object is a oneOf
  variant — the rule "required + inline + single-value string
  enum" already targets the discriminator pattern by definition.
  This avoids cross-module coupling between `oneOf` codegen and
  per-object codegen.

## Test Plan

- [x] `gleam test` — 776 passes (4 new unit tests for #309).
- [x] `bash integration_test/run.sh` — Step 20 round-trips a
  `TextPostRequest`, asserts the encoder emits `"kind":"text"`,
  the decoder accepts it, and a `kind: "media"` wire payload is
  rejected.
- [x] `gleam format` — clean.
- [x] `gleam run -m glinter` — 0 errors / 0 warnings.
- [x] `bash scripts/check_sync.sh` — versions/counts in sync.
- [x] `bash scripts/check_readme_examples.sh` — README snippets
  compile.
- [x] Existing golden fixtures unchanged (no spec uses single-value
  required string enums, so encoder/decoder/types output is
  byte-identical).

Closes #309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Required single-value enum fields are now inlined as constants in generated code—constructor arguments omitted, JSON encoders emit literals directly, and decoders validate wire values.
  
* **Tests**
  * Added unit and integration tests validating constant enum inlining behavior and wire validation.

* **Documentation**
  * Updated test metrics and added changelog entry documenting breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->