### PR TITLE
refactor(openapi): make resolve.gleam cross-target via dual-target external (#344)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,7 @@ BEAM-only packages (`simplifile`, `glint`, `argv`, `yay`).
 | `oaspec/internal/openapi/schema.gleam` | Schema AST |
 | `oaspec/internal/openapi/spec.gleam` | OpenAPI document AST |
 | `oaspec/internal/openapi/value.gleam` | Target-neutral `JsonValue` type |
+| `oaspec/internal/openapi/resolve.gleam` | `$ref` resolution (uses dual-target `@external` so the phantom-type cast is a runtime no-op on both BEAM and JS) |
 
 ### BEAM-coupled (requires the Erlang target today)
 
@@ -101,7 +102,6 @@ or transitively depend on a BEAM-only data type (e.g. yay nodes).
 | `oaspec/internal/openapi/parser_error.gleam` | Carries `yay` node positions |
 | `oaspec/internal/openapi/parser_schema.gleam` | Operates on `yay` nodes |
 | `oaspec/internal/openapi/parser_value.gleam` | Bridges `yay` nodes to the pure `JsonValue` type |
-| `oaspec/internal/openapi/resolve.gleam` | Uses `@external(erlang, "gleam_stdlib", "identity")` (could be lifted) |
 
 The four `.erl` files in `src/` (`oaspec_ffi.erl`, `oaspec_json_ffi.erl`,
 `yaml_loc_ffi.erl`) are unconditionally Erlang-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: make `oaspec/internal/openapi/resolve` cross-target.**
+  The `coerce_stage` phantom-type cast now declares both an Erlang
+  and a JavaScript `@external` so it is a runtime no-op on either
+  Gleam target. The function is unchanged at runtime — `OpenApiSpec`
+  is byte-for-byte identical before and after the cast — but the
+  module no longer counts as BEAM-coupled in `ARCHITECTURE.md`.
+  (#344)
+
 ## [0.34.0] - 2026-04-30
 
 ### Changed

--- a/src/oaspec/internal/openapi/resolve.gleam
+++ b/src/oaspec/internal/openapi/resolve.gleam
@@ -23,8 +23,13 @@ pub fn resolve(
   Ok(coerce_stage(resolved))
 }
 
-/// Safe phantom type cast — stage has no runtime representation.
+/// Safe phantom type cast — `stage` has no runtime representation, so
+/// `coerce_stage` is the identity function under a different phantom
+/// label. Declared as a target-specific external so the cast is a true
+/// no-op on both BEAM and JavaScript runtimes (avoids the cost of a
+/// destructure-and-rebuild that pure Gleam would otherwise require).
 @external(erlang, "gleam_stdlib", "identity")
+@external(javascript, "../gleam_stdlib/gleam_stdlib.mjs", "identity")
 fn coerce_stage(spec: OpenApiSpec(a)) -> OpenApiSpec(b)
 
 /// Internal resolve that preserves the input stage parameter.


### PR DESCRIPTION
## Summary

Continuation of #344. Adds a JavaScript-target `@external` to the `coerce_stage` phantom-type cast in `oaspec/internal/openapi/resolve` so the cast is a runtime no-op on both BEAM and JavaScript. The module no longer counts as BEAM-coupled.

## Changes

- `src/oaspec/internal/openapi/resolve.gleam` — `coerce_stage` now declares both `@external(erlang, "gleam_stdlib", "identity")` and `@external(javascript, "../gleam_stdlib/gleam_stdlib.mjs", "identity")`. Same runtime behaviour, but compilable on either target.
- `ARCHITECTURE.md` — moves `resolve.gleam` from the BEAM-coupled table to the Pure table with a note explaining the dual-target external pattern.
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`.

## Design Decisions

- **Dual-target `@external` rather than a destructure-and-rebuild rewrite.** `OpenApiSpec(stage)` propagates the `stage` phantom into nested `PathItem(stage)`, `Components(stage)`, and `Callback(stage)` types. Pattern-matching one level only would not satisfy the type system; recursively destructuring every nested type would be a sprawling change and add a meaningful per-call cost on a hot path. The dual external keeps the cast a true no-op while still satisfying #344's "pure / cross-target" goal at the module level.
- **JS path `../gleam_stdlib/gleam_stdlib.mjs`** matches the on-disk layout produced by the Gleam build: each package's compiled JS sits one directory up from the importing module under its package name. Verified by inspecting `build/packages/gleam_stdlib/src/gleam_stdlib.mjs`, which exports `function identity(x)`.
- **Issue #344 stays open.** This PR closes one more BEAM-coupled module from the table. The remaining BEAM-coupled set is now centred on the parser layer (`parser.gleam`, `parser_schema.gleam`, `parser_error.gleam`, `parser_value.gleam`, `external_loader.gleam`, `location_index.gleam`) plus the CLI / config / writer / formatter / progress shell — all of which have legitimate IO or yay-typed reasons.

## Limitations

- The JS-target external is declared but not yet exercised by CI; that requires the JS-target build job that is the last bullet of #344. This PR is a prerequisite (no longer hard-failing on `target = "javascript"` for resolve), not the proof.
- The Gleam compiler does not, today, validate that the JS external path resolves at the parse step — a wrong path only surfaces when actually building for the JS target. Until the CI job lands, this is verified by hand.

Refs #344