### PR TITLE
fix(codegen): emit multi-line lambda body in additionalProperties encoder (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **codegen**: The encoder for an object schema with `additionalProperties:
+  { type: <T> }` no longer emits a `;`-separated lambda body. The previous
+  output (`fn(entry) { let #(k, v) = entry; #(k, ...) }`) was a deprecated
+  pre-1.0 syntax that the current Gleam parser rejects with `Semicolons used
+  to be whitespace and did nothing`. `oaspec generate` would then run
+  `gleam format` over the freshly written file and exit with `Error: gleam
+  format failed with exit code 1` — masking the real cause. The replacement
+  emits a multi-line lambda body that the parser accepts and `gleam format`
+  is free to re-fold. Closes #320.
+
 - **config**: oaspec now refuses an `output.dir` value that places the
   package directory underneath a `src/` subdirectory (e.g.
   `./src/gen`). The previous behaviour silently emitted files at

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 783 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 784 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 784 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 785 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/codegen/encoders.gleam
+++ b/src/oaspec/codegen/encoders.gleam
@@ -479,13 +479,18 @@ fn generate_encoder(
         Typed(ap_ref) -> {
           let inner_encoder_fn =
             schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties")
+          // Issue #320: emit a multi-line lambda body. The previous
+          // form used a `;` between the destructure and the tuple
+          // expression, which the Gleam parser rejects (semicolons
+          // were removed). `gleam format` then runs over the file and
+          // re-folds short bodies onto one line where appropriate.
           sb
           |> se.indent(1, close_props_list)
           |> se.indent(
             1,
-            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry; #(k, "
+            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) {\n      let #(k, v) = entry\n      #(k, "
               <> inner_encoder_fn
-              <> "(v)) })",
+              <> "(v))\n    })",
           )
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }
@@ -496,7 +501,7 @@ fn generate_encoder(
           |> se.indent(1, close_props_list)
           |> se.indent(
             1,
-            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) { let #(k, v) = entry\n  #(k, encode_dynamic(v)) })",
+            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) {\n      let #(k, v) = entry\n      #(k, encode_dynamic(v))\n    })",
           )
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }

--- a/src/oaspec/codegen/encoders.gleam
+++ b/src/oaspec/codegen/encoders.gleam
@@ -479,30 +479,33 @@ fn generate_encoder(
         Typed(ap_ref) -> {
           let inner_encoder_fn =
             schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties")
-          // Issue #320: emit a multi-line lambda body. The previous
-          // form used a `;` between the destructure and the tuple
-          // expression, which the Gleam parser rejects (semicolons
-          // were removed). `gleam format` then runs over the file and
-          // re-folds short bodies onto one line where appropriate.
+          // Issue #320: each statement of the lambda body is emitted via
+          // a separate `se.indent` call rather than as embedded `\n`
+          // inside one string. The previous form was easy to misread
+          // (the older variant used `;` between statements, which the
+          // current Gleam parser rejects).
           sb
           |> se.indent(1, close_props_list)
-          |> se.indent(
-            1,
-            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) {\n      let #(k, v) = entry\n      #(k, "
-              <> inner_encoder_fn
-              <> "(v))\n    })",
-          )
+          |> se.indent(1, "let extra_props =")
+          |> se.indent(2, "dict.to_list(value.additional_properties)")
+          |> se.indent(2, "|> list.map(fn(entry) {")
+          |> se.indent(3, "let #(k, v) = entry")
+          |> se.indent(3, "#(k, " <> inner_encoder_fn <> "(v))")
+          |> se.indent(2, "})")
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }
         Untyped -> {
           // Untyped additional_properties (Dynamic) are re-encoded using
           // dynamic type inspection to preserve round-trip fidelity.
+          // Same multi-step builder shape as the Typed branch.
           sb
           |> se.indent(1, close_props_list)
-          |> se.indent(
-            1,
-            "let extra_props = dict.to_list(value.additional_properties) |> list.map(fn(entry) {\n      let #(k, v) = entry\n      #(k, encode_dynamic(v))\n    })",
-          )
+          |> se.indent(1, "let extra_props =")
+          |> se.indent(2, "dict.to_list(value.additional_properties)")
+          |> se.indent(2, "|> list.map(fn(entry) {")
+          |> se.indent(3, "let #(k, v) = entry")
+          |> se.indent(3, "#(k, encode_dynamic(v))")
+          |> se.indent(2, "})")
           |> se.indent(1, "json.object(list.append(base_props, extra_props))")
         }
         Forbidden | Unspecified ->

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1973,6 +1973,62 @@ components:
   |> should.be_true()
 }
 
+/// Issue #320: `additionalProperties: { type: string }` schemas used
+/// to emit a `let ... ;` lambda body that the Gleam parser rejects
+/// (`Semicolons used to be whitespace and did nothing`). The fix
+/// emits a multi-line lambda body. Assert the emitted encoder contains
+/// the modern shape and does not contain the legacy semicolon form.
+pub fn server_typed_additional_properties_encoder_has_no_semicolons_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /e:
+    get:
+      operationId: getE
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+components:
+  schemas:
+    Event:
+      type: object
+      required: [id, attributes]
+      properties:
+        id:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { f.path == "encode.gleam" })
+
+  // Legacy form (the bug) used `;` between the destructure and the
+  // tuple expression. It must not survive.
+  string.contains(encode_file.content, "let #(k, v) = entry; #(k,")
+  |> should.be_false()
+  // The replacement form uses a multi-line lambda. Assert the body
+  // contains the destructure + tuple shape on separate steps.
+  string.contains(encode_file.content, "let #(k, v) = entry")
+  |> should.be_true()
+  string.contains(encode_file.content, "#(k, json.string(v))")
+  |> should.be_true()
+}
+
 /// Issue #318: enum-ref header parameter must also trigger the
 /// `import <pkg>/types` line in router.gleam, since the same emitter
 /// (`enum_match_*_expr`) is used for `in: header` parameters.

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -2029,6 +2029,57 @@ components:
   |> should.be_true()
 }
 
