### PR TITLE
fix(decoders): enforce exactly-one-match semantics for oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`oneOf` decoders now enforce exactly-one-match semantics**, per
+  JSON Schema 2020-12 §10.2.1.3. Generated non-discriminator
+  `oneOf` decoders previously emitted `decode.one_of(first,
+  [rest..])`, which is first-match (i.e. `anyOf`) semantics — a
+  body that validated against multiple branches was silently
+  accepted as the first-listed variant, with the other branches'
+  fields dropped. The generator now emits a body that runs every
+  branch independently against the raw `Dynamic` (via
+  `decode.run`), counts successes, and:
+  - succeeds with the matched variant when exactly one branch
+    matched,
+  - fails with `"<TypeName>: matched multiple oneOf branches;
+    expected exactly one"` when 2+ branches matched (the new
+    rejection — previously accepted),
+  - fails with `"<TypeName>: no oneOf branch matched"` when zero
+    branches matched (same as before, just with a clearer
+    message).
+  This adds `gleam/list` and `gleam/result` to the imports of any
+  generated `decode.gleam` that surfaces a non-discriminator
+  `oneOf`. Discriminator-based `oneOf` decoders are unchanged
+  (the discriminator already picks a single variant, so multi-
+  match is structurally impossible). Behavioral change for
+  clients sending bodies that match multiple branches: their
+  previously-passing JSON now rejects, which is the spec's
+  intended behavior. (#337)
+
 - **`additionalProperties: false` is now enforced at decode time.**
   Generated decoders for closed object schemas previously accepted
   JSON bodies containing unknown fields and silently dropped them —

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 791 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 792 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -1,4 +1,5 @@
 import gleam/dict
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
@@ -88,6 +89,18 @@ fn generate_decoders(
     })
   let needs_dict = component_needs_dict || operation_needs_dict
 
