### PR TITLE
refactor(codegen): precompute analyzed operations on Context (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Internal: precompute the analyzed-operations list once per generation
+  context.** `Context` now holds the result of
+  `operations.collect_operations` (with merged path-level params, effective
+  security, effective servers, and synthesized operationIds) and exposes it
+  through a new `context.operations/1` accessor. Every codegen and
+  validation pass — `client`, `decoders`, `encoders`, `ir_build`, `server`,
+  `types`, `validate`, and `capability_check` — now reads this shared list
+  instead of rebuilding it at unrelated call sites. Step 1 toward #371; the
+  schema-query consolidation called out in that issue is left for a
+  follow-up PR.
 - **Internal: split the external `$ref` loader into an IO shell and a pure
   rewrite planner.** The new `oaspec/internal/openapi/external_loader_planner`
   module now owns ref-string parsing, schema/parameter/requestBody/response/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 875 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 879 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -13,7 +13,6 @@ import oaspec/internal/codegen/context.{
 import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/import_analysis
 import oaspec/internal/codegen/ir_build
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{type Resolved, ParameterSchema, Value}
@@ -38,7 +37,7 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 
 /// Generate the client module with functions for each operation.
 fn generate_client(ctx: Context) -> String {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
 
   // Determine which imports are needed based on parameter types
   let all_params =

--- a/src/oaspec/internal/codegen/context.gleam
+++ b/src/oaspec/internal/codegen/context.gleam
@@ -1,23 +1,40 @@
 import oaspec/config.{type Config}
-import oaspec/internal/openapi/spec.{type OpenApiSpec, type Resolved}
+import oaspec/internal/openapi/operations
+import oaspec/internal/openapi/spec.{
+  type HttpMethod, type OpenApiSpec, type Operation, type Resolved,
+}
 
 /// The version of oaspec used for generated code headers.
 pub const version = "0.38.0"
+
+/// One analyzed operation: its `operationId` (synthesized when missing),
+/// the operation record with path-level parameters, security, and servers
+/// already merged in, the URL path it lives under, and the HTTP method.
+pub type AnalyzedOperation =
+  #(String, Operation(Resolved), String, HttpMethod)
 
 /// Context for code generation, carrying all needed state.
 /// Only accepts a resolved spec — codegen must not operate on unresolved ASTs.
 ///
 /// Opaque: external callers construct via `new/2` and read fields via
-/// the accessors `spec/1` / `config/1`. This keeps the internal shape
-/// free to evolve (e.g. add derived caches) without rippling into every
-/// pattern match across the codebase.
+/// the accessors `spec/1` / `config/1` / `operations/1`. The shape is
+/// free to evolve (e.g. add more derived caches) without rippling into
+/// every pattern match across the codebase.
 pub opaque type Context {
-  Context(spec: OpenApiSpec(Resolved), config: Config)
+  Context(
+    spec: OpenApiSpec(Resolved),
+    config: Config,
+    operations: List(AnalyzedOperation),
+  )
 }
 
-/// Create a new generation context from a resolved spec.
+/// Create a new generation context from a resolved spec. The list of
+/// analyzed operations (with merged path-level params, effective security,
+/// effective servers, and synthesized operationIds) is computed once here
+/// so every codegen pass can read it via `operations/1` instead of
+/// rebuilding the same list at unrelated call sites (issue #371).
 pub fn new(spec: OpenApiSpec(Resolved), config: Config) -> Context {
-  Context(spec:, config:)
+  Context(spec:, config:, operations: operations.collect_operations(spec))
 }
 
 /// The resolved OpenAPI spec this context wraps.
@@ -28,6 +45,13 @@ pub fn spec(ctx: Context) -> OpenApiSpec(Resolved) {
 /// The generation config this context wraps.
 pub fn config(ctx: Context) -> Config {
   ctx.config
+}
+
+/// The shared analyzed operations list, precomputed at context construction.
+/// Every codegen pass should read this rather than recompute via
+/// `operations.collect_operations` directly.
+pub fn operations(ctx: Context) -> List(AnalyzedOperation) {
+  ctx.operations
 }
 
 /// Target for a generated file, indicating where it should be written.

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -13,7 +13,6 @@ import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
 import oaspec/internal/codegen/types as type_gen
 import oaspec/internal/openapi/dedup
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
@@ -30,7 +29,7 @@ import oaspec/internal/util/string_extra as se
 /// Encoder generation lives in `src/oaspec/internal/codegen/encoders.gleam`; see
 /// `generate.gleam::generate_shared` for how the two halves are combined.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let decode_content = generate_decoders(ctx, operations)
 
   [

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -23,7 +23,6 @@ import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
 import oaspec/internal/codegen/types as type_gen
 import oaspec/internal/openapi/dedup
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/schema.{
   type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema,
   Forbidden, Inline, IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema,
@@ -35,7 +34,7 @@ import oaspec/internal/util/string_extra as se
 
 /// Generate the `encode.gleam` module for the resolved spec.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let content = generate_encoders(ctx, operations)
   [
     GeneratedFile(

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -18,7 +18,6 @@ import oaspec/internal/codegen/ir.{
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
 import oaspec/internal/openapi/dedup
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   BooleanSchema, Forbidden, Inline, IntegerSchema, NumberSchema, ObjectSchema,
@@ -72,7 +71,7 @@ pub fn build_types_module(ctx: Context) -> Module {
 /// body produce no declaration — matching the former string-builder
 /// behavior that simply skipped them.
 pub fn build_request_types_module(ctx: Context) -> Module {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let imports = compute_request_type_imports(operations, ctx)
   let declarations =
     list.filter_map(operations, fn(op) {
@@ -208,7 +207,7 @@ fn request_body_type(
 /// become `VariantWithType("String")`; JSON (and other structured) bodies
 /// become `VariantWithType(<qualified schema type>)`.
 pub fn build_response_types_module(ctx: Context) -> Module {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let header_records = build_response_header_records(operations)
   let needs_option_for_headers = response_headers_need_option(header_records)
   let imports = case
@@ -871,7 +870,7 @@ fn schema_type_decls(
 // ---------------------------------------------------------------------------
 
 fn anonymous_type_decls(ctx: Context) -> List(Declaration) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, _path, _method): #(
       String,

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -12,7 +12,6 @@ import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/import_analysis
 import oaspec/internal/codegen/server_request_decode as decode_helpers
 import oaspec/internal/openapi/dedup
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{type Resolved, Value}
 import oaspec/internal/util/content_type
@@ -33,7 +32,7 @@ import oaspec/internal/util/string_extra as se
 ///   is always overwritten so the wiring stays in lock-step with the
 ///   spec.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let handlers_content = generate_handlers(ctx, operations)
   let handlers_generated_content = generate_handlers_generated(ctx, operations)
   let router_content = generate_router(ctx, operations)

--- a/src/oaspec/internal/codegen/types.gleam
+++ b/src/oaspec/internal/codegen/types.gleam
@@ -6,13 +6,12 @@ import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/ir_render
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/schema.{type SchemaObject, type SchemaRef}
 import oaspec/internal/openapi/spec.{type Resolved}
 
 /// Generate type definitions from OpenAPI schemas.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let types_content = generate_types(ctx)
   let request_types_content = generate_request_types(ctx, operations)
   let response_types_content = generate_response_types(ctx, operations)

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -5,7 +5,6 @@ import gleam/regexp
 import gleam/string
 import oaspec/config
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
@@ -27,7 +26,7 @@ import oaspec/openapi/diagnostic.{
 /// silently renaming duplicates would mutate the generated public API
 /// surface without telling the user, which is worse than failing the spec.
 pub fn validate(ctx: Context) -> List(Diagnostic) {
-  let operations = operations.collect_operations(ctx)
+  let operations = context.operations(ctx)
   let op_errors = validate_operations(ctx, operations)
   let opid_errors = validate_unique_operation_ids(operations)
   let schema_errors = validate_component_schemas(ctx)

--- a/src/oaspec/internal/openapi/capability_check.gleam
+++ b/src/oaspec/internal/openapi/capability_check.gleam
@@ -6,7 +6,6 @@ import gleam/string
 import oaspec/config
 import oaspec/internal/capability
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   Inline, ObjectSchema, OneOfSchema, Reference, Typed,
@@ -232,7 +231,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
       ),
     ]
   }
-  let ops = operations.collect_operations(ctx)
+  let ops = context.operations(ctx)
   let response_warnings =
     list.flat_map(ops, fn(op) {
       let #(op_id, operation, _path, _method) = op

--- a/src/oaspec/internal/openapi/operations.gleam
+++ b/src/oaspec/internal/openapi/operations.gleam
@@ -2,19 +2,23 @@ import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
-import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/openapi/spec.{
-  type HttpMethod, type Operation, type Resolved,
+  type HttpMethod, type OpenApiSpec, type Operation, type Resolved,
 }
 
 /// Collect all operations from the spec with their IDs, paths, and methods.
 /// Handles path-level parameter inheritance, security inheritance, and
 /// operationId generation from method + path when not specified.
+///
+/// Pure: depends only on the resolved spec, not on the codegen Context.
+/// The Context now precomputes this list once at construction time and
+/// every codegen pass reads it through `context.operations/1` instead of
+/// re-running this traversal (issue #371).
 pub fn collect_operations(
-  ctx: Context,
+  resolved_spec: OpenApiSpec(Resolved),
 ) -> List(#(String, Operation(Resolved), String, HttpMethod)) {
   let paths =
-    list.sort(dict.to_list(context.spec(ctx).paths), fn(a, b) {
+    list.sort(dict.to_list(resolved_spec.paths), fn(a, b) {
       string.compare(a.0, b.0)
     })
   list.flat_map(paths, fn(entry) {
@@ -55,7 +59,7 @@ pub fn collect_operations(
             // Some([...]) → use operation-level.
             let effective_security = case operation.security {
               Some(sec) -> sec
-              None -> context.spec(ctx).security
+              None -> resolved_spec.security
             }
             // Inherit path-level servers when operation doesn't define its own.
             // OpenAPI precedence: operation.servers > path_item.servers > spec.servers

--- a/test/context_test.gleam
+++ b/test/context_test.gleam
@@ -1,0 +1,62 @@
+//// Tests for the precomputed analyzed-operations cache on `Context`.
+//// `context.operations(ctx)` is the shared analyzed view that every codegen
+//// pass should consume — these tests pin down its shape and ensure it stays
+//// in sync with `operations.collect_operations` (issue #371).
+
+import gleam/list
+import gleam/string
+import gleeunit
+import gleeunit/should
+import oaspec/internal/codegen/context
+import oaspec/internal/openapi/operations
+import test_helpers
+
+pub fn main() {
+  gleeunit.main()
+}
+
+const petstore = "test/fixtures/petstore.yaml"
+
+pub fn operations_matches_direct_collect_test() {
+  let ctx = test_helpers.make_ctx(petstore)
+  let cached = context.operations(ctx)
+  let direct = operations.collect_operations(context.spec(ctx))
+  cached
+  |> should.equal(direct)
+}
+
+pub fn operations_is_idempotent_across_calls_test() {
+  // The cache is computed once at context.new/2 — repeated reads must not
+  // re-run the traversal (and therefore must be the exact same list).
+  let ctx = test_helpers.make_ctx(petstore)
+  context.operations(ctx)
+  |> should.equal(context.operations(ctx))
+}
+
+pub fn operations_petstore_op_ids_test() {
+  let ctx = test_helpers.make_ctx(petstore)
+  let op_ids =
+    context.operations(ctx)
+    |> list.map(fn(op) { op.0 })
+  // petstore.yaml fixture defines operationIds explicitly, so the synthesizer
+  // path is not exercised here — but we lock in the canonical set so any
+  // accidental reshuffling shows up as a failed test.
+  op_ids
+  |> list.contains("listPets")
+  |> should.be_true()
+  op_ids
+  |> list.contains("createPet")
+  |> should.be_true()
+}
+
+pub fn operations_paths_are_sorted_test() {
+  let ctx = test_helpers.make_ctx(petstore)
+  let paths =
+    context.operations(ctx)
+    |> list.map(fn(op) { op.2 })
+  // collect_operations sorts paths alphabetically before flat-mapping methods,
+  // so the resulting path sequence must be non-decreasing.
+  paths
+  |> list.sort(string.compare)
+  |> should.equal(paths)
+}


### PR DESCRIPTION
## Summary

Move the analyzed-operations list — operations with merged path-level
parameters, effective security, effective servers, and synthesized
operationIds — into a precomputed cache on `Context`. Every codegen and
validation pass now reads it through `context.operations/1` instead of
calling `operations.collect_operations(ctx)` directly.

`operations.collect_operations` is now a pure function on
`OpenApiSpec(Resolved)` (no Context dependency), called once at
`context.new/2`. The result is shared across:

- `oaspec/internal/codegen/client`
- `oaspec/internal/codegen/decoders`
- `oaspec/internal/codegen/encoders`
- `oaspec/internal/codegen/ir_build` (3 call sites)
- `oaspec/internal/codegen/server`
- `oaspec/internal/codegen/types`
- `oaspec/internal/codegen/validate`
- `oaspec/internal/openapi/capability_check`

Adds `test/context_test.gleam` pinning the cache shape: it matches a
direct `operations.collect_operations` call, is idempotent across reads,
preserves the explicit operationIds in `petstore.yaml`, and stays
path-sorted.

## Scope split

This is step 1 toward #371. The schema-query consolidation called out in
the same issue (helpers spread across `client_request`,
`server_request_decode`, `guards`, `validate`, `schema_utils` doing ad
hoc ref resolution where a shared query could be reused) is intentionally
deferred to a follow-up PR to keep this diff scoped to the operations
layer. The issue therefore stays open for that work.

## Test plan

- [x] `mise exec -- gleam format --check src/ test/`
- [x] `mise exec -- gleam check`
- [x] `mise exec -- gleam build --warnings-as-errors`
- [x] `mise exec -- gleam run -m glinter -- --stats` (0 errors, 0 warnings)
- [x] `mise exec -- gleam test --target erlang` (879 passed; 4 new context tests)
- [x] `bash scripts/check_sync.sh`
