### PR TITLE
refactor(openapi): split yay error bridge out of parser_error (#344)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,6 +82,7 @@ BEAM-only packages (`simplifile`, `glint`, `argv`, `yay`).
 | `oaspec/internal/openapi/spec.gleam` | OpenAPI document AST |
 | `oaspec/internal/openapi/value.gleam` | Target-neutral `JsonValue` type |
 | `oaspec/internal/openapi/resolve.gleam` | `$ref` resolution (uses dual-target `@external` so the phantom-type cast is a runtime no-op on both BEAM and JS) |
+| `oaspec/internal/openapi/parser_error.gleam` | Pure helper for `missing_field` diagnostics with hint detail |
 
 ### BEAM-coupled (requires the Erlang target today)
 
@@ -99,9 +100,9 @@ or transitively depend on a BEAM-only data type (e.g. yay nodes).
 | `oaspec/internal/progress.gleam` | Monotonic clock via FFI for elapsed-time reporting |
 | `oaspec/internal/openapi/external_loader.gleam` | Loads remote `$ref` files via `simplifile` |
 | `oaspec/internal/openapi/location_index.gleam` | Walks yamerl AST via `yaml_loc_ffi` |
-| `oaspec/internal/openapi/parser_error.gleam` | Carries `yay` node positions |
 | `oaspec/internal/openapi/parser_schema.gleam` | Operates on `yay` nodes |
 | `oaspec/internal/openapi/parser_value.gleam` | Bridges `yay` nodes to the pure `JsonValue` type |
+| `oaspec/internal/openapi/parser_yay_error.gleam` | Bridges `yay` extraction / selector errors to pure diagnostic hints |
 
 The four `.erl` files in `src/` (`oaspec_ffi.erl`, `oaspec_json_ffi.erl`,
 `yaml_loc_ffi.erl`) are unconditionally Erlang-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: split the `yay` error bridge out of
+  `oaspec/internal/openapi/parser_error`.** The diagnostic-assembly
+  helper now lives in a pure Gleam module (`missing_field_with_hint`,
+  no `yay` import), and the BEAM-coupled `yay.ExtractionError` /
+  `yay.SelectorError` adapters that wrap it have moved to a new
+  `parser_yay_error` sibling module. Behavior is unchanged; this
+  shrinks the BEAM-coupled module count by one and makes
+  `parser_error.gleam` actually compile on any Gleam target. (#344)
+
 ## [0.35.0] - 2026-04-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   helper now lives in a pure Gleam module (`missing_field_with_hint`,
   no `yay` import), and the BEAM-coupled `yay.ExtractionError` /
   `yay.SelectorError` adapters that wrap it have moved to a new
-  `parser_yay_error` sibling module. Behavior is unchanged; this
-  shrinks the BEAM-coupled module count by one and makes
-  `parser_error.gleam` actually compile on any Gleam target. (#344)
+  `parser_yay_error` sibling module. Behavior is unchanged; this is
+  a relocation rather than a net reduction in BEAM-coupled modules,
+  but `parser_error.gleam` itself now compiles on any Gleam target,
+  in line with the boundary documented in `ARCHITECTURE.md`. (#344)
 
 ## [0.35.0] - 2026-04-30
 

--- a/src/oaspec/internal/openapi/parser_error.gleam
+++ b/src/oaspec/internal/openapi/parser_error.gleam
@@ -1,49 +1,24 @@
-//// Shared helpers for parser modules that need to turn a `yay`-level
-//// extraction / selector failure into a `Diagnostic`. Split out of
-//// `parser.gleam` so both top-level flow parsing and schema parsing can
-//// depend on the same error shape without duplicating the hint-assembly
-//// logic.
+//// Pure helper for assembling `missing_field` diagnostics with a
+//// "Check your OpenAPI spec structure. (...)" hint, used by the parser
+//// modules. The detail string carries whatever extractor- or
+//// selector-internal information would otherwise be silently dropped.
+////
+//// Target-neutral: this module knows nothing about `yay`. The
+//// `yay` → detail-string conversion lives in the BEAM-coupled
+//// `parser_yay_error` sibling.
 
-import gleam/int
 import gleam/option.{Some}
 import oaspec/openapi/diagnostic.{type Diagnostic, type SourceLoc, Diagnostic}
-import yay
 
-/// Build a `missing_field` diagnostic from a `yay.ExtractionError`, folding
-/// the extractor-internal detail into the diagnostic's hint so nothing is
+/// Build a `missing_field` diagnostic whose hint surfaces the given
+/// detail string so an extractor- or selector-internal failure is not
 /// silently dropped.
-pub fn missing_field_from_extraction(
-  err: yay.ExtractionError,
+pub fn missing_field_with_hint(
+  detail detail: String,
   path path: String,
   field field: String,
   loc loc: SourceLoc,
 ) -> Diagnostic {
-  let base = diagnostic.missing_field(path:, field:, loc:)
-  Diagnostic(
-    ..base,
-    hint: Some(
-      "Check your OpenAPI spec structure. ("
-      <> yay.extraction_error_to_string(err)
-      <> ")",
-    ),
-  )
-}
-
-/// Build a `missing_field` diagnostic from a `yay.SelectorError`. The
-/// selector error is collapsed to its constructor name since the detail
-/// isn't meaningful to users, but we still thread it through rather than
-/// discarding it outright.
-pub fn missing_field_from_selector(
-  err: yay.SelectorError,
-  path path: String,
-  field field: String,
-  loc loc: SourceLoc,
-) -> Diagnostic {
-  let detail = case err {
-    yay.NodeNotFound(at:) ->
-      "selector resolved up to segment " <> int.to_string(at)
-    yay.SelectorParseError -> "selector parse error"
-  }
   let base = diagnostic.missing_field(path:, field:, loc:)
   Diagnostic(
     ..base,

--- a/src/oaspec/internal/openapi/parser_schema.gleam
+++ b/src/oaspec/internal/openapi/parser_schema.gleam
@@ -9,8 +9,8 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
 import oaspec/internal/openapi/location_index.{type LocationIndex}
-import oaspec/internal/openapi/parser_error
 import oaspec/internal/openapi/parser_value
+import oaspec/internal/openapi/parser_yay_error
 import oaspec/internal/openapi/schema.{
   type Discriminator, type SchemaObject, type SchemaRef, AllOfSchema,
   AnyOfSchema, ArraySchema, BooleanSchema, Discriminator, Inline, IntegerSchema,
@@ -484,7 +484,7 @@ fn parse_discriminator(
 ) -> Result(Discriminator, Diagnostic) {
   use disc_node <- result.try(
     yay.select_sugar(from: node, selector: "discriminator")
-    |> result.map_error(parser_error.missing_field_from_selector(
+    |> result.map_error(parser_yay_error.missing_field_from_selector(
       _,
       path: "schema",
       field: "discriminator",
@@ -494,7 +494,7 @@ fn parse_discriminator(
 
   use property_name <- result.try(
     yay.extract_string(disc_node, "propertyName")
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "discriminator",
       field: "propertyName",

--- a/src/oaspec/internal/openapi/parser_yay_error.gleam
+++ b/src/oaspec/internal/openapi/parser_yay_error.gleam
@@ -1,0 +1,47 @@
+//// `yay` → diagnostic bridge. Turns extractor and selector failures
+//// from the `yay` YAML library into the project's `Diagnostic` type
+//// via the pure `parser_error.missing_field_with_hint` helper.
+////
+//// Split out of `parser_error` so the diagnostic-assembly logic itself
+//// stays target-neutral and only the yay-specific detail extraction
+//// carries the BEAM coupling. See ARCHITECTURE.md for the boundary.
+
+import gleam/int
+import oaspec/internal/openapi/parser_error
+import oaspec/openapi/diagnostic.{type Diagnostic, type SourceLoc}
+import yay
+
+/// Build a `missing_field` diagnostic from a `yay.ExtractionError`,
+/// folding the extractor-internal detail into the diagnostic's hint so
+/// nothing is silently dropped.
+pub fn missing_field_from_extraction(
+  err: yay.ExtractionError,
+  path path: String,
+  field field: String,
+  loc loc: SourceLoc,
+) -> Diagnostic {
+  parser_error.missing_field_with_hint(
+    detail: yay.extraction_error_to_string(err),
+    path:,
+    field:,
+    loc:,
+  )
+}
+
+/// Build a `missing_field` diagnostic from a `yay.SelectorError`. The
+/// selector error is collapsed to its constructor name since the
+/// detail isn't meaningful to users, but we still thread it through
+/// rather than discarding it outright.
+pub fn missing_field_from_selector(
+  err: yay.SelectorError,
+  path path: String,
+  field field: String,
+  loc loc: SourceLoc,
+) -> Diagnostic {
+  let detail = case err {
+    yay.NodeNotFound(at:) ->
+      "selector resolved up to segment " <> int.to_string(at)
+    yay.SelectorParseError -> "selector parse error"
+  }
+  parser_error.missing_field_with_hint(detail:, path:, field:, loc:)
+}

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -8,9 +8,9 @@ import gleam/result
 import gleam/string
 import oaspec/internal/openapi/external_loader
 import oaspec/internal/openapi/location_index.{type LocationIndex}
-import oaspec/internal/openapi/parser_error
 import oaspec/internal/openapi/parser_schema
 import oaspec/internal/openapi/parser_value
+import oaspec/internal/openapi/parser_yay_error
 import oaspec/internal/openapi/schema.{type SchemaRef}
 import oaspec/internal/openapi/spec.{
   type Callback, type Components, type Contact, type Encoding, type ExternalDoc,
@@ -283,7 +283,7 @@ fn parse_root(
         }
       })
     })
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "",
       field: "openapi",
@@ -378,7 +378,7 @@ fn parse_optional_components(
 fn parse_info(root: yay.Node, index: LocationIndex) -> Result(Info, Diagnostic) {
   use info_node <- result.try(
     yay.select_sugar(from: root, selector: "info")
-    |> result.map_error(parser_error.missing_field_from_selector(
+    |> result.map_error(parser_yay_error.missing_field_from_selector(
       _,
       path: "",
       field: "info",
@@ -388,7 +388,7 @@ fn parse_info(root: yay.Node, index: LocationIndex) -> Result(Info, Diagnostic) 
 
   use title <- result.try(
     yay.extract_string(info_node, "title")
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "info",
       field: "title",
@@ -398,7 +398,7 @@ fn parse_info(root: yay.Node, index: LocationIndex) -> Result(Info, Diagnostic) 
 
   use version <- result.try(
     yay.extract_string(info_node, "version")
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "info",
       field: "version",
@@ -451,7 +451,7 @@ fn parse_server(
 ) -> Result(Server, Diagnostic) {
   use url <- result.try(
     yay.extract_string(node, "url")
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "servers",
       field: "url",
@@ -635,7 +635,7 @@ fn parse_operation_at(
 ) -> Result(Operation(Unresolved), Diagnostic) {
   use op_node <- result.try(
     yay.select_sugar(from: node, selector: method_key)
-    |> result.map_error(parser_error.missing_field_from_selector(
+    |> result.map_error(parser_yay_error.missing_field_from_selector(
       _,
       path:,
       field: method_key,
@@ -776,7 +776,7 @@ fn parse_parameter(
     _ -> {
       use name <- result.try(
         yay.extract_string(node, "name")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "parameter",
           field: "name",
@@ -786,7 +786,7 @@ fn parse_parameter(
 
       use in_str <- result.try(
         yay.extract_string(node, "in")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "parameter." <> name,
           field: "in",
@@ -959,7 +959,7 @@ fn parse_request_body_at(
 ) -> Result(RefOr(RequestBody(Unresolved)), Diagnostic) {
   use rb_node <- result.try(
     yay.select_sugar(from: node, selector: "requestBody")
-    |> result.map_error(parser_error.missing_field_from_selector(
+    |> result.map_error(parser_yay_error.missing_field_from_selector(
       _,
       path: context,
       field: "requestBody",
@@ -1158,7 +1158,7 @@ fn parse_response(
       use description <- result.try(
         yay.extract_string(node, "description")
         |> result.map(Some)
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "response",
           field: "description",
@@ -1182,7 +1182,7 @@ fn parse_components(
 ) -> Result(Components(Unresolved), Diagnostic) {
   use components_node <- result.try(
     yay.select_sugar(from: root, selector: "components")
-    |> result.map_error(parser_error.missing_field_from_selector(
+    |> result.map_error(parser_yay_error.missing_field_from_selector(
       _,
       path: "",
       field: "components",
@@ -1457,7 +1457,7 @@ fn parse_security_scheme(
 ) -> Result(spec.SecurityScheme, Diagnostic) {
   use type_str <- result.try(
     yay.extract_string(node, "type")
-    |> result.map_error(parser_error.missing_field_from_extraction(
+    |> result.map_error(parser_yay_error.missing_field_from_extraction(
       _,
       path: "securityScheme",
       field: "type",
@@ -1469,7 +1469,7 @@ fn parse_security_scheme(
     "apiKey" -> {
       use name <- result.try(
         yay.extract_string(node, "name")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "securityScheme.apiKey",
           field: "name",
@@ -1482,7 +1482,7 @@ fn parse_security_scheme(
       )
       use in_str <- result.try(
         yay.extract_string(node, "in")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "securityScheme.apiKey",
           field: "in",
@@ -1504,7 +1504,7 @@ fn parse_security_scheme(
     "http" -> {
       use scheme <- result.try(
         yay.extract_string(node, "scheme")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "securityScheme.http",
           field: "scheme",
@@ -1533,7 +1533,7 @@ fn parse_security_scheme(
         |> result.unwrap(None)
       use open_id_connect_url <- result.try(
         yay.extract_string(node, "openIdConnectUrl")
-        |> result.map_error(parser_error.missing_field_from_extraction(
+        |> result.map_error(parser_yay_error.missing_field_from_extraction(
           _,
           path: "securityScheme.openIdConnect",
           field: "openIdConnectUrl",


### PR DESCRIPTION
## Summary

Continuation of #344. Splits the BEAM-only `yay` error coupling out of `oaspec/internal/openapi/parser_error` so the diagnostic-assembly logic itself becomes pure Gleam. Same shape as the earlier `value` / `parser_value` split.

## Changes

- `src/oaspec/internal/openapi/parser_error.gleam` — keeps only the pure helper `missing_field_with_hint(detail: String, path, field, loc) -> Diagnostic`. No `yay` import. No BEAM coupling.
- `src/oaspec/internal/openapi/parser_yay_error.gleam` (new) — owns the `yay.ExtractionError` / `yay.SelectorError` adapters. Each adapter computes a detail string from the yay error and delegates to `parser_error.missing_field_with_hint`.
- `src/oaspec/openapi/parser.gleam`, `src/oaspec/internal/openapi/parser_schema.gleam` — 18 call sites flipped from `parser_error.missing_field_from_*` to `parser_yay_error.missing_field_from_*`. Behaviour unchanged at every site.
- `ARCHITECTURE.md` — adds `parser_error.gleam` to the Pure table and lists the new `parser_yay_error.gleam` under BEAM-coupled with its bridge role.
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`.

## Design Decisions

- **Same pattern as the earlier value / parser_value split.** Pure module owns the type and the target-neutral logic; sibling BEAM-coupled module owns the yay adapter. Kept the public function names identical at the new module so all 18 call sites only change their import path, not the call shape.
- **Detail string is computed in the adapter, not at the call site.** Pushing the yay → string conversion into a closure at every call site would add noise without buying anything; the adapter is the right home for it.
- **Issue #344 stays open.** The remaining BEAM-coupled set after this PR is centered on the parser layer's actual yay-node consumption (`parser_schema`, `parser_value`, `openapi/parser`, `external_loader`, `location_index`) plus the CLI / config / writer / formatter / progress shell. Decoupling `parser_schema` from yay nodes is the largest single piece of work remaining and is what unblocks the `target = "javascript"` CI bullet.

## Limitations

- This refactor changes only where the yay coupling sits, not whether the parsing layer can run on a non-BEAM target. The actual parse step still depends on yay; that is the next step.
- `parser_yay_error.gleam` is intentionally a thin file — removing it would require either inlining the yay adapter back into `parser_error` (re-coupling) or pushing the yay error → string conversion to every call site (more verbose). The thin sibling is the cleaner middle ground and is consistent with `parser_value.gleam`.

Refs #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized OpenAPI parser error-handling modules to separate pure diagnostic functions from YAML parsing-specific logic, improving code maintainability and reducing module coupling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->