### PR TITLE
fix(config): reject output.dir paths under existing src/ subtree (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **config**: oaspec now refuses an `output.dir` value that places the
+  package directory underneath a `src/` subdirectory (e.g.
+  `./src/gen`). The previous behaviour silently emitted files at
+  `src/gen/<pkg>/types.gleam` while imports inside those files said
+  `import <pkg>/types` — paths the Gleam compiler can't resolve, so
+  `gleam build` failed with a wall of `Unknown module ...` errors and
+  no diagnostic from oaspec. The check accepts both `./src` (generated
+  modules live directly under the project's `src/`) and any path
+  outside an existing `src/` tree (treated as a standalone Gleam
+  project root). Closes #319.
+
 - **codegen**: Generated `router.gleam` now imports the package's
   `types` module when an OpenAPI operation has an `$ref`-based string
   enum query, header, or cookie parameter. Previously the router body

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 778 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 783 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/cli.gleam
+++ b/src/oaspec/cli.gleam
@@ -542,7 +542,11 @@ fn load_config(
     None -> cfg
     Some(path) -> config.with_output(cfg, Some(path))
   }
-  config.validate_output_package_match(cfg)
+  use _ <- result.try(
+    config.validate_output_package_match(cfg)
+    |> result.map_error(OutputValidationError),
+  )
+  config.validate_output_dir_layout(cfg)
   |> result.map(fn(_) { cfg })
   |> result.map_error(OutputValidationError)
 }

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -306,6 +306,73 @@ fn basename(path: String) -> String {
   |> result.unwrap("")
 }
 
+/// Validate the on-disk layout implied by `output.dir`.
+///
+/// Issue #319: when `output.dir` is something like `./src/gen`, generated
+/// code lands at `src/gen/<pkg>/types.gleam` whose Gleam module path is
+/// `gen/<pkg>/types` — but oaspec emits `import <pkg>/types`, which the
+/// compiler can't resolve. Catch this at config time so the user sees a
+/// clear error instead of a wall of `Unknown module ...` from
+/// `gleam build`.
+///
+/// Heuristic: in the path leading up to the package directory, `src`
+/// must either be the immediate parent of the package (the "<dir> is
+/// the project's src/" pattern) or be absent (the standalone-Gleam-
+/// project pattern). `src` in any other position is the foot-gun.
+pub fn validate_output_dir_layout(config: Config) -> Result(Nil, ConfigError) {
+  case config.mode {
+    Server | Both ->
+      case path_has_misplaced_src(config.output_server) {
+        False -> Ok(Nil)
+        True ->
+          Error(misplaced_src_error("output.server", config.output_server))
+      }
+    Client -> Ok(Nil)
+  }
+  |> result.try(fn(_) {
+    case config.mode {
+      Client | Both ->
+        case path_has_misplaced_src(config.output_client) {
+          False -> Ok(Nil)
+          True ->
+            Error(misplaced_src_error("output.client", config.output_client))
+        }
+      Server -> Ok(Nil)
+    }
+  })
+}
+
+fn misplaced_src_error(field: String, path: String) -> ConfigError {
+  InvalidValue(
+    field: field,
+    detail: "'"
+      <> path
+      <> "' contains a 'src' segment that is not the immediate parent of the package directory. Generated code lands inside src/.../<package>/, but oaspec emits imports as `<package>/...`, which the Gleam compiler resolves relative to src/, not relative to <dir>. Either set the path so that 'src' is the direct parent of the package directory (e.g. './src'), or move the output outside any 'src/' tree (e.g. './gen') and treat that directory as a standalone Gleam project root with its own gleam.toml.",
+  )
+}
+
+fn path_has_misplaced_src(path: String) -> Bool {
+  let segments =
+    path
+    |> string.split("/")
+    |> list.filter(fn(s) { s != "" && s != "." })
+  case list.reverse(segments) {
+    // Strip the final segment (the package directory). Inspect what's
+    // left — the "directory chain" leading up to the package.
+    [_pkg, ..rest_reversed] -> {
+      let parent_segments = list.reverse(rest_reversed)
+      case list.last(parent_segments) {
+        // 'src' is the immediate parent of the package — correct shape.
+        Ok("src") -> False
+        // No parent segment, or some other parent: foot-gun iff 'src'
+        // appears anywhere earlier in the path.
+        _ -> list.any(parent_segments, fn(s) { s == "src" })
+      }
+    }
+    [] -> False
+  }
+}
+
 /// Convert config error to a human-readable string.
 pub fn error_to_string(error: ConfigError) -> String {
   case error {

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -222,6 +222,79 @@ pub fn config_package_dir_match_test() {
   should.be_ok(result)
 }
 
+// Issue #319: output.dir layout validation. `src/<sub>/<package>` is the
+// foot-gun pattern; `src/<package>` and `<gen-root>/<package>` are fine.
+
+pub fn config_output_dir_under_src_subdir_is_rejected_test() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/gen/api",
+      output_client: "./src/gen/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_error(result)
+}
+
+pub fn config_output_dir_directly_under_src_is_accepted_test() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/api",
+      output_client: "./src/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_ok(result)
+}
+
+pub fn config_output_dir_outside_src_is_accepted_test() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/api",
+      output_client: "./gen/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_ok(result)
+}
+
+pub fn config_output_dir_deep_under_src_is_rejected_test() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./pkg/src/gen/api",
+      output_client: "./pkg/src/gen/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_error(result)
+}
+
+pub fn config_output_dir_client_only_under_src_subdir_is_rejected_test() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/api",
+      output_client: "./src/gen/api_client",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_error(result)
+}
+
 // --- Parser Tests ---
 
 pub fn parse_petstore_test() {


### PR DESCRIPTION
## Summary

`output.dir` values that put the package directory underneath an existing `src/` subtree (e.g. `./src/gen`) silently produced uncompilable code: the generator wrote files at `src/gen/<pkg>/types.gleam` while imports inside those files said `import <pkg>/types`, which Gleam can't resolve relative to `src/`. The user only learned about the trap from a wall of `Unknown module ...` errors at `gleam build` time.

This adds a config-time validator that rejects the foot-gun pattern with a clear error before any files are written.

Closes #319.

## Changes

- `src/oaspec/config.gleam` — new public function `validate_output_dir_layout(config) -> Result(Nil, ConfigError)`. It walks the path leading up to the package directory and accepts:
  - `src` as the immediate parent of the package (`./src/<pkg>` — the documented "<dir> is the project's src/" pattern), and
  - paths with no `src` segment at all (treated as a standalone Gleam project root),
  but rejects `src` appearing as any other segment (`./src/gen/<pkg>`, `./pkg/src/gen/<pkg>`, …).
- `src/oaspec/cli.gleam` — wires the new validator into `load_config()` after `validate_output_package_match()`. Both errors flow through the existing `OutputValidationError` variant, so the user-facing message style is unchanged.
- `test/oaspec_test.gleam` — five new tests cover:
  - `./src/gen/api` rejected
  - `./src/api` accepted
  - `./gen/api` accepted (standalone project pattern)
  - `./pkg/src/gen/api` rejected (deep `src` segment)
  - server OK + client foot-gun → rejected (the `mode: Both` short-circuit must check both sides)
- `CHANGELOG.md` — Unreleased entry documenting the fix.
- `README.md` — bumps the unit test count to 783 (sync-check requirement).

## Design Decisions

- **Validation, not auto-derivation.** The issue suggested two options: validate, or compute imports relative to the chosen `dir`. Validation is far less invasive and addresses the documented foot-gun directly. Auto-deriving imports would require threading the relative path through every codegen module that emits an `import <pkg>/...` line — a substantial refactor.
- **Heuristic, not stat-based.** I considered checking for an actual `gleam.toml` near `output.dir` to distinguish "standalone project root" from "subdirectory of an existing project". The path-segment heuristic is simpler and covers the documented case; a `gleam.toml` lookup would touch the filesystem from a config validator that today is a pure function.
- **Error message includes both fixes.** When the validator fails, the message tells the user the two valid shapes (`./src` or a standalone root). The aim is "fix the foot-gun without re-reading the README".

## Verification

- `gleam format --check src/ test/` — clean
- `gleam build --warnings-as-errors` — clean
- `gleam test` — 783 passed (5 new tests)
- `bash scripts/check_sync.sh` — clean (README test count synced)
