### PR TITLE
fix(codegen): import types module in router for enum-ref params (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen**: Generated `router.gleam` now imports the package's
+  `types` module when an OpenAPI operation has an `$ref`-based string
+  enum query, header, or cookie parameter. Previously the router body
+  emitted `types.<EnumType><Variant>` references in the inline match
+  expressions for those parameters but the import was gated only on
+  deep object / form / multipart bodies, so a spec like `parameters: [{
+  in: query, name: status, schema: { $ref:
+  '#/components/schemas/BookStatus' } }]` produced a router that
+  failed to compile (`Unknown module types`). Closes #318.
+
 ## [0.24.0] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 776 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 778 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/server.gleam
+++ b/src/oaspec/codegen/server.gleam
@@ -606,8 +606,18 @@ fn generate_router(
     config.package(context.config(ctx)) <> "/handlers",
     config.package(context.config(ctx)) <> "/handlers_generated",
   ]
+  // Issue #318: enum query / header / cookie parameters resolved through
+  // `$ref` cause the router body to emit `types.<EnumType><Variant>`
+  // references (see decode_helpers.enum_match_result_expr and
+  // enum_match_option_expr). The `types` import must be present in
+  // those cases too, not just for deep object / form / multipart.
+  let has_enum_ref_params =
+    decode_helpers.operations_have_enum_ref_params(operations, ctx)
   let pkg_imports = case
-    has_deep_object || has_form_urlencoded_body || has_multipart_body
+    has_deep_object
+    || has_form_urlencoded_body
+    || has_multipart_body
+    || has_enum_ref_params
   {
     True ->
       list.append(pkg_imports, [config.package(context.config(ctx)) <> "/types"])

--- a/src/oaspec/codegen/server_request_decode.gleam
+++ b/src/oaspec/codegen/server_request_decode.gleam
@@ -317,6 +317,42 @@ pub fn schema_ref_string_enum(
   }
 }
 
+/// True iff any query / header / cookie parameter on any of the given
+/// operations has a `$ref` schema that resolves to a string-enum.
+///
+/// Issue #318: the router emits `types.<EnumType><Variant>` references
+/// for these parameters (see `enum_match_result_expr` and
+/// `enum_match_option_expr` below), but the import of the `types`
+/// module is gated on a separate set of features (deep object, form,
+/// multipart). This helper lets the router-import logic ask "does any
+/// of my emitted code reference `types`?" without re-implementing the
+/// per-param dispatch.
+pub fn operations_have_enum_ref_params(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  ctx: Context,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(operation.parameters, fn(ref_p) {
+      case ref_p {
+        Value(p) -> parameter_is_enum_ref(p, ctx)
+        _ -> False
+      }
+    })
+  })
+}
+
+fn parameter_is_enum_ref(p: spec.Parameter(Resolved), ctx: Context) -> Bool {
+  case p.in_, spec.parameter_schema(p) {
+    spec.InQuery, Some(s) | spec.InHeader, Some(s) | spec.InCookie, Some(s) ->
+      case schema_ref_string_enum(s, ctx) {
+        Some(_) -> True
+        None -> False
+      }
+    _, _ -> False
+  }
+}
+
 /// Render the inline Gleam expression that converts a raw query-string
 /// `<bound_var>` into `Result(types.<TypeName><Variant>, Nil)`. Used by
 /// the required-enum query path (server.gleam opens a case on this

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1892,6 +1892,11 @@ components:
   // `Some(v)` that would assign a raw String into the enum slot.
   string.contains(router_file.content, "Ok([v, ..]) -> Some(v)")
   |> should.be_false()
+  // Issue #318: when the router body references types.* (e.g.
+  // `Some(types.VisibilityPublic)`), the file must `import api/types`
+  // so the generated module compiles without manual edits.
+  string.contains(router_file.content, "import api/types")
+  |> should.be_true()
 }
 
 /// Required `$ref` enum query parameter must emit the same Result