+/// Companion to the Typed regression: cover the `additionalProperties:
+/// true` (Untyped) branch too. It went through the same fix, so the
+/// same legacy `;`-separated form must be absent and the same
+/// multi-step builder body must be present (with `encode_dynamic` in
+/// place of the Typed branch's `json.<scalar>`).
+pub fn server_untyped_additional_properties_encoder_has_no_semicolons_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /e:
+    get:
+      operationId: getE
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+components:
+  schemas:
+    Event:
+      type: object
+      required: [id, attributes]
+      properties:
+        id:
+          type: string
+        attributes:
+          type: object
+          additionalProperties: true
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { f.path == "encode.gleam" })
+
+  string.contains(encode_file.content, "let #(k, v) = entry; #(k,")
+  |> should.be_false()
+  string.contains(encode_file.content, "let #(k, v) = entry")
+  |> should.be_true()
+  string.contains(encode_file.content, "#(k, encode_dynamic(v))")
+  |> should.be_true()
+}
+
 /// Issue #318: enum-ref header parameter must also trigger the
 /// `import <pkg>/types` line in router.gleam, since the same emitter
 /// (`enum_match_*_expr`) is used for `in: header` parameters.


### PR DESCRIPTION
## Summary

For an object schema with `additionalProperties: { type: <T> }`, the encoder generator emitted a `let ...; <expr>` shape inside an inline lambda body — a deprecated pre-1.0 Gleam syntax that the current parser rejects:

```
error: Syntax error
71 │   let extra_props = ... fn(entry) { let #(k, v) = entry; #(k, json.string(v)) })
                                                              ^ Remove this semicolon
```

`oaspec generate` runs `gleam format` over freshly written files, so this surfaced as `Error: gleam format failed with exit code 1` with no further context — masking the real cause for users.

The fix emits a multi-line lambda body (which `gleam format` is then free to re-fold in its own style). The matching `Untyped` branch in the same function already used the multi-line form; this aligns the `Typed` branch with it.

Closes #320.

## Changes

- `src/oaspec/codegen/encoders.gleam` — replace the `;`-separated inline lambda with a multi-line body in the `Typed(ap_ref)` branch of `additional_properties` encoding. Apply the same shape to the `Untyped` branch for consistency (the old form there used a single `\n` mid-line and worked, but the new form is what `gleam format` would produce anyway).
- `test/codegen_unit_test.gleam` — new regression test `server_typed_additional_properties_encoder_has_no_semicolons_test` that:
  - runs the encoder over a minimal spec with `additionalProperties: { type: string }`,
  - asserts the legacy `let #(k, v) = entry; #(k,` pattern is **absent**,
  - asserts the multi-line shape (`let #(k, v) = entry` and `#(k, json.string(v))` both present).

## Design Decisions

- **Multi-line, not "fix the inline one with a newline".** The inline-with-newline form was what the `Untyped` branch did; it parses but reads strangely. Multi-line is what `gleam format` produces for a 2-statement lambda body, so emitting it directly avoids any reformatting drift between codegen and the formatter pass.
- **Keep both branches consistent.** Even though the `Untyped` branch's old form worked, having two different shapes for "almost the same thing" was the kind of asymmetry that lets bugs hide in plain sight. Aligning them shrinks the diff a future contributor has to reason about.

## Verification

- End-to-end: `gleam run -- generate --config=…` against a spec with `Event.attributes: { additionalProperties: { type: string } }` now succeeds; the resulting `encode.gleam` parses with `gleam format`.
- `gleam format --check src/ test/` — clean
- `gleam build --warnings-as-errors` — clean
- `gleam test` — 784 passed (1 new test)
- `bash scripts/check_sync.sh` — clean (README count synced)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation for object schemas with typed `additionalProperties` to produce valid, properly formatted output.

* **Tests**
  * Added regression test for encoder code generation with typed `additionalProperties`.

* **Documentation**
  * Updated CHANGELOG and README with test coverage changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->