### PR TITLE
refactor(progress): make progress.gleam cross-target via dual @external + JS ffi (#344)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,6 @@ state. It does not commit the project to any particular split.
 |   src/oaspec/openapi/parser.gleam yay + FFI      |
 |   src/oaspec/codegen/writer.gleam simplifile     |
 |   src/oaspec/internal/formatter.gleam subprocess |
-|   src/oaspec/internal/progress.gleam clock FFI   |
 |   src/oaspec_*ffi.erl, src/yaml_loc_ffi.erl      |
 +-------------------|------------------------------+
                     | calls
@@ -83,6 +82,7 @@ BEAM-only packages (`simplifile`, `glint`, `argv`, `yay`).
 | `oaspec/internal/openapi/value.gleam` | Target-neutral `JsonValue` type |
 | `oaspec/internal/openapi/resolve.gleam` | `$ref` resolution (uses dual-target `@external` so the phantom-type cast is a runtime no-op on both BEAM and JS) |
 | `oaspec/internal/openapi/parser_error.gleam` | Pure helper for `missing_field` diagnostics with hint detail |
+| `oaspec/internal/progress.gleam` | Pipeline progress reporter (uses dual-target `@external` so the monotonic millisecond clock resolves on both BEAM and JS) |
 
 ### BEAM-coupled (requires the Erlang target today)
 
@@ -97,15 +97,17 @@ or transitively depend on a BEAM-only data type (e.g. yay nodes).
 | `oaspec/openapi/parser.gleam` | Loads files (`simplifile`), parses YAML (`yay`), JSON FFI (`oaspec_json_ffi`) |
 | `oaspec/internal/cli.gleam` | `glint` CLI framework, file IO, FFI for TTY/color |
 | `oaspec/internal/formatter.gleam` | Spawns `gleam format` subprocess via FFI |
-| `oaspec/internal/progress.gleam` | Monotonic clock via FFI for elapsed-time reporting |
 | `oaspec/internal/openapi/external_loader.gleam` | Loads remote `$ref` files via `simplifile` |
 | `oaspec/internal/openapi/location_index.gleam` | Walks yamerl AST via `yaml_loc_ffi` |
 | `oaspec/internal/openapi/parser_schema.gleam` | Operates on `yay` nodes |
 | `oaspec/internal/openapi/parser_value.gleam` | Bridges `yay` nodes to the pure `JsonValue` type |
 | `oaspec/internal/openapi/parser_yay_error.gleam` | Bridges `yay` extraction / selector errors to pure diagnostic hints |
 
-The four `.erl` files in `src/` (`oaspec_ffi.erl`, `oaspec_json_ffi.erl`,
-`yaml_loc_ffi.erl`) are unconditionally Erlang-only.
+The three `.erl` files in `src/` (`oaspec_ffi.erl`, `oaspec_json_ffi.erl`,
+`yaml_loc_ffi.erl`) are unconditionally Erlang-only. A sibling
+`oaspec_ffi.mjs` provides JavaScript implementations for the subset
+of `oaspec_ffi` helpers actually called from cross-target Gleam
+modules (today: `monotonic_ms`).
 
 ### Adapters (out of tree)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: make `oaspec/internal/progress` cross-target.** The
+  `monotonic_ms` clock helper now declares both an Erlang
+  `@external` (existing `oaspec_ffi:monotonic_ms/0`) and a
+  JavaScript `@external` backed by a new `src/oaspec_ffi.mjs` that
+  uses `performance.now()` for monotonic semantics, falling back to
+  `Date.now()` if `performance` is unavailable. Behavior on the
+  Erlang target is unchanged; this brings the BEAM-coupled module
+  count down by one and lets `progress.gleam` actually compile on
+  any Gleam target. (#344)
+
 ## [0.36.0] - 2026-04-30
 
 ### Changed

--- a/src/oaspec/internal/progress.gleam
+++ b/src/oaspec/internal/progress.gleam
@@ -14,6 +14,7 @@ import gleam/io
 import gleam/string
 
 @external(erlang, "oaspec_ffi", "monotonic_ms")
+@external(javascript, "../../oaspec_ffi.mjs", "monotonic_ms")
 fn monotonic_ms() -> Int
 
 /// A progress reporter. The `emit` callback receives a one-line

--- a/src/oaspec_ffi.mjs
+++ b/src/oaspec_ffi.mjs
@@ -1,0 +1,20 @@
+// JavaScript-target counterparts for the helpers exposed in
+// oaspec_ffi.erl. Only functions actually called from cross-target
+// Gleam modules need a JS implementation; the BEAM-only CLI helpers
+// (find_executable, run_executable, is_stdout_tty, no_color_set) are
+// not declared with a JS @external and therefore do not need a JS
+// version here.
+
+export function monotonic_ms() {
+  // performance.now() is monotonic (unaffected by system clock changes)
+  // and available in modern Node (>= 16) and all browsers. Fall back to
+  // Date.now() if performance is somehow unavailable; the elapsed-time
+  // semantics tolerate the slight loss of monotonicity for the brief
+  // intervals oaspec actually measures.
+  const ms =
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+      ? performance.now()
+      : Date.now();
+  return Math.trunc(ms);
+}


### PR DESCRIPTION
## Summary

Continuation of #344. Adds a JavaScript implementation of `oaspec_ffi:monotonic_ms/0` and gives `oaspec/internal/progress`'s `monotonic_ms` external both an Erlang and a JavaScript binding so the progress reporter compiles on either Gleam target. Behavior on the Erlang target is unchanged. This genuinely shrinks the BEAM-coupled module count (no new BEAM-coupled `.gleam` module is added; the new `.mjs` is a JS FFI sibling, not a Gleam module).

## Changes

- `src/oaspec_ffi.mjs` (new) — JavaScript FFI sibling of `oaspec_ffi.erl`, currently exporting only `monotonic_ms` (the subset of `oaspec_ffi` actually called from cross-target Gleam modules). Uses `performance.now()` for monotonic semantics, falls back to `Date.now()` when `performance` is unavailable.
- `src/oaspec/internal/progress.gleam` — `monotonic_ms` now declares `@external(erlang, "oaspec_ffi", "monotonic_ms")` and `@external(javascript, "../../oaspec_ffi.mjs", "monotonic_ms")`. No other change to the module.
- `ARCHITECTURE.md` — moves `progress.gleam` from the BEAM-coupled table to the Pure table (with a note about the dual-target `@external`), drops it from the Shell-layer ASCII overview, fixes the FFI footnote (was "four .erl files", now correctly "three .erl files" plus the new `oaspec_ffi.mjs`).
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`.

## Design Decisions

- **Path `../../oaspec_ffi.mjs`** is source-relative. Verified against the canonical pattern in `gleam_time`: `gleam/time/timestamp.gleam` (depth 2 from `src/`) uses `../../gleam_time_ffi.mjs` to reach `src/gleam_time_ffi.mjs`. `progress.gleam` is at the same depth, so the same form applies.
- **`performance.now()` over `Date.now()`** to preserve the monotonic semantics promised by `oaspec_ffi.erl`'s `monotonic_ms` docstring (`erlang:monotonic_time(millisecond)` is unaffected by system-clock adjustments). The fallback to `Date.now()` is a defensive guard — on the elapsed-time scales `progress.gleam` actually measures (sub-second to a few seconds per pipeline stage), Date.now() drift is irrelevant.
- **Only `monotonic_ms` is ported, not the rest of `oaspec_ffi.erl`**. `find_executable`, `run_executable`, `is_stdout_tty`, and `no_color_set` are only called from BEAM-only callers (`cli.gleam`, `formatter.gleam`) and have no reason to be cross-target today. The `.mjs` file is intentionally narrow.

## Limitations

- The JS-target external is declared but not yet exercised by CI; that requires the JS-target build job tracked as the last bullet of #344. This PR is a prerequisite (one fewer module hard-failing on `target = "javascript"`), not the proof.
- `Math.trunc(performance.now())` truncates a sub-millisecond high-resolution timestamp. The Erlang side returns whole milliseconds from `erlang:monotonic_time(millisecond)`, so the truncation matches the Erlang side's resolution.

Refs #344