### PR TITLE
refactor(openapi): split yay bridge out of JsonValue module (#344)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,6 +80,7 @@ BEAM-only packages (`simplifile`, `glint`, `argv`, `yay`).
 | `oaspec/internal/openapi/resolver.gleam` | `$ref` resolution |
 | `oaspec/internal/openapi/schema.gleam` | Schema AST |
 | `oaspec/internal/openapi/spec.gleam` | OpenAPI document AST |
+| `oaspec/internal/openapi/value.gleam` | Target-neutral `JsonValue` type |
 
 ### BEAM-coupled (requires the Erlang target today)
 
@@ -99,7 +100,7 @@ or transitively depend on a BEAM-only data type (e.g. yay nodes).
 | `oaspec/internal/openapi/location_index.gleam` | Walks yamerl AST via `yaml_loc_ffi` |
 | `oaspec/internal/openapi/parser_error.gleam` | Carries `yay` node positions |
 | `oaspec/internal/openapi/parser_schema.gleam` | Operates on `yay` nodes |
-| `oaspec/internal/openapi/value.gleam` | Wraps `yay` value types |
+| `oaspec/internal/openapi/parser_value.gleam` | Bridges `yay` nodes to the pure `JsonValue` type |
 | `oaspec/internal/openapi/resolve.gleam` | Uses `@external(erlang, "gleam_stdlib", "identity")` (could be lifted) |
 
 The four `.erl` files in `src/` (`oaspec_ffi.erl`, `oaspec_json_ffi.erl`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: split the BEAM-only `yay` bridge out of
+  `oaspec/internal/openapi/value`.** The `JsonValue` type now lives
+  in a pure Gleam module with no `yay` dependency, and the
+  `extract_optional` / `extract_map` helpers that walk `yay` nodes
+  have moved to a new `parser_value` sibling module. Behavior is
+  unchanged; this shrinks the BEAM-coupled module count by one and
+  makes `value.gleam` actually compile on any Gleam target, in line
+  with the boundary documented in `ARCHITECTURE.md`. (#344)
+
 ## [0.33.0] - 2026-04-30
 
 ### Added

--- a/src/oaspec/internal/openapi/parser_schema.gleam
+++ b/src/oaspec/internal/openapi/parser_schema.gleam
@@ -10,12 +10,12 @@ import gleam/option.{None, Some}
 import gleam/result
 import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/parser_error
+import oaspec/internal/openapi/parser_value
 import oaspec/internal/openapi/schema.{
   type Discriminator, type SchemaObject, type SchemaRef, AllOfSchema,
   AnyOfSchema, ArraySchema, BooleanSchema, Discriminator, Inline, IntegerSchema,
   NumberSchema, ObjectSchema, OneOfSchema, StringSchema,
 }
-import oaspec/internal/openapi/value
 import oaspec/openapi/diagnostic.{type Diagnostic}
 import yay
 
@@ -68,11 +68,11 @@ fn parse_schema_object(
     |> result.unwrap(None)
     |> option.unwrap(False)
 
-  let default = value.extract_optional(node, "default")
+  let default = parser_value.extract_optional(node, "default")
 
-  let example = value.extract_optional(node, "example")
+  let example = parser_value.extract_optional(node, "example")
 
-  let const_value = value.extract_optional(node, "const")
+  let const_value = parser_value.extract_optional(node, "const")
 
   let unsupported_keywords = detect_unsupported_keywords(node)
 

--- a/src/oaspec/internal/openapi/parser_value.gleam
+++ b/src/oaspec/internal/openapi/parser_value.gleam
@@ -1,0 +1,66 @@
+//// yay → JsonValue bridge helpers used by the parsing layer.
+////
+//// Split out of `oaspec/internal/openapi/value` so the JsonValue type itself
+//// stays target-neutral (pure Gleam, no yay/BEAM dependency) and only the
+//// extraction helpers that touch yay nodes carry the BEAM-only coupling.
+//// See ARCHITECTURE.md for the overall core / shell boundary.
+
+import gleam/dict.{type Dict}
+import gleam/list
+import gleam/option.{type Option}
+import oaspec/internal/openapi/value.{
+  type JsonValue, JsonArray, JsonBool, JsonFloat, JsonInt, JsonNull, JsonObject,
+  JsonString,
+}
+import yay
+
+/// Convert a yay.Node to a JsonValue.
+fn from_node(node: yay.Node) -> JsonValue {
+  case node {
+    yay.NodeNil -> JsonNull
+    yay.NodeStr(s) -> JsonString(s)
+    yay.NodeBool(b) -> JsonBool(b)
+    yay.NodeInt(i) -> JsonInt(i)
+    yay.NodeFloat(f) -> JsonFloat(f)
+    yay.NodeSeq(items) -> JsonArray(list.map(items, from_node))
+    yay.NodeMap(entries) ->
+      JsonObject(
+        list.filter_map(entries, fn(entry) {
+          let #(k, v) = entry
+          case k {
+            yay.NodeStr(key) -> Ok(#(key, from_node(v)))
+            _ -> Error(Nil)
+          }
+        })
+        |> dict.from_list,
+      )
+  }
+}
+
+/// Try to extract a JsonValue from a node at a given key.
+/// Returns None if the key is absent or nil.
+pub fn extract_optional(node: yay.Node, key: String) -> Option(JsonValue) {
+  case yay.select_sugar(from: node, selector: key) {
+    Ok(yay.NodeNil) -> option.None
+    Ok(child) -> option.Some(from_node(child))
+    // nolint: thrown_away_error -- yay.SelectorError here only signals absent/mismatched key; absence is represented as None
+    Error(_) -> option.None
+  }
+}
+
+/// Extract a dict of JsonValues from a node at a given key.
+/// Returns empty dict if key is absent.
+pub fn extract_map(node: yay.Node, key: String) -> Dict(String, JsonValue) {
+  case yay.select_sugar(from: node, selector: key) {
+    Ok(yay.NodeMap(entries)) ->
+      list.filter_map(entries, fn(entry) {
+        let #(k, v) = entry
+        case k {
+          yay.NodeStr(name) -> Ok(#(name, from_node(v)))
+          _ -> Error(Nil)
+        }
+      })
+      |> dict.from_list
+    _ -> dict.new()
+  }
+}

--- a/src/oaspec/internal/openapi/value.gleam
+++ b/src/oaspec/internal/openapi/value.gleam
@@ -1,7 +1,12 @@
+//// Target-neutral JSON-compatible value type used to preserve arbitrary data
+//// from OpenAPI specs (default, example, const, ...). This module is pure
+//// Gleam: it defines the type only, with no `yay` or BEAM-specific
+//// dependency, so it can be compiled on any Gleam target.
+////
+//// The yay → JsonValue bridge helpers (`extract_optional`, `extract_map`)
+//// live in the BEAM-coupled `parser_value` sibling module.
+
 import gleam/dict.{type Dict}
-import gleam/list
-import gleam/option
-import yay
 
 /// A JSON-compatible value type for preserving arbitrary data from OpenAPI specs.
 /// Used for example, default, const, and other values that aren't necessarily strings.
@@ -13,55 +18,4 @@ pub type JsonValue {
   JsonString(String)
   JsonArray(List(JsonValue))
   JsonObject(Dict(String, JsonValue))
-}
-
-/// Convert a yay.Node to a JsonValue.
-fn from_node(node: yay.Node) -> JsonValue {
-  case node {
-    yay.NodeNil -> JsonNull
-    yay.NodeStr(s) -> JsonString(s)
-    yay.NodeBool(b) -> JsonBool(b)
-    yay.NodeInt(i) -> JsonInt(i)
-    yay.NodeFloat(f) -> JsonFloat(f)
-    yay.NodeSeq(items) -> JsonArray(list.map(items, from_node))
-    yay.NodeMap(entries) ->
-      JsonObject(
-        list.filter_map(entries, fn(entry) {
-          let #(k, v) = entry
-          case k {
-            yay.NodeStr(key) -> Ok(#(key, from_node(v)))
-            _ -> Error(Nil)
-          }
-        })
-        |> dict.from_list,
-      )
-  }
-}
-
-/// Try to extract a JsonValue from a node at a given key.
-/// Returns None if the key is absent or nil.
-pub fn extract_optional(node: yay.Node, key: String) -> option.Option(JsonValue) {
-  case yay.select_sugar(from: node, selector: key) {
-    Ok(yay.NodeNil) -> option.None
-    Ok(child) -> option.Some(from_node(child))
-    // nolint: thrown_away_error -- yay.SelectorError here only signals absent/mismatched key; absence is represented as None
-    Error(_) -> option.None
-  }
-}
-
-/// Extract a dict of JsonValues from a node at a given key.
-/// Returns empty dict if key is absent.
-pub fn extract_map(node: yay.Node, key: String) -> Dict(String, JsonValue) {
-  case yay.select_sugar(from: node, selector: key) {
-    Ok(yay.NodeMap(entries)) ->
-      list.filter_map(entries, fn(entry) {
-        let #(k, v) = entry
-        case k {
-          yay.NodeStr(name) -> Ok(#(name, from_node(v)))
-          _ -> Error(Nil)
-        }
-      })
-      |> dict.from_list
-    _ -> dict.new()
-  }
 }

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -10,6 +10,7 @@ import oaspec/internal/openapi/external_loader
 import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/parser_error
 import oaspec/internal/openapi/parser_schema
+import oaspec/internal/openapi/parser_value
 import oaspec/internal/openapi/schema.{type SchemaRef}
 import oaspec/internal/openapi/spec.{
   type Callback, type Components, type Contact, type Encoding, type ExternalDoc,
@@ -22,7 +23,6 @@ import oaspec/internal/openapi/spec.{
   Ref, RequestBody, Response, SecurityRequirement, Server, ServerVariable, Tag,
   Value,
 }
-import oaspec/internal/openapi/value
 import oaspec/internal/progress.{type Reporter}
 import oaspec/internal/util/http
 import oaspec/openapi/diagnostic.{type Diagnostic, NoSourceLoc, SourceLoc}
@@ -859,7 +859,7 @@ fn parse_parameter(
         |> option.unwrap(False)
 
       use content <- result.try(parse_content_map(node, index))
-      let examples = value.extract_map(node, "examples")
+      let examples = parser_value.extract_map(node, "examples")
 
       let payload = case param_schema {
         Ok(sr) -> spec.ParameterSchema(sr)
@@ -1023,8 +1023,9 @@ fn parse_required_content(
                 _ -> Ok(None)
               },
             )
-            let mt_example = value.extract_optional(value_node, "example")
-            let mt_examples = value.extract_map(value_node, "examples")
+            let mt_example =
+              parser_value.extract_optional(value_node, "example")
+            let mt_examples = parser_value.extract_map(value_node, "examples")
             use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,
@@ -1079,8 +1080,9 @@ fn parse_content(
                 _ -> Ok(None)
               },
             )
-            let mt_example = value.extract_optional(value_node, "example")
-            let mt_examples = value.extract_map(value_node, "examples")
+            let mt_example =
+              parser_value.extract_optional(value_node, "example")
+            let mt_examples = parser_value.extract_map(value_node, "examples")
             use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,
@@ -1201,7 +1203,7 @@ fn parse_components(
   ))
   use path_items <- result.try(parse_path_items_map(components_node, index))
   use headers <- result.try(parse_headers_map(components_node, index))
-  let examples = value.extract_map(components_node, "examples")
+  let examples = parser_value.extract_map(components_node, "examples")
   use links <- result.try(parse_links_map(components_node))
   use callbacks <- result.try(parse_components_callbacks_map(
     components_node,
@@ -1984,8 +1986,9 @@ fn parse_content_map(
                 _ -> Ok(None)
               },
             )
-            let mt_example = value.extract_optional(value_node, "example")
-            let mt_examples = value.extract_map(value_node, "examples")
+            let mt_example =
+              parser_value.extract_optional(value_node, "example")
+            let mt_examples = parser_value.extract_map(value_node, "examples")
             use mt_encoding <- result.try(parse_encoding_map(value_node, index))
             Ok(dict.insert(
               acc,


### PR DESCRIPTION
## Summary

Continuation of #344. Splits the BEAM-only `yay` bridge out of `oaspec/internal/openapi/value` so the `JsonValue` type itself becomes pure Gleam with no `yay` dependency. Behavior is unchanged.

## Changes

- `src/oaspec/internal/openapi/value.gleam` — keeps only the `JsonValue` type and its constructors. No `yay` import. No BEAM coupling.
- `src/oaspec/internal/openapi/parser_value.gleam` (new) — owns the yay → `JsonValue` bridge: the private `from_node` and the public `extract_optional` / `extract_map` helpers. This is the BEAM-coupled module that consumers of `value.gleam`'s old API (`parser.gleam`, `parser_schema.gleam`) now import.
- `src/oaspec/openapi/parser.gleam`, `src/oaspec/internal/openapi/parser_schema.gleam` — import sites updated to call `parser_value.extract_optional` / `parser_value.extract_map` instead of `value.*`.
- `ARCHITECTURE.md` — moves `value.gleam` from the BEAM-coupled table to the Pure table; adds the new `parser_value.gleam` to the BEAM-coupled table with its bridge role.
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`.

## Design Decisions

- **`JsonValue` was already structurally pure** (its constructors don't reference `yay` types). The only thing keeping `value.gleam` BEAM-coupled was the file-level `import yay` needed by the helpers. Moving the helpers next door turns the existing logical boundary into a physical one, with no API change for callers that only used the type.
- **`parser_value.gleam` naming** matches the existing parser-layer sibling pattern (`parser.gleam` / `parser_error.gleam` / `parser_schema.gleam`). The file lives under `internal/openapi/` because the helpers are only meant for the parser layer; nothing under the pure subgraph needs to call them.
- **No callers had to change beyond the import sites.** `test/oaspec_test.gleam` still uses `value.JsonString` / `value.JsonBool` / `value.JsonInt` since those are pure constructors that stay in `value.gleam`.
- **Issue #344 stays open** — this PR closes one concrete sub-step (one fewer BEAM-coupled module). The remaining work (decoupling `parser_schema.gleam` and friends from yay-typed inputs, then adding a JS-target CI job) is still tracked there.

## Limitations

- `parser_schema.gleam`, `parser_error.gleam`, and `openapi/parser.gleam` themselves remain BEAM-coupled by design — they sit at the yay → core boundary and that boundary is still inside the parsing layer rather than at its output. Lifting it further is a larger piece of work and is the next step toward the `target = "javascript"` CI bullet of #344.

Refs #344