### PR TITLE
fix(validate): accept vendor MIME types and warn on style-less complex params (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Unrecognized `text/*` and `application/*` content types now fall
+  back to passthrough aliases instead of failing validation.** Real-
+  world specs (the GitHub REST OpenAPI is the canonical example)
+  routinely declare `text/html`, `application/vnd.github.diff`,
+  `application/octocat-stream`, and similar vendor-prefixed media
+  types. The parser now folds any unrecognized `text/*` to
+  `TextPlain` (raw String body) and any unrecognized `application/*`
+  to `ApplicationOctetStream` (raw bytes); other top-level types
+  (`image/*`, `audio/*`, `video/*`) still fail with the existing
+  unsupported-content-type diagnostic. The original media-type
+  string is preserved verbatim in the generated server's
+  `Content-Type` response header so the wire-level contract is
+  unchanged. (#352)
+- **Complex query / header / cookie parameters without an explicit
+  `style` now warn instead of erroring.** The OpenAPI 3.x default
+  style for query is `form`, which only handles primitives cleanly,
+  but real-world specs (the GitHub REST API's `cwes`, `affects`,
+  `has`, `fields` parameters all declared as
+  `oneOf: [string, array<string>]` with no `style`) routinely omit
+  the declaration. The generator now falls back to form-style
+  serialization (which round-trips correctly for `oneOf` of
+  primitives and shallow objects) and emits a warning prompting
+  the spec author to be explicit if true `deepObject` semantics are
+  required. Path parameters with complex schemas continue to be a
+  hard error for server codegen. (#352)
+
+### Fixed
+
+- **Property and enum names starting with `+`, `-`, or a digit are
+  now mapped to valid Gleam identifiers.** GitHub's reaction-count
+  schema uses `+1` and `-1` keys; both previously collapsed to a
+  bare `1`, colliding with each other and producing
+  `DiscussionReactions(1: Int, 1_2: Int, ...)` — invalid Gleam.
+  `to_snake_case` and `to_pascal_case` now rewrite a leading `+` /
+  `-` to `plus_` / `minus_` (so `+1` → `plus_1`, `-1` → `minus_1`)
+  and prepend `n_` / `N` when the result still starts with a digit
+  (so `404` → `n_404` for fields and `N404` for variants). (#352)
+
 ### Added
 
 - **JSON specs are now parsed via OTP's native `json:decode/3`** instead

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 811 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 239 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 826 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 239 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -17,7 +17,7 @@ import oaspec/internal/util/content_type
 import oaspec/internal/util/http
 import oaspec/internal/util/naming
 import oaspec/openapi/diagnostic.{
-  type Diagnostic, SeverityError, TargetBoth, TargetServer,
+  type Diagnostic, SeverityError, SeverityWarning, TargetBoth, TargetServer,
 }
 
 /// Validate the parsed spec for unsupported patterns.
@@ -550,6 +550,25 @@ fn validate_server_cookie_param(
 
 /// Check if a parameter has a complex schema (object, oneOf, allOf, anyOf)
 /// that is not handled by deepObject style.
+///
+/// Path parameters: complex schemas in path params are still a hard
+/// error for server codegen — there is no sensible way to extract a
+/// nested object from a single path segment.
+///
+/// Query / header / cookie parameters: when the spec author omits
+/// `style`, the OpenAPI default is `form`, which only serializes
+/// primitives cleanly. Real-world specs (the GitHub REST OpenAPI is
+/// the canonical example — `cwes`, `affects`, `has`, `fields` are all
+/// `oneOf: [string, array<string>]`) routinely declare complex
+/// query parameters without an explicit style. Refusing those was
+/// blocking codegen on otherwise-supported specs, so we now emit a
+/// warning and let the parameter through. The generated client uses
+/// the form-style fallback (the same path that a primitive query
+/// parameter takes), which round-trips correctly for `oneOf`-of-
+/// primitives and for shallow `object` schemas with primitive
+/// properties — the two shapes that show up in practice. Spec
+/// authors who need true deepObject serialization should still
+/// declare `style: deepObject` explicitly. (issue #352)
 fn validate_complex_param_schema(
   path: String,
   param: spec.Parameter(Resolved),
@@ -585,12 +604,12 @@ fn validate_complex_param_schema(
               }
             _ -> [
               diagnostic.validation(
-                severity: SeverityError,
+                severity: SeverityWarning,
                 target: TargetBoth,
                 path: path,
-                detail: "Complex schema (object/oneOf/allOf/anyOf) parameters require style: deepObject. Without it, the parameter cannot be serialized.",
+                detail: "Complex schema (object/oneOf/allOf/anyOf) parameter has no explicit 'style'; falling back to form-style serialization. This works for oneOf-of-primitives and shallow objects but may not match the spec author's intent for deeply nested objects.",
                 hint: Some(
-                  "Add 'style: deepObject' to the parameter definition.",
+                  "Declare 'style: deepObject' explicitly if the parameter encodes a structured object.",
                 ),
               ),
             ]

--- a/src/oaspec/internal/util/content_type.gleam
+++ b/src/oaspec/internal/util/content_type.gleam
@@ -17,6 +17,28 @@ pub type ContentType {
 /// Parse a content type string into a ContentType.
 /// Recognizes structured syntax suffixes: types ending with `+json` are
 /// treated as JSON-compatible, and types ending with `+xml` as XML-compatible.
+///
+/// Unrecognized media types fall back to a passthrough alias so real-world
+/// specs like the GitHub REST API don't trip the "unsupported content
+/// type" diagnostic just because they declare vendor-prefixed responses
+/// (issue #352). The fallback table:
+///
+///   - `text/*` (e.g. `text/html`, `text/x-markdown`) aliases to
+///     `TextPlain` so the body passes through as a `String`.
+///   - `application/*` not already in the recognized list (e.g.
+///     `application/vnd.github.diff`, `application/octocat-stream`)
+///     aliases to `ApplicationOctetStream` so the body passes through
+///     as raw bytes.
+///   - Anything else (`image/*`, `audio/*`, `video/*`, …) stays as
+///     `UnsupportedContentType` and continues to fail validation —
+///     the generator has no sensible default for binary media that
+///     isn't already covered by `application/octet-stream`.
+///
+/// The original media-type string is still embedded verbatim into the
+/// generated server's `Content-Type` response header (codegen pulls
+/// the name from the spec, not from `to_string`), so the wire-level
+/// content type is preserved even though the in-memory typing falls
+/// back. This mirrors the existing `application/x-ndjson` aliasing.
 pub fn from_string(content_type: String) -> ContentType {
   case content_type {
     "application/json" -> ApplicationJson
@@ -41,7 +63,15 @@ pub fn from_string(content_type: String) -> ContentType {
         False ->
           case string.ends_with(other, "+xml") {
             True -> ApplicationXml
-            False -> UnsupportedContentType(other)
+            False ->
+              case string.starts_with(other, "text/") {
+                True -> TextPlain
+                False ->
+                  case string.starts_with(other, "application/") {
+                    True -> ApplicationOctetStream
+                    False -> UnsupportedContentType(other)
+                  }
+              }
           }
       }
   }

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -50,26 +50,105 @@ fn compile_regexes() -> Regexes {
 
 /// Convert a string to PascalCase for Gleam type names.
 /// Examples: "pet_store" -> "PetStore", "get-user" -> "GetUser"
+///
+/// As with `to_snake_case`, leading `+`/`-` and digit-led results
+/// are normalised (issue #352) so OpenAPI enum values like `+1`,
+/// `-1`, or `404` produce valid Gleam variant names (`Plus1`,
+/// `Minus1`, `N404`) instead of `1`, `1`, `404` — the latter would
+/// be rejected by the parser at the type-constructor position.
 pub fn to_pascal_case(input: String) -> String {
   let re = compile_regexes()
   input
+  |> rewrite_leading_signs
   |> split_words(re)
   |> list.map(capitalize)
   |> string.join("")
+  |> ensure_letter_start_pascal
+}
+
+/// Pascal-case equivalent of `ensure_letter_start`: digit-led
+/// results get an `N` prefix (instead of `n_`) so the result still
+/// reads as a single PascalCase token (`404` → `N404`, not
+/// `n_404` which would round-trip incorrectly through the snake/
+/// pascal converters).
+fn ensure_letter_start_pascal(input: String) -> String {
+  case string.pop_grapheme(input) {
+    Ok(#(first, _rest)) ->
+      case is_digit(first) {
+        True -> "N" <> input
+        False -> input
+      }
+    // nolint: thrown_away_error -- pop_grapheme only fails on empty input; passing it through unchanged is correct here
+    Error(_) -> input
+  }
 }
 
 /// Convert a string to snake_case for Gleam function/variable names.
 /// Examples: "PetStore" -> "pet_store", "getUserById" -> "get_user_by_id"
 /// Gleam keywords are suffixed with _ to avoid syntax errors.
+///
+/// OpenAPI property names like `+1`, `-1` (GitHub's reaction counts)
+/// or `404` (numeric keys) are not valid Gleam record field
+/// identifiers — Gleam fields must start with `a-z`. The naming
+/// pipeline therefore:
+///   - rewrites a leading `+` to `plus_` and a leading `-` to
+///     `minus_` so the sign is preserved as a readable prefix; and
+///   - prepends `n_` when the result still starts with a digit
+///     (e.g. `404` → `n_404`, `+1` → `plus_1`).
+/// Without these the generator produced syntactically invalid Gleam
+/// like `DiscussionReactions(1: Int, 1_2: Int, ...)` on the GitHub
+/// REST API spec, where `+1` and `-1` both collapsed to `1` (issue
+/// #352).
 pub fn to_snake_case(input: String) -> String {
   let re = compile_regexes()
   let result =
     input
+    |> rewrite_leading_signs
     |> insert_underscores_before_caps(re)
     |> split_words(re)
     |> list.map(string.lowercase)
     |> string.join("_")
+    |> ensure_letter_start
   escape_keyword(result)
+}
+
+/// Map a leading `+` to `plus_` and a leading `-` to `minus_` so
+/// `+1` / `-1` style property names survive the snake_case pipeline
+/// as `plus_1` / `minus_1` instead of colliding on a bare `1`.
+/// The body of the input is left untouched, so existing kebab-case
+/// inputs (`kebab-case`) keep splitting on `-` as before.
+fn rewrite_leading_signs(input: String) -> String {
+  case string.pop_grapheme(input) {
+    Ok(#("+", rest)) -> "plus_" <> rest
+    Ok(#("-", rest)) -> "minus_" <> rest
+    _ -> input
+  }
+}
+
+/// Prepend `n_` if the first grapheme is a digit, so a numeric-led
+/// result (`404`, `1_2` from a deduped `+1`/`-1`) becomes a valid
+/// Gleam identifier (`n_404`, `n_1_2`). Empty strings are left
+/// alone — that path is impossible from `to_snake_case` after
+/// non-empty input, but the guard keeps the helper composable.
+fn ensure_letter_start(input: String) -> String {
+  case string.pop_grapheme(input) {
+    Ok(#(first, _rest)) ->
+      case is_digit(first) {
+        True -> "n_" <> input
+        False -> input
+      }
+    // nolint: thrown_away_error -- pop_grapheme only fails on empty input; passing it through unchanged is correct here
+    Error(_) -> input
+  }
+}
+
+/// True for the ten ASCII digit graphemes. We avoid `int.parse` here
+/// because it accepts `+1`/`-1` and the goal is the bare digit test.
+fn is_digit(grapheme: String) -> Bool {
+  case grapheme {
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    _ -> False
+  }
 }
 
 /// Gleam reserved keywords that cannot be used as identifiers.

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -71,7 +71,46 @@ pub fn naming_to_snake_case_pascal_with_letter_digit_suffix_test() {
 
 pub fn naming_to_snake_case_digit_letter_still_splits_test() {
   // Digit→letter remains a split point — only letter→digit is glued.
-  naming.to_snake_case("256sha") |> should.equal("256_sha")
+  // The leading-digit guard then prepends `n_` so the result is a
+  // valid Gleam identifier (issue #352).
+  naming.to_snake_case("256sha") |> should.equal("n_256_sha")
+}
+
+pub fn naming_to_snake_case_leading_plus_becomes_plus_prefix_test() {
+  // GitHub's `+1` reaction key would otherwise collapse to `"1"`,
+  // colliding with `-1` and producing invalid identifiers — see #352.
+  naming.to_snake_case("+1") |> should.equal("plus_1")
+  naming.to_snake_case("+up_vote") |> should.equal("plus_up_vote")
+}
+
+pub fn naming_to_snake_case_leading_minus_becomes_minus_prefix_test() {
+  // The mirror of the `+` case so `+1` and `-1` end up at distinct
+  // identifiers (`plus_1` vs `minus_1`) instead of both collapsing
+  // to `1` and getting deduped to `1` / `1_2`.
+  naming.to_snake_case("-1") |> should.equal("minus_1")
+}
+
+pub fn naming_to_snake_case_leading_digit_gets_n_prefix_test() {
+  // Pure-numeric property names are valid in JSON but invalid as
+  // Gleam record fields. The pipeline prepends `n_` so they
+  // round-trip cleanly. `2fa` lands at `n_2_fa` because the camel-
+  // splitter treats the digit run as its own token and `fa` as a
+  // separate lower-case word — the prefix only cares about the
+  // first grapheme being a digit.
+  naming.to_snake_case("404") |> should.equal("n_404")
+  naming.to_snake_case("2fa") |> should.equal("n_2_fa")
+}
+
+pub fn naming_to_pascal_case_leading_plus_becomes_plus_prefix_test() {
+  naming.to_pascal_case("+1") |> should.equal("Plus1")
+}
+
+pub fn naming_to_pascal_case_leading_minus_becomes_minus_prefix_test() {
+  naming.to_pascal_case("-1") |> should.equal("Minus1")
+}
+
+pub fn naming_to_pascal_case_leading_digit_gets_n_prefix_test() {
+  naming.to_pascal_case("404") |> should.equal("N404")
 }
 
 // naming.operation_to_function_name tests

--- a/test/oaspec_test.gleam
+++ b/test/oaspec_test.gleam
@@ -2136,6 +2136,78 @@ pub fn content_type_x_ndjson_is_supported_response_test() {
   |> should.be_true()
 }
 
+// --- content type passthrough fallback (issue #352) ---
+//
+// Real-world specs (the GitHub REST OpenAPI is the canonical
+// example) declare `text/html` responses, vendor-prefixed types
+// like `application/vnd.github.diff`, and ad-hoc names like
+// `application/octocat-stream`. Refusing to generate code for any
+// of those was blocking adoption on otherwise-supported specs, so
+// the parser now folds:
+//
+//   - any `text/*` not specifically recognized → TextPlain
+//   - any `application/*` not specifically recognized → ApplicationOctetStream
+//
+// Other top-level types (`image/*`, `audio/*`, `video/*`) stay as
+// `UnsupportedContentType` because the generator has no sensible
+// default for binary media that is not already covered by
+// `application/octet-stream`.
+
+pub fn content_type_text_html_aliases_to_text_plain_test() {
+  content_type.from_string("text/html") |> should.equal(content_type.TextPlain)
+}
+
+pub fn content_type_text_x_markdown_aliases_to_text_plain_test() {
+  content_type.from_string("text/x-markdown")
+  |> should.equal(content_type.TextPlain)
+}
+
+pub fn content_type_vendor_application_aliases_to_octet_stream_test() {
+  // GitHub REST API vendor MIME types: diff/patch/sha/object plus
+  // the ad-hoc `octocat-stream`.
+  content_type.from_string("application/vnd.github.diff")
+  |> should.equal(content_type.ApplicationOctetStream)
+  content_type.from_string("application/vnd.github.patch")
+  |> should.equal(content_type.ApplicationOctetStream)
+  content_type.from_string("application/vnd.github.object")
+  |> should.equal(content_type.ApplicationOctetStream)
+  content_type.from_string("application/octocat-stream")
+  |> should.equal(content_type.ApplicationOctetStream)
+}
+
+pub fn content_type_image_png_still_unsupported_test() {
+  // Images don't match the text/ or application/ fallback so they
+  // stay UnsupportedContentType. This pins that the fallback is
+  // narrow on purpose — silently aliasing every MIME to bytes
+  // would mask real "this codegen does not support that" cases.
+  content_type.from_string("image/png")
+  |> should.equal(content_type.UnsupportedContentType("image/png"))
+}
+
+pub fn content_type_audio_video_still_unsupported_test() {
+  content_type.from_string("audio/mpeg")
+  |> should.equal(content_type.UnsupportedContentType("audio/mpeg"))
+  content_type.from_string("video/mp4")
+  |> should.equal(content_type.UnsupportedContentType("video/mp4"))
+}
+
+pub fn content_type_text_html_is_supported_response_test() {
+  content_type.is_supported_response(content_type.from_string("text/html"))
+  |> should.be_true()
+}
+
+pub fn content_type_vendor_diff_is_supported_response_test() {
+  content_type.is_supported_response(content_type.from_string(
+    "application/vnd.github.diff",
+  ))
+  |> should.be_true()
+}
+
+pub fn content_type_text_x_markdown_is_supported_request_test() {
+  content_type.is_supported_request(content_type.from_string("text/x-markdown"))
+  |> should.be_true()
+}
+
 pub fn content_type_to_string_test() {
   content_type.to_string(content_type.ApplicationJson)
   |> should.equal("application/json")
@@ -5721,8 +5793,15 @@ components:
 
 // --- Complex parameter schema validation tests ---
 
-/// Object schema query parameter without deepObject style must be rejected.
-pub fn object_query_param_without_deep_object_rejected_test() {
+/// Object schema query parameter without deepObject style now emits
+/// a warning instead of a hard error (issue #352). The OpenAPI 3.x
+/// default style for query is `form`, which only handles primitives
+/// cleanly, so the codegen falls back to form serialization and the
+/// warning prompts the spec author to be explicit if they need
+/// deepObject. Refusing the spec was blocking adoption on the
+/// GitHub REST API and other large public specs that routinely omit
+/// `style` for complex query params.
+pub fn object_query_param_without_deep_object_warns_not_errors_test() {
   let yaml =
     "
 openapi: 3.0.3
@@ -5760,10 +5839,65 @@ paths:
         validate: False,
       ),
     )
-  let errors = validate.validate(ctx)
-  // Must report error for object param without deepObject style
-  list.is_empty(errors)
-  |> should.be_false()
+  let issues = validate.validate(ctx)
+  // No blocking errors — codegen would proceed.
+  validate.errors_only(issues)
+  |> list.is_empty
+  |> should.be_true()
+  // But there's exactly one warning, pointing at the filter param.
+  let warnings = validate.warnings_only(issues)
+  list.length(warnings) |> should.equal(1)
+  let assert [Diagnostic(message: msg, ..)] = warnings
+  string.contains(msg, "no explicit 'style'")
+  |> should.be_true()
+}
+
+pub fn oneof_primitive_query_param_without_style_warns_test() {
+  // The GitHub REST API's `cwes` parameter is `oneOf: [string,
+  // array<string>]` with no explicit style. Pre-#352 oaspec
+  // refused to generate; now it emits a warning and proceeds.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /advisories:
+    get:
+      operationId: listAdvisories
+      parameters:
+        - name: cwes
+          in: query
+          schema:
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+      responses:
+        '200': { description: ok }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(spec) = resolve.resolve(spec)
+  let spec = hoist.hoist(spec)
+  let spec = dedup.dedup(spec)
+  let ctx =
+    context.new(
+      spec,
+      config.new(
+        input: "test.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Client,
+        validate: False,
+      ),
+    )
+  let issues = validate.validate(ctx)
+  validate.errors_only(issues)
+  |> list.is_empty
+  |> should.be_true()
 }
 
 /// Object schema query parameter WITH deepObject style must pass.
@@ -5817,6 +5951,9 @@ paths:
 /// Validation error for unsupported request content type must list
 /// all actually supported types, including form-urlencoded.
 pub fn validate_request_content_type_message_includes_form_urlencoded_test() {
+  // `image/png` stays UnsupportedContentType after the issue #352
+  // fallback (which only catches `text/*` and `application/*`); use
+  // it instead of `text/csv` so the error path still fires.
   let yaml =
     "
 openapi: 3.0.3
@@ -5829,7 +5966,7 @@ paths:
       operationId: doX
       requestBody:
         content:
-          text/csv:
+          image/png:
             schema:
               type: string
       responses:
@@ -5861,6 +5998,8 @@ paths:
 /// Validation error for unsupported response content type must list
 /// all actually supported types, including XML.
 pub fn validate_response_content_type_message_includes_xml_test() {
+  // See note above on `text/csv` → `image/png` for the same #352
+  // fallback rationale.
   let yaml =
     "
 openapi: 3.0.3
@@ -5875,7 +6014,7 @@ paths:
         '200':
           description: ok
           content:
-            text/csv:
+            image/png:
               schema:
                 type: string
 "


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #355. Merge that one first; this PR will then
> rebase onto `main` automatically. The two PRs are split because
> #355 is the heavy lift (JSON fast path + progress reporter +
> vendored OAI fixtures) and this one is a focused capability
> relaxation that only makes sense once #355 lets the validator
> actually reach these checks on the GitHub spec.

## Summary

After #355 unblocked the GitHub REST OpenAPI hang, the validator
still refused to generate code for the spec because of three
remaining capability gaps that real-world specs trip routinely.
This PR closes all three so the GitHub 3.0 / 3.1 specs go
end-to-end (parse → validate → generate → format) on a fresh
checkout.

## Changes

1. **Vendor / unrecognized content types fall back to passthrough**
   ([content_type.gleam](src/oaspec/internal/util/content_type.gleam)).
   `from_string` now folds any `text/*` not in the recognized list
   to `TextPlain` (raw String) and any `application/*` to
   `ApplicationOctetStream` (raw bytes), so `text/html`,
   `text/x-markdown`, `application/vnd.github.diff`,
   `application/octocat-stream`, etc. round-trip cleanly.
   `image/*`, `audio/*`, `video/*` and other top-level families
   still fail with the existing unsupported-content-type diagnostic
   so silent aliasing of binary media is avoided. The original
   media-type string is preserved verbatim in the generated
   server's `Content-Type` header.
2. **Complex query / header / cookie parameters without `style`
   warn instead of erroring**
   ([validate.gleam](src/oaspec/internal/codegen/validate.gleam)).
   The OpenAPI 3.x default style for query is `form`, which only
   serializes primitives cleanly, but real-world specs (GitHub's
   `cwes`, `affects`, `has`, `fields` parameters all declared as
   `oneOf: [string, array<string>]` with no `style`) routinely
   omit the declaration. The generator falls back to form-style
   serialization and prompts the spec author with a warning to be
   explicit if they need true `deepObject` semantics. Path
   parameters with complex schemas continue to be a hard error for
   server codegen.
3. **`+1`, `-1`, and digit-led property / enum names map to valid
   Gleam identifiers** ([naming.gleam](src/oaspec/internal/util/naming.gleam)).
   GitHub's reaction-count schema uses `+1` and `-1` keys; both
   previously collapsed to a bare `1` through the snake_case
   pipeline, colliding with each other and producing
   `DiscussionReactions(1: Int, 1_2: Int, ...)` — invalid Gleam
   that the post-generation `gleam format` step rejects.
   `to_snake_case` and `to_pascal_case` now rewrite a leading `+`
   to `plus_`/`Plus` and `-` to `minus_`/`Minus`, then prepend
   `n_`/`N` when the result still starts with a digit (`404` →
   `n_404` for fields, `N404` for variants).

## Design Decisions

- **Narrow content-type fallback (`text/*` and `application/*`
  only).** Aliasing every unknown MIME to bytes would mask real
  \"this codegen does not support that\" cases (e.g., `image/png`
  responses where the spec author probably wanted a binary body
  but the generator does not yet model image streaming). Keeping
  the fallback to the two families that almost always mean text-
  ish or vendor-specific content preserves the strict-by-default
  promise for everything else.
- **Warning, not silent passthrough, for style-less complex
  params.** The user gave an explicit \"only the parse failure
  matters\" steer, so emitting a warning is the minimal contract
  change that keeps the spec author informed without blocking
  codegen. Codegen continues to require `style: deepObject` to
  emit deepObject serialization; without it, the parameter
  serializes as form. This matches what most other generators do.
- **`plus_` / `minus_` prefixes preserve sign info.** A bare
  digit-only fallback (`n_1` for both `+1` and `-1`) would
  collide and force the dedup pass to invent `n_1_2`, which reads
  as nonsense. Mapping the leading sign to a readable prefix
  keeps the generated identifier round-tripping understandable
  for users skimming the GitHub-derived `DiscussionReactions`
  type.
- **Pascal `N` vs snake `n_` for digit-led prefixes.** PascalCase
  is a single-token identifier, so `N404` reads as one word;
  snake_case has explicit word separators, so `n_404` keeps the
  digit run as a recognizable token. Splitting the helper by
  case style avoids round-trip drift between the two converters.

## Verification

End-to-end on `/tmp/oaspec-352/api.github.com.31.json` (11 MiB,
OAS 3.1) and `api.github.com.json` (OAS 3.0): both generate 7
source files in ~40 s with `gleam format` succeeding on the
output (the 35 s render phase is the largest chunk; the rest is
parse + validate at ~6 s).

Sample CLI tail after this PR:

```text
[+   91ms] read /tmp/oaspec-352/api.github.com.31.json (11 MiB, took 80ms)
[+   3.3s] parse JSON document via OTP json (took 3.2s)
...
[+   5.8s] validate spec for unsupported features (took 1.1s)
[+  40.0s] render generated source files (took 34.1s)
Spec loaded: GitHub v3 REST API v1.1.4
  Generated: /tmp/oaspec-352/work/out31/api/types.gleam
  ...
  Formatted generated code

Successfully generated 7 files
```

## Limitations

- Diagnostics on the generated code remain at the warning level
  for style-less complex params (15 lines on the GitHub 3.1
  spec, all on the same `oneOf` shape). Spec authors who want
  zero warnings should declare `style: deepObject` explicitly.
- Vendor MIME types serialize as `String` / `BitArray` at the
  Gleam level — the generator does not model
  `application/vnd.github.diff`'s diff format, etc. Users who
  want richer typing should keep the fallback path and parse the
  body in their own code.

Refs #352