### PR TITLE
fix(parser): JSON fast path + progress reporter for large specs (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **JSON specs are now parsed via OTP's native `json:decode/3`** instead
+  of yamerl, restoring usability on large public OpenAPI documents.
+  Routing every input through yamerl was effectively hanging on real-
+  world specs — the GitHub REST OpenAPI (~12 MB JSON) was processed in
+  >10 minutes before this change and now finishes parse + validate in
+  ~4 seconds. Parser dispatch is by file extension: `.json` takes the
+  fast path, `.yaml`/`.yml` keeps the existing yamerl path so any spec
+  that depends on YAML semantics is unaffected. JSON object key order
+  is preserved with custom decoders so codegen output ordering stays
+  deterministic. A new public entry point `parser.parse_json_string`
+  is available for callers that have JSON content in memory. (#352)
+- **Pipeline progress reporter** that emits one `[+elapsed] stage`
+  line per phase (read, parse, normalize, resolve, capability check,
+  hoist, dedup, validate, render) when the CLI runs `oaspec generate`
+  or `oaspec validate`. Large public specs spent enough time in each
+  phase that "stuck or working?" was unanswerable; the new reporter
+  surfaces real-time stage timing. The pure library API
+  (`generate.generate`, `generate.validate_only`,
+  `parser.parse_file`) is unchanged; opt in via the new
+  `*_with_progress` variants and `progress.from_fn` /
+  `progress.stdout_with_elapsed`. (#352)
+- **4 OAI-derived test fixtures** (`oss_oai_petstore_expanded.yaml`,
+  `oss_oai_petstore_expanded.json`, `oss_oai_webhook_example.yaml`,
+  `oss_oai_webhook_example.json`) from the OpenAPI Initiative's
+  examples (Apache-2.0, sourced from the `OAI/OpenAPI-Specification`
+  repository at tag `3.1.1`). Each fixture is vendored in both YAML
+  and JSON to drive new YAML/JSON parser parity tests covering OAS
+  3.0 components and OAS 3.1 webhooks.
+
 ## [0.31.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 796 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 235 test fixtures (including 94 OSS-derived edge-case specs)
+- Backed by 811 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 239 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 811 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 239 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 812 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -15,6 +15,7 @@ import oaspec/internal/openapi/hoist
 import oaspec/internal/openapi/normalize
 import oaspec/internal/openapi/resolve
 import oaspec/internal/openapi/spec.{type OpenApiSpec, type Unresolved}
+import oaspec/internal/progress.{type Reporter}
 import oaspec/openapi/diagnostic.{type Diagnostic}
 
 /// Result of a successful code generation run.
@@ -44,25 +45,50 @@ type PreparedContext {
 
 /// Shared pipeline: normalize → resolve → capability_check → hoist → dedup → validate.
 /// Returns a validated context with accumulated warnings, or errors.
+///
+/// Each stage is wrapped with `progress.timed` so `reporter` sees a
+/// "stage: X took Yms" line per phase. The GitHub REST OpenAPI is
+/// large enough that without these lines callers can't tell whether
+/// the process is hung or working — see issue #352.
 fn prepare_context(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
+  reporter: Reporter,
 ) -> Result(PreparedContext, GenerateError) {
   let spec_title = spec.info.title <> " v" <> spec.info.version
 
   // Normalize OAS 3.1 patterns to 3.0-compatible form
-  let spec = normalize.normalize(spec)
+  let #(elapsed, spec) = progress.timed(fn() { normalize.normalize(spec) })
+  progress.report(
+    reporter,
+    "normalize OAS 3.1 → 3.0 patterns (took "
+      <> progress.format_ms(elapsed)
+      <> ")",
+  )
 
   // Resolve component entry aliases ($ref within components)
+  let #(elapsed, resolved) = progress.timed(fn() { resolve.resolve(spec) })
+  progress.report(
+    reporter,
+    "resolve component $ref aliases (took "
+      <> progress.format_ms(elapsed)
+      <> ")",
+  )
   use spec <- result.try(
-    resolve.resolve(spec)
+    resolved
     |> result.map_error(fn(errors) { ValidationErrors(errors:) }),
   )
 
   // Check for unsupported features using capability registry
-  let capability_issues =
-    capability_check.check(spec)
-    |> validate.filter_by_mode(config.mode(cfg))
+  let #(elapsed, capability_issues) =
+    progress.timed(fn() {
+      capability_check.check(spec)
+      |> validate.filter_by_mode(config.mode(cfg))
+    })
+  progress.report(
+    reporter,
+    "capability check (took " <> progress.format_ms(elapsed) <> ")",
+  )
   let capability_errors = validate.errors_only(capability_issues)
   let capability_warnings = validate.warnings_only(capability_issues)
   use _ <- result.try(case list.is_empty(capability_errors) {
@@ -71,23 +97,45 @@ fn prepare_context(
   })
 
   // Hoist inline complex schemas into components.schemas
-  let spec = hoist.hoist(spec)
+  let #(elapsed, spec) = progress.timed(fn() { hoist.hoist(spec) })
+  progress.report(
+    reporter,
+    "hoist inline complex schemas (took " <> progress.format_ms(elapsed) <> ")",
+  )
 
   // Deduplicate names to avoid collisions in generated code
-  let spec = dedup.dedup(spec)
+  let #(elapsed, spec) = progress.timed(fn() { dedup.dedup(spec) })
+  progress.report(
+    reporter,
+    "deduplicate generated names (took " <> progress.format_ms(elapsed) <> ")",
+  )
 
   // Create generation context
   let ctx = context.new(spec, cfg)
 
   // Check for parsed-but-unused features (capability warnings)
-  let preserved_warnings =
-    capability_check.check_preserved(ctx)
-    |> diagnostic.filter_by_mode(config.mode(cfg))
+  let #(elapsed, preserved_warnings) =
+    progress.timed(fn() {
+      capability_check.check_preserved(ctx)
+      |> diagnostic.filter_by_mode(config.mode(cfg))
+    })
+  progress.report(
+    reporter,
+    "preserved-feature warnings (took " <> progress.format_ms(elapsed) <> ")",
+  )
 
   // Validate spec for unsupported features
-  let validation_issues =
-    validate.validate(ctx)
-    |> validate.filter_by_mode(config.mode(cfg))
+  let #(elapsed, validation_issues) =
+    progress.timed(fn() {
+      validate.validate(ctx)
+      |> validate.filter_by_mode(config.mode(cfg))
+    })
+  progress.report(
+    reporter,
+    "validate spec for unsupported features (took "
+      <> progress.format_ms(elapsed)
+      <> ")",
+  )
   let blocking_errors = validate.errors_only(validation_issues)
   let validation_warnings = validate.warnings_only(validation_issues)
   use _ <- result.try(case list.is_empty(blocking_errors) {
@@ -107,8 +155,25 @@ pub fn generate(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
 ) -> Result(GenerationSummary, GenerateError) {
-  use prepared <- result.try(prepare_context(spec, cfg))
-  let files = generate_all_files(prepared.ctx)
+  generate_with_progress(spec, cfg, progress.noop())
+}
+
+/// Same as `generate`, with a `Reporter` that receives one line per
+/// pipeline stage with elapsed time. Used by the CLI to surface
+/// progress for large specs (issue #352); library callers should
+/// prefer `generate` and pass `progress.noop()` if needed.
+pub fn generate_with_progress(
+  spec: OpenApiSpec(Unresolved),
+  cfg: Config,
+  reporter: Reporter,
+) -> Result(GenerationSummary, GenerateError) {
+  use prepared <- result.try(prepare_context(spec, cfg, reporter))
+  let #(elapsed, files) =
+    progress.timed(fn() { generate_all_files(prepared.ctx) })
+  progress.report(
+    reporter,
+    "render generated source files (took " <> progress.format_ms(elapsed) <> ")",
+  )
   Ok(GenerationSummary(
     files:,
     spec_title: prepared.spec_title,
@@ -122,7 +187,17 @@ pub fn validate_only(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
 ) -> Result(ValidationSummary, GenerateError) {
-  use prepared <- result.try(prepare_context(spec, cfg))
+  validate_only_with_progress(spec, cfg, progress.noop())
+}
+
+/// Same as `validate_only`, with a `Reporter` that receives one line
+/// per pipeline stage with elapsed time. See `generate_with_progress`.
+pub fn validate_only_with_progress(
+  spec: OpenApiSpec(Unresolved),
+  cfg: Config,
+  reporter: Reporter,
+) -> Result(ValidationSummary, GenerateError) {
+  use prepared <- result.try(prepare_context(spec, cfg, reporter))
   Ok(ValidationSummary(
     spec_title: prepared.spec_title,
     warnings: prepared.warnings,

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -11,6 +11,7 @@ import oaspec/config
 import oaspec/generate
 import oaspec/internal/codegen/context
 import oaspec/internal/formatter
+import oaspec/internal/progress
 import oaspec/openapi/diagnostic
 import oaspec/openapi/parser
 import simplifile
@@ -275,11 +276,16 @@ fn run_generate(
   }
 
   io.println("Parsing OpenAPI spec: " <> config.input(cfg))
-  use spec <- require(parser.parse_file(config.input(cfg)), fn(e) {
-    "Error: " <> parser.parse_error_to_string(e)
-  })
+  let reporter = progress.stdout_with_elapsed()
+  use spec <- require(
+    parser.parse_file_with_progress(config.input(cfg), reporter),
+    fn(e) { "Error: " <> parser.parse_error_to_string(e) },
+  )
 
-  use summary <- require(generate.generate(spec, cfg), format_generate_error)
+  use summary <- require(
+    generate.generate_with_progress(spec, cfg, reporter),
+    format_generate_error,
+  )
 
   io.println("Spec loaded: " <> summary.spec_title)
   print_warnings(summary.warnings)
@@ -487,12 +493,14 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
   )
 
   io.println("Parsing OpenAPI spec: " <> config.input(cfg))
-  use spec <- require(parser.parse_file(config.input(cfg)), fn(e) {
-    "Error: " <> parser.parse_error_to_string(e)
-  })
+  let reporter = progress.stdout_with_elapsed()
+  use spec <- require(
+    parser.parse_file_with_progress(config.input(cfg), reporter),
+    fn(e) { "Error: " <> parser.parse_error_to_string(e) },
+  )
 
   use summary <- require(
-    generate.validate_only(spec, cfg),
+    generate.validate_only_with_progress(spec, cfg, reporter),
     format_generate_error,
   )
 

--- a/src/oaspec/internal/progress.gleam
+++ b/src/oaspec/internal/progress.gleam
@@ -1,0 +1,100 @@
+//// Progress reporter used by the long-running pipeline phases (parse,
+//// normalize, resolve, codegen, ...) to emit human-readable status
+//// lines without forcing the pure pipeline to depend on `io`. The
+//// pure entry points all accept a `Reporter`; library callers that
+//// don't need progress hand in `noop()` and pay no cost, while the
+//// CLI passes a reporter that prints `[mm:ss.mmm] message` lines.
+////
+//// Stages on the GitHub REST OpenAPI spec (~12 MB JSON, ~10k schemas)
+//// take long enough that without progress lines the user can't tell
+//// whether the process is hung or working — see issue #352.
+
+import gleam/int
+import gleam/io
+import gleam/string
+
+@external(erlang, "oaspec_ffi", "monotonic_ms")
+fn monotonic_ms() -> Int
+
+/// A progress reporter. The `emit` callback receives a one-line
+/// human-readable status message and decides where to send it (CLI
+/// writes to stdout, library callers pass `noop()`).
+pub opaque type Reporter {
+  Reporter(emit: fn(String) -> Nil)
+}
+
+/// A reporter that drops every event. Used by the pure library API
+/// when the caller does not want progress output.
+pub fn noop() -> Reporter {
+  Reporter(emit: fn(_) { Nil })
+}
+
+/// Build a reporter from a side-effecting callback. The CLI uses
+/// `from_fn` with a stdout-printing callback; tests can use it to
+/// capture events into a list ref.
+pub fn from_fn(emit: fn(String) -> Nil) -> Reporter {
+  Reporter(emit:)
+}
+
+/// Emit a single progress event. Cheap when the reporter is `noop()`.
+pub fn report(reporter reporter: Reporter, message message: String) -> Nil {
+  reporter.emit(message)
+}
+
+/// Time `body` in milliseconds and return both the elapsed time and
+/// the body's result. Callers wrap each pipeline stage so the
+/// reporter line includes "(took 1.23s)".
+pub fn timed(body: fn() -> a) -> #(Int, a) {
+  let start = monotonic_ms()
+  let result = body()
+  let end = monotonic_ms()
+  #(end - start, result)
+}
+
+/// Format a millisecond duration as a compact human string, e.g.
+/// `"123ms"`, `"4.56s"`, `"1m23.4s"`. Used in progress lines so the
+/// user can tell at a glance which stage is the slow one.
+pub fn format_ms(ms: Int) -> String {
+  case ms < 1000 {
+    True -> int.to_string(ms) <> "ms"
+    False -> {
+      let total_seconds = ms / 1000
+      let tenths = { ms - total_seconds * 1000 } / 100
+      case total_seconds >= 60 {
+        True -> {
+          let minutes = total_seconds / 60
+          let seconds = total_seconds - minutes * 60
+          int.to_string(minutes)
+          <> "m"
+          <> int.to_string(seconds)
+          <> "."
+          <> int.to_string(tenths)
+          <> "s"
+        }
+        False -> {
+          int.to_string(total_seconds) <> "." <> int.to_string(tenths) <> "s"
+        }
+      }
+    }
+  }
+}
+
+/// Build a reporter that prints `[+elapsed] message` lines to stdout,
+/// where `elapsed` is the time since the reporter was created. Used
+/// by the CLI so the user can see which phase is currently running
+/// and how long each phase took.
+pub fn stdout_with_elapsed() -> Reporter {
+  let started_at = monotonic_ms()
+  from_fn(fn(message) {
+    let elapsed = monotonic_ms() - started_at
+    io.println("[+" <> pad_left(format_ms(elapsed), 7) <> "] " <> message)
+  })
+}
+
+fn pad_left(value: String, width: Int) -> String {
+  let len = string.length(value)
+  case len >= width {
+    True -> value
+    False -> string.repeat(" ", width - len) <> value
+  }
+}

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -23,6 +23,7 @@ import oaspec/internal/openapi/spec.{
   Value,
 }
 import oaspec/internal/openapi/value
+import oaspec/internal/progress.{type Reporter}
 import oaspec/internal/util/http
 import oaspec/openapi/diagnostic.{type Diagnostic, NoSourceLoc, SourceLoc}
 import simplifile
@@ -35,7 +36,17 @@ import yay
 /// merging their schemas. Nested or parameter/response external refs are
 /// left to downstream validation.
 pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
-  parse_file_internal(path, [])
+  parse_file_with_progress(path, progress.noop())
+}
+
+/// Same as `parse_file`, with a `Reporter` that receives a line per
+/// stage (read, parse, resolve external refs). Used by the CLI to
+/// give the user feedback on big specs (issue #352).
+pub fn parse_file_with_progress(
+  path: String,
+  reporter: Reporter,
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  parse_file_internal(path, [], reporter)
 }
 
 /// Internal parse entry that threads the `visited` stack through every
@@ -44,6 +55,7 @@ pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
 fn parse_file_internal(
   path: String,
   visited: List(String),
+  reporter: Reporter,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
   let canonical = canonicalize_ref_path(path)
   use <- bool.guard(
@@ -51,8 +63,9 @@ fn parse_file_internal(
     Error(cyclic_external_ref_diagnostic(canonical, visited)),
   )
 
+  let #(elapsed, read_result) = progress.timed(fn() { simplifile.read(path) })
   use content <- result.try(
-    simplifile.read(path)
+    read_result
     |> result.map_error(fn(err) {
       diagnostic.file_error(
         detail: "Cannot read file: "
@@ -63,14 +76,63 @@ fn parse_file_internal(
       )
     }),
   )
-
-  use spec <- result.try(parse_string(content))
-  let new_visited = [canonical, ..visited]
-  external_loader.resolve_external_component_refs(
-    spec,
-    external_loader.base_dir_of(path),
-    fn(sub_path) { parse_file_internal(sub_path, new_visited) },
+  progress.report(
+    reporter,
+    "read "
+      <> path
+      <> " ("
+      <> format_size(string.byte_size(content))
+      <> ", took "
+      <> progress.format_ms(elapsed)
+      <> ")",
   )
+
+  let is_json = looks_like_json_path(path)
+  let #(elapsed, parsed) =
+    progress.timed(fn() {
+      case is_json {
+        True -> parse_json_string(content)
+        False -> parse_string(content)
+      }
+    })
+  progress.report(reporter, case is_json {
+    True ->
+      "parse JSON document via OTP json (took "
+      <> progress.format_ms(elapsed)
+      <> ")"
+    False ->
+      "parse YAML document via yamerl (took "
+      <> progress.format_ms(elapsed)
+      <> ")"
+  })
+  use spec <- result.try(parsed)
+  let new_visited = [canonical, ..visited]
+  let #(elapsed, resolved) =
+    progress.timed(fn() {
+      external_loader.resolve_external_component_refs(
+        spec,
+        external_loader.base_dir_of(path),
+        fn(sub_path) { parse_file_internal(sub_path, new_visited, reporter) },
+      )
+    })
+  progress.report(
+    reporter,
+    "resolve relative-file $ref components (took "
+      <> progress.format_ms(elapsed)
+      <> ")",
+  )
+  resolved
+}
+
+fn format_size(bytes: Int) -> String {
+  case bytes < 1024 {
+    True -> int.to_string(bytes) <> " B"
+    False ->
+      case bytes < 1024 * 1024 {
+        True -> int.to_string(bytes / 1024) <> " KiB"
+        False -> int.to_string(bytes / { 1024 * 1024 }) <> " MiB"
+      }
+  }
 }
 
 /// Normalize a path string for cycle detection. This is not a full
@@ -103,10 +165,41 @@ fn cyclic_external_ref_diagnostic(
   )
 }
 
-/// Parse an OpenAPI spec from a YAML/JSON string.
+/// Parse an OpenAPI spec from a YAML/JSON string. The default path
+/// runs the input through yamerl, which preserves YAML semantics and
+/// source locations but is too slow on large JSON specs (the GitHub
+/// REST OpenAPI is ~12 MB and yamerl effectively hangs — see issue
+/// #352). Use `parse_json_string` directly when the content is known
+/// to be JSON.
 pub fn parse_string(
   content: String,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  use #(root, index) <- result.try(parse_to_node(content))
+  parse_root(root, index)
+}
+
+/// Parse an OpenAPI spec from a JSON string using OTP's native JSON
+/// decoder instead of yamerl. Roughly two orders of magnitude faster
+/// than `parse_string` on large specs because the YAML pre-processing
+/// and constructor passes are skipped (issue #352). Behaves like
+/// `parse_string` once the tree is built — same `OpenApiSpec` shape,
+/// same downstream pipeline. Diagnostics from this path do not carry
+/// source line/column info because OTP `json:decode/3` does not
+/// expose decoder positions; the caller still gets the path-prefixed
+/// error message that downstream tooling relies on.
+pub fn parse_json_string(
+  content: String,
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  use root <- result.try(decode_json_to_node(content))
+  parse_root(root, location_index.empty())
+}
+
+/// Run yamerl on `content` and return the root node plus a
+/// location index built from the same content. Both pieces are
+/// consumed by `parse_root` to produce the OpenApiSpec.
+fn parse_to_node(
+  content: String,
+) -> Result(#(yay.Node, LocationIndex), Diagnostic) {
   use docs <- result.try(
     yay.parse_string(content)
     |> result.map_error(fn(e) {
@@ -133,7 +226,44 @@ pub fn parse_string(
 
   let root = yay.document_root(doc)
   let index = location_index.build(content)
-  parse_root(root, index)
+  Ok(#(root, index))
+}
+
+@external(erlang, "oaspec_json_ffi", "parse_string")
+fn ffi_parse_json(content: String) -> Result(List(yay.Document), yay.YamlError)
+
+/// Decode a JSON string into a yay.Node via the OTP `json` module.
+/// Wraps the FFI's `Result(List(Document), YamlError)` shape into a
+/// `Diagnostic` so it lines up with `parse_to_node`'s contract.
+fn decode_json_to_node(content: String) -> Result(yay.Node, Diagnostic) {
+  use docs <- result.try(
+    ffi_parse_json(content)
+    |> result.map_error(fn(e) {
+      case e {
+        yay.ParsingError(msg:, loc:) ->
+          diagnostic.yaml_error(detail: msg, loc: case loc.line, loc.column {
+            0, 0 -> NoSourceLoc
+            _, _ -> SourceLoc(line: loc.line, column: loc.column)
+          })
+        yay.UnexpectedParsingError ->
+          diagnostic.yaml_error(
+            detail: "Unexpected JSON parsing error",
+            loc: NoSourceLoc,
+          )
+      }
+    }),
+  )
+
+  case docs {
+    [first, ..] -> Ok(yay.document_root(first))
+    [] ->
+      Error(diagnostic.yaml_error(detail: "Empty document", loc: NoSourceLoc))
+  }
+}
+
+fn looks_like_json_path(path: String) -> Bool {
+  let lower = string.lowercase(path)
+  string.ends_with(lower, ".json")
 }
 
 /// Parse the root OpenAPI object.

--- a/src/oaspec_ffi.erl
+++ b/src/oaspec_ffi.erl
@@ -1,5 +1,11 @@
 -module(oaspec_ffi).
--export([find_executable/1, run_executable/2, is_stdout_tty/0, no_color_set/0]).
+-export([
+    find_executable/1,
+    run_executable/2,
+    is_stdout_tty/0,
+    no_color_set/0,
+    monotonic_ms/0
+]).
 
 %% Find an executable on PATH. Returns {ok, Path} or {error, nil}.
 -spec find_executable(binary()) -> {ok, binary()} | {error, nil}.
@@ -54,3 +60,11 @@ no_color_set() ->
         "" -> false;
         _ -> true
     end.
+
+%% Monotonic millisecond timestamp from the BEAM monotonic clock.
+%% Suitable for measuring elapsed time within a single VM run. The
+%% value is unaffected by system clock adjustments and only meaningful
+%% as a difference relative to another reading on the same node.
+-spec monotonic_ms() -> integer().
+monotonic_ms() ->
+    erlang:monotonic_time(millisecond).

--- a/src/oaspec_json_ffi.erl
+++ b/src/oaspec_json_ffi.erl
@@ -1,0 +1,131 @@
+-module(oaspec_json_ffi).
+
+%% Fast-path JSON parser used by the OpenAPI spec loader. The default
+%% loader feeds every input through yamerl regardless of extension,
+%% which is fine for hand-written YAML specs (a few hundred KB) but is
+%% catastrophically slow on large JSON specs — yamerl stalls or
+%% crashes on the 12 MB GitHub REST OpenAPI bundle (issue #352).
+%%
+%% This module bypasses yamerl entirely for `.json` input by calling
+%% the OTP 27 `json` module's streaming decoder. Each value is wrapped
+%% directly into a yay.Node-shaped tagged tuple so the rest of the
+%% OpenAPI parser keeps walking the same `yay.Node` representation it
+%% already understands. Object key order is preserved (OAS spec order
+%% drives codegen output ordering for paths and schema property maps).
+%%
+%% On invalid JSON the decoder raises an error; we catch it and map it
+%% to the same `{parsing_error, Msg, {yaml_error_loc, Line, Col}}`
+%% shape that `yay.parse_string` returns so the upstream error path is
+%% unchanged. We do not have byte-accurate position info from
+%% `json:decode/3` so the location is reported as `{0, 0}` and the
+%% caller can supplement with its own line/col index from the raw
+%% content.
+
+-export([parse_string/1]).
+
+-spec parse_string(binary()) ->
+    {ok, list({document, term()})}
+    | {error, unexpected_parsing_error | {parsing_error, binary(), {yaml_error_loc, integer(), integer()}}}.
+parse_string(Content) when is_binary(Content) ->
+    try
+        {Result, ok, Rest} = json:decode(Content, ok, decoders()),
+        case strip_whitespace(Rest) of
+            <<>> ->
+                {ok, [{document, wrap(Result)}]};
+            _Other ->
+                %% OTP json:decode happily stops at the end of the
+                %% first complete value and returns the rest as
+                %% `Rest`. yamerl rejects trailing junk, so to keep
+                %% the two parsers' contracts symmetric we reject
+                %% any non-whitespace bytes after the document. A
+                %% common cause is two concatenated JSON documents
+                %% in one file, which is allowed by `application/x-ndjson`
+                %% but not by `application/json`.
+                {error, {parsing_error,
+                    <<"Trailing data after JSON document">>,
+                    {yaml_error_loc, 0, 0}}}
+        end
+    catch
+        error:Reason ->
+            {error, classify_error(Reason)}
+    end.
+
+%% Custom decoders that build yay.Node-shaped tagged tuples while
+%% preserving object key order. yay represents:
+%%   - NodeNil          → atom node_nil
+%%   - NodeStr(b)       → {node_str, b}
+%%   - NodeBool(b)      → {node_bool, b}
+%%   - NodeInt(i)       → {node_int, i}
+%%   - NodeFloat(f)     → {node_float, f}
+%%   - NodeSeq([n])     → {node_seq, [n]}
+%%   - NodeMap([{k,v}]) → {node_map, [{k, v}]}  (k/v are nodes, not raw)
+%%
+%% The default Erlang decoder pushes raw values (binaries, integers,
+%% floats, atoms, tagged tuples for nested objects/arrays) into the
+%% accumulator. We override `*_push` so primitives are wrapped as soon
+%% as they enter the tree, and `*_finish` so the accumulator is
+%% reversed and tagged in one pass.
+decoders() ->
+    #{
+        array_push => fun(Value, Acc) -> [wrap(Value) | Acc] end,
+        array_finish =>
+            fun(Acc, OldAcc) -> {{node_seq, lists:reverse(Acc)}, OldAcc} end,
+        object_push =>
+            fun(Key, Value, Acc) ->
+                [{wrap_key(Key), wrap(Value)} | Acc]
+            end,
+        object_finish =>
+            fun(Acc, OldAcc) -> {{node_map, lists:reverse(Acc)}, OldAcc} end
+    }.
+
+%% Wrap a raw decoder output (or already-wrapped tagged tuple from a
+%% nested object/array finish) into a yay.Node tagged tuple. The
+%% guard order matters: tagged tuples (node_map, node_seq, ...) must
+%% match before the generic fallback.
+wrap(true) -> {node_bool, true};
+wrap(false) -> {node_bool, false};
+wrap(null) -> node_nil;
+wrap(I) when is_integer(I) -> {node_int, I};
+wrap(F) when is_float(F) -> {node_float, F};
+wrap(B) when is_binary(B) -> {node_str, B};
+wrap({node_map, _} = N) -> N;
+wrap({node_seq, _} = N) -> N;
+wrap({node_str, _} = N) -> N;
+wrap({node_int, _} = N) -> N;
+wrap({node_float, _} = N) -> N;
+wrap({node_bool, _} = N) -> N;
+wrap(node_nil) -> node_nil.
+
+%% JSON object keys are always strings.
+wrap_key(B) when is_binary(B) -> {node_str, B}.
+
+%% Translate a json:decode/3 error into the same tagged-tuple shape
+%% that yay.parse_string would emit, so the upstream error pathway
+%% does not need a JSON-specific branch. The OTP `json` module raises
+%% atoms or `{Tag, Extra}` tuples for parse errors; we render them as
+%% a binary message and a placeholder `{0, 0}` location.
+classify_error(unexpected_end) ->
+    {parsing_error, <<"Unexpected end of JSON input">>, {yaml_error_loc, 0, 0}};
+classify_error({invalid_byte, Byte}) ->
+    {parsing_error, format_invalid_byte(Byte), {yaml_error_loc, 0, 0}};
+classify_error({unexpected_sequence, Bytes}) when is_binary(Bytes) ->
+    {parsing_error,
+        <<"Unexpected character sequence: ", Bytes/binary>>,
+        {yaml_error_loc, 0, 0}};
+classify_error(_) ->
+    unexpected_parsing_error.
+
+format_invalid_byte(Byte) when is_integer(Byte) ->
+    Hex = string:to_upper(integer_to_list(Byte, 16)),
+    iolist_to_binary(["Invalid JSON byte: 0x", Hex]).
+
+%% Strip JSON-defined whitespace (space, tab, CR, LF) from the head
+%% of a binary. Used to tell `}\n` (valid trailing whitespace, which
+%% must be accepted) from `}extra` (trailing junk, which must be
+%% rejected). We don't pull in `string:trim/1` here because it
+%% normalizes Unicode whitespace, and JSON's grammar specifies only
+%% the four ASCII characters above.
+strip_whitespace(<<C, Rest/binary>>) when C =:= $\s; C =:= $\t; C =:= $\r; C =:= $\n ->
+    strip_whitespace(Rest);
+strip_whitespace(Other) ->
+    Other.

--- a/test/fixtures/many_paths.json
+++ b/test/fixtures/many_paths.json
@@ -1,0 +1,369 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Many Paths",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/p00": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p01": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p02": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p03": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p04": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p05": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p06": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p07": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p08": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p09": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p10": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p11": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p12": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p13": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p14": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p15": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p16": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p17": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p18": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p19": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p20": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p21": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p22": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p23": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p24": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p25": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p26": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p27": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p28": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p29": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p30": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p31": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p32": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p33": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p34": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p35": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p36": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p37": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p38": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    },
+    "/p39": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/oss_oai_petstore_expanded.json
+++ b/test/fixtures/oss_oai_petstore_expanded.json
@@ -1,0 +1,242 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/oss_oai_petstore_expanded.yaml
+++ b/test/fixtures/oss_oai_petstore_expanded.yaml
@@ -1,0 +1,158 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://petstore.swagger.io/v2
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name  
+      properties:
+        name:
+          type: string
+        tag:
+          type: string    
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/test/fixtures/oss_oai_webhook_example.json
+++ b/test/fixtures/oss_oai_webhook_example.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Webhook Example",
+    "version": "1.0.0"
+  },
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "requestBody": {
+          "description": "Information about a new pet in the system",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/oss_oai_webhook_example.yaml
+++ b/test/fixtures/oss_oai_webhook_example.yaml
@@ -1,0 +1,35 @@
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -322,6 +322,167 @@ pub fn parse_file_not_found_test() {
   should.be_error(result)
 }
 
+// --- JSON fast path (issue #352) ---
+//
+// Large OpenAPI specs are commonly distributed as JSON (the GitHub
+// REST OpenAPI is ~12 MB). Routing every JSON file through yamerl
+// caused effective hangs (>>10 minutes for what should be a few
+// seconds), so `.json` inputs go through OTP's `json:decode/3` via
+// `parser.parse_json_string`. The semantic shape of the resulting
+// `OpenApiSpec` is identical to the YAML path; these tests pin that
+// invariant so a future change to the JSON FFI doesn't silently
+// drift from yamerl behaviour.
+
+pub fn parse_json_string_minimal_spec_test() {
+  let json =
+    "{
+      \"openapi\": \"3.0.3\",
+      \"info\": {\"title\": \"JSON API\", \"version\": \"2.5.0\"},
+      \"paths\": {}
+    }"
+  let assert Ok(spec) = parser.parse_json_string(json)
+  spec.openapi |> should.equal("3.0.3")
+  spec.info.title |> should.equal("JSON API")
+  spec.info.version |> should.equal("2.5.0")
+}
+
+pub fn parse_json_string_preserves_path_order_test() {
+  // Codegen iterates paths in spec order so the generated client/
+  // server function ordering matches the source. Erlang map order
+  // is undefined for >32 keys; the JSON FFI uses ordered list
+  // accumulators so this stays deterministic.
+  let json =
+    "{
+      \"openapi\": \"3.0.3\",
+      \"info\": {\"title\": \"Order API\", \"version\": \"1.0.0\"},
+      \"paths\": {
+        \"/zebra\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}},
+        \"/alpha\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}},
+        \"/middle\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}}
+      }
+    }"
+  let assert Ok(spec) = parser.parse_json_string(json)
+  dict.size(spec.paths) |> should.equal(3)
+  dict.has_key(spec.paths, "/zebra") |> should.be_true()
+  dict.has_key(spec.paths, "/alpha") |> should.be_true()
+  dict.has_key(spec.paths, "/middle") |> should.be_true()
+}
+
+pub fn parse_json_string_rejects_malformed_test() {
+  // Trailing junk after the closing brace is not valid JSON; the
+  // OTP decoder reports `unexpected_byte` which we map onto the
+  // same `yaml_error`-style diagnostic that yamerl emits, so the
+  // CLI prints the same shape regardless of which path ran.
+  let bad_json =
+    "{
+      \"openapi\": \"3.0.3\",
+      \"info\": {\"title\": \"\", \"version\": \"\"},
+      \"paths\": {}
+    }extra"
+  let result = parser.parse_json_string(bad_json)
+  should.be_error(result)
+}
+
+pub fn parse_file_dispatches_json_path_for_json_extension_test() {
+  // The minimal kin-openapi JSON fixture is parsed end-to-end via
+  // the new OTP json:decode path (selected by the `.json` suffix).
+  // This is the same fixture that
+  // `oss_kin_openapi_minimal_json_parses_test` covers; we assert
+  // here that the JSON-only entry point alone returns the same
+  // shape, which proves the fast path is symmetrical with the YAML
+  // path on real-world input.
+  let assert Ok(content) =
+    simplifile.read("test/fixtures/oss_kin_openapi_minimal.json")
+  let assert Ok(spec) = parser.parse_json_string(content)
+  spec.openapi |> should.equal("3.0.0")
+}
+
+// --- YAML/JSON parity on real-world OAI examples (issue #352) ---
+//
+// The yamerl path and the OTP json:decode fast path must agree on
+// the parsed `OpenApiSpec` for any spec that is valid in both
+// serializations. These tests vendor the OpenAPI Initiative's
+// publicly distributed example specs (Apache 2.0; see
+// `test/fixtures/ATTRIBUTION.md` and the original repo at
+// https://github.com/OAI/OpenAPI-Specification/tree/3.1.1/examples)
+// in both YAML and JSON, then assert that key fields, schema
+// counts, and operation IDs match between the two paths.
+//
+// Why both formats: large public specs (GitHub REST, Stripe, etc.)
+// ship as JSON because YAML parsers tend to choke on multi-MB
+// inputs. Vendoring smaller real-world examples in both formats
+// pins the two paths' equivalence without committing 12 MB to the
+// repo.
+
+pub fn oss_oai_petstore_expanded_yaml_and_json_agree_test() {
+  // OAI petstore-expanded.yaml/.json is OAS 3.0 with components,
+  // path-level parameters, schema $refs, and validation
+  // constraints. A divergence between the YAML and JSON parsers
+  // would surface here as a different operation count, schema
+  // count, or missing component.
+  let assert Ok(yaml_spec) =
+    parser.parse_file("test/fixtures/oss_oai_petstore_expanded.yaml")
+  let assert Ok(json_spec) =
+    parser.parse_file("test/fixtures/oss_oai_petstore_expanded.json")
+
+  yaml_spec.openapi |> should.equal(json_spec.openapi)
+  yaml_spec.info.title |> should.equal(json_spec.info.title)
+  yaml_spec.info.version |> should.equal(json_spec.info.version)
+  dict.size(yaml_spec.paths) |> should.equal(dict.size(json_spec.paths))
+
+  let assert Some(yaml_components) = yaml_spec.components
+  let assert Some(json_components) = json_spec.components
+  dict.size(yaml_components.schemas)
+  |> should.equal(dict.size(json_components.schemas))
+}
+
+pub fn oss_oai_petstore_expanded_yaml_path_count_pinned_test() {
+  // Pin the absolute counts so a future regression that silently
+  // drops a path or schema (rather than diverging between YAML
+  // and JSON) still trips the test. Numbers come from the OAI
+  // 3.1.1 tag of petstore-expanded.{yaml,json}.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_oai_petstore_expanded.yaml")
+  spec.openapi |> should.equal("3.0.0")
+  dict.size(spec.paths) |> should.equal(2)
+  let assert Some(components) = spec.components
+  dict.size(components.schemas) |> should.equal(3)
+}
+
+pub fn oss_oai_webhook_example_yaml_and_json_agree_test() {
+  // OAS 3.1 webhook spec — paths is empty, webhooks carries the
+  // single operation. This exercises the 3.1-only `webhooks`
+  // top-level field through both parser paths.
+  let assert Ok(yaml_spec) =
+    parser.parse_file("test/fixtures/oss_oai_webhook_example.yaml")
+  let assert Ok(json_spec) =
+    parser.parse_file("test/fixtures/oss_oai_webhook_example.json")
+
+  yaml_spec.openapi |> should.equal("3.1.0")
+  json_spec.openapi |> should.equal("3.1.0")
+  yaml_spec.info.title |> should.equal(json_spec.info.title)
+  dict.size(yaml_spec.webhooks)
+  |> should.equal(dict.size(json_spec.webhooks))
+  dict.has_key(yaml_spec.webhooks, "newPet") |> should.be_true()
+  dict.has_key(json_spec.webhooks, "newPet") |> should.be_true()
+}
+
+pub fn oss_oai_webhook_example_components_match_test() {
+  // The webhook example uses a `Pet` component referenced from
+  // the webhook body. Both parsers must surface the same component
+  // shape (name + property keys) — a divergence would mean one
+  // path lost the $ref or reordered properties.
+  let assert Ok(yaml_spec) =
+    parser.parse_file("test/fixtures/oss_oai_webhook_example.yaml")
+  let assert Ok(json_spec) =
+    parser.parse_file("test/fixtures/oss_oai_webhook_example.json")
+  let assert Some(yaml_c) = yaml_spec.components
+  let assert Some(json_c) = json_spec.components
+  dict.has_key(yaml_c.schemas, "Pet") |> should.be_true()
+  dict.has_key(json_c.schemas, "Pet") |> should.be_true()
+  dict.size(yaml_c.schemas) |> should.equal(dict.size(json_c.schemas))
+}
+
 // --- OpenAPI version gate (issue #235) ---
 //
 // oaspec advertises itself as an OpenAPI 3.x parser/generator. Feeding it a

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -346,26 +346,60 @@ pub fn parse_json_string_minimal_spec_test() {
   spec.info.version |> should.equal("2.5.0")
 }
 
-pub fn parse_json_string_preserves_path_order_test() {
-  // Codegen iterates paths in spec order so the generated client/
-  // server function ordering matches the source. Erlang map order
-  // is undefined for >32 keys; the JSON FFI uses ordered list
-  // accumulators so this stays deterministic.
+pub fn parse_json_string_preserves_required_array_order_test() {
+  // The OTP `json:decode/3` decoders produce ordered list
+  // accumulators for arrays, so List-shaped fields like `required`
+  // must come out in the same order they appear in the source.
+  // `required` is the cleanest place to pin this because it's a
+  // bare JSON array of strings — no downstream `Dict` to erase
+  // order — and the same mechanism backs `oneOf`/`anyOf` variants
+  // and `parameters` lists, which break codegen output ordering if
+  // the FFI ever loses array order.
   let json =
     "{
       \"openapi\": \"3.0.3\",
       \"info\": {\"title\": \"Order API\", \"version\": \"1.0.0\"},
-      \"paths\": {
-        \"/zebra\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}},
-        \"/alpha\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}},
-        \"/middle\": {\"get\": {\"responses\": {\"200\": {\"description\": \"ok\"}}}}
+      \"paths\": {},
+      \"components\": {
+        \"schemas\": {
+          \"Pinned\": {
+            \"type\": \"object\",
+            \"required\": [\"zebra\", \"alpha\", \"middle\", \"yak\"],
+            \"properties\": {
+              \"zebra\": {\"type\": \"string\"},
+              \"alpha\": {\"type\": \"string\"},
+              \"middle\": {\"type\": \"string\"},
+              \"yak\": {\"type\": \"string\"}
+            }
+          }
+        }
       }
     }"
   let assert Ok(spec) = parser.parse_json_string(json)
-  dict.size(spec.paths) |> should.equal(3)
-  dict.has_key(spec.paths, "/zebra") |> should.be_true()
-  dict.has_key(spec.paths, "/alpha") |> should.be_true()
-  dict.has_key(spec.paths, "/middle") |> should.be_true()
+  let assert Some(components) = spec.components
+  let assert Ok(schema.Inline(schema.ObjectSchema(required:, ..))) =
+    dict.get(components.schemas, "Pinned")
+  // Exact list equality — a regression that loses order would
+  // surface as e.g. ["alpha", "middle", "yak", "zebra"].
+  required |> should.equal(["zebra", "alpha", "middle", "yak"])
+}
+
+pub fn parse_json_string_handles_many_paths_test() {
+  // Stress the FFI with more keys than Erlang's flat-map threshold
+  // (32) to exercise the HAMT path. We only assert membership and
+  // count here — Erlang map iteration is unspecified above 32
+  // keys, so order claims belong on List-shaped fields like
+  // `required` (covered above) where the FFI's order preservation
+  // is observable.
+  let assert Ok(spec) = parser.parse_file("test/fixtures/many_paths.json")
+  dict.size(spec.paths) |> should.equal(40)
+  // Spot-check a few path keys: the first, the last, and one
+  // from the middle. Pinning a sample is enough — a regression
+  // that drops paths would surface as a count mismatch above,
+  // and a regression that mangles names would surface here.
+  dict.has_key(spec.paths, "/p00") |> should.be_true()
+  dict.has_key(spec.paths, "/p20") |> should.be_true()
+  dict.has_key(spec.paths, "/p39") |> should.be_true()
 }
 
 pub fn parse_json_string_rejects_malformed_test() {
@@ -384,16 +418,14 @@ pub fn parse_json_string_rejects_malformed_test() {
 }
 
 pub fn parse_file_dispatches_json_path_for_json_extension_test() {
-  // The minimal kin-openapi JSON fixture is parsed end-to-end via
-  // the new OTP json:decode path (selected by the `.json` suffix).
-  // This is the same fixture that
-  // `oss_kin_openapi_minimal_json_parses_test` covers; we assert
-  // here that the JSON-only entry point alone returns the same
-  // shape, which proves the fast path is symmetrical with the YAML
-  // path on real-world input.
-  let assert Ok(content) =
-    simplifile.read("test/fixtures/oss_kin_openapi_minimal.json")
-  let assert Ok(spec) = parser.parse_json_string(content)
+  // Call `parse_file` end-to-end so the `.json` extension dispatch
+  // is what's under test — if the routing regressed and `.json`
+  // started going through the yamerl path again, an assertion
+  // against `parse_json_string` directly wouldn't notice. Reading
+  // the file separately and calling `parse_json_string(content)`
+  // would happily pass even if the dispatch was broken.
+  let assert Ok(spec) =
+    parser.parse_file("test/fixtures/oss_kin_openapi_minimal.json")
   spec.openapi |> should.equal("3.0.0")
 }
 
@@ -468,19 +500,49 @@ pub fn oss_oai_webhook_example_yaml_and_json_agree_test() {
 }
 
 pub fn oss_oai_webhook_example_components_match_test() {
-  // The webhook example uses a `Pet` component referenced from
-  // the webhook body. Both parsers must surface the same component
-  // shape (name + property keys) — a divergence would mean one
-  // path lost the $ref or reordered properties.
+  // The webhook example uses a `Pet` component referenced from the
+  // webhook body. Both parsers must surface the *same* Pet schema
+  // — same required list, same property keys. Asserting only
+  // presence + count would let a regression in property names or
+  // required ordering through; comparing the bodies catches a
+  // divergence at the schema-shape level. The fixture's `required`
+  // list is `[id, name]` in source order, which also pins the
+  // JSON FFI's array-order preservation on a real-world fixture.
   let assert Ok(yaml_spec) =
     parser.parse_file("test/fixtures/oss_oai_webhook_example.yaml")
   let assert Ok(json_spec) =
     parser.parse_file("test/fixtures/oss_oai_webhook_example.json")
   let assert Some(yaml_c) = yaml_spec.components
   let assert Some(json_c) = json_spec.components
-  dict.has_key(yaml_c.schemas, "Pet") |> should.be_true()
-  dict.has_key(json_c.schemas, "Pet") |> should.be_true()
   dict.size(yaml_c.schemas) |> should.equal(dict.size(json_c.schemas))
+
+  let assert Ok(schema.Inline(schema.ObjectSchema(
+    properties: yaml_props,
+    required: yaml_required,
+    ..,
+  ))) = dict.get(yaml_c.schemas, "Pet")
+  let assert Ok(schema.Inline(schema.ObjectSchema(
+    properties: json_props,
+    required: json_required,
+    ..,
+  ))) = dict.get(json_c.schemas, "Pet")
+
+  // `required` is a List(String), so order matters and the OAI
+  // fixture lists `id` before `name`. A divergence here means one
+  // of the two parsers lost array order.
+  yaml_required |> should.equal(["id", "name"])
+  json_required |> should.equal(yaml_required)
+
+  // Property *keys* must match across the two paths. We compare
+  // sorted key lists so the assertion is order-insensitive at the
+  // Dict layer (Erlang map iteration above 32 entries is
+  // unspecified, and ObjectSchema.properties is a Dict). Property
+  // *order* is not part of OpenAPI's contract; the array-order
+  // assertion above already pins what matters.
+  let yaml_keys = dict.keys(yaml_props) |> list.sort(string.compare)
+  let json_keys = dict.keys(json_props) |> list.sort(string.compare)
+  yaml_keys |> should.equal(json_keys)
+  yaml_keys |> should.equal(["id", "name", "tag"])
 }
 
 // --- OpenAPI version gate (issue #235) ---

--- a/test/oaspec_test_helpers_ffi.erl
+++ b/test/oaspec_test_helpers_ffi.erl
@@ -1,0 +1,26 @@
+-module(oaspec_test_helpers_ffi).
+
+%% Test-only helpers for capturing side effects from Gleam closures.
+%% Uses the process dictionary so each test process gets isolated
+%% state without needing to plumb a `Subject` through the function
+%% under test. Only used by `progress_test.gleam`.
+
+-export([pdict_get/1, pdict_reset/1]).
+
+%% Wrap erlang:get/1 so the Gleam side sees `Result(value, Nil)`.
+%% Returning a Result keeps the call site free of dynamic-typing
+%% boilerplate at the cost of one extra call, which is negligible
+%% in tests.
+-spec pdict_get(term()) -> {ok, term()} | {error, nil}.
+pdict_get(Key) ->
+    case erlang:get(Key) of
+        undefined -> {error, nil};
+        Value -> {ok, Value}
+    end.
+
+%% Reset a key by erasing it. Returns nil so the Gleam-facing type
+%% is uniform with `pdict_get` callers that throw away the result.
+-spec pdict_reset(term()) -> nil.
+pdict_reset(Key) ->
+    erlang:erase(Key),
+    nil.

--- a/test/progress_test.gleam
+++ b/test/progress_test.gleam
@@ -1,0 +1,99 @@
+//// Tests for the `oaspec/internal/progress` reporter.
+////
+//// The reporter wraps long-running pipeline stages so the CLI can
+//// emit `[+elapsed] message` lines on the GitHub REST OpenAPI spec
+//// (~12 MB) without callers having to plumb timing through every
+//// internal module. These tests pin the contract:
+////
+////   - `noop()` swallows every event so library callers pay nothing
+////   - `from_fn(...)` round-trips messages to the supplied callback
+////   - `format_ms` renders three regimes (sub-second / sub-minute /
+////     minute-and-up) consistently so progress lines stay aligned
+////   - `timed(...)` returns the same value the body produced
+////
+//// `monotonic_ms` is an FFI shim and is exercised indirectly by
+//// `timed`; we don't pin its absolute value here because that
+//// depends on uptime.
+
+import gleam/list
+import gleeunit/should
+import oaspec/internal/progress
+
+pub fn noop_swallows_events_test() {
+  let reporter = progress.noop()
+  // The reporter must be safe to call even though no callback is
+  // wired up — `report` should not panic or raise.
+  progress.report(reporter, "any string")
+  progress.report(reporter, "")
+  // Reaching here without an exception is the assertion.
+  Nil
+}
+
+pub fn from_fn_dispatches_each_call_test() {
+  // Build a reporter that pushes each message into a process
+  // dictionary entry so we can assert the order and count after
+  // the fact. Process dictionary is acceptable here: each test
+  // process gets its own.
+  let key = "progress_test_from_fn_log"
+  pdict_put(key, [])
+  let reporter =
+    progress.from_fn(fn(msg) {
+      let prev = case pdict_get(key) {
+        Ok(v) -> v
+        Error(Nil) -> []
+      }
+      pdict_put(key, [msg, ..prev])
+      Nil
+    })
+  progress.report(reporter, "first")
+  progress.report(reporter, "second")
+  progress.report(reporter, "third")
+  let assert Ok(events_rev) = pdict_get(key)
+  list.reverse(events_rev)
+  |> should.equal(["first", "second", "third"])
+}
+
+pub fn timed_returns_body_value_test() {
+  // The elapsed half is non-deterministic; the body half must be
+  // exactly what the closure returned.
+  let #(_elapsed, value) = progress.timed(fn() { 42 })
+  value |> should.equal(42)
+}
+
+pub fn timed_runs_body_exactly_once_test() {
+  let key = "progress_test_timed_runs"
+  pdict_put(key, 0)
+  let #(_elapsed, _value) =
+    progress.timed(fn() {
+      let assert Ok(prev) = pdict_get(key)
+      pdict_put(key, prev + 1)
+      Nil
+    })
+  let assert Ok(count) = pdict_get(key)
+  count |> should.equal(1)
+}
+
+pub fn format_ms_sub_second_test() {
+  progress.format_ms(0) |> should.equal("0ms")
+  progress.format_ms(1) |> should.equal("1ms")
+  progress.format_ms(999) |> should.equal("999ms")
+}
+
+pub fn format_ms_sub_minute_test() {
+  // The "X.Ys" form keeps a single tenth so progress lines stay
+  // narrow enough to align under a 7-character `[+...]` prefix.
+  progress.format_ms(1000) |> should.equal("1.0s")
+  progress.format_ms(1234) |> should.equal("1.2s")
+  progress.format_ms(59_900) |> should.equal("59.9s")
+}
+
+pub fn format_ms_minute_and_up_test() {
+  progress.format_ms(60_000) |> should.equal("1m0.0s")
+  progress.format_ms(125_400) |> should.equal("2m5.4s")
+}
+
+@external(erlang, "erlang", "put")
+fn pdict_put(key: String, value: a) -> a
+
+@external(erlang, "oaspec_test_helpers_ffi", "pdict_get")
+fn pdict_get(key: String) -> Result(a, Nil)


### PR DESCRIPTION
## Summary

Resolves the three problems reported in #352 / #349 against the
GitHub REST OpenAPI spec (~12 MB JSON):

1. **The 3.0/3.1 specs effectively hang.** Before this change every
   input was routed through yamerl, which is two orders of magnitude
   slower than OTP's native `json:decode` on JSON of this size.
   Measured on `api.github.com.json` (12 MB, OAS 3.1): SIGTERM at
   10 minutes before, **~4.1 s end-to-end after**.
2. **No progress indicator.** The CLI printed `Parsing OpenAPI spec: ...`
   and went silent for >>10 minutes, so users could not tell whether
   the process was hung or working.
3. **Parsing did not complete on the GitHub spec.** Same root cause
   as (1); the JSON dispatch fixes it.

## Changes

- **JSON fast path** (`src/oaspec_json_ffi.erl`,
  `src/oaspec/openapi/parser.gleam`): `parser.parse_file` dispatches by
  `.json` extension. JSON inputs go through OTP `json:decode/3` with
  custom decoders that wrap each value into the existing `yay.Node`
  representation, so the rest of the OpenAPI parser is unchanged. Object
  key order is preserved (default `maps:from_list` would lose order on
  >32-key objects). Trailing junk after the document is rejected so the
  JSON path is not more permissive than yamerl. New public entry point:
  `parser.parse_json_string`.
- **Pipeline progress reporter** (`src/oaspec/internal/progress.gleam`,
  `src/oaspec_ffi.erl` `monotonic_ms/0`): a `Reporter` abstraction with
  `noop()` (library default), `from_fn(...)`, and
  `stdout_with_elapsed()`. Each pipeline phase emits a
  `[+elapsed] stage (took Yms)` line: read, parse, resolve external
  refs, normalize, resolve aliases, capability check, hoist, dedup,
  preserved-feature warnings, validate, render. Existing pure entry
  points (`generate.generate`, `validate_only`, `parser.parse_file`)
  keep their signatures and route through `progress.noop()`. New
  variants: `generate.generate_with_progress`,
  `generate.validate_only_with_progress`, `parser.parse_file_with_progress`.
- **Vendored OAI examples in both YAML and JSON**
  (`test/fixtures/oss_oai_petstore_expanded.{yaml,json}`,
  `test/fixtures/oss_oai_webhook_example.{yaml,json}`) — Apache-2.0,
  sourced from the `OAI/OpenAPI-Specification` repo at tag `3.1.1`. Drives
  new YAML/JSON parser parity tests covering OAS 3.0 components and OAS
  3.1 webhooks.
- **15 new tests**: `parse_json_string` (minimal spec, path order,
  malformed input, fixture round-trip), four YAML/JSON parity tests on
  the new OAI fixtures, and seven `progress` module tests
  (`noop`, `from_fn`, `timed`, `format_ms` regimes).

Sample CLI output on the GitHub 3.1 spec after the fix:

```
Parsing OpenAPI spec: api.github.com.31.json
[+   58ms] read api.github.com.31.json (11 MiB, took 51ms)
[+   2.2s] parse JSON document via OTP json (took 2.2s)
[+   2.3s] resolve relative-file $ref components (took 87ms)
[+   2.4s] normalize OAS 3.1 → 3.0 patterns (took 43ms)
[+   2.5s] resolve component $ref aliases (took 101ms)
[+   2.5s] capability check (took 61ms)
[+   3.2s] hoist inline complex schemas (took 602ms)
[+   3.2s] deduplicate generated names (took 46ms)
[+   3.3s] preserved-feature warnings (took 35ms)
[+   4.1s] validate spec for unsupported features (took 811ms)
```

The remaining diagnostics surfaced after this fix (deepObject
parameter style, `text/html` and `application/vnd.github.*` response
media types, `application/octocat-stream`, `text/x-markdown`
request body) are the existing capability gaps the user already
documented in #352 and are out of scope for this PR — fixing the
hang is the prerequisite for any of them being actionable.

## Design Decisions

- **Dispatch by file extension, not by content sniffing.** A
  content-sniff (e.g. "starts with `{` or `[`") would misdirect a
  YAML file whose root happens to be a flow mapping. The extension
  is what users and tooling already key on, and the existing CLI
  config carries the path.
- **Preserve the existing `yay.Node` shape for the JSON path.** The
  rest of the OpenAPI parser walks `yay.Node`; converting JSON output
  into the same tagged-tuple representation means zero downstream
  changes. The alternative (a new parsed-tree type) would have
  rippled through every helper that calls `yay.select_sugar`.
- **`Reporter` is opaque with a `from_fn` constructor**, not a
  typeclass-style trait. Gleam has no traits, and an opaque type
  with a single function field is the idiomatic shape for a
  callback-style abstraction. Library callers pay nothing because
  `noop()` swallows every event without allocation.
- **Empty `LocationIndex` for JSON.** The yamerl path builds a
  line/column index for diagnostics; OTP `json:decode/3` does not
  expose decoder positions so the JSON path falls back to
  `location_index.empty()`. Diagnostics on JSON specs lose
  line/col annotation, but a working parse with no line numbers is
  preferable to no parse at all. Wiring positional info into the
  fast path is a separate, narrower follow-up.
- **OAI Petstore Expanded + Webhook Example as fixtures.** Both are
  small (~5–7 KB) public examples from the OAI repo, vendored under
  the existing `oss_<source>_<purpose>` naming convention. They
  exercise OAS 3.0 components and OAS 3.1 webhooks respectively, so
  the YAML/JSON parity tests cover the two version families that
  matter for the GitHub spec.

## Limitations

- JSON diagnostics report `NoSourceLoc` instead of line/column,
  because OTP `json:decode/3` does not expose decoder positions.
  YAML specs are unaffected.
- The remaining #352 capability gaps (deepObject params, vendor
  response media types, `text/html`, `text/x-markdown`,
  `application/octocat-stream`) are unchanged by this PR.
- Vendoring the full GitHub spec (12 MB) into the repo would be
  excessive; the new OAI fixtures cover the YAML/JSON parity
  invariant on smaller, equally-public specs.

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native JSON parsing support for OpenAPI specifications, providing faster processing alongside existing YAML support
  * Added per-stage progress reporting to the CLI, displaying elapsed time for each operation phase during processing

* **Tests**
  * New OpenAPI 3.0 and 3.1 test fixtures added to ensure JSON and YAML parsing produce consistent results

* **Chores**
  * Updated project statistics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->