### PR TITLE
docs(readme): document format: byte / format: binary pass-through behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.28.0] - 2026-04-29
+### Documentation
+
+- README "OpenAPI Support" now has an explicit section on
+  `format: byte` / `format: binary` documenting the current
+  pass-through-as-String behaviour and the implications for callers
+  (manual base64 decode required for `format: byte`, no validation
+  on invalid base64 input). Materialising `format: byte` as
+  `BitArray` automatically remains a future enhancement tracked on
+  #338. (#338)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,31 @@ Coverage is strongest in these areas:
 - Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code.
 - Generation safety: name collision handling, keyword escaping, validation guards, and capability errors with clear failure modes
 
+### `format: byte` and `format: binary`
+
+The OpenAPI `format` keyword on a `string` schema is **passed through as
+metadata only** in the current release. Generated fields keep the Gleam
+type `String`; the encoded contract (`format: byte` = base64 per OAS 3.0
+§4.7.4 / OAS 3.1 alignment with JSON Schema, `format: binary` = raw
+bytes) is not enforced or materialised by the generator.
+
+Practical implications:
+
+- `format: byte`: the field is decoded and emitted as the literal
+  base64 character string. Callers that need the underlying bytes must
+  base64-decode themselves (e.g. with `yabase/facade.decode_base64`).
+  Invalid base64 input is **not rejected** at decode time.
+- `format: binary`: the field is decoded and emitted as a plain
+  `String`. For `multipart/form-data` request bodies, the higher-level
+  body codepath (`client_request`) already handles binary bodies
+  correctly via `BytesBody`; this caveat only applies when `binary`
+  appears as a field-level format on a string schema outside that
+  context.
+
+A future release may auto-decode `format: byte` to `BitArray` or emit
+a `format` docstring on the generated field; tracking issue
+[#338](https://github.com/nao1215/oaspec/issues/338).
+
 <!-- BEGIN GENERATED:BOUNDARIES -->
 ## Current Boundaries
 


### PR DESCRIPTION
## Summary

Document the current pass-through-as-`String` behaviour of `format: byte` and `format: binary` so callers know what to expect. The deeper enhancement (auto-decode `format: byte` to `BitArray` or emit a `format` docstring on the generated field) is a non-trivial codegen change and is left as a follow-up tracked on the same issue.

## Changes

- `README.md`: new "`format: byte` and `format: binary`" subsection inside "OpenAPI Support", placed before the auto-generated boundaries block. Spells out:
  - `format: byte` is decoded as the literal base64 character string; callers must base64-decode themselves
  - invalid base64 input is **not** rejected at decode time
  - `format: binary` on a string schema is also pass-through; the body-level `BytesBody` codepath is unaffected
- `CHANGELOG.md`: `Documentation` entry under `[Unreleased]` linking back to the issue

## Design Decisions

Scope is intentionally narrow: this PR is docs-only. Two follow-up paths remain:

1. **Auto-materialise `format: byte`** to `BitArray` in generated types, with the decoder running base64 on the way in and the encoder running base64 on the way out. This is what most other OpenAPI generators (`openapi-generator`, `oapi-codegen`, `prism`) do. The generator change is non-trivial because it touches `types.gleam`, `decoders.gleam`, `encoders.gleam`, and the per-format dispatch in `schema_dispatch.gleam`.
2. **Emit a docstring on the generated field** when the source schema has `format: byte` or `format: binary`. Less invasive than (1); user keeps `String` but knows the contract.

Either follow-up can be tracked under the same issue (#338) once a maintainer picks the trade-off. This PR removes the most pressing pain point — silent surprise — by making the current behaviour discoverable from the README.

Closes #338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on OpenAPI `format: byte` and `format: binary` handling semantics, including current behavior, runtime expectations, and limitations.
  * Clarified that format specifications are preserved as metadata without enforcement, with notes on potential future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->