+  // Strict non-discriminator `oneOf` decoders use `list.filter_map` and
+  // `result.map` to count matches across branches per JSON Schema 2020-12
+  // §10.2.1.3 — they must reject when 2+ branches match (Issue #337).
+  let needs_strict_oneof_runtime =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      type_gen.schema_has_non_discriminator_oneof(schema_ref, ctx)
+    })
+    || list.any(operation_inline_schemas, fn(schema_ref) {
+      type_gen.schema_has_non_discriminator_oneof(schema_ref, ctx)
+    })
+
   // Check if types module is needed (any non-primitive schema)
   let needs_types =
     list.any(schemas, fn(entry) {
@@ -105,6 +118,10 @@ fn generate_decoders(
   let base_imports = case needs_dict {
     True -> ["gleam/dict", "gleam/dynamic/decode", "gleam/json"]
     False -> ["gleam/dynamic/decode", "gleam/json"]
+  }
+  let base_imports = case needs_strict_oneof_runtime {
+    True -> list.append(base_imports, ["gleam/list", "gleam/result"])
+    False -> base_imports
   }
   let base_imports = case needs_types {
     True ->
@@ -1149,7 +1166,13 @@ fn generate_oneof_decoder(
               <> ") {",
             )
 
-          // Build a chain of decode.one_of attempts
+          // Issue #337: emit a strict-oneOf body. The previous
+          // `decode.one_of(first, [rest..])` chain was first-match
+          // (anyOf semantics); JSON Schema 2020-12 §10.2.1.3 demands
+          // exactly-one-match for `oneOf`. Run each branch
+          // independently against the raw Dynamic, count successful
+          // matches, succeed iff exactly one matched, and emit a
+          // distinct failure diagnostic when 2+ branches matched.
           let sb = case ref_variants {
             [] ->
               sb
@@ -1161,35 +1184,72 @@ fn generate_oneof_decoder(
                   <> type_name
                   <> "\")",
               )
-            [first, ..rest] -> {
+            [first, ..] -> {
               let first_variant_type = naming.schema_to_type_name(first)
               let first_decoder = naming.to_snake_case(first) <> "_decoder()"
               let sb =
                 sb
-                |> se.indent(
-                  1,
-                  "decode.one_of("
-                    <> first_decoder
-                    <> " |> decode.map(types."
-                    <> type_name
-                    <> first_variant_type
-                    <> "), [",
-                )
+                |> se.indent(1, "use raw <- decode.then(decode.dynamic)")
               let sb =
-                list.fold(rest, sb, fn(sb, ref_name) {
+                list.index_fold(ref_variants, sb, fn(sb, ref_name, idx) {
                   let variant_type = naming.schema_to_type_name(ref_name)
                   let decoder = naming.to_snake_case(ref_name) <> "_decoder()"
                   sb
                   |> se.indent(
-                    2,
-                    decoder
-                      <> " |> decode.map(types."
+                    1,
+                    "let r"
+                      <> int.to_string(idx)
+                      <> " = decode.run(raw, "
+                      <> decoder
+                      <> ") |> result.map(types."
                       <> type_name
                       <> variant_type
-                      <> "),",
+                      <> ")",
                   )
                 })
-              sb |> se.indent(1, "])")
+              let attempts_list =
+                "["
+                <> se.join_with(
+                  list.index_map(ref_variants, fn(_, idx) {
+                    "r" <> int.to_string(idx)
+                  }),
+                  ", ",
+                )
+                <> "]"
+              sb
+              |> se.indent(
+                1,
+                "let oks = list.filter_map(" <> attempts_list <> ", fn(r) {",
+              )
+              |> se.indent(2, "case r {")
+              |> se.indent(3, "Ok(v) -> Ok(v)")
+              |> se.indent(3, "Error(_) -> Error(Nil)")
+              |> se.indent(2, "}")
+              |> se.indent(1, "})")
+              |> se.indent(1, "case oks {")
+              |> se.indent(2, "[single] -> decode.success(single)")
+              |> se.indent(
+                2,
+                "[first, _, ..] -> decode.failure(first, \""
+                  <> type_name
+                  <> ": matched multiple oneOf branches; expected exactly one\")",
+              )
+              |> se.indent(2, "[] -> {")
+              |> se.indent(
+                3,
+                "use fallback <- decode.then(" <> first_decoder <> ")",
+              )
+              |> se.indent(
+                3,
+                "decode.failure(types."
+                  <> type_name
+                  <> first_variant_type
+                  <> "(fallback), \""
+                  <> type_name
+                  <> ": no oneOf branch matched\")",
+              )
+              |> se.indent(2, "}")
+              |> se.indent(1, "}")
             }
           }
 

--- a/src/oaspec/internal/codegen/schema_utils.gleam
+++ b/src/oaspec/internal/codegen/schema_utils.gleam
@@ -8,7 +8,7 @@ import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, Forbidden, Inline,
-  ObjectSchema, Reference, StringSchema, Typed, Untyped,
+  ObjectSchema, OneOfSchema, Reference, StringSchema, Typed, Untyped,
 }
 
 /// Check if a schema has typed or untyped additionalProperties that would need Dict.
@@ -50,6 +50,38 @@ pub fn schema_has_forbidden_additional_properties(
         Ok(schema_obj) ->
           schema_has_forbidden_additional_properties(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having forbidden additionalProperties; the resolver reports the ref error separately
+        Error(_) -> False
+      }
+    _ -> False
+  }
+}
+
+/// Check if a schema is — or transitively contains — a `oneOf` with at least
+/// one $ref variant and no discriminator. The strict-oneOf decoder body
+/// generated for that shape uses `list.filter_map` and `result.map`, so the
+/// generator must add `gleam/list` and `gleam/result` to the imports of
+/// `decode.gleam` when this returns True.
+pub fn schema_has_non_discriminator_oneof(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case schema_ref {
+    Inline(OneOfSchema(schemas:, discriminator: option.None, ..)) ->
+      list.any(schemas, fn(s) {
+        case s {
+          Reference(..) -> True
+          _ -> False
+        }
+      })
+    Inline(OneOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_non_discriminator_oneof(s, ctx) })
+    Inline(AllOfSchema(schemas:, ..)) ->
+      list.any(schemas, fn(s) { schema_has_non_discriminator_oneof(s, ctx) })
+    Reference(..) ->
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+        Ok(schema_obj) ->
+          schema_has_non_discriminator_oneof(Inline(schema_obj), ctx)
+        // nolint: thrown_away_error -- unresolved refs are treated as not having strict-oneOf needs; the resolver reports the ref error separately
         Error(_) -> False
       }
     _ -> False

--- a/src/oaspec/internal/codegen/types.gleam
+++ b/src/oaspec/internal/codegen/types.gleam
@@ -110,6 +110,16 @@ pub fn schema_has_forbidden_additional_properties(
   schema_utils.schema_has_forbidden_additional_properties(schema_ref, ctx)
 }
 
+/// Check if a schema is — or contains — a non-discriminator `oneOf` whose
+/// strict decoder needs `gleam/list` + `gleam/result` imported in
+/// `decode.gleam`.
+pub fn schema_has_non_discriminator_oneof(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  schema_utils.schema_has_non_discriminator_oneof(schema_ref, ctx)
+}
+
 /// Check if a schema has any optional or nullable fields that would need Option.
 pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
   schema_utils.schema_has_optional_fields(schema_ref, ctx)

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -13487,6 +13487,67 @@ components:
   }
 }
 
+// --- Issue #337: oneOf decoders must enforce exactly-one-match
+//                 semantics, not first-match (anyOf) ---
+
+pub fn oneof_decoder_rejects_multi_branch_matches_test() {
+  // A non-discriminator `oneOf` whose two branches each accept a
+  // body that the other also accepts (no closed-schema enforcement
+  // in this fixture). The generated decoder must NOT compile down
+  // to `decode.one_of(first, [rest..])` — that is `anyOf`
+  // (first-match) semantics. JSON Schema 2020-12 §10.2.1.3 demands
+  // that exactly one branch validates; otherwise the decode must
+  // fail.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /uploads:
+    post:
+      operationId: createUpload
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    InlineUpload:
+      type: object
+      required: [content_b64]
+      properties:
+        content_b64: { type: string }
+    ReferencedUpload:
+      type: object
+      required: [source_url]
+      properties:
+        source_url: { type: string }
+    UploadEnvelope:
+      oneOf:
+        - $ref: '#/components/schemas/InlineUpload'
+        - $ref: '#/components/schemas/ReferencedUpload'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let assert Ok(decode_file) =
+    list.find(decoders.generate(ctx), fn(f) { f.path == "decode.gleam" })
+
+  // Strict-oneOf marker: the generator must emit per-branch
+  // independent runs (`decode.run`) so it can count successful
+  // matches, plus a multi-match rejection diagnostic. The exact
+  // wording is an implementation detail; the literal `oneOf` in
+  // the failure message is the canonical disambiguator vs.
+  // existing `additionalProperties` / discriminator failure paths.
+  let runs_each_branch = string.contains(decode_file.content, "decode.run(")
+  let multi_match_marker =
+    string.contains(decode_file.content, "matched multiple")
+    || string.contains(decode_file.content, "oneOf")
+  case runs_each_branch && multi_match_marker {
+    True -> Nil
+    False -> should.fail()
+  }
+}
+
 pub fn additional_properties_false_via_allof_emits_unknown_key_check_test() {
   // Same contract as the direct case, but the closedness signal
   // arrives through allOf composition: `Upload` itself does not


### PR DESCRIPTION
## Summary

Generated `oneOf` decoders previously emitted `decode.one_of(first, [rest..])`, which is first-match (i.e. `anyOf`) semantics — a body that validated against multiple branches was silently accepted as the first-listed variant, with the other branches' fields dropped. JSON Schema 2020-12 §10.2.1.3 demands exactly-one-match for `oneOf`. The non-discriminator path now emits a body that runs every branch independently, counts successes, and fails when 2+ branches match.

## Changes

- `src/oaspec/internal/codegen/schema_utils.gleam`: new `schema_has_non_discriminator_oneof/2` helper recursing through `allOf`, `oneOf`, and `$ref` so transitive instances are detected too
- `src/oaspec/internal/codegen/types.gleam`: re-export the new helper
- `src/oaspec/internal/codegen/decoders.gleam`:
  - Add `gleam/list` and `gleam/result` to the `decode.gleam` import header when any non-discriminator `oneOf` is present (the strict body uses `list.filter_map` and `result.map`)
  - Replace the body of `generate_oneof_decoder` non-discriminator path. The new body:
    1. Pulls the raw `Dynamic` via `use raw <- decode.then(decode.dynamic)`
    2. Runs every branch's decoder via `decode.run(raw, ...) |> result.map(types.<Type><Variant>)`
    3. Filters successes with `list.filter_map`
    4. Branches on the result: `[single]` → `decode.success`; `[first, _, ..]` → `decode.failure(first, "<TypeName>: matched multiple oneOf branches; expected exactly one")`; `[]` → re-runs the first decoder via `decode.then` to produce a typed default and fails with `"<TypeName>: no oneOf branch matched"`
- `test/oaspec_test.gleam`: new `oneof_decoder_rejects_multi_branch_matches_test` asserting the generated decoder body uses `decode.run(` (per-branch independent runs) and emits the multi-match diagnostic
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`
- `README.md`: bump unit-test count 791 → 792

## Design Decisions

1. **Per-branch independent runs**, not nested `decode.one_of`. The whole point is to count how many branches match — `decode.one_of`'s short-circuit-on-first-success behaviour is what we're moving away from.
2. **Discriminator path unchanged.** Discriminator-based `oneOf` already picks one variant by the discriminator value before running its decoder, so multi-match is structurally impossible. Touching that path would risk regressing #308.
3. **Failure diagnostic includes the type name.** The error message starts with `"<TypeName>:"` so a generic `Result(_, json.DecodeError)` from a downstream consumer is greppable per oneOf type.
4. **Detection helper is type-aware (Inline+Reference recursion).** A non-discriminator `oneOf` reachable only through `$ref` or `allOf` still needs the runtime imports, so the helper resolves refs and recurses through composition keywords.
5. **Same import-header pattern as `needs_dict`.** The new `needs_strict_oneof_runtime` flag flows through both component schemas and operation-inline schemas, mirroring the fix from #336 — anonymous request/response oneOf schemas trigger the import too.
6. **Two-variant `case` works for N variants.** The branch list pattern `[single]` / `[first, _, ..]` / `[]` is exhaustive over `List(t)` regardless of variant count, so the same generator code handles 2-variant and N-variant `oneOf` schemas without exploding into `2^N` case arms.

Closes #337
