### PR TITLE
feat(validate): support text/plain request bodies (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`text/plain` is now a supported request body content type** in both
+  client and server modes. Specs that declare a `text/plain` request
+  body (e.g. GitHub REST `markdown.render-raw`) previously tripped the
+  "unsupported request content type" diagnostic; they now generate
+  working code. Client codegen wraps the body in `transport.TextBody`
+  as a raw string (no JSON quoting), and the server router passes the
+  request body through to handlers as `String`. (#352)
+
 ## [0.30.0] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 795 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 796 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
 
 ## Why oaspec?
 
@@ -102,7 +102,7 @@ diagnostic instead of producing broken output.
   fail fast with a dedicated diagnostic that shows the visited chain.
 - Parameters: path, query, header, cookie, plus array styles (`form`,
   `pipeDelimited`, `spaceDelimited`) and objects via `deepObject`
-- Request bodies: `application/json`,
+- Request bodies: `application/json`, `text/plain`,
   `application/x-www-form-urlencoded`, `multipart/form-data`
 - Typed response variants, typed response headers, and `$ref` /
   `default` responses
@@ -397,7 +397,7 @@ Coverage is strongest in these areas:
 - Schemas: component schemas, primitive aliases, enums, nullable fields, arrays, objects, `allOf`, `oneOf`, `anyOf`, and typed `additionalProperties`
 - References: local `$ref` resolution for schemas, parameters, request bodies, responses, and path items, including circular-reference detection
 - Parameters: path, query, header, and cookie parameters, including array serialization (`style: form`, `style: pipeDelimited`, `style: spaceDelimited`) and objects via `style: deepObject`
-- Request bodies: `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data`
+- Request bodies: `application/json`, `text/plain`, `application/x-www-form-urlencoded`, and `multipart/form-data`
 - Responses: typed status-code variants, `$ref` responses, `default` responses, typed response headers, and text or binary passthrough cases
 - Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code.
 - Generation safety: name collision handling, keyword escaping, validation guards, and capability errors with clear failure modes

--- a/src/oaspec/internal/capability.gleam
+++ b/src/oaspec/internal/capability.gleam
@@ -180,6 +180,12 @@ pub fn registry() -> List(Capability) {
       "Binary upload (raw bytes; passes through as the body parameter without JSON decoding)",
     ),
     Capability(
+      "text/plain",
+      "request",
+      Supported,
+      "Plain text request bodies (raw string passthrough; no JSON encoding)",
+    ),
+    Capability(
       "+json/+xml suffix",
       "content-type",
       Supported,
@@ -268,7 +274,7 @@ pub fn registry() -> List(Capability) {
       "server: unsupported request content type",
       "server-validation",
       Unsupported,
-      "Server router only supports application/json, application/x-www-form-urlencoded, and multipart/form-data",
+      "Server router only supports application/json, application/x-www-form-urlencoded, multipart/form-data, application/octet-stream, and text/plain",
     ),
     // Codegen scope
     Capability("webhooks", "scope", ParsedNotUsed, "Parsed but no codegen"),

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -1251,6 +1251,21 @@ fn generate_body_emission(
           generate_multipart_body_emission(sb, rb, op_id, ctx)
         "application/x-www-form-urlencoded" ->
           generate_form_urlencoded_body_emission(sb, rb, op_id, ctx)
+        "text/plain" ->
+          // Plain-text bodies must travel as the raw string the caller
+          // supplies. The default `_ ->` arm runs the value through the
+          // schema-aware encoder, which would JSON-quote a string schema —
+          // that's wrong for text/plain (the wire payload would be
+          // `"foo"` instead of `foo`).
+          case rb.required {
+            True -> sb |> se.indent(1, "let body = transport.TextBody(body)")
+            False ->
+              sb
+              |> se.indent(1, "let body = case body {")
+              |> se.indent(2, "Some(b) -> transport.TextBody(b)")
+              |> se.indent(2, "None -> transport.EmptyBody")
+              |> se.indent(1, "}")
+          }
         _ -> {
           let encode_expr = client_request.get_body_encode_expr(rb, op_id, ctx)
           case rb.required {

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -672,9 +672,9 @@ fn validate_request_body(
             path: op_id <> ".requestBody",
             detail: "Content type '"
               <> media_type
-              <> "' is not supported. Supported request content types: application/json (and +json suffix types), multipart/form-data, application/x-www-form-urlencoded, application/octet-stream.",
+              <> "' is not supported. Supported request content types: application/json (and +json suffix types), text/plain, multipart/form-data, application/x-www-form-urlencoded, application/octet-stream.",
             hint: Some(
-              "Use application/json (or a +json suffix type like application/problem+json), multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream.",
+              "Use application/json (or a +json suffix type like application/problem+json), text/plain, multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream.",
             ),
           ),
         ]
@@ -883,6 +883,7 @@ fn validate_server_request_body_content_types(
           && key != "application/x-www-form-urlencoded"
           && key != "multipart/form-data"
           && key != "application/octet-stream"
+          && key != "text/plain"
           && content_type.is_supported_request(content_type.from_string(key))
         })
       list.map(non_json_but_supported, fn(media_type) {

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1188,6 +1188,51 @@ components:
   |> should.be_true()
 }
 
+// Issue #352: text/plain request bodies must travel as the raw string the
+// caller supplies. The generated client must wrap the body parameter in
+// `transport.TextBody(body)` directly, with no JSON quoting, and the
+// content-type header must echo the spec's "text/plain" verbatim.
+pub fn client_text_plain_request_body_emits_raw_text_body_test() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /markdown/raw:
+    post:
+      operationId: renderRaw
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema: { type: string }
+      responses:
+        '200':
+          description: rendered HTML
+          content:
+            text/plain:
+              schema: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = client_gen.generate(ctx)
+  let assert [client_file] = files
+
+  // Body must be wrapped raw — no `json.string` / `json.to_string` on the
+  // request side for a text/plain body.
+  string.contains(client_file.content, "let body = transport.TextBody(body)")
+  |> should.be_true()
+  string.contains(client_file.content, "json.to_string(json.string(body))")
+  |> should.be_false()
+
+  // Content-type header echoes the spec literal.
+  string.contains(client_file.content, "\"text/plain\"")
+  |> should.be_true()
+}
+
 // ===================================================================
 // Encoder: optional non-nullable field omits key on None (issue #303)
 // ===================================================================

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -675,7 +675,11 @@ paths:
   errors |> should.equal([])
 }
 
-pub fn validate_rejects_text_plain_request_body_test() {
+// Issue #352: text/plain must be accepted as a request body content type so
+// real-world specs (e.g. GitHub `markdown.render-raw`) stop tripping the
+// "unsupported request content type" diagnostic. Mirrors the octet-stream
+// acceptance test below.
+pub fn validate_accepts_text_plain_request_body_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -699,10 +703,9 @@ paths:
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
   list.any(error_strings, fn(s) {
-    string.contains(s, "multipart/form-data")
-    && string.contains(s, "form-urlencoded")
+    string.contains(s, "text/plain") && string.contains(s, "is not supported")
   })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 // Issue #265: application/octet-stream must be accepted as a request body
@@ -2028,7 +2031,7 @@ pub fn content_type_is_supported_request_test() {
   |> should.be_true()
 
   content_type.is_supported_request(content_type.TextPlain)
-  |> should.be_false()
+  |> should.be_true()
 }
 
 pub fn content_type_is_supported_response_test() {
@@ -4593,6 +4596,7 @@ pub fn capability_registry_covers_content_type_request_helpers_test() {
     "application/x-www-form-urlencoded",
     "multipart/form-data",
     "application/octet-stream",
+    "text/plain",
   ]
   let registry_request_names =
     capability.registry()


### PR DESCRIPTION
## Summary

`text/plain` is now an accepted request body content type in both client
and server modes. Previously the validator rejected it with the
"unsupported request content type" diagnostic, which blocked specs like
GitHub REST `markdown.render-raw` from generating. This is a focused
slice of #352 — vendor-prefixed response media types (`application/vnd.github.*`,
`text/html`) and `deepObject` parameter complaints are still open.

## Changes

- `src/oaspec/internal/capability.gleam`: register `text/plain` as a
  Supported `request` capability and refresh the
  `server: unsupported request content type` description so it lists
  every MIME the server allow-list now accepts.
- `src/oaspec/internal/codegen/validate.gleam`: drop `text/plain` from
  the "non-json-but-supported" filter that drives server-mode rejection,
  and mention `text/plain` in the client-mode error message + hint.
- `src/oaspec/internal/codegen/client.gleam`: add a `text/plain`
  branch in `generate_body_emission` that wraps the body in
  `transport.TextBody(body)` directly, bypassing the schema-aware
  encoder so a string schema is not JSON-quoted on the wire.
- `test/oaspec_test.gleam`: flip
  `validate_rejects_text_plain_request_body_test` →
  `validate_accepts_text_plain_request_body_test`, update the
  `is_supported_request` and registry-coverage tests accordingly.
- `test/codegen_unit_test.gleam`: new
  `client_text_plain_request_body_emits_raw_text_body_test` to lock in
  the raw-string body emission and `"text/plain"` content-type header.
- `README.md`: list `text/plain` under request bodies (twice — overview
  and "Coverage is strongest" section), bump the unit test count
  (795 → 796) so `scripts/check_sync.sh` stays green.
- `CHANGELOG.md`: Unreleased entry under Added.

## Design Decisions

- **Both client and server**, not just client. The server router's
  `generate_body_decode_expr` already falls through to a raw `body`
  passthrough for content types it does not special-case (the same
  pattern octet-stream relies on), and `request_body_type` returns
  `String` for a `{type: string}` schema, so the server contract
  type-checks end-to-end without any further codegen work. Restricting
  this PR to client-only would have left the README ambiguous and
  forced a near-identical follow-up.
- **Dedicated `text/plain` branch in `generate_body_emission`** rather
  than reusing the default arm. The default arm runs the body through
  `get_body_encode_expr`, which JSON-quotes a string schema
  (`json.to_string(json.string(body))`). For `text/plain` that would
  put a quoted JSON string on the wire; the spec-literal media type
  expects the raw caller-supplied string, so the new branch wraps the
  body in `transport.TextBody(body)` directly with no encoding.
- **Server allow-list extended via the explicit MIME check**, mirroring
  octet-stream. The list is a five-element MIME comparison rather than
  a registry lookup so the diff stays minimal and the existing
  drift-detection test still owns the source-of-truth invariant
  between the registry and `is_supported_request`.

## Limitations

- The remaining #352 gaps (vendor-prefixed response media types,
  `deepObject` requirements on complex parameters, and the OpenAPI 3.0
  GitHub spec hang) are unaffected by this PR — they need separate
  diagnostics work.
- A `text/plain` body declared with a non-string schema (e.g.
  `{type: object}`) will not be rejected during validation. The
  generated request type would be the typed record while the wire
  body is a plain string, which would fail at runtime; the same
  caveat already applies to the existing octet-stream support.

Refs #352