### PR TITLE
refactor(openapi): split external_loader into IO shell and pure planner (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: split the external `$ref` loader into an IO shell and a pure
+  rewrite planner.** The new `oaspec/internal/openapi/external_loader_planner`
+  module now owns ref-string parsing, schema/parameter/requestBody/response/
+  pathItem lookups inside parsed external documents, alias resolution, and
+  collision diagnostics. `external_loader` is now ~530 lines smaller and
+  delegates every pure decision to the planner, so each external-ref
+  diagnostic — local collision, cross-file collision, missing component,
+  alias chain, chained external ref — can be unit tested without staging
+  fixture files on disk. Closes #372.
+
 ## [0.38.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 827 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 875 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/openapi/external_loader.gleam
+++ b/src/oaspec/internal/openapi/external_loader.gleam
@@ -49,16 +49,14 @@
 //// silently dropping one side.
 
 import filepath
-import gleam/bool
 import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
-import gleam/string
+import oaspec/internal/openapi/external_loader_planner as planner
 import oaspec/internal/openapi/schema.{type SchemaRef, Inline, Reference}
 import oaspec/internal/openapi/spec.{
-  type Components, type OpenApiSpec, type Parameter, type PathItem,
-  type RequestBody, type Response, type Unresolved, Components, OpenApiSpec,
+  type Components, type OpenApiSpec, type Unresolved, Components, OpenApiSpec,
 }
 import oaspec/internal/util/http
 import oaspec/openapi/diagnostic.{type Diagnostic}
@@ -79,7 +77,7 @@ pub fn resolve_external_component_refs(
   case spec.components, base_dir {
     Some(components), Some(dir) -> {
       let original_local_names =
-        local_schema_names(dict.to_list(components.schemas))
+        planner.local_schema_names(dict.to_list(components.schemas))
       use #(top_resolved, top_imported) <- result.try(process_components(
         components,
         dir,
@@ -169,22 +167,22 @@ fn process_components(
     list.try_fold(entries, #([], dict.new()), fn(acc, entry) {
       let #(pending, imported) = acc
       let #(name, schema_ref) = entry
-      case extract_external_ref(schema_ref) {
+      case planner.extract_external_ref(schema_ref) {
         Some(#(rel_path, fragment_name)) -> {
           let resolved_path = filepath.join(base_dir, rel_path)
-          use _ <- result.try(check_local_collision(
+          use _ <- result.try(planner.check_local_collision(
             name,
             fragment_name,
             resolved_path,
             original_local_names,
           ))
-          use _ <- result.try(check_cross_file_collision(
+          use _ <- result.try(planner.check_cross_file_collision(
             fragment_name,
             resolved_path,
             imported,
           ))
           use loaded <- result.try(parse_file(resolved_path))
-          use target <- result.try(find_external_schema(
+          use target <- result.try(planner.find_external_schema(
             loaded,
             fragment_name,
             resolved_path,
@@ -216,61 +214,6 @@ fn process_components(
   Ok(#(Components(..components, schemas: merged), imported))
 }
 
-/// Names in the current spec that are *not themselves* external refs.
-/// These are the schemas the external loader must not silently overwrite.
-fn local_schema_names(entries: List(#(String, SchemaRef))) -> List(String) {
-  list.filter_map(entries, fn(entry) {
-    case extract_external_ref(entry.1) {
-      Some(_) -> Error(Nil)
-      None -> Ok(entry.0)
-    }
-  })
-}
-
-/// Detect external refs like `./other.yaml#/components/parameters/Foo`.
-/// Returns Some(#(file_path, component_prefix, name)) or None.
-/// Supported prefixes: parameters, requestBodies, responses, pathItems.
-fn extract_external_component_ref(
-  ref_str: String,
-) -> option.Option(#(String, String, String)) {
-  let is_relative =
-    string.starts_with(ref_str, "./") || string.starts_with(ref_str, "../")
-  use <- bool.guard(!is_relative, None)
-  case string.split_once(ref_str, "#") {
-    Ok(#(file_path, fragment)) ->
-      try_component_prefix(file_path, fragment, [
-        "/components/parameters/",
-        "/components/requestBodies/",
-        "/components/responses/",
-        "/components/pathItems/",
-      ])
-    _ -> None
-  }
-}
-
-/// Try each component prefix against a fragment, returning the first match.
-fn try_component_prefix(
-  file_path: String,
-  fragment: String,
-  prefixes: List(String),
-) -> option.Option(#(String, String, String)) {
-  case prefixes {
-    [] -> None
-    [prefix, ..rest] ->
-      case string.starts_with(fragment, prefix) {
-        True -> {
-          let name = string.replace(fragment, prefix, "")
-          case string.contains(name, "/"), name {
-            False, "" -> None
-            False, _ -> Some(#(file_path, prefix, name))
-            True, _ -> None
-          }
-        }
-        False -> try_component_prefix(file_path, fragment, rest)
-      }
-  }
-}
-
 /// Walk `components.parameters`, `request_bodies`, `responses`, and
 /// `path_items`: for each `Ref(ref_str)` entry that is an external
 /// component ref (e.g., `./other.yaml#/components/parameters/Foo`),
@@ -287,7 +230,7 @@ fn process_whole_object_refs(
     base_dir,
     parse_file,
     "/components/parameters/",
-    find_external_parameter,
+    planner.find_external_parameter,
   ))
   // request_bodies
   use new_request_bodies <- result.try(resolve_ref_or_dict(
@@ -295,7 +238,7 @@ fn process_whole_object_refs(
     base_dir,
     parse_file,
     "/components/requestBodies/",
-    find_external_request_body,
+    planner.find_external_request_body,
   ))
   // responses
   use new_responses <- result.try(resolve_ref_or_dict(
@@ -303,7 +246,7 @@ fn process_whole_object_refs(
     base_dir,
     parse_file,
     "/components/responses/",
-    find_external_response,
+    planner.find_external_response,
   ))
   // path_items
   use new_path_items <- result.try(resolve_ref_or_dict(
@@ -311,7 +254,7 @@ fn process_whole_object_refs(
     base_dir,
     parse_file,
     "/components/pathItems/",
-    find_external_path_item,
+    planner.find_external_path_item,
   ))
   Ok(
     Components(
@@ -340,7 +283,7 @@ fn resolve_ref_or_dict(
       let #(name, ref_or_val) = entry
       case ref_or_val {
         spec.Ref(ref_str) ->
-          case extract_external_component_ref(ref_str) {
+          case planner.extract_external_component_ref(ref_str) {
             Some(#(file_path, prefix, obj_name)) if prefix == target_prefix -> {
               let resolved_path = filepath.join(base_dir, file_path)
               use loaded <- result.try(parse_file(resolved_path))
@@ -358,206 +301,6 @@ fn resolve_ref_or_dict(
       dict.insert(d, pair.0, pair.1)
     }),
   )
-}
-
-/// Look up a parameter by name in an external file's components.
-fn find_external_parameter(
-  loaded: OpenApiSpec(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(Parameter(Unresolved), Diagnostic) {
-  case loaded.components {
-    Some(components) ->
-      case dict.get(components.parameters, name) {
-        Ok(spec.Value(p)) -> Ok(p)
-        Ok(spec.Ref(_)) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External parameter '"
-              <> name
-              <> "' in '"
-              <> source_path
-              <> "' is itself a $ref; chained external refs are not supported.",
-            hint: Some(
-              "Inline the parameter in the external file or flatten the ref chain.",
-            ),
-          ))
-        Error(Nil) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External file '"
-              <> source_path
-              <> "' has no components.parameters."
-              <> name,
-            hint: Some(
-              "Verify the ref path and that the referenced file defines the parameter.",
-            ),
-          ))
-      }
-    None ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '" <> source_path <> "' has no components block.",
-        hint: Some(
-          "Add a components.parameters section to the referenced file.",
-        ),
-      ))
-  }
-}
-
-/// Look up a request body by name in an external file's components.
-fn find_external_request_body(
-  loaded: OpenApiSpec(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(RequestBody(Unresolved), Diagnostic) {
-  case loaded.components {
-    Some(components) ->
-      case dict.get(components.request_bodies, name) {
-        Ok(spec.Value(rb)) -> Ok(rb)
-        Ok(spec.Ref(_)) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External request body '"
-              <> name
-              <> "' in '"
-              <> source_path
-              <> "' is itself a $ref; chained external refs are not supported.",
-            hint: Some(
-              "Inline the request body in the external file or flatten the ref chain.",
-            ),
-          ))
-        Error(Nil) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External file '"
-              <> source_path
-              <> "' has no components.requestBodies."
-              <> name,
-            hint: Some(
-              "Verify the ref path and that the referenced file defines the request body.",
-            ),
-          ))
-      }
-    None ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '" <> source_path <> "' has no components block.",
-        hint: Some(
-          "Add a components.requestBodies section to the referenced file.",
-        ),
-      ))
-  }
-}
-
-/// Look up a response by name in an external file's components.
-fn find_external_response(
-  loaded: OpenApiSpec(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(Response(Unresolved), Diagnostic) {
-  case loaded.components {
-    Some(components) ->
-      case dict.get(components.responses, name) {
-        Ok(spec.Value(r)) -> Ok(r)
-        Ok(spec.Ref(_)) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External response '"
-              <> name
-              <> "' in '"
-              <> source_path
-              <> "' is itself a $ref; chained external refs are not supported.",
-            hint: Some(
-              "Inline the response in the external file or flatten the ref chain.",
-            ),
-          ))
-        Error(Nil) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External file '"
-              <> source_path
-              <> "' has no components.responses."
-              <> name,
-            hint: Some(
-              "Verify the ref path and that the referenced file defines the response.",
-            ),
-          ))
-      }
-    None ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '" <> source_path <> "' has no components block.",
-        hint: Some("Add a components.responses section to the referenced file."),
-      ))
-  }
-}
-
-/// Look up a path item by name in an external file's components.
-fn find_external_path_item(
-  loaded: OpenApiSpec(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(PathItem(Unresolved), Diagnostic) {
-  case loaded.components {
-    Some(components) ->
-      case dict.get(components.path_items, name) {
-        Ok(spec.Value(pi)) -> Ok(pi)
-        Ok(spec.Ref(_)) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External path item '"
-              <> name
-              <> "' in '"
-              <> source_path
-              <> "' is itself a $ref; chained external refs are not supported.",
-            hint: Some(
-              "Inline the path item in the external file or flatten the ref chain.",
-            ),
-          ))
-        Error(Nil) ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External file '"
-              <> source_path
-              <> "' has no components.pathItems."
-              <> name,
-            hint: Some(
-              "Verify the ref path and that the referenced file defines the path item.",
-            ),
-          ))
-      }
-    None ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '" <> source_path <> "' has no components block.",
-        hint: Some("Add a components.pathItems section to the referenced file."),
-      ))
-  }
 }
 
 /// Walk each `components.schemas` entry that is an `Inline(ObjectSchema)` and
@@ -1681,21 +1424,21 @@ fn maybe_hoist_ref(
   imports: dict.Dict(String, #(String, SchemaRef)),
   original_local_names: List(String),
 ) -> Result(#(SchemaRef, dict.Dict(String, #(String, SchemaRef))), Diagnostic) {
-  case extract_external_ref(schema_ref) {
+  case planner.extract_external_ref(schema_ref) {
     Some(#(rel_path, fragment_name)) -> {
       let resolved_path = filepath.join(base_dir, rel_path)
-      use _ <- result.try(check_nested_local_collision(
+      use _ <- result.try(planner.check_nested_local_collision(
         fragment_name,
         resolved_path,
         original_local_names,
       ))
-      use _ <- result.try(check_nested_cross_file_collision(
+      use _ <- result.try(planner.check_nested_cross_file_collision(
         fragment_name,
         resolved_path,
         imports,
       ))
       use loaded <- result.try(parse_file(resolved_path))
-      use target <- result.try(find_external_schema(
+      use target <- result.try(planner.find_external_schema(
         loaded,
         fragment_name,
         resolved_path,
@@ -1710,278 +1453,5 @@ fn maybe_hoist_ref(
       Ok(#(local_ref, new_imports))
     }
     None -> Ok(#(schema_ref, imports))
-  }
-}
-
-/// Reject a nested property ref whose fragment name collides with a schema
-/// that was authored inline in the main spec. Without this guard the nested
-/// import would silently rebind to the local schema — even if its shape is
-/// unrelated — because the merged dict already holds that slot.
-fn check_nested_local_collision(
-  fragment_name: String,
-  source_path: String,
-  original_local_names: List(String),
-) -> Result(Nil, Diagnostic) {
-  use <- bool.guard(
-    !list.contains(original_local_names, fragment_name),
-    Ok(Nil),
-  )
-  Error(diagnostic.validation(
-    severity: diagnostic.SeverityError,
-    target: diagnostic.TargetBoth,
-    path: source_path,
-    detail: "Nested property $ref imports schema '"
-      <> fragment_name
-      <> "' from '"
-      <> source_path
-      <> "', but a local schema with the same name is already defined.",
-    hint: Some(
-      "Rename one of the colliding schemas, or point the external ref at a file whose fragment name is unique.",
-    ),
-  ))
-}
-
-/// Same shape as `check_cross_file_collision` but reads from the
-/// `imports: Dict(fragment_name, #(source_path, target_schema))` dict used
-/// by the nested-property phase.
-fn check_nested_cross_file_collision(
-  fragment_name: String,
-  resolved_path: String,
-  imports: dict.Dict(String, #(String, SchemaRef)),
-) -> Result(Nil, Diagnostic) {
-  case dict.get(imports, fragment_name) {
-    // nolint: thrown_away_error -- dict.get Error only signals absent key; no diagnostic to propagate
-    Error(_) -> Ok(Nil)
-    Ok(#(prev_path, _)) ->
-      case prev_path == resolved_path {
-        True -> Ok(Nil)
-        False ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: resolved_path,
-            detail: "Nested property $ref imports schema '"
-              <> fragment_name
-              <> "' from '"
-              <> resolved_path
-              <> "', but the same name was already imported from '"
-              <> prev_path
-              <> "'.",
-            hint: Some(
-              "Rename one of the schemas in the source files so imports do not collide.",
-            ),
-          ))
-      }
-  }
-}
-
-/// Reject an external ref whose fragment name would collide with a schema
-/// already defined locally in the same spec. The case where the entry name
-/// equals the fragment name (`Widget: $ref: './other.yaml#/.../Widget'`) is
-/// intentionally allowed — we treat it as the user asking for that slot to
-/// hold the imported schema.
-fn check_local_collision(
-  entry_name: String,
-  fragment_name: String,
-  source_path: String,
-  original_local_names: List(String),
-) -> Result(Nil, Diagnostic) {
-  use <- bool.guard(entry_name == fragment_name, Ok(Nil))
-  use <- bool.guard(
-    !list.contains(original_local_names, fragment_name),
-    Ok(Nil),
-  )
-  Error(diagnostic.validation(
-    severity: diagnostic.SeverityError,
-    target: diagnostic.TargetBoth,
-    path: source_path,
-    detail: "External $ref imports schema '"
-      <> fragment_name
-      <> "' from '"
-      <> source_path
-      <> "', but a local schema with the same name is already defined.",
-    hint: Some(
-      "Rename one of the colliding schemas, or point the external ref at a file whose fragment name is unique.",
-    ),
-  ))
-}
-
-/// Reject two external refs that both pull the same fragment name from
-/// different source files. Re-importing the same name from the same path is
-/// allowed (idempotent) to keep error messages narrow.
-fn check_cross_file_collision(
-  fragment_name: String,
-  resolved_path: String,
-  imported: dict.Dict(String, String),
-) -> Result(Nil, Diagnostic) {
-  case dict.get(imported, fragment_name) {
-    // nolint: thrown_away_error -- dict.get Error only signals absent key; no diagnostic to propagate
-    Error(_) -> Ok(Nil)
-    Ok(prev_path) ->
-      case prev_path == resolved_path {
-        True -> Ok(Nil)
-        False ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: resolved_path,
-            detail: "External $ref imports schema '"
-              <> fragment_name
-              <> "' from '"
-              <> resolved_path
-              <> "', but the same name was already imported from '"
-              <> prev_path
-              <> "'.",
-            hint: Some(
-              "Rename one of the schemas in the source files so imports do not collide.",
-            ),
-          ))
-      }
-  }
-}
-
-/// Detect a `./...#/components/schemas/Name` or `../...#/components/schemas/Name`
-/// ref. Returns `Some(#(file_path, schema_name))` when it matches, `None`
-/// otherwise.
-fn extract_external_ref(
-  schema_ref: SchemaRef,
-) -> option.Option(#(String, String)) {
-  case schema_ref {
-    Reference(ref:, ..) ->
-      case string.starts_with(ref, "./") || string.starts_with(ref, "../") {
-        True ->
-          case string.split_once(ref, "#") {
-            Ok(#(file_path, fragment)) ->
-              case string.starts_with(fragment, "/components/schemas/") {
-                True -> {
-                  let name =
-                    string.replace(fragment, "/components/schemas/", "")
-                  case string.contains(name, "/"), name {
-                    False, "" -> None
-                    False, _ -> Some(#(file_path, name))
-                    True, _ -> None
-                  }
-                }
-                False -> None
-              }
-            _ -> None
-          }
-        False -> None
-      }
-    _ -> None
-  }
-}
-
-fn find_external_schema(
-  loaded: OpenApiSpec(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(SchemaRef, Diagnostic) {
-  case loaded.components {
-    Some(components) -> find_schema_follow_alias(components, name, source_path)
-    None ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '" <> source_path <> "' has no components block.",
-        hint: Some(
-          "Add a components.schemas section to the referenced file or inline the schema.",
-        ),
-      ))
-  }
-}
-
-/// Look up `name` in the external file's `components.schemas`. If the
-/// value is inline, return it directly. If it is a local alias
-/// (`#/components/schemas/Other`) pointing at another schema *in the
-/// same file*, follow the alias one level. Cross-file chained refs and
-/// longer alias chains still surface a diagnostic.
-fn find_schema_follow_alias(
-  components: spec.Components(Unresolved),
-  name: String,
-  source_path: String,
-) -> Result(SchemaRef, Diagnostic) {
-  case dict.get(components.schemas, name) {
-    Ok(Inline(_) as s) -> Ok(s)
-    Ok(Reference(ref:, ..)) ->
-      case local_schema_name_from_ref(ref) {
-        Some(aliased) ->
-          case dict.get(components.schemas, aliased) {
-            Ok(Inline(_) as s) -> Ok(s)
-            _ ->
-              Error(diagnostic.validation(
-                severity: diagnostic.SeverityError,
-                target: diagnostic.TargetBoth,
-                path: source_path,
-                detail: "External schema '"
-                  <> name
-                  <> "' in '"
-                  <> source_path
-                  <> "' aliases '"
-                  <> aliased
-                  <> "', but the target is itself a $ref or missing; only a single level of aliasing inside the same file is supported.",
-                hint: Some(
-                  "Flatten the alias chain in the external file so the target resolves to an inline schema.",
-                ),
-              ))
-          }
-        None ->
-          Error(diagnostic.validation(
-            severity: diagnostic.SeverityError,
-            target: diagnostic.TargetBoth,
-            path: source_path,
-            detail: "External schema '"
-              <> name
-              <> "' in '"
-              <> source_path
-              <> "' is itself a $ref pointing outside this file; chained external refs are not supported yet.",
-            hint: Some(
-              "Inline the external schema or flatten the ref to live inside the same file.",
-            ),
-          ))
-      }
-    Error(Nil) ->
-      Error(diagnostic.validation(
-        severity: diagnostic.SeverityError,
-        target: diagnostic.TargetBoth,
-        path: source_path,
-        detail: "External file '"
-          <> source_path
-          <> "' has no components.schemas."
-          <> name,
-        hint: Some(
-          "Verify the ref path and that the referenced file defines the schema.",
-        ),
-      ))
-  }
-}
-
-/// If `ref` is a local component-schemas ref inside the same file (no
-/// leading file part), return the schema name. Otherwise return None
-/// so the caller can surface a cross-file diagnostic.
-fn local_schema_name_from_ref(ref: String) -> option.Option(String) {
-  let prefix = "#/components/schemas/"
-  case string.starts_with(ref, prefix) {
-    True -> {
-      let name = string.replace(ref, prefix, "")
-      case string.contains(name, "/"), name {
-        False, "" -> None
-        False, _ -> Some(name)
-        True, _ -> None
-      }
-    }
-    False -> None
-  }
-}
-
-/// Helper used by `parser.parse_file` to compute a spec's base directory.
-/// Empty-string (current working directory) is returned when the filepath
-/// module can't extract a parent — callers can then pass `Some("")` which
-/// resolves relative refs against CWD.
-pub fn base_dir_of(path: String) -> option.Option(String) {
-  case filepath.directory_name(path) {
-    "" -> Some(".")
-    dir -> Some(dir)
   }
 }

--- a/src/oaspec/internal/openapi/external_loader_planner.gleam
+++ b/src/oaspec/internal/openapi/external_loader_planner.gleam
@@ -1,0 +1,554 @@
+//// Pure planning helpers for the external `$ref` loader. This module
+//// contains every decision the loader makes that does not require
+//// filesystem IO: ref-string parsing, schema lookups inside a parsed
+//// external document, alias resolution, and collision diagnostics.
+////
+//// The companion `external_loader` module orchestrates the IO side
+//// (calling the `parse_file` callback) and delegates each pure decision
+//// here. Splitting these responsibilities lets every diagnostic — local
+//// collision, cross-file collision, missing component, alias chain,
+//// chained external ref — be unit tested without staging fixture files
+//// on disk (issue #372).
+
+import filepath
+import gleam/bool
+import gleam/dict
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import oaspec/internal/openapi/schema.{type SchemaRef, Inline, Reference}
+import oaspec/internal/openapi/spec.{
+  type Components, type OpenApiSpec, type Parameter, type PathItem,
+  type RequestBody, type Response, type Unresolved,
+}
+import oaspec/openapi/diagnostic.{type Diagnostic}
+
+/// Names in the current spec that are *not themselves* external refs.
+/// These are the schemas the external loader must not silently overwrite.
+pub fn local_schema_names(entries: List(#(String, SchemaRef))) -> List(String) {
+  list.filter_map(entries, fn(entry) {
+    case extract_external_ref(entry.1) {
+      Some(_) -> Error(Nil)
+      None -> Ok(entry.0)
+    }
+  })
+}
+
+/// Detect external refs like `./other.yaml#/components/parameters/Foo`.
+/// Returns Some(#(file_path, component_prefix, name)) or None.
+/// Supported prefixes: parameters, requestBodies, responses, pathItems.
+pub fn extract_external_component_ref(
+  ref_str: String,
+) -> Option(#(String, String, String)) {
+  let is_relative =
+    string.starts_with(ref_str, "./") || string.starts_with(ref_str, "../")
+  use <- bool.guard(!is_relative, None)
+  case string.split_once(ref_str, "#") {
+    Ok(#(file_path, fragment)) ->
+      try_component_prefix(file_path, fragment, [
+        "/components/parameters/",
+        "/components/requestBodies/",
+        "/components/responses/",
+        "/components/pathItems/",
+      ])
+    _ -> None
+  }
+}
+
+/// Try each component prefix against a fragment, returning the first match.
+fn try_component_prefix(
+  file_path: String,
+  fragment: String,
+  prefixes: List(String),
+) -> Option(#(String, String, String)) {
+  case prefixes {
+    [] -> None
+    [prefix, ..rest] ->
+      case string.starts_with(fragment, prefix) {
+        True -> {
+          let name = string.replace(fragment, prefix, "")
+          case string.contains(name, "/"), name {
+            False, "" -> None
+            False, _ -> Some(#(file_path, prefix, name))
+            True, _ -> None
+          }
+        }
+        False -> try_component_prefix(file_path, fragment, rest)
+      }
+  }
+}
+
+/// Look up a parameter by name in an external file's components.
+pub fn find_external_parameter(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(Parameter(Unresolved), Diagnostic) {
+  case loaded.components {
+    Some(components) ->
+      case dict.get(components.parameters, name) {
+        Ok(spec.Value(p)) -> Ok(p)
+        Ok(spec.Ref(_)) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External parameter '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref; chained external refs are not supported.",
+            hint: Some(
+              "Inline the parameter in the external file or flatten the ref chain.",
+            ),
+          ))
+        Error(Nil) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External file '"
+              <> source_path
+              <> "' has no components.parameters."
+              <> name,
+            hint: Some(
+              "Verify the ref path and that the referenced file defines the parameter.",
+            ),
+          ))
+      }
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some(
+          "Add a components.parameters section to the referenced file.",
+        ),
+      ))
+  }
+}
+
+/// Look up a request body by name in an external file's components.
+pub fn find_external_request_body(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(RequestBody(Unresolved), Diagnostic) {
+  case loaded.components {
+    Some(components) ->
+      case dict.get(components.request_bodies, name) {
+        Ok(spec.Value(rb)) -> Ok(rb)
+        Ok(spec.Ref(_)) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External request body '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref; chained external refs are not supported.",
+            hint: Some(
+              "Inline the request body in the external file or flatten the ref chain.",
+            ),
+          ))
+        Error(Nil) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External file '"
+              <> source_path
+              <> "' has no components.requestBodies."
+              <> name,
+            hint: Some(
+              "Verify the ref path and that the referenced file defines the request body.",
+            ),
+          ))
+      }
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some(
+          "Add a components.requestBodies section to the referenced file.",
+        ),
+      ))
+  }
+}
+
+/// Look up a response by name in an external file's components.
+pub fn find_external_response(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(Response(Unresolved), Diagnostic) {
+  case loaded.components {
+    Some(components) ->
+      case dict.get(components.responses, name) {
+        Ok(spec.Value(r)) -> Ok(r)
+        Ok(spec.Ref(_)) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External response '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref; chained external refs are not supported.",
+            hint: Some(
+              "Inline the response in the external file or flatten the ref chain.",
+            ),
+          ))
+        Error(Nil) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External file '"
+              <> source_path
+              <> "' has no components.responses."
+              <> name,
+            hint: Some(
+              "Verify the ref path and that the referenced file defines the response.",
+            ),
+          ))
+      }
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some("Add a components.responses section to the referenced file."),
+      ))
+  }
+}
+
+/// Look up a path item by name in an external file's components.
+pub fn find_external_path_item(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(PathItem(Unresolved), Diagnostic) {
+  case loaded.components {
+    Some(components) ->
+      case dict.get(components.path_items, name) {
+        Ok(spec.Value(pi)) -> Ok(pi)
+        Ok(spec.Ref(_)) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External path item '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref; chained external refs are not supported.",
+            hint: Some(
+              "Inline the path item in the external file or flatten the ref chain.",
+            ),
+          ))
+        Error(Nil) ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External file '"
+              <> source_path
+              <> "' has no components.pathItems."
+              <> name,
+            hint: Some(
+              "Verify the ref path and that the referenced file defines the path item.",
+            ),
+          ))
+      }
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some("Add a components.pathItems section to the referenced file."),
+      ))
+  }
+}
+
+/// Reject a nested property ref whose fragment name collides with a schema
+/// that was authored inline in the main spec. Without this guard the nested
+/// import would silently rebind to the local schema — even if its shape is
+/// unrelated — because the merged dict already holds that slot.
+pub fn check_nested_local_collision(
+  fragment_name: String,
+  source_path: String,
+  original_local_names: List(String),
+) -> Result(Nil, Diagnostic) {
+  use <- bool.guard(
+    !list.contains(original_local_names, fragment_name),
+    Ok(Nil),
+  )
+  Error(diagnostic.validation(
+    severity: diagnostic.SeverityError,
+    target: diagnostic.TargetBoth,
+    path: source_path,
+    detail: "Nested property $ref imports schema '"
+      <> fragment_name
+      <> "' from '"
+      <> source_path
+      <> "', but a local schema with the same name is already defined.",
+    hint: Some(
+      "Rename one of the colliding schemas, or point the external ref at a file whose fragment name is unique.",
+    ),
+  ))
+}
+
+/// Same shape as `check_cross_file_collision` but reads from the
+/// `imports: Dict(fragment_name, #(source_path, target_schema))` dict used
+/// by the nested-property phase.
+pub fn check_nested_cross_file_collision(
+  fragment_name: String,
+  resolved_path: String,
+  imports: dict.Dict(String, #(String, SchemaRef)),
+) -> Result(Nil, Diagnostic) {
+  case dict.get(imports, fragment_name) {
+    // nolint: thrown_away_error -- dict.get Error only signals absent key; no diagnostic to propagate
+    Error(_) -> Ok(Nil)
+    Ok(#(prev_path, _)) ->
+      case prev_path == resolved_path {
+        True -> Ok(Nil)
+        False ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: resolved_path,
+            detail: "Nested property $ref imports schema '"
+              <> fragment_name
+              <> "' from '"
+              <> resolved_path
+              <> "', but the same name was already imported from '"
+              <> prev_path
+              <> "'.",
+            hint: Some(
+              "Rename one of the schemas in the source files so imports do not collide.",
+            ),
+          ))
+      }
+  }
+}
+
+/// Reject an external ref whose fragment name would collide with a schema
+/// already defined locally in the same spec. The case where the entry name
+/// equals the fragment name (`Widget: $ref: './other.yaml#/.../Widget'`) is
+/// intentionally allowed — we treat it as the user asking for that slot to
+/// hold the imported schema.
+pub fn check_local_collision(
+  entry_name: String,
+  fragment_name: String,
+  source_path: String,
+  original_local_names: List(String),
+) -> Result(Nil, Diagnostic) {
+  use <- bool.guard(entry_name == fragment_name, Ok(Nil))
+  use <- bool.guard(
+    !list.contains(original_local_names, fragment_name),
+    Ok(Nil),
+  )
+  Error(diagnostic.validation(
+    severity: diagnostic.SeverityError,
+    target: diagnostic.TargetBoth,
+    path: source_path,
+    detail: "External $ref imports schema '"
+      <> fragment_name
+      <> "' from '"
+      <> source_path
+      <> "', but a local schema with the same name is already defined.",
+    hint: Some(
+      "Rename one of the colliding schemas, or point the external ref at a file whose fragment name is unique.",
+    ),
+  ))
+}
+
+/// Reject two external refs that both pull the same fragment name from
+/// different source files. Re-importing the same name from the same path is
+/// allowed (idempotent) to keep error messages narrow.
+pub fn check_cross_file_collision(
+  fragment_name: String,
+  resolved_path: String,
+  imported: dict.Dict(String, String),
+) -> Result(Nil, Diagnostic) {
+  case dict.get(imported, fragment_name) {
+    // nolint: thrown_away_error -- dict.get Error only signals absent key; no diagnostic to propagate
+    Error(_) -> Ok(Nil)
+    Ok(prev_path) ->
+      case prev_path == resolved_path {
+        True -> Ok(Nil)
+        False ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: resolved_path,
+            detail: "External $ref imports schema '"
+              <> fragment_name
+              <> "' from '"
+              <> resolved_path
+              <> "', but the same name was already imported from '"
+              <> prev_path
+              <> "'.",
+            hint: Some(
+              "Rename one of the schemas in the source files so imports do not collide.",
+            ),
+          ))
+      }
+  }
+}
+
+/// Detect a `./...#/components/schemas/Name` or `../...#/components/schemas/Name`
+/// ref. Returns `Some(#(file_path, schema_name))` when it matches, `None`
+/// otherwise.
+pub fn extract_external_ref(schema_ref: SchemaRef) -> Option(#(String, String)) {
+  case schema_ref {
+    Reference(ref:, ..) ->
+      case string.starts_with(ref, "./") || string.starts_with(ref, "../") {
+        True ->
+          case string.split_once(ref, "#") {
+            Ok(#(file_path, fragment)) ->
+              case string.starts_with(fragment, "/components/schemas/") {
+                True -> {
+                  let name =
+                    string.replace(fragment, "/components/schemas/", "")
+                  case string.contains(name, "/"), name {
+                    False, "" -> None
+                    False, _ -> Some(#(file_path, name))
+                    True, _ -> None
+                  }
+                }
+                False -> None
+              }
+            _ -> None
+          }
+        False -> None
+      }
+    _ -> None
+  }
+}
+
+/// Look up a schema by name in an external file. Returns the inline schema
+/// (resolving one level of local aliasing) or surfaces a diagnostic if the
+/// file lacks `components`, the schema is missing, or the alias chain is
+/// not single-hop / cross-file.
+pub fn find_external_schema(
+  loaded: OpenApiSpec(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(SchemaRef, Diagnostic) {
+  case loaded.components {
+    Some(components) -> find_schema_follow_alias(components, name, source_path)
+    None ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '" <> source_path <> "' has no components block.",
+        hint: Some(
+          "Add a components.schemas section to the referenced file or inline the schema.",
+        ),
+      ))
+  }
+}
+
+/// Look up `name` in the external file's `components.schemas`. If the
+/// value is inline, return it directly. If it is a local alias
+/// (`#/components/schemas/Other`) pointing at another schema *in the
+/// same file*, follow the alias one level. Cross-file chained refs and
+/// longer alias chains still surface a diagnostic.
+pub fn find_schema_follow_alias(
+  components: Components(Unresolved),
+  name: String,
+  source_path: String,
+) -> Result(SchemaRef, Diagnostic) {
+  case dict.get(components.schemas, name) {
+    Ok(Inline(_) as s) -> Ok(s)
+    Ok(Reference(ref:, ..)) ->
+      case local_schema_name_from_ref(ref) {
+        Some(aliased) ->
+          case dict.get(components.schemas, aliased) {
+            Ok(Inline(_) as s) -> Ok(s)
+            _ ->
+              Error(diagnostic.validation(
+                severity: diagnostic.SeverityError,
+                target: diagnostic.TargetBoth,
+                path: source_path,
+                detail: "External schema '"
+                  <> name
+                  <> "' in '"
+                  <> source_path
+                  <> "' aliases '"
+                  <> aliased
+                  <> "', but the target is itself a $ref or missing; only a single level of aliasing inside the same file is supported.",
+                hint: Some(
+                  "Flatten the alias chain in the external file so the target resolves to an inline schema.",
+                ),
+              ))
+          }
+        None ->
+          Error(diagnostic.validation(
+            severity: diagnostic.SeverityError,
+            target: diagnostic.TargetBoth,
+            path: source_path,
+            detail: "External schema '"
+              <> name
+              <> "' in '"
+              <> source_path
+              <> "' is itself a $ref pointing outside this file; chained external refs are not supported yet.",
+            hint: Some(
+              "Inline the external schema or flatten the ref to live inside the same file.",
+            ),
+          ))
+      }
+    Error(Nil) ->
+      Error(diagnostic.validation(
+        severity: diagnostic.SeverityError,
+        target: diagnostic.TargetBoth,
+        path: source_path,
+        detail: "External file '"
+          <> source_path
+          <> "' has no components.schemas."
+          <> name,
+        hint: Some(
+          "Verify the ref path and that the referenced file defines the schema.",
+        ),
+      ))
+  }
+}
+
+/// If `ref` is a local component-schemas ref inside the same file (no
+/// leading file part), return the schema name. Otherwise return None
+/// so the caller can surface a cross-file diagnostic.
+pub fn local_schema_name_from_ref(ref: String) -> Option(String) {
+  let prefix = "#/components/schemas/"
+  case string.starts_with(ref, prefix) {
+    True -> {
+      let name = string.replace(ref, prefix, "")
+      case string.contains(name, "/"), name {
+        False, "" -> None
+        False, _ -> Some(name)
+        True, _ -> None
+      }
+    }
+    False -> None
+  }
+}
+
+/// Helper used by `parser.parse_file` to compute a spec's base directory.
+/// Empty-string (current working directory) is returned when the filepath
+/// module can't extract a parent — callers can then pass `Some("")` which
+/// resolves relative refs against CWD.
+pub fn base_dir_of(path: String) -> Option(String) {
+  case filepath.directory_name(path) {
+    "" -> Some(".")
+    dir -> Some(dir)
+  }
+}

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -7,6 +7,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import oaspec/internal/openapi/external_loader
+import oaspec/internal/openapi/external_loader_planner
 import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/parser_schema
 import oaspec/internal/openapi/parser_value
@@ -111,7 +112,7 @@ fn parse_file_internal(
     progress.timed(fn() {
       external_loader.resolve_external_component_refs(
         spec,
-        external_loader.base_dir_of(path),
+        external_loader_planner.base_dir_of(path),
         fn(sub_path) { parse_file_internal(sub_path, new_visited, reporter) },
       )
     })

--- a/test/external_loader_planner_test.gleam
+++ b/test/external_loader_planner_test.gleam
@@ -1,0 +1,514 @@
+//// Unit tests for the pure planner helpers used by `external_loader`.
+//// Every case here exercises ref parsing, schema lookup, alias chaining,
+//// or collision diagnostics without touching the filesystem (issue #372).
+
+import gleam/dict
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+import oaspec/internal/openapi/external_loader_planner as planner
+import oaspec/internal/openapi/schema.{
+  type SchemaObject, BooleanSchema, Inline, IntegerSchema, Reference,
+}
+import oaspec/internal/openapi/spec.{
+  type Components, type OpenApiSpec, Components, OpenApiSpec, Value,
+}
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// --- helpers --------------------------------------------------------
+
+fn empty_components() -> Components(spec.Unresolved) {
+  Components(
+    schemas: dict.new(),
+    parameters: dict.new(),
+    request_bodies: dict.new(),
+    responses: dict.new(),
+    security_schemes: dict.new(),
+    path_items: dict.new(),
+    headers: dict.new(),
+    examples: dict.new(),
+    links: dict.new(),
+    callbacks: dict.new(),
+  )
+}
+
+fn make_spec(
+  components: option.Option(Components(spec.Unresolved)),
+) -> OpenApiSpec(spec.Unresolved) {
+  OpenApiSpec(
+    openapi: "3.0.3",
+    info: spec.Info(
+      title: "T",
+      description: None,
+      version: "1",
+      summary: None,
+      terms_of_service: None,
+      contact: None,
+      license: None,
+    ),
+    paths: dict.new(),
+    components: components,
+    servers: [],
+    security: [],
+    webhooks: dict.new(),
+    tags: [],
+    external_docs: None,
+    json_schema_dialect: None,
+  )
+}
+
+fn int_schema() -> SchemaObject {
+  IntegerSchema(
+    metadata: schema.default_metadata(),
+    format: None,
+    minimum: None,
+    maximum: None,
+    exclusive_minimum: None,
+    exclusive_maximum: None,
+    multiple_of: None,
+  )
+}
+
+fn bool_schema() -> SchemaObject {
+  BooleanSchema(metadata: schema.default_metadata())
+}
+
+fn make_param(name: String) -> spec.Parameter(spec.Unresolved) {
+  spec.Parameter(
+    name: name,
+    in_: spec.InQuery,
+    description: None,
+    required: False,
+    payload: spec.ParameterSchema(Inline(int_schema())),
+    style: None,
+    explode: None,
+    deprecated: False,
+    allow_reserved: False,
+    examples: dict.new(),
+  )
+}
+
+fn make_request_body() -> spec.RequestBody(spec.Unresolved) {
+  spec.RequestBody(description: None, content: dict.new(), required: False)
+}
+
+fn make_response() -> spec.Response(spec.Unresolved) {
+  spec.Response(
+    description: None,
+    content: dict.new(),
+    headers: dict.new(),
+    links: dict.new(),
+  )
+}
+
+fn make_path_item() -> spec.PathItem(spec.Unresolved) {
+  spec.PathItem(
+    summary: None,
+    description: None,
+    get: None,
+    post: None,
+    put: None,
+    delete: None,
+    patch: None,
+    head: None,
+    options: None,
+    trace: None,
+    parameters: [],
+    servers: [],
+  )
+}
+
+// --- extract_external_ref ------------------------------------------
+
+pub fn extract_external_ref_relative_test() {
+  Reference(ref: "./other.yaml#/components/schemas/Foo", name: "Foo")
+  |> planner.extract_external_ref
+  |> should.equal(Some(#("./other.yaml", "Foo")))
+}
+
+pub fn extract_external_ref_parent_dir_test() {
+  Reference(ref: "../shared.yaml#/components/schemas/Bar", name: "Bar")
+  |> planner.extract_external_ref
+  |> should.equal(Some(#("../shared.yaml", "Bar")))
+}
+
+pub fn extract_external_ref_local_returns_none_test() {
+  Reference(ref: "#/components/schemas/Pet", name: "Pet")
+  |> planner.extract_external_ref
+  |> should.equal(None)
+}
+
+pub fn extract_external_ref_inline_returns_none_test() {
+  Inline(int_schema())
+  |> planner.extract_external_ref
+  |> should.equal(None)
+}
+
+pub fn extract_external_ref_no_fragment_returns_none_test() {
+  Reference(ref: "./other.yaml", name: "")
+  |> planner.extract_external_ref
+  |> should.equal(None)
+}
+
+pub fn extract_external_ref_wrong_prefix_returns_none_test() {
+  Reference(ref: "./other.yaml#/components/parameters/Foo", name: "Foo")
+  |> planner.extract_external_ref
+  |> should.equal(None)
+}
+
+pub fn extract_external_ref_nested_fragment_returns_none_test() {
+  Reference(ref: "./other.yaml#/components/schemas/Outer/properties", name: "x")
+  |> planner.extract_external_ref
+  |> should.equal(None)
+}
+
+// --- extract_external_component_ref --------------------------------
+
+pub fn extract_component_ref_parameters_test() {
+  planner.extract_external_component_ref(
+    "./other.yaml#/components/parameters/Foo",
+  )
+  |> should.equal(Some(#("./other.yaml", "/components/parameters/", "Foo")))
+}
+
+pub fn extract_component_ref_request_bodies_test() {
+  planner.extract_external_component_ref(
+    "./other.yaml#/components/requestBodies/Body",
+  )
+  |> should.equal(Some(#("./other.yaml", "/components/requestBodies/", "Body")))
+}
+
+pub fn extract_component_ref_responses_test() {
+  planner.extract_external_component_ref(
+    "../shared.yaml#/components/responses/NotFound",
+  )
+  |> should.equal(
+    Some(#("../shared.yaml", "/components/responses/", "NotFound")),
+  )
+}
+
+pub fn extract_component_ref_path_items_test() {
+  planner.extract_external_component_ref(
+    "./other.yaml#/components/pathItems/Reusable",
+  )
+  |> should.equal(Some(#("./other.yaml", "/components/pathItems/", "Reusable")))
+}
+
+pub fn extract_component_ref_schemas_returns_none_test() {
+  // schemas are handled by extract_external_ref, not this one.
+  planner.extract_external_component_ref("./other.yaml#/components/schemas/Foo")
+  |> should.equal(None)
+}
+
+pub fn extract_component_ref_local_returns_none_test() {
+  planner.extract_external_component_ref("#/components/parameters/Foo")
+  |> should.equal(None)
+}
+
+// --- local_schema_names ---------------------------------------------
+
+pub fn local_schema_names_filters_external_test() {
+  let entries = [
+    #("Local", Inline(int_schema())),
+    #(
+      "ExternalAlias",
+      Reference(ref: "./other.yaml#/components/schemas/Pet", name: "Pet"),
+    ),
+    #(
+      "InternalAlias",
+      Reference(ref: "#/components/schemas/Other", name: "Other"),
+    ),
+  ]
+  // ExternalAlias is filtered out; InternalAlias and Local stay because
+  // an internal alias is not an external ref.
+  planner.local_schema_names(entries)
+  |> should.equal(["Local", "InternalAlias"])
+}
+
+pub fn local_schema_names_empty_test() {
+  planner.local_schema_names([])
+  |> should.equal([])
+}
+
+// --- local_schema_name_from_ref ------------------------------------
+
+pub fn local_schema_name_from_ref_local_test() {
+  planner.local_schema_name_from_ref("#/components/schemas/Widget")
+  |> should.equal(Some("Widget"))
+}
+
+pub fn local_schema_name_from_ref_cross_file_test() {
+  planner.local_schema_name_from_ref("./other.yaml#/components/schemas/Widget")
+  |> should.equal(None)
+}
+
+pub fn local_schema_name_from_ref_nested_path_test() {
+  planner.local_schema_name_from_ref(
+    "#/components/schemas/Outer/properties/inner",
+  )
+  |> should.equal(None)
+}
+
+pub fn local_schema_name_from_ref_empty_name_test() {
+  planner.local_schema_name_from_ref("#/components/schemas/")
+  |> should.equal(None)
+}
+
+// --- base_dir_of ----------------------------------------------------
+
+pub fn base_dir_of_with_directory_test() {
+  planner.base_dir_of("specs/api/openapi.yaml")
+  |> should.equal(Some("specs/api"))
+}
+
+pub fn base_dir_of_bare_filename_test() {
+  // filepath.directory_name returns "" for a bare filename; the planner
+  // substitutes "." so callers resolve relative refs against CWD.
+  planner.base_dir_of("openapi.yaml")
+  |> should.equal(Some("."))
+}
+
+// --- check_local_collision -----------------------------------------
+
+pub fn check_local_collision_entry_equals_fragment_ok_test() {
+  // Widget: $ref: './other.yaml#/.../Widget' is intentionally allowed.
+  planner.check_local_collision("Widget", "Widget", "./other.yaml", ["Widget"])
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_local_collision_unique_fragment_ok_test() {
+  planner.check_local_collision("Alias", "Imported", "./other.yaml", [
+    "Alias", "Other",
+  ])
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_local_collision_conflict_errors_test() {
+  planner.check_local_collision("Alias", "Widget", "./other.yaml", [
+    "Widget", "Other",
+  ])
+  |> should.be_error()
+}
+
+// --- check_cross_file_collision ------------------------------------
+
+pub fn check_cross_file_collision_empty_ok_test() {
+  planner.check_cross_file_collision("Pet", "./a.yaml", dict.new())
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_cross_file_collision_same_path_idempotent_test() {
+  let imported = dict.from_list([#("Pet", "./a.yaml")])
+  planner.check_cross_file_collision("Pet", "./a.yaml", imported)
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_cross_file_collision_different_path_errors_test() {
+  let imported = dict.from_list([#("Pet", "./a.yaml")])
+  planner.check_cross_file_collision("Pet", "./b.yaml", imported)
+  |> should.be_error()
+}
+
+// --- check_nested_local_collision ----------------------------------
+
+pub fn check_nested_local_collision_no_conflict_test() {
+  planner.check_nested_local_collision("Pet", "./a.yaml", ["Other"])
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_nested_local_collision_conflict_errors_test() {
+  planner.check_nested_local_collision("Pet", "./a.yaml", ["Pet"])
+  |> should.be_error()
+}
+
+// --- check_nested_cross_file_collision -----------------------------
+
+pub fn check_nested_cross_file_collision_same_path_ok_test() {
+  let target = Inline(int_schema())
+  let imports = dict.from_list([#("Pet", #("./a.yaml", target))])
+  planner.check_nested_cross_file_collision("Pet", "./a.yaml", imports)
+  |> should.equal(Ok(Nil))
+}
+
+pub fn check_nested_cross_file_collision_different_path_errors_test() {
+  let target = Inline(int_schema())
+  let imports = dict.from_list([#("Pet", #("./a.yaml", target))])
+  planner.check_nested_cross_file_collision("Pet", "./b.yaml", imports)
+  |> should.be_error()
+}
+
+// --- find_schema_follow_alias --------------------------------------
+
+pub fn find_schema_follow_alias_inline_test() {
+  let schemas = dict.from_list([#("Pet", Inline(int_schema()))])
+  let components = Components(..empty_components(), schemas: schemas)
+  planner.find_schema_follow_alias(components, "Pet", "./a.yaml")
+  |> should.equal(Ok(Inline(int_schema())))
+}
+
+pub fn find_schema_follow_alias_single_local_alias_test() {
+  let target = Inline(bool_schema())
+  let schemas =
+    dict.from_list([
+      #("Pet", Reference(ref: "#/components/schemas/Animal", name: "Animal")),
+      #("Animal", target),
+    ])
+  let components = Components(..empty_components(), schemas: schemas)
+  planner.find_schema_follow_alias(components, "Pet", "./a.yaml")
+  |> should.equal(Ok(target))
+}
+
+pub fn find_schema_follow_alias_chained_alias_errors_test() {
+  let schemas =
+    dict.from_list([
+      #("Pet", Reference(ref: "#/components/schemas/Animal", name: "Animal")),
+      #("Animal", Reference(ref: "#/components/schemas/Beast", name: "Beast")),
+    ])
+  let components = Components(..empty_components(), schemas: schemas)
+  planner.find_schema_follow_alias(components, "Pet", "./a.yaml")
+  |> should.be_error()
+}
+
+pub fn find_schema_follow_alias_cross_file_alias_errors_test() {
+  let schemas =
+    dict.from_list([
+      #(
+        "Pet",
+        Reference(
+          ref: "./other.yaml#/components/schemas/Animal",
+          name: "Animal",
+        ),
+      ),
+    ])
+  let components = Components(..empty_components(), schemas: schemas)
+  planner.find_schema_follow_alias(components, "Pet", "./a.yaml")
+  |> should.be_error()
+}
+
+pub fn find_schema_follow_alias_missing_test() {
+  let components = empty_components()
+  planner.find_schema_follow_alias(components, "Missing", "./a.yaml")
+  |> should.be_error()
+}
+
+// --- find_external_schema (None components branch) ----------------
+
+pub fn find_external_schema_no_components_test() {
+  planner.find_external_schema(make_spec(None), "Pet", "./a.yaml")
+  |> should.be_error()
+}
+
+pub fn find_external_schema_with_components_test() {
+  let schemas = dict.from_list([#("Pet", Inline(int_schema()))])
+  let components = Components(..empty_components(), schemas: schemas)
+  planner.find_external_schema(make_spec(Some(components)), "Pet", "./a.yaml")
+  |> should.equal(Ok(Inline(int_schema())))
+}
+
+// --- find_external_parameter ---------------------------------------
+
+pub fn find_external_parameter_inline_test() {
+  let param = make_param("limit")
+  let parameters = dict.from_list([#("limit", Value(param))])
+  let components = Components(..empty_components(), parameters: parameters)
+  planner.find_external_parameter(
+    make_spec(Some(components)),
+    "limit",
+    "./a.yaml",
+  )
+  |> should.equal(Ok(param))
+}
+
+pub fn find_external_parameter_chained_ref_errors_test() {
+  let parameters =
+    dict.from_list([#("limit", spec.Ref("#/components/parameters/Other"))])
+  let components = Components(..empty_components(), parameters: parameters)
+  planner.find_external_parameter(
+    make_spec(Some(components)),
+    "limit",
+    "./a.yaml",
+  )
+  |> should.be_error()
+}
+
+pub fn find_external_parameter_missing_errors_test() {
+  let components = empty_components()
+  planner.find_external_parameter(
+    make_spec(Some(components)),
+    "limit",
+    "./a.yaml",
+  )
+  |> should.be_error()
+}
+
+pub fn find_external_parameter_no_components_errors_test() {
+  planner.find_external_parameter(make_spec(None), "limit", "./a.yaml")
+  |> should.be_error()
+}
+
+// --- find_external_request_body ------------------------------------
+
+pub fn find_external_request_body_inline_test() {
+  let body = make_request_body()
+  let bodies = dict.from_list([#("Body", Value(body))])
+  let components = Components(..empty_components(), request_bodies: bodies)
+  planner.find_external_request_body(
+    make_spec(Some(components)),
+    "Body",
+    "./a.yaml",
+  )
+  |> should.equal(Ok(body))
+}
+
+pub fn find_external_request_body_missing_errors_test() {
+  planner.find_external_request_body(
+    make_spec(Some(empty_components())),
+    "Body",
+    "./a.yaml",
+  )
+  |> should.be_error()
+}
+
+// --- find_external_response ----------------------------------------
+
+pub fn find_external_response_inline_test() {
+  let response = make_response()
+  let responses = dict.from_list([#("OK", Value(response))])
+  let components = Components(..empty_components(), responses: responses)
+  planner.find_external_response(make_spec(Some(components)), "OK", "./a.yaml")
+  |> should.equal(Ok(response))
+}
+
+pub fn find_external_response_chained_ref_errors_test() {
+  let responses =
+    dict.from_list([#("OK", spec.Ref("#/components/responses/Other"))])
+  let components = Components(..empty_components(), responses: responses)
+  planner.find_external_response(make_spec(Some(components)), "OK", "./a.yaml")
+  |> should.be_error()
+}
+
+// --- find_external_path_item ---------------------------------------
+
+pub fn find_external_path_item_inline_test() {
+  let path_item = make_path_item()
+  let path_items = dict.from_list([#("Reusable", Value(path_item))])
+  let components = Components(..empty_components(), path_items: path_items)
+  planner.find_external_path_item(
+    make_spec(Some(components)),
+    "Reusable",
+    "./a.yaml",
+  )
+  |> should.equal(Ok(path_item))
+}
+
+pub fn find_external_path_item_missing_errors_test() {
+  planner.find_external_path_item(
+    make_spec(Some(empty_components())),
+    "Reusable",
+    "./a.yaml",
+  )
+  |> should.be_error()
+}


### PR DESCRIPTION
## Summary

Split `oaspec/internal/openapi/external_loader.gleam` into an IO shell and a
pure rewrite planner so external-`$ref` diagnostics can be unit tested without
staging fixture files on disk.

The new `external_loader_planner` module owns every decision the loader
made that did not require filesystem IO:

- ref-string parsing (`extract_external_ref`, `extract_external_component_ref`,
  `local_schema_name_from_ref`, `base_dir_of`)
- schema / parameter / requestBody / response / pathItem lookups inside
  a parsed external document
- alias resolution (`find_schema_follow_alias`, single-hop in-file alias chain)
- collision diagnostics (`check_local_collision`, `check_cross_file_collision`,
  `check_nested_local_collision`, `check_nested_cross_file_collision`)

`external_loader.gleam` keeps the orchestration side: walking
`components.schemas`, parameters, request bodies, responses, headers,
path items, callbacks, and every operation slot, then threading the
imported-schemas dict through each phase. It now calls `planner.*` for
every pure decision, dropping ~530 lines of duplicated logic.

## Test plan

- [x] `mise exec -- gleam format --check src/ test/`
- [x] `mise exec -- gleam check`
- [x] `mise exec -- gleam build --warnings-as-errors`
- [x] `mise exec -- gleam run -m glinter -- --stats` (0 errors, 0 warnings on
  changed files)
- [x] `mise exec -- gleam test --target erlang` (875 passed, includes 38 new
  planner unit tests covering ref parsing, schema lookups, alias chain
  handling, and every collision branch)
- [x] `bash scripts/check_sync.sh`

Closes #372.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test suite from 827 to 875 tests with comprehensive validation of external reference handling, including parsing, component lookups, collision detection, and schema resolution.

* **Refactor**
  * Reorganized internal code structure for external reference handling to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->