### PR TITLE
fix(decoders): enforce additionalProperties: false at decode time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`additionalProperties: false` is now enforced at decode time.**
+  Generated decoders for closed object schemas previously accepted
+  JSON bodies containing unknown fields and silently dropped them —
+  the strictest opt-in OpenAPI validation knob was a no-op. The
+  decoder now reads the raw JSON object as `Dict(String, Dynamic)`,
+  drops the declared property keys, and fails the decode with the
+  reason `"additionalProperties"` if any extras remain. The check
+  happens in the decoder body because `gleam/dynamic/decode`
+  consumes only declared fields, so a post-decode validator could
+  not recover the raw key set. Behavioural change for clients
+  already mishandling extras: their previously-passing JSON now
+  rejects, surfacing the spec violation. The shape `additional_properties: true` and `additionalProperties: { schema }`
+  variants are unchanged. (#336)
+
 ### Changed
 
 - **`guards.gleam` codegen** no longer emits byte-identical per-field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   reason `"additionalProperties"` if any extras remain. The check
   happens in the decoder body because `gleam/dynamic/decode`
   consumes only declared fields, so a post-decode validator could
-  not recover the raw key set. Behavioural change for clients
+  not recover the raw key set. Behavioral change for clients
   already mishandling extras: their previously-passing JSON now
-  rejects, surfacing the spec violation. The shape `additional_properties: true` and `additionalProperties: { schema }`
+  rejects, surfacing the spec violation. The `additionalProperties: true` and `additionalProperties: { schema }`
   variants are unchanged. (#336)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 789 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 790 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 790 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 791 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -66,11 +66,15 @@ fn generate_decoders(
       type_gen.schema_has_optional_fields(schema_ref, ctx)
     })
 
-  // Check if dict module is needed (any schema with typed or untyped additionalProperties)
+  // Check if dict module is needed (any schema with typed/untyped
+  // additionalProperties surfaces a Dict in the record; `additionalProperties:
+  // false` also needs Dict at decode time for the closed-schema unknown-key
+  // check, even though the field is suppressed from the record).
   let needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
       type_gen.schema_has_additional_properties(schema_ref, ctx)
+      || type_gen.schema_has_forbidden_additional_properties(schema_ref, ctx)
     })
 
   // Check if types module is needed (any non-primitive schema)
@@ -589,7 +593,26 @@ fn generate_object_decoder(
           <> ")",
       )
     }
-    Forbidden | Unspecified -> sb
+    // Closed schema: read every key, drop the declared ones, and reject
+    // the decode if anything remains. The check has to live in the decoder
+    // body because `gleam/dynamic/decode` consumes only declared fields,
+    // so a post-decode validator would have nothing to inspect.
+    Forbidden -> {
+      sb
+      |> se.indent(
+        1,
+        "use all_props <- decode.then(decode.dict(decode.string, decode.new_primitive_decoder(\"Dynamic\", fn(x) { Ok(x) })))",
+      )
+      |> se.indent(
+        1,
+        "let extra_props = dict.drop(all_props, " <> known_keys_expr <> ")",
+      )
+      |> se.indent(1, "use _ <- decode.then(case dict.is_empty(extra_props) {")
+      |> se.indent(2, "True -> decode.success(Nil)")
+      |> se.indent(2, "False -> decode.failure(Nil, \"additionalProperties\")")
+      |> se.indent(1, "})")
+    }
+    Unspecified -> sb
   }
 
   let param_names =

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -70,12 +70,23 @@ fn generate_decoders(
   // additionalProperties surfaces a Dict in the record; `additionalProperties:
   // false` also needs Dict at decode time for the closed-schema unknown-key
   // check, even though the field is suppressed from the record).
-  let needs_dict =
+  // Anonymous request/response schemas also reach the same code path via
+  // `generate_anonymous_decoders`, so they must be inspected too — otherwise
+  // `gleam/dict` is missing from the import header and the generated module
+  // fails to compile.
+  let operation_inline_schemas = collect_operation_inline_schemas(operations)
+  let component_needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
       type_gen.schema_has_additional_properties(schema_ref, ctx)
       || type_gen.schema_has_forbidden_additional_properties(schema_ref, ctx)
     })
+  let operation_needs_dict =
+    list.any(operation_inline_schemas, fn(schema_ref) {
+      type_gen.schema_has_additional_properties(schema_ref, ctx)
+      || type_gen.schema_has_forbidden_additional_properties(schema_ref, ctx)
+    })
+  let needs_dict = component_needs_dict || operation_needs_dict
 
   // Check if types module is needed (any non-primitive schema)
   let needs_types =
@@ -225,6 +236,46 @@ fn generate_anonymous_request_body_decoder(
     Some(spec.Ref(_)) -> sb
     None -> sb
   }