@@ -1960,6 +1965,11 @@ components:
     router_file.content,
     "[#(\"content-type\", \"application/problem+json\")]",
   )
+  |> should.be_true()
+  // Issue #318: when the router body references types.* (e.g.
+  // `Ok(types.PriorityLow)`), the file must `import api/types` so the
+  // generated module compiles without manual edits.
+  string.contains(router_file.content, "import api/types")
   |> should.be_true()
 }
 

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1973,6 +1973,97 @@ components:
   |> should.be_true()
 }
 
+/// Issue #318: enum-ref header parameter must also trigger the
+/// `import <pkg>/types` line in router.gleam, since the same emitter
+/// (`enum_match_*_expr`) is used for `in: header` parameters.
+pub fn server_enum_ref_header_param_imports_types_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - in: header
+          name: X-Mode
+          required: false
+          schema:
+            $ref: '#/components/schemas/Mode'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Mode:
+      type: string
+      enum: [auto, manual]
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  // The router emits `types.Mode<Variant>` references for the inline
+  // header decode; the file must import the types module so it compiles.
+  string.contains(router_file.content, "import api/types")
+  |> should.be_true()
+}
+
+/// Issue #318: enum-ref cookie parameter must also trigger the
+/// `import <pkg>/types` line in router.gleam.
+pub fn server_enum_ref_cookie_param_imports_types_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - in: cookie
+          name: theme
+          required: false
+          schema:
+            $ref: '#/components/schemas/Theme'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Theme:
+      type: string
+      enum: [light, dark]
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+
+  string.contains(router_file.content, "import api/types")
+  |> should.be_true()
+}
+
 // ===================================================================
 // Router error responses use Problem JSON (issue #307)
 // ===================================================================


### PR DESCRIPTION
## Summary

Generated `router.gleam` was missing `import <package>/types` whenever an OpenAPI operation had an `$ref`-based string-enum query, header, or cookie parameter. The router body emits `Some(types.<EnumType><Variant>)` (and `Ok(types.<EnumType><Variant>)`) inline-match expressions in those cases, so the file fails to compile straight from `oaspec generate`.

The import was previously gated only on deep object / form-urlencoded / multipart body usage. This adds a fourth condition: enum-ref params on any operation.

Closes #318.

## Changes

- `src/oaspec/codegen/server_request_decode.gleam` — new helper `operations_have_enum_ref_params(operations, ctx)` that checks every query / header / cookie parameter against the existing `schema_ref_string_enum` predicate.
- `src/oaspec/codegen/server.gleam` — extends the `types` import condition with the new helper.
- `test/codegen_unit_test.gleam` — extends the two existing enum-query tests (optional and required) to assert that `import api/types` is present in the emitted router. Both assertions fail on `main`; both pass with the fix.

## Design Decisions

- The helper lives next to `schema_ref_string_enum` (the predicate the router decode emitters consume), since the new helper is a logical "is this set of operations going to make me emit such expressions?" question.
- Path parameters are excluded — path enums are decoded as strings in the URL match, not via the inline `case` machinery that produces `types.*` references.
- The condition is added with `||` rather than replacing the existing checks. The existing deep-object / form / multipart cases stay distinct and their semantics are unchanged.

## Verification

- `gleam format --check src/ test/` — clean
- `gleam check` — clean
- `gleam build --warnings-as-errors` — clean
- `gleam test` — 776 passed (the two enum-query tests now also assert the import; both pass)
- `bash integration_test/run.sh` — clean
- `gleam run -m gleescript` + `bash scripts/smoke_escript.sh ./oaspec` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation issue where router code referencing string enum parameters (query/header/cookie) would fail to compile due to missing imports. The generator now properly ensures required type modules are imported in all applicable cases.

* **Tests**
  * Enhanced test coverage to verify router imports are correctly generated for enum parameter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->