### PR TITLE
fix(parser): accept type: 'null' in oneOf/anyOf and standalone (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`type: 'null'` inside `oneOf` / `anyOf`** is now accepted as the
+  OpenAPI 3.1 nullable-via-union form. Previously the parser rejected
+  it with `Unrecognized schema type 'null'`, which blocked specs like
+  the GitHub REST OpenAPI from being generated. The null branch is
+  filtered out and `nullable: true` is lifted onto the parent schema's
+  metadata, matching the existing behaviour for the array form
+  `type: [T, 'null']`. A standalone `type: 'null'` schema (outside any
+  composition) is also accepted now and represented as an unrestricted
+  nullable schema, mirroring the existing fallback for
+  `type: ['null']`. (#349)
+
 ## [0.29.0] - 2026-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 792 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 795 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/openapi/parser_schema.gleam
+++ b/src/oaspec/internal/openapi/parser_schema.gleam
@@ -104,8 +104,17 @@ fn parse_schema_object(
     _ ->
       case yay.select_sugar(from: node, selector: "oneOf") {
         Ok(yay.NodeSeq(items)) -> {
+          let #(non_null_items, has_null) = partition_null_branches(items)
+          let metadata = case has_null {
+            True -> schema.SchemaMetadata(..metadata, nullable: True)
+            False -> metadata
+          }
           use schemas <- result.try(
-            list.try_map(items, parse_schema_ref(_, path <> ".oneOf", index)),
+            list.try_map(non_null_items, parse_schema_ref(
+              _,
+              path <> ".oneOf",
+              index,
+            )),
           )
           use discriminator <- result.try(
             case
@@ -126,8 +135,17 @@ fn parse_schema_object(
         _ ->
           case yay.select_sugar(from: node, selector: "anyOf") {
             Ok(yay.NodeSeq(items)) -> {
+              let #(non_null_items, has_null) = partition_null_branches(items)
+              let metadata = case has_null {
+                True -> schema.SchemaMetadata(..metadata, nullable: True)
+                False -> metadata
+              }
               use schemas <- result.try(
-                list.try_map(items, parse_schema_ref(_, path <> ".anyOf", index)),
+                list.try_map(non_null_items, parse_schema_ref(
+                  _,
+                  path <> ".anyOf",
+                  index,
+                )),
               )
               use discriminator <- result.try(
                 case
@@ -149,6 +167,42 @@ fn parse_schema_object(
           }
       }
   }
+}
+
+/// Detect a schema branch that is a standalone `type: "null"` (the
+/// OpenAPI 3.1 way to express nullability inside a oneOf/anyOf).
+///
+/// Returns `True` only if the node is an inline schema whose only
+/// shape-bearing key is `type: "null"`. A `$ref` to a separately-
+/// defined `type: "null"` schema is not detected here — those are
+/// handled by the standalone `parse_typed_schema` "null" branch.
+fn is_null_branch(node: yay.Node) -> Bool {
+  // A `$ref` branch is never a null literal at this level.
+  case yay.extract_optional_string(node, "$ref") {
+    Ok(Some(_)) -> False
+    _ ->
+      case yay.select_sugar(from: node, selector: "type") {
+        Ok(yay.NodeStr("null")) -> True
+        _ -> False
+      }
+  }
+}
+
+/// Split oneOf/anyOf members into the non-null branches and a flag
+/// indicating whether any branch was a `type: "null"` literal. Used
+/// to translate OpenAPI 3.1 nullable-via-union into the existing
+/// `nullable: True` metadata flag, mirroring how the array form of
+/// `type` ([T, "null"]) is already handled in `parse_typed_schema`.
+fn partition_null_branches(items: List(yay.Node)) -> #(List(yay.Node), Bool) {
+  let #(non_null, has_null) =
+    list.fold(items, #([], False), fn(acc, item) {
+      let #(kept, seen) = acc
+      case is_null_branch(item) {
+        True -> #(kept, True)
+        False -> #([item, ..kept], seen)
+      }
+    })
+  #(list.reverse(non_null), has_null)
 }
 
 /// Detect unsupported JSON Schema 2020-12 keywords present in a schema node.
@@ -221,6 +275,14 @@ fn parse_typed_schema(
           }
         }
       }
+      Ok(yay.NodeStr("null")) ->
+        // OpenAPI 3.1 allows `type: "null"` to mean "the value is
+        // JSON null". Mirror the existing array-form fallback for
+        // `type: ["null"]` (no non-null types): treat as an
+        // unrestricted nullable schema by lifting the null marker
+        // to the metadata `nullable` flag and falling through to
+        // the regular "object" branch for any sibling keywords.
+        Ok(#("object", schema.SchemaMetadata(..metadata, nullable: True)))
       Ok(yay.NodeStr(type_name)) -> Ok(#(type_name, metadata))
       _ -> {
         // When type is absent, default to "object".

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -3911,6 +3911,114 @@ security:
   string.contains(content, "config.bearer_auth") |> should.be_false()
 }
 
+// --- Issue #349: type: 'null' inside anyOf must parse, not error ---
+pub fn openapi_31_anyof_with_null_branch_parses_test() {
+  // The GitHub OpenAPI 3.1 spec uses `anyOf: [$ref, type: 'null']` to
+  // express nullability. Before #349, this surfaced as
+  // "Unrecognized schema type 'null'" because parse_typed_schema was
+  // reached with a literal "null" string. Now the null branch is
+  // stripped and lifted to the parent's `nullable` flag.
+  let yaml =
+    "
+openapi: 3.1.0
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Installation:
+      type: object
+      properties:
+        suspended_by:
+          anyOf:
+            - $ref: '#/components/schemas/User'
+            - type: 'null'
+    User:
+      type: object
+      properties:
+        login: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Some(components) = spec.components
+  let assert Ok(schema.Inline(schema.ObjectSchema(properties: props, ..))) =
+    dict.get(components.schemas, "Installation")
+  let assert Ok(schema.Inline(schema.AnyOfSchema(
+    metadata: meta,
+    schemas: branches,
+    ..,
+  ))) = dict.get(props, "suspended_by")
+  // The null branch must have been filtered out, leaving only the
+  // $ref to User.
+  list.length(branches) |> should.equal(1)
+  // And nullability must have been lifted onto the parent schema.
+  meta.nullable |> should.be_true()
+}
+
+pub fn openapi_31_oneof_with_null_branch_parses_test() {
+  let yaml =
+    "
+openapi: 3.1.0
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    Maybe:
+      oneOf:
+        - type: string
+        - type: 'null'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Some(components) = spec.components
+  let assert Ok(schema.Inline(schema.OneOfSchema(
+    metadata: meta,
+    schemas: branches,
+    ..,
+  ))) = dict.get(components.schemas, "Maybe")
+  list.length(branches) |> should.equal(1)
+  meta.nullable |> should.be_true()
+}
+
+pub fn openapi_31_standalone_null_type_parses_as_nullable_test() {
+  // `type: 'null'` as a standalone schema (outside oneOf/anyOf) must
+  // not error either. We treat it as an unrestricted nullable schema,
+  // mirroring the existing fallback for `type: ['null']`.
+  let yaml =
+    "
+openapi: 3.1.0
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      operationId: getX
+      responses:
+        '200': { description: ok }
+components:
+  schemas:
+    OnlyNull:
+      type: 'null'
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Some(components) = spec.components
+  let assert Ok(schema.Inline(schema.ObjectSchema(metadata: meta, ..))) =
+    dict.get(components.schemas, "OnlyNull")
+  meta.nullable |> should.be_true()
+}
+
 // --- Finding 2: OpenAPI 3.1 type: [string, 'null'] must parse as nullable string ---
 pub fn openapi_31_type_array_nullable_test() {
   let yaml =


### PR DESCRIPTION
## Summary

Accept `type: 'null'` inside `oneOf` / `anyOf` (and as a standalone schema) so OpenAPI 3.1 specs that use the nullable-via-union form, like the GitHub REST OpenAPI, can be code-generated. Closes the bug reported in #349.

## Changes

- `src/oaspec/internal/openapi/parser_schema.gleam`
  - new `is_null_branch` and `partition_null_branches` helpers
  - `parse_schema_object` now strips `type: 'null'` members from `oneOf` / `anyOf` and lifts `nullable: True` onto the parent metadata
  - `parse_typed_schema` now accepts a standalone `NodeStr("null")` and treats it as an unrestricted nullable schema (mirrors the existing fallback for the array form `type: ['null']`)
- `test/oaspec_test.gleam` — three new tests:
  - `openapi_31_anyof_with_null_branch_parses_test` (the GitHub-spec shape)
  - `openapi_31_oneof_with_null_branch_parses_test`
  - `openapi_31_standalone_null_type_parses_as_nullable_test`
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design Decisions

- Translate `type: 'null'` into the existing `nullable: True` flag rather than introducing a new `NullSchema` SchemaObject variant. Adding a variant would require touching every codegen pattern-match (decoders, encoders, guards, types, ir, ...) and is far more invasive than the bug warrants. The existing `nullable` mechanism already handles the same semantic ("value or null") for OAS 3.0 specs and the array form of `type` in OAS 3.1.
- Stripping the null branch happens in `parse_schema_object` (before recursion) rather than as a post-process on the parsed children, so the rest of the parser never sees the null branch and downstream helpers (like `parse_discriminator`) keep operating on a clean union.
- For the standalone case, fall through to the regular `"object"` branch via the type-string extraction step rather than building an `ObjectSchema` directly. Keeps the path identical to the existing `type: ['null']` array fallback so any future change to that fallback automatically applies here.
- `is_null_branch` rejects `$ref` branches (a `$ref` to a schema that happens to be `type: "null"` is handled by the standalone path during ref resolution). This avoids double-stripping.

Closes #349