+}
+
+/// Collect every inline schema reachable via operations' request bodies and
+/// responses. Used by the `needs_*` import-decision pass so anonymous closed
+/// or open-with-additionalProperties object schemas don't slip through and
+/// leave `gleam/dict` un-imported when the body of the generated decoder
+/// references it.
+fn collect_operation_inline_schemas(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> List(SchemaRef) {
+  list.flat_map(operations, fn(op) {
+    let #(_op_id, operation, _path, _method) = op
+    let response_schemas =
+      list.flat_map(dict.to_list(operation.responses), fn(entry) {
+        let #(_status, ref_or_response) = entry
+        case ref_or_response {
+          Value(response) ->
+            list.filter_map(dict.to_list(response.content), fn(content_entry) {
+              let #(_, media_type) = content_entry
+              case media_type.schema {
+                Some(Inline(schema_obj)) -> Ok(Inline(schema_obj))
+                _ -> Error(Nil)
+              }
+            })
+          spec.Ref(_) -> []
+        }
+      })
+    let request_schemas = case operation.request_body {
+      Some(Value(rb)) ->
+        list.filter_map(dict.to_list(rb.content), fn(content_entry) {
+          let #(_, media_type) = content_entry
+          case media_type.schema {
+            Some(Inline(schema_obj)) -> Ok(Inline(schema_obj))
+            _ -> Error(Nil)
+          }
+        })
+      _ -> []
+    }
+    list.append(response_schemas, request_schemas)
+  })
 }
 
 /// Generate decoder for an anonymous schema with a composed name.

--- a/src/oaspec/internal/codegen/schema_utils.gleam
+++ b/src/oaspec/internal/codegen/schema_utils.gleam
@@ -7,8 +7,8 @@ import gleam/option.{type Option, None, Some}
 import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
-  type SchemaObject, type SchemaRef, AllOfSchema, Inline, ObjectSchema,
-  Reference, StringSchema, Typed, Untyped,
+  type SchemaObject, type SchemaRef, AllOfSchema, Forbidden, Inline,
+  ObjectSchema, Reference, StringSchema, Typed, Untyped,
 }
 
 /// Check if a schema has typed or untyped additionalProperties that would need Dict.
@@ -26,6 +26,30 @@ pub fn schema_has_additional_properties(
         Ok(schema_obj) ->
           schema_has_additional_properties(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having additionalProperties; the resolver reports the ref error separately
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a schema has `additionalProperties: false` (needs Dict for the
+/// closed-schema unknown-key check at decode time). Recurses through allOf
+/// children and resolves `$ref` so nested closed schemas are surfaced too.
+pub fn schema_has_forbidden_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case schema_ref {
+    Inline(ObjectSchema(additional_properties: Forbidden, ..)) -> True
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) {
+        schema_has_forbidden_additional_properties(s, ctx)
+      })
+    Reference(..) ->
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+        Ok(schema_obj) ->
+          schema_has_forbidden_additional_properties(Inline(schema_obj), ctx)
+        // nolint: thrown_away_error -- unresolved refs are treated as not having forbidden additionalProperties; the resolver reports the ref error separately
         Error(_) -> False
       }
     _ -> False

--- a/src/oaspec/internal/codegen/types.gleam
+++ b/src/oaspec/internal/codegen/types.gleam
@@ -101,6 +101,15 @@ pub fn schema_has_additional_properties(
   schema_utils.schema_has_additional_properties(schema_ref, ctx)
 }
 
+/// Check if a schema has `additionalProperties: false` (needs Dict for the
+/// closed-schema unknown-key check at decode time).
+pub fn schema_has_forbidden_additional_properties(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  schema_utils.schema_has_forbidden_additional_properties(schema_ref, ctx)
+}
+
 /// Check if a schema has any optional or nullable fields that would need Option.
 pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
   schema_utils.schema_has_optional_fields(schema_ref, ctx)

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13432,3 +13432,57 @@ fn count_occurrences(haystack: String, needle: String) -> Int {
     Ok(#(_, after)) -> 1 + count_occurrences(after, needle)
   }
 }
+
+// --- Issue #336: additionalProperties: false must be enforced at
+//                 decode time (extra fields rejected, not dropped) ---
+
+pub fn additional_properties_false_emits_unknown_key_check_test() {
+  // A schema with `additionalProperties: false` must produce a
+  // decoder that rejects JSON objects containing keys outside the
+  // declared property set. The check happens in the decoder body
+  // because composite/post-decode validation cannot recover the
+  // raw JSON object's key set after `gleam/dynamic/decode` has run.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /uploads:
+    post:
+      operationId: createUpload
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Upload:
+      type: object
+      additionalProperties: false
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let assert Ok(decode_file) =
+    list.find(decoders.generate(ctx), fn(f) { f.path == "decode.gleam" })
+
+  // The decoder must mention the unknown-key rejection. Whether it
+  // calls a runtime helper or inlines the check is an implementation
+  // detail; we assert the spec-driven contract: the closed-schema
+  // signal `\"additionalProperties\": false` materialises in the
+  // decoder body either via a dict-based pre-check (decoding to
+  // Dict to inspect keys) or via a custom failure for unknown keys.
+  let has_dict_check =
+    string.contains(decode_file.content, "decode.dict(decode.string,")
+    && string.contains(decode_file.content, "dict.drop(")
+  let has_unknown_key_failure =
+    string.contains(decode_file.content, "additionalProperties")
+    && string.contains(decode_file.content, "decode.failure")
+  case has_dict_check && has_unknown_key_failure {
+    True -> Nil
+    False -> should.fail()
+  }
+}

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13486,3 +13486,54 @@ components:
     False -> should.fail()
   }
 }
+
+pub fn additional_properties_false_via_allof_emits_unknown_key_check_test() {
+  // Same contract as the direct case, but the closedness signal
+  // arrives through allOf composition: `Upload` itself does not
+  // declare `additionalProperties: false`; it inherits the
+  // restriction from `BaseClosed` via allOf. The codegen pass must
+  // still emit the unknown-key rejection on the Upload decoder
+  // because the merged schema is closed.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /uploads:
+    post:
+      operationId: createUpload
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    BaseClosed:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string }
+    Upload:
+      allOf:
+        - $ref: '#/components/schemas/BaseClosed'
+        - type: object
+          required: [name]
+          properties:
+            name: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let assert Ok(decode_file) =
+    list.find(decoders.generate(ctx), fn(f) { f.path == "decode.gleam" })
+
+  let has_dict_check =
+    string.contains(decode_file.content, "decode.dict(decode.string,")
+    && string.contains(decode_file.content, "dict.drop(")
+  let has_unknown_key_failure =
+    string.contains(decode_file.content, "additionalProperties")
+    && string.contains(decode_file.content, "decode.failure")
+  case has_dict_check && has_unknown_key_failure {
+    True -> Nil
+    False -> should.fail()
+  }
+}


### PR DESCRIPTION
## Summary

Generated decoders previously accepted JSON bodies containing unknown fields and silently dropped them, even when the OpenAPI schema declared `additionalProperties: false`. The strictest opt-in OpenAPI validation knob was a no-op. The decoder now reads the raw JSON object, drops the declared keys, and fails the decode with the reason `"additionalProperties"` if any extras remain.

## Changes

- `src/oaspec/internal/codegen/schema_utils.gleam`: new `schema_has_forbidden_additional_properties/2` helper recursing through `allOf` children and resolving `$ref`s
- `src/oaspec/internal/codegen/types.gleam`: re-export the new helper so codegen modules can use it through the existing `type_gen` import path
- `src/oaspec/internal/codegen/decoders.gleam`:
  - Extend `needs_dict` to include schemas with `additionalProperties: false` so the `gleam/dict` import is added when only the closed-schema check needs it
  - Split the no-op `Forbidden | Unspecified -> sb` branch in `generate_object_decoder` so `Forbidden` emits the actual unknown-key check (decode raw `Dict(String, Dynamic)`, `dict.drop` the declared keys, fail decode if extras remain). `Unspecified` keeps the existing no-op behaviour.
- `test/oaspec_test.gleam`: new `additional_properties_false_emits_unknown_key_check_test` asserting the generated decoder body contains both the dict-based pre-check (`decode.dict(decode.string,` + `dict.drop(`) and the unknown-key failure signal (`additionalProperties` + `decode.failure`)
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`
- `README.md`: bump unit-test count 789 → 790

## Design Decisions

1. **Decoder-body check, not post-decode validator.** `gleam/dynamic/decode` consumes only declared fields, so a post-decode pass would have nothing to inspect — the raw key set is gone by the time the record exists. The check has to live inside the decoder pipeline before the success constructor runs.
2. **Decode raw `Dict(String, Dynamic)` first, then drop declared keys.** Same shape the `Typed`/`Untyped` branches already use, just terminated by an emptiness check instead of a re-decode of the extras. Keeps the three branches structurally similar.
3. **Failure value is `Nil`.** The decoder discards the result of the unknown-key check (`use _ <- decode.then(...)`), so the binding type is `Nil` — that's what `decode.failure(Nil, "additionalProperties")` reports against on a violation.
4. **Helper extends `schema_utils`, not the existing `schema_has_additional_properties`.** Overloading the existing helper would silently change `needs_dict` and the record-shape decisions in `ir_build` and `types`, both of which intentionally treat `Forbidden` as "no `additional_properties` field on the record". A separate helper keeps the closed-schema decoder check independent of the surface-it-as-a-Dict question.
5. **Behavioural change for clients already mishandling extras.** Their previously-passing JSON now rejects, surfacing the spec violation. That's the intended behaviour change the issue asks for — silently accepting extras was the bug.

Closes #336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoder enforcement of `additionalProperties: false` constraints. Decoders now properly reject JSON objects containing unknown fields instead of silently dropping them, ensuring strict schema validation is enforced at decode time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->