### PR TITLE
refactor(codegen): move client router and guards onto structured IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 311 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 314 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -4,6 +4,7 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
 import oaspec/config
+import oaspec/internal/codegen/client_ir
 import oaspec/internal/codegen/client_request
 import oaspec/internal/codegen/client_response
 import oaspec/internal/codegen/client_security
@@ -11,12 +12,9 @@ import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/guards
-import oaspec/internal/codegen/import_analysis
 import oaspec/internal/codegen/ir_build
-import oaspec/internal/openapi/resolver
-import oaspec/internal/openapi/schema.{Inline, Reference}
-import oaspec/internal/openapi/spec.{type Resolved, ParameterSchema, Value}
-import oaspec/internal/util/content_type as ct_util
+import oaspec/internal/openapi/schema
+import oaspec/internal/openapi/spec.{type Resolved, Value}
 import oaspec/internal/util/http
 import oaspec/internal/util/naming
 import oaspec/internal/util/string_extra as se
@@ -38,322 +36,8 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 /// Generate the client module with functions for each operation.
 fn generate_client(ctx: Context) -> String {
   let operations = context.operations(ctx)
-
-  // Determine which imports are needed based on parameter types
-  let all_params =
-    list.flat_map(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.filter_map(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> Ok(p)
-          _ -> Error(Nil)
-        }
-      })
-    })
-  let needs_bool =
-    list.any(all_params, fn(p) {
-      case p.payload {
-        ParameterSchema(Inline(schema.BooleanSchema(..))) -> True
-        _ -> False
-      }
-    })
-  let needs_float =
-    list.any(all_params, fn(p) {
-      case p.payload {
-        ParameterSchema(Inline(schema.NumberSchema(..))) -> True
-        _ -> False
-      }
-    })
-  let has_multi_content_response =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(dict.to_list(operation.responses), fn(entry) {
-        let #(_, ref_or) = entry
-        case ref_or {
-          Value(response) -> list.length(dict.to_list(response.content)) > 1
-          _ -> False
-        }
-      })
-    })
-
-  let has_form_urlencoded =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(ce) {
-            let #(key, _) = ce
-            key == "application/x-www-form-urlencoded"
-          })
-        _ -> False
-      }
-    })
-
-  let has_multipart =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(ce) {
-            let #(key, _) = ce
-            key == "multipart/form-data"
-          })
-        _ -> False
-      }
-    })
-
-  let needs_list =
-    has_form_urlencoded
-    || has_multi_content_response
-    || list.any(all_params, fn(p) { p.in_ == spec.InQuery })
-    || list.any(all_params, fn(p) { p.in_ == spec.InCookie })
-    || list.any(all_params, fn(p) { p.in_ == spec.InHeader })
-    || list.any(all_params, fn(p) {
-      case p.payload {
-        ParameterSchema(Inline(schema.ArraySchema(..))) -> True
-        ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
-            Ok(schema.ArraySchema(..)) -> True
-            _ -> False
-          }
-        _ -> False
-      }
-    })
-
-  let needs_dyn_decode =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(dict.to_list(operation.responses), fn(entry) {
-        let #(_, ref_or) = entry
-        case ref_or {
-          Value(response) ->
-            list.any(dict.to_list(response.content), fn(ce) {
-              let #(media_type_name, mt) = ce
-              case media_type_name {
-                "text/plain" -> False
-                _ ->
-                  case mt.schema {
-                    Some(Inline(schema.ArraySchema(items: Inline(_), ..))) ->
-                      True
-                    Some(Inline(schema.StringSchema(..))) -> True
-                    Some(Inline(schema.IntegerSchema(..))) -> True
-                    Some(Inline(schema.NumberSchema(..))) -> True
-                    Some(Inline(schema.BooleanSchema(..))) -> True
-                    _ -> False
-                  }
-              }
-            })
-          _ -> False
-        }
-      })
-    })
-
-  let needs_json =
-    needs_dyn_decode
-    || list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(ce) {
-            let #(_, mt) = ce
-            case mt.schema {
-              Some(Inline(schema.StringSchema(..))) -> True
-              Some(Inline(schema.IntegerSchema(..))) -> True
-              Some(Inline(schema.NumberSchema(..))) -> True
-              Some(Inline(schema.BooleanSchema(..))) -> True
-              _ -> False
-            }
-          })
-        _ -> False
-      }
-    })
-
-  let needs_string =
-    has_multi_content_response
-    || has_form_urlencoded
-    || has_multipart
-    || list.any(all_params, fn(p) {
-      p.in_ == spec.InPath || p.in_ == spec.InCookie
-    })
-
-  // Decode/encode/types modules — same logic as before.
-  let needs_typed_schemas =
-    import_analysis.operations_need_typed_schemas(operations)
-
-  // `type Option` is only referenced in operation signatures when
-  // optional params / bodies exist; `Some` and `None` are also used
-  // for the `base_url` field of every emitted `transport.Request`
-  // literal, so we track them independently.
-  let needs_option_type =
-    import_analysis.operations_have_optional_params(operations)
-    || import_analysis.operations_have_optional_body(operations)
-  let needs_some_ctor =
-    needs_option_type || any_operation_has_server(operations, ctx)
-  let needs_none_ctor =
-    needs_option_type || any_operation_has_no_server(operations, ctx)
-  let option_import_items = case
-    needs_option_type,
-    needs_some_ctor,
-    needs_none_ctor
-  {
-    True, _, _ -> Some("gleam/option.{type Option, None, Some}")
-    False, True, True -> Some("gleam/option.{None, Some}")
-    False, True, False -> Some("gleam/option.{Some}")
-    False, False, True -> Some("gleam/option.{None}")
-    False, False, False -> None
-  }
-
-  let needs_int =
-    list.any(all_params, fn(p) {
-      case p.payload {
-        ParameterSchema(Inline(schema.IntegerSchema(..))) -> True
-        ParameterSchema(Inline(schema.ArraySchema(
-          items: Inline(schema.IntegerSchema(..)),
-          ..,
-        ))) -> True
-        ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
-            Ok(schema.IntegerSchema(..)) -> True
-            Ok(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..)) ->
-              True
-            _ -> False
-          }
-        _ -> False
-      }
-    })
-
-  // Need binary helpers when any response declares binary content.
-  let needs_bytes_helper =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(dict.to_list(operation.responses), fn(entry) {
-        let #(_, ref_or) = entry
-        case ref_or {
-          Value(response) ->
-            list.any(dict.to_list(response.content), fn(ce) {
-              let #(name, _) = ce
-              ct_util.from_string(name) == ct_util.ApplicationOctetStream
-            })
-          _ -> False
-        }
-      })
-    })
-
-  // Need text helpers when any response decodes a body — which is
-  // basically every spec-decoded response. We compute this once here
-  // so we can suppress the helper for spec'd-empty operations.
-  let needs_text_helper =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(dict.to_list(operation.responses), fn(entry) {
-        let #(_, ref_or) = entry
-        case ref_or {
-          Value(response) ->
-            list.any(dict.to_list(response.content), fn(ce) {
-              let #(_, mt) = ce
-              case mt.schema {
-                Some(_) -> True
-                None -> False
-              }
-            })
-          _ -> False
-        }
-      })
-    })
-
-  // result is always needed: every operation uses `use _ <- result.try`.
-  let base_imports = [
-    "gleam/result",
-    "oaspec/transport",
-    config.package(context.config(ctx)) <> "/decode",
-    config.package(context.config(ctx)) <> "/response_types",
-  ]
-  let base_imports = case needs_int {
-    True -> ["gleam/int", ..base_imports]
-    False -> base_imports
-  }
-  let base_imports = case option_import_items {
-    Some(import_line) -> [import_line, ..base_imports]
-    None -> base_imports
-  }
-  let base_imports = case needs_typed_schemas {
-    True ->
-      list.append(
-        [
-          config.package(context.config(ctx)) <> "/types",
-          config.package(context.config(ctx)) <> "/encode",
-        ],
-        base_imports,
-      )
-    False -> base_imports
-  }
-  // request_types is always needed (every operation emits a
-  // _with_request wrapper).
-  let base_imports = [
-    config.package(context.config(ctx)) <> "/request_types",
-    ..base_imports
-  ]
-  let base_imports = case needs_string {
-    True -> ["gleam/string", ..base_imports]
-    False -> base_imports
-  }
-  let imports = case needs_dyn_decode {
-    True -> ["gleam/dynamic/decode as dyn_decode", ..base_imports]
-    False -> base_imports
-  }
-  let imports = case needs_json {
-    True -> ["gleam/json", ..imports]
-    False -> imports
-  }
-  let imports = case needs_bool {
-    True -> ["gleam/bool", ..imports]
-    False -> imports
-  }
-  let imports = case needs_float {
-    True -> ["gleam/float", ..imports]
-    False -> imports
-  }
-  let imports = case needs_list {
-    True -> ["gleam/list", ..imports]
-    False -> imports
-  }
-
-  // uri for path-parameter percent-encoding, cookie value encoding, and
-  // form-urlencoded body assembly.
-  let needs_uri =
-    has_form_urlencoded
-    || list.any(all_params, fn(p) {
-      p.in_ == spec.InPath || p.in_ == spec.InCookie
-    })
-  let imports = case needs_uri {
-    True -> ["gleam/uri", ..imports]
-    False -> imports
-  }
-
-  let needs_guards =
-    config.validate(context.config(ctx))
-    && list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) -> {
-          let content_entries = dict.to_list(rb.content)
-          case content_entries {
-            [#(_, mt)] ->
-              case mt.schema {
-                Some(schema.Reference(name:, ..)) ->
-                  guards.schema_has_validator(name, ctx)
-                _ -> False
-              }
-            _ -> False
-          }
-        }
-        _ -> False
-      }
-    })
-  let imports = case needs_guards {
-    True -> [config.package(context.config(ctx)) <> "/guards", ..imports]
-    False -> imports
-  }
+  let requirements = client_ir.analyze(ctx)
+  let imports = client_ir.imports(requirements, ctx)
 
   let sb =
     se.file_header(context.version)
@@ -372,7 +56,7 @@ fn generate_client(ctx: Context) -> String {
     |> se.indent(2, "headers: List(#(String, String)),")
     |> se.indent(2, "body: transport.Body,")
     |> se.indent(1, ")")
-  let sb = case needs_guards {
+  let sb = case requirements.needs_guards {
     True ->
       sb
       |> se.indent(1, "ValidationError(errors: List(guards.ValidationFailure))")
@@ -387,11 +71,11 @@ fn generate_client(ctx: Context) -> String {
   let sb = generate_default_base_url(sb, ctx)
 
   // text_body / bytes_body helpers
-  let sb = case needs_text_helper {
+  let sb = case requirements.needs_text_helper {
     True -> generate_text_body_helper(sb)
     False -> sb
   }
-  let sb = case needs_bytes_helper {
+  let sb = case requirements.needs_bytes_helper {
     True -> generate_bytes_body_helper(sb)
     False -> sb
   }
@@ -404,36 +88,6 @@ fn generate_client(ctx: Context) -> String {
     })
 
   se.to_string(sb)
-}
-
-fn any_operation_has_server(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-  ctx: Context,
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_, operation, _, _) = op
-    case operation.servers {
-      [] ->
-        case context.spec(ctx).servers {
-          [] -> False
-          _ -> True
-        }
-      _ -> True
-    }
-  })
-}
-
-fn any_operation_has_no_server(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-  ctx: Context,
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_, operation, _, _) = op
-    case operation.servers {
-      [] -> list.is_empty(context.spec(ctx).servers)
-      _ -> False
-    }
-  })
 }
 
 /// Substitute server variable placeholders.

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -286,7 +286,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
 }
 
 /// Optional `gleam/option` import line for client signatures and ctors.
-pub fn option_import(requirements: ClientRequirements) -> Option(String) {
+fn option_import(requirements: ClientRequirements) -> Option(String) {
   case
     requirements.needs_option_type,
     requirements.needs_some_ctor,

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -1,0 +1,394 @@
+import gleam/dict
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import oaspec/config
+import oaspec/internal/codegen/context.{type Context}
+import oaspec/internal/codegen/guards
+import oaspec/internal/codegen/import_analysis
+import oaspec/internal/openapi/resolver
+import oaspec/internal/openapi/schema.{Inline, Reference}
+import oaspec/internal/openapi/spec.{ParameterSchema, Value}
+import oaspec/internal/util/content_type as ct_util
+
+/// Structured import / helper requirements for client generation.
+pub type ClientRequirements {
+  ClientRequirements(
+    needs_bool: Bool,
+    needs_float: Bool,
+    has_multi_content_response: Bool,
+    has_form_urlencoded: Bool,
+    has_multipart: Bool,
+    needs_list: Bool,
+    needs_dyn_decode: Bool,
+    needs_json: Bool,
+    needs_string: Bool,
+    needs_typed_schemas: Bool,
+    needs_option_type: Bool,
+    needs_some_ctor: Bool,
+    needs_none_ctor: Bool,
+    needs_int: Bool,
+    needs_bytes_helper: Bool,
+    needs_text_helper: Bool,
+    needs_uri: Bool,
+    needs_guards: Bool,
+  )
+}
+
+/// Compute semantic requirements for the generated client module.
+pub fn analyze(ctx: Context) -> ClientRequirements {
+  let operations = context.operations(ctx)
+  let all_params =
+    list.flat_map(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.filter_map(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) -> Ok(p)
+          _ -> Error(Nil)
+        }
+      })
+    })
+
+  let needs_bool =
+    list.any(all_params, fn(p) {
+      case p.payload {
+        ParameterSchema(Inline(schema.BooleanSchema(..))) -> True
+        _ -> False
+      }
+    })
+  let needs_float =
+    list.any(all_params, fn(p) {
+      case p.payload {
+        ParameterSchema(Inline(schema.NumberSchema(..))) -> True
+        _ -> False
+      }
+    })
+  let has_multi_content_response =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) -> list.length(dict.to_list(response.content)) > 1
+          _ -> False
+        }
+      })
+    })
+
+  let has_form_urlencoded =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          list.any(dict.to_list(rb.content), fn(ce) {
+            let #(key, _) = ce
+            key == "application/x-www-form-urlencoded"
+          })
+        _ -> False
+      }
+    })
+
+  let has_multipart =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          list.any(dict.to_list(rb.content), fn(ce) {
+            let #(key, _) = ce
+            key == "multipart/form-data"
+          })
+        _ -> False
+      }
+    })
+
+  let needs_list =
+    has_form_urlencoded
+    || has_multi_content_response
+    || list.any(all_params, fn(p) { p.in_ == spec.InQuery })
+    || list.any(all_params, fn(p) { p.in_ == spec.InCookie })
+    || list.any(all_params, fn(p) { p.in_ == spec.InHeader })
+    || list.any(all_params, fn(p) {
+      case p.payload {
+        ParameterSchema(Inline(schema.ArraySchema(..))) -> True
+        ParameterSchema(Reference(..) as sr) ->
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+            Ok(schema.ArraySchema(..)) -> True
+            _ -> False
+          }
+        _ -> False
+      }
+    })
+
+  let needs_dyn_decode =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.content), fn(ce) {
+              let #(media_type_name, mt) = ce
+              case media_type_name {
+                "text/plain" -> False
+                _ ->
+                  case mt.schema {
+                    Some(Inline(schema.ArraySchema(items: Inline(_), ..))) ->
+                      True
+                    Some(Inline(schema.StringSchema(..))) -> True
+                    Some(Inline(schema.IntegerSchema(..))) -> True
+                    Some(Inline(schema.NumberSchema(..))) -> True
+                    Some(Inline(schema.BooleanSchema(..))) -> True
+                    _ -> False
+                  }
+              }
+            })
+          _ -> False
+        }
+      })
+    })
+
+  let needs_json =
+    needs_dyn_decode
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          list.any(dict.to_list(rb.content), fn(ce) {
+            let #(_, mt) = ce
+            case mt.schema {
+              Some(Inline(schema.StringSchema(..))) -> True
+              Some(Inline(schema.IntegerSchema(..))) -> True
+              Some(Inline(schema.NumberSchema(..))) -> True
+              Some(Inline(schema.BooleanSchema(..))) -> True
+              _ -> False
+            }
+          })
+        _ -> False
+      }
+    })
+
+  let needs_string =
+    has_multi_content_response
+    || has_form_urlencoded
+    || has_multipart
+    || list.any(all_params, fn(p) {
+      p.in_ == spec.InPath || p.in_ == spec.InCookie
+    })
+
+  let needs_typed_schemas =
+    import_analysis.operations_need_typed_schemas(operations)
+  let needs_option_type =
+    import_analysis.operations_have_optional_params(operations)
+    || import_analysis.operations_have_optional_body(operations)
+  let needs_some_ctor = needs_option_type || any_operation_has_server(ctx)
+  let needs_none_ctor = needs_option_type || any_operation_has_no_server(ctx)
+
+  let needs_int =
+    list.any(all_params, fn(p) {
+      case p.payload {
+        ParameterSchema(Inline(schema.IntegerSchema(..))) -> True
+        ParameterSchema(Inline(schema.ArraySchema(
+          items: Inline(schema.IntegerSchema(..)),
+          ..,
+        ))) -> True
+        ParameterSchema(Reference(..) as sr) ->
+          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+            Ok(schema.IntegerSchema(..)) -> True
+            Ok(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..)) ->
+              True
+            _ -> False
+          }
+        _ -> False
+      }
+    })
+
+  let needs_bytes_helper =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.content), fn(ce) {
+              let #(name, _) = ce
+              ct_util.from_string(name) == ct_util.ApplicationOctetStream
+            })
+          _ -> False
+        }
+      })
+    })
+
+  let needs_text_helper =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.content), fn(ce) {
+              let #(_, mt) = ce
+              case mt.schema {
+                Some(_) -> True
+                None -> False
+              }
+            })
+          _ -> False
+        }
+      })
+    })
+
+  let needs_uri =
+    has_form_urlencoded
+    || list.any(all_params, fn(p) {
+      p.in_ == spec.InPath || p.in_ == spec.InCookie
+    })
+
+  let needs_guards =
+    config.validate(context.config(ctx))
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) -> {
+          let content_entries = dict.to_list(rb.content)
+          case content_entries {
+            [#(_, mt)] ->
+              case mt.schema {
+                Some(schema.Reference(name:, ..)) ->
+                  guards.schema_has_validator(name, ctx)
+                _ -> False
+              }
+            _ -> False
+          }
+        }
+        _ -> False
+      }
+    })
+
+  ClientRequirements(
+    needs_bool: needs_bool,
+    needs_float: needs_float,
+    has_multi_content_response: has_multi_content_response,
+    has_form_urlencoded: has_form_urlencoded,
+    has_multipart: has_multipart,
+    needs_list: needs_list,
+    needs_dyn_decode: needs_dyn_decode,
+    needs_json: needs_json,
+    needs_string: needs_string,
+    needs_typed_schemas: needs_typed_schemas,
+    needs_option_type: needs_option_type,
+    needs_some_ctor: needs_some_ctor,
+    needs_none_ctor: needs_none_ctor,
+    needs_int: needs_int,
+    needs_bytes_helper: needs_bytes_helper,
+    needs_text_helper: needs_text_helper,
+    needs_uri: needs_uri,
+    needs_guards: needs_guards,
+  )
+}
+
+/// Optional `gleam/option` import line for client signatures and ctors.
+pub fn option_import(requirements: ClientRequirements) -> Option(String) {
+  case
+    requirements.needs_option_type,
+    requirements.needs_some_ctor,
+    requirements.needs_none_ctor
+  {
+    True, _, _ -> Some("gleam/option.{type Option, None, Some}")
+    False, True, True -> Some("gleam/option.{None, Some}")
+    False, True, False -> Some("gleam/option.{Some}")
+    False, False, True -> Some("gleam/option.{None}")
+    False, False, False -> None
+  }
+}
+
+/// Render the final import list from structured requirements.
+pub fn imports(requirements: ClientRequirements, ctx: Context) -> List(String) {
+  let base_imports = [
+    "gleam/result",
+    "oaspec/transport",
+    config.package(context.config(ctx)) <> "/decode",
+    config.package(context.config(ctx)) <> "/response_types",
+  ]
+  let base_imports = case requirements.needs_int {
+    True -> ["gleam/int", ..base_imports]
+    False -> base_imports
+  }
+  let base_imports = case option_import(requirements) {
+    Some(import_line) -> [import_line, ..base_imports]
+    None -> base_imports
+  }
+  let base_imports = case requirements.needs_typed_schemas {
+    True ->
+      list.append(
+        [
+          config.package(context.config(ctx)) <> "/types",
+          config.package(context.config(ctx)) <> "/encode",
+        ],
+        base_imports,
+      )
+    False -> base_imports
+  }
+  let base_imports = [
+    config.package(context.config(ctx)) <> "/request_types",
+    ..base_imports
+  ]
+  let base_imports = case requirements.needs_string {
+    True -> ["gleam/string", ..base_imports]
+    False -> base_imports
+  }
+  let imports = case requirements.needs_dyn_decode {
+    True -> ["gleam/dynamic/decode as dyn_decode", ..base_imports]
+    False -> base_imports
+  }
+  let imports = case requirements.needs_json {
+    True -> ["gleam/json", ..imports]
+    False -> imports
+  }
+  let imports = case requirements.needs_bool {
+    True -> ["gleam/bool", ..imports]
+    False -> imports
+  }
+  let imports = case requirements.needs_float {
+    True -> ["gleam/float", ..imports]
+    False -> imports
+  }
+  let imports = case requirements.needs_list {
+    True -> ["gleam/list", ..imports]
+    False -> imports
+  }
+  let imports = case requirements.needs_uri {
+    True -> ["gleam/uri", ..imports]
+    False -> imports
+  }
+  case requirements.needs_guards {
+    True -> [config.package(context.config(ctx)) <> "/guards", ..imports]
+    False -> imports
+  }
+}
+
+fn any_operation_has_server(ctx: Context) -> Bool {
+  list.any(context.operations(ctx), fn(op) {
+    let #(_, operation, _, _) = op
+    case operation.servers {
+      [] ->
+        case context.spec(ctx).servers {
+          [] -> False
+          _ -> True
+        }
+      _ -> True
+    }
+  })
+}
+
+fn any_operation_has_no_server(ctx: Context) -> Bool {
+  list.any(context.operations(ctx), fn(op) {
+    let #(_, operation, _, _) = op
+    case operation.servers {
+      [] ->
+        case context.spec(ctx).servers {
+          [] -> True
+          _ -> False
+        }
+      _ -> False
+    }
+  })
+}

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/dict
 import gleam/float
 import gleam/int
@@ -1311,36 +1312,33 @@ fn build_unique_items_guard_function(
   prop_name: String,
   unique_items: Bool,
 ) -> Option(GuardFunction) {
-  case unique_items {
-    False -> None
-    True ->
-      Some(GuardFunction(
-        name: guard_function_name(schema_name, prop_name, "unique"),
-        docs: [
-          "Validate unique items for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        ],
-        param_decl: "value: List(a)",
-        return_type: "Result(List(a), ValidationFailure)",
-        body: string.join(
-          [
-            "  case list.length(value) == list.length(list.unique(value)) {",
-            "    True -> Ok(value)",
-            "    False -> "
-              <> validation_failure_literal(
-              prop_name,
-              "uniqueItems",
-              "items must be unique",
-            ),
-            "  }",
-          ],
-          "\n",
+  use <- bool.guard(when: !unique_items, return: None)
+  Some(GuardFunction(
+    name: guard_function_name(schema_name, prop_name, "unique"),
+    docs: [
+      "Validate unique items for "
+      <> schema_name
+      <> field_label(prop_name)
+      <> ".",
+    ],
+    param_decl: "value: List(a)",
+    return_type: "Result(List(a), ValidationFailure)",
+    body: string.join(
+      [
+        "  case list.length(value) == list.length(list.unique(value)) {",
+        "    True -> Ok(value)",
+        "    False -> "
+          <> validation_failure_literal(
+          prop_name,
+          "uniqueItems",
+          "items must be unique",
         ),
-        kind: FieldValidator,
-      ))
-  }
+        "  }",
+      ],
+      "\n",
+    ),
+    kind: FieldValidator,
+  ))
 }
 
 fn build_properties_count_guard_function(

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -1,11 +1,9 @@
-import gleam/bool
 import gleam/dict
 import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/order
-import gleam/result
 import gleam/set.{type Set}
 import gleam/string
 import oaspec/config
@@ -22,6 +20,27 @@ import oaspec/internal/openapi/schema.{
 }
 import oaspec/internal/util/naming
 import oaspec/internal/util/string_extra as se
+
+pub type GuardFunctionKind {
+  FieldValidator
+  DelegatingFieldValidator(canonical_name: String)
+  CompositeValidator
+}
+
+pub type GuardFunction {
+  GuardFunction(
+    name: String,
+    docs: List(String),
+    param_decl: String,
+    return_type: String,
+    body: String,
+    kind: GuardFunctionKind,
+  )
+}
+
+pub type GuardModule {
+  GuardModule(imports: List(String), functions: List(GuardFunction))
+}
 
 /// Check whether a named component schema has a composite validator.
 /// Used by server/client generators to decide whether to emit guard calls.
@@ -41,22 +60,22 @@ pub fn schema_has_validator(name: String, ctx: Context) -> Bool {
 
 /// Generate guard/validation functions from OpenAPI schemas that have constraints.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let content = generate_guards(ctx)
-  case string.contains(content, "pub fn validate_") {
-    True -> [
+  let module = build_module(ctx)
+  case list.is_empty(module.functions) {
+    True -> []
+    False -> [
       GeneratedFile(
         path: "guards.gleam",
-        content: content,
+        content: render_module(module),
         target: context.SharedTarget,
         write_mode: context.Overwrite,
       ),
     ]
-    False -> []
   }
 }
 
-/// Generate validation guard functions for schemas with constraints.
-fn generate_guards(ctx: Context) -> String {
+/// Build the structured guard module before rendering.
+pub fn build_module(ctx: Context) -> GuardModule {
   let schemas = case context.spec(ctx).components {
     Some(components) ->
       list.sort(dict.to_list(components.schemas), fn(a, b) {
@@ -133,33 +152,325 @@ fn generate_guards(ctx: Context) -> String {
     False -> imports
   }
 
+  let field_validators =
+    list.flat_map(schemas, fn(entry) {
+      let #(name, schema_ref) = entry
+      collect_guard_functions_for_schema(name, schema_ref, ctx)
+    })
+    |> dedupe_guard_functions()
+
+  let composite_validators =
+    list.flat_map(schemas, fn(entry) {
+      let #(name, schema_ref) = entry
+      maybe_one(build_composite_guard_function(name, schema_ref, ctx))
+    })
+
+  GuardModule(
+    imports: imports,
+    functions: list.append(field_validators, composite_validators),
+  )
+}
+
+/// Render the structured guard module to Gleam source.
+fn render_module(module: GuardModule) -> String {
   let sb =
     se.file_header(context.version)
-    |> se.imports(imports)
+    |> se.imports(module.imports)
     |> emit_validation_failure_type()
 
+  list.fold(module.functions, sb, render_guard_function)
+  |> se.to_string()
+}
+
+fn render_guard_function(
+  sb: se.StringBuilder,
+  function: GuardFunction,
+) -> se.StringBuilder {
   let sb =
-    list.fold(schemas, sb, fn(sb, entry) {
-      let #(name, schema_ref) = entry
-      generate_guards_for_schema(sb, name, schema_ref, ctx)
+    list.fold(function.docs, sb, fn(sb, doc) { sb |> se.line("/// " <> doc) })
+  let sb =
+    sb
+    |> se.line(
+      "pub fn "
+      <> function.name
+      <> "("
+      <> function.param_decl
+      <> ") -> "
+      <> function.return_type
+      <> " {",
+    )
+  let sb =
+    function.body
+    |> string.split(on: "\n")
+    |> list.fold(sb, fn(sb, line) { sb |> se.line(line) })
+  sb
+  |> se.line("}")
+  |> se.blank_line()
+}
+
+fn dedupe_guard_functions(functions: List(GuardFunction)) -> List(GuardFunction) {
+  let canonical_by_key =
+    list.fold(functions, dict.new(), fn(acc, function) {
+      case function.kind {
+        FieldValidator ->
+          case dict.get(acc, dedupe_key(function)) {
+            Error(Nil) -> dict.insert(acc, dedupe_key(function), function.name)
+            Ok(existing) ->
+              case string.compare(function.name, existing) {
+                order.Lt ->
+                  dict.insert(acc, dedupe_key(function), function.name)
+                _ -> acc
+              }
+          }
+        _ -> acc
+      }
     })
 
-  // Generate composite validate_<type> functions that call all field validators
-  let sb =
-    list.fold(schemas, sb, fn(sb, entry) {
-      let #(name, schema_ref) = entry
-      generate_composite_validator(sb, name, schema_ref, ctx)
-    })
+  list.map(functions, fn(function) {
+    case function.kind {
+      FieldValidator ->
+        case dict.get(canonical_by_key, dedupe_key(function)) {
+          Ok(canonical_name) ->
+            case canonical_name == function.name {
+              True -> function
+              False -> emit_guard_delegator(function, canonical_name)
+            }
+          Error(Nil) -> function
+        }
+      _ -> function
+    }
+  })
+}
 
-  // #339: when the same field appears in multiple schemas via allOf
-  // flattening, the per-field validators have byte-identical bodies.
-  // Collapse the duplicates: keep one canonical definition and
-  // rewrite the rest as 1-line delegating stubs that forward to it.
-  // The composite validators (which call the per-field validators by
-  // name) keep working unchanged because the duplicate names still
-  // exist — they just delegate now.
-  se.to_string(sb)
-  |> dedupe_field_validator_definitions
+fn dedupe_key(function: GuardFunction) -> String {
+  function.param_decl <> "->" <> function.return_type <> "{\n" <> function.body
+}
+
+fn emit_guard_delegator(
+  function: GuardFunction,
+  canonical_name: String,
+) -> GuardFunction {
+  GuardFunction(
+    ..function,
+    body: "  " <> canonical_name <> "(value)",
+    kind: DelegatingFieldValidator(canonical_name),
+  )
+}
+
+fn collect_guard_functions_for_schema(
+  name: String,
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> List(GuardFunction) {
+  case schema_ref {
+    Inline(schema) ->
+      collect_guard_functions_for_schema_object(name, schema, ctx)
+    Reference(name:, ..) ->
+      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+        Ok(schema) ->
+          collect_guard_functions_for_schema_object(name, schema, ctx)
+        _ -> []
+      }
+  }
+}
+
+fn collect_guard_functions_for_schema_object(
+  name: String,
+  schema: SchemaObject,
+  ctx: Context,
+) -> List(GuardFunction) {
+  case schema {
+    ObjectSchema(properties:, min_properties:, max_properties:, ..) ->
+      list.append(
+        maybe_one(build_properties_count_guard_function(
+          name,
+          "",
+          min_properties,
+          max_properties,
+        )),
+        ir_build.sorted_entries(properties)
+          |> list.flat_map(fn(entry) {
+            let #(prop_name, prop_ref) = entry
+            collect_field_guard_functions(name, prop_name, prop_ref, ctx)
+          }),
+      )
+
+    AllOfSchema(schemas:, ..) ->
+      list.append(
+        [],
+        ir_build.sorted_entries(
+          allof_merge.merge_allof_schemas(schemas, ctx).properties,
+        )
+          |> list.flat_map(fn(entry) {
+            let #(prop_name, prop_ref) = entry
+            collect_field_guard_functions(name, prop_name, prop_ref, ctx)
+          }),
+      )
+
+    StringSchema(min_length:, max_length:, pattern:, ..) ->
+      list.flatten([
+        maybe_one(build_string_guard_function(name, "", min_length, max_length)),
+        maybe_one(build_string_pattern_guard_function(name, "", pattern)),
+      ])
+
+    IntegerSchema(
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      list.flatten([
+        maybe_one(build_integer_guard_function(name, "", minimum, maximum)),
+        maybe_one(build_integer_exclusive_guard_function(
+          name,
+          "",
+          exclusive_minimum,
+          exclusive_maximum,
+        )),
+        maybe_one(build_integer_multiple_of_guard_function(
+          name,
+          "",
+          multiple_of,
+        )),
+      ])
+
+    NumberSchema(
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    ) ->
+      list.flatten([
+        maybe_one(build_float_guard_function(name, "", minimum, maximum)),
+        maybe_one(build_float_exclusive_guard_function(
+          name,
+          "",
+          exclusive_minimum,
+          exclusive_maximum,
+        )),
+        maybe_one(build_float_multiple_of_guard_function(name, "", multiple_of)),
+      ])
+
+    ArraySchema(min_items:, max_items:, unique_items:, ..) ->
+      list.flatten([
+        maybe_one(build_list_guard_function(name, "", min_items, max_items)),
+        maybe_one(build_unique_items_guard_function(name, "", unique_items)),
+      ])
+
+    _ -> []
+  }
+}
+
+fn collect_field_guard_functions(
+  schema_name: String,
+  prop_name: String,
+  prop_ref: SchemaRef,
+  ctx: Context,
+) -> List(GuardFunction) {
+  let resolved = case prop_ref {
+    Inline(schema) -> Ok(schema)
+    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
+  }
+  case resolved {
+    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) ->
+      list.flatten([
+        maybe_one(build_string_guard_function(
+          schema_name,
+          prop_name,
+          min_length,
+          max_length,
+        )),
+        maybe_one(build_string_pattern_guard_function(
+          schema_name,
+          prop_name,
+          pattern,
+        )),
+      ])
+
+    Ok(IntegerSchema(
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    )) ->
+      list.flatten([
+        maybe_one(build_integer_guard_function(
+          schema_name,
+          prop_name,
+          minimum,
+          maximum,
+        )),
+        maybe_one(build_integer_exclusive_guard_function(
+          schema_name,
+          prop_name,
+          exclusive_minimum,
+          exclusive_maximum,
+        )),
+        maybe_one(build_integer_multiple_of_guard_function(
+          schema_name,
+          prop_name,
+          multiple_of,
+        )),
+      ])
+
+    Ok(NumberSchema(
+      minimum:,
+      maximum:,
+      exclusive_minimum:,
+      exclusive_maximum:,
+      multiple_of:,
+      ..,
+    )) ->
+      list.flatten([
+        maybe_one(build_float_guard_function(
+          schema_name,
+          prop_name,
+          minimum,
+          maximum,
+        )),
+        maybe_one(build_float_exclusive_guard_function(
+          schema_name,
+          prop_name,
+          exclusive_minimum,
+          exclusive_maximum,
+        )),
+        maybe_one(build_float_multiple_of_guard_function(
+          schema_name,
+          prop_name,
+          multiple_of,
+        )),
+      ])
+
+    Ok(ArraySchema(min_items:, max_items:, unique_items:, ..)) ->
+      list.flatten([
+        maybe_one(build_list_guard_function(
+          schema_name,
+          prop_name,
+          min_items,
+          max_items,
+        )),
+        maybe_one(build_unique_items_guard_function(
+          schema_name,
+          prop_name,
+          unique_items,
+        )),
+      ])
+
+    _ -> []
+  }
+}
+
+fn maybe_one(value: Option(a)) -> List(a) {
+  case value {
+    Some(v) -> [v]
+    None -> []
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -174,224 +485,6 @@ fn generate_guards(ctx: Context) -> String {
 /// the canonical one. The composite validators continue to call the
 /// per-field validators by the original names, so call-site code is
 /// unchanged.
-fn dedupe_field_validator_definitions(source: String) -> String {
-  // Split on the boundary between top-level pub functions. The first
-  // chunk is the file header (imports, type defs, helpers); each
-  // subsequent chunk is one `pub fn` definition (with the leading
-  // "pub fn " stripped by the split).
-  case string.split(source, on: "\npub fn ") {
-    [] -> source
-    [_only_header] -> source
-    [head, ..raw_chunks] -> {
-      // Parse each chunk into structured form. Chunks that don't
-      // match the expected per-field validator shape are passed
-      // through unchanged.
-      let parsed = list.map(raw_chunks, parse_function_chunk)
-      // Group eligible chunks by body and pick a canonical name per
-      // group (lex-first). Keys are body strings; values are the
-      // canonical function name.
-      let canonical_by_body = build_body_to_canonical_name_map(parsed)
-      // Rewrite each chunk: if the chunk is a duplicate (its name
-      // isn't the canonical for its body), emit a delegating stub.
-      let rewritten =
-        list.map(parsed, fn(p) {
-          rewrite_chunk_if_duplicate(p, canonical_by_body)
-        })
-      // Re-join with the original separator.
-      head <> string.concat(list.map(rewritten, fn(c) { "\npub fn " <> c }))
-    }
-  }
-}
-
-/// Lightweight parse of a single `pub fn` chunk. The chunk does NOT
-/// include the leading `pub fn `. `name` is everything up to the
-/// first `(`. `signature_and_body` keeps the full original text from
-/// after the name onward, used as-is when emission is unchanged.
-type ParsedChunk {
-  ParsedChunk(
-    /// Function name (e.g. `validate_inline_upload_title_length`).
-    name: String,
-    /// Parameter declaration block, e.g. `value: String`.
-    param_decl: String,
-    /// Return type, e.g. `Result(String, ValidationFailure)`.
-    return_type: String,
-    /// The function body, including surrounding whitespace —
-    /// everything between the first `{` (after the signature) and
-    /// the matching `}` of the function definition. Used as the
-    /// dedup key.
-    body: String,
-    /// Trailing text after the closing `}` (typically `\n` and any
-    /// blank-line separator before the next function). Preserved so
-    /// reconstruction keeps the original formatting.
-    trailing: String,
-    /// The full original chunk text. Used verbatim when the chunk
-    /// is the canonical / unique definition.
-    original: String,
-  )
-}
-
-fn parse_function_chunk(chunk: String) -> ParsedChunk {
-  // Try to extract `name(params) -> return_type {body}trailing`.
-  // When parsing fails (chunk doesn't match the expected per-field
-  // validator shape), fall back to a passthrough record with empty
-  // structured fields and the original text intact.
-  let fallback =
-    ParsedChunk(
-      name: "",
-      param_decl: "",
-      return_type: "",
-      body: "",
-      trailing: "",
-      original: chunk,
-    )
-  parse_function_chunk_strict(chunk)
-  |> result.unwrap(fallback)
-}
-
-fn parse_function_chunk_strict(chunk: String) -> Result(ParsedChunk, Nil) {
-  use #(name, after_open_paren) <- result.try(string.split_once(chunk, on: "("))
-  use #(param_decl, after_arrow) <- result.try(string.split_once(
-    after_open_paren,
-    on: ") -> ",
-  ))
-  use #(return_type, after_open_brace) <- result.try(string.split_once(
-    after_arrow,
-    on: " {\n",
-  ))
-  use #(body, trailing) <- result.try(rsplit_once_on_close_brace(
-    after_open_brace,
-  ))
-  Ok(ParsedChunk(
-    name: name,
-    param_decl: param_decl,
-    return_type: return_type,
-    body: body,
-    trailing: trailing,
-    original: chunk,
-  ))
-}
-
-/// Split a string at its LAST occurrence of `\n}\n`. Used to find
-/// the closing `}` of the function (the trailing `\n` after `}`
-/// always exists in the generator's output). Returns the portion
-/// before `\n}` (the body, excluding the closing brace itself) and
-/// the portion after `}\n` (the trailing formatting before the
-/// next function — typically a blank line plus the next function's
-/// doc-comment block).
-fn rsplit_once_on_close_brace(s: String) -> Result(#(String, String), Nil) {
-  let needle = "\n}\n"
-  case string.split(s, on: needle) {
-    [_only] -> Error(Nil)
-    parts -> {
-      // All but the last chunk belong to the body (including any
-      // intermediate `\n}\n` that legitimately appear inside nested
-      // case expressions — though in practice generated function
-      // bodies never contain bare `\n}\n` because case branches
-      // indent further).
-      case list.reverse(parts) {
-        [] -> Error(Nil)
-        [last_part, ..rev_rest] -> {
-          let body =
-            list.reverse(rev_rest)
-            |> string.join(needle)
-          // `last_part` is what came AFTER the final `\n}\n` —
-          // i.e. the inter-function whitespace + the next
-          // function's doc-comment lines (if any). Return body
-          // (without the closing brace) and last_part (the
-          // trailing block, which the caller is responsible for
-          // re-emitting verbatim after its own closing brace).
-          Ok(#(body, last_part))
-        }
-      }
-    }
-  }
-}
-
-/// Group eligible chunks (parsed successfully and whose name starts
-/// with the `validate_` per-field-validator prefix) by their body
-/// content. For each body that has multiple defining chunks, pick
-/// the lex-first name as canonical. Returns a Dict keyed by body.
-fn build_body_to_canonical_name_map(
-  parsed: List(ParsedChunk),
-) -> dict.Dict(String, String) {
-  list.fold(parsed, dict.new(), fn(acc, chunk) {
-    case is_dedupable(chunk) {
-      False -> acc
-      True ->
-        case dict.get(acc, chunk.body) {
-          Error(Nil) -> dict.insert(acc, chunk.body, chunk.name)
-          Ok(existing) ->
-            case string.compare(chunk.name, existing) {
-              order.Lt -> dict.insert(acc, chunk.body, chunk.name)
-              _ -> acc
-            }
-        }
-    }
-  })
-}
-
-/// A chunk is dedup-eligible if it's a per-field validator (its name
-/// starts with `validate_` and ends with one of the recognised
-/// constraint suffixes used by `generate_*_guard`). The composite
-/// `validate_<type>` functions are NOT dedup-eligible because their
-/// names are the public stable surface that downstream code calls.
-fn is_dedupable(chunk: ParsedChunk) -> Bool {
-  use <- bool.guard(
-    when: !string.starts_with(chunk.name, "validate_"),
-    return: False,
-  )
-  list.any(per_field_validator_suffixes(), fn(suffix) {
-    string.ends_with(chunk.name, suffix)
-  })
-}
-
-fn per_field_validator_suffixes() -> List(String) {
-  [
-    "_length", "_pattern", "_range", "_exclusive", "_multiple_of", "_count",
-    "_unique",
-  ]
-}
-
-/// If `chunk` is a duplicate of an earlier definition for the same
-/// body, emit a one-line delegator that forwards to the canonical
-/// name. Otherwise emit the chunk verbatim.
-fn rewrite_chunk_if_duplicate(
-  chunk: ParsedChunk,
-  canonical_by_body: dict.Dict(String, String),
-) -> String {
-  case dict.get(canonical_by_body, chunk.body) {
-    // Body has no canonical entry (chunk wasn't dedup-eligible) →
-    // pass through unchanged.
-    Error(Nil) -> chunk.original
-    Ok(canonical_name) ->
-      case canonical_name == chunk.name {
-        // This chunk IS the canonical → keep its full body.
-        True -> chunk.original
-        // This chunk is a duplicate → emit a delegating stub.
-        False -> emit_delegator(chunk, canonical_name)
-      }
-  }
-}
-
-fn emit_delegator(chunk: ParsedChunk, canonical_name: String) -> String {
-  // Per-field validators always take a single parameter named
-  // `value`, so the delegator just passes it through. The closing
-  // `}\n` here matches the `\n}\n` that `parse_function_chunk`
-  // stripped while extracting the body. The chunk's `trailing`
-  // (everything after the original `\n}\n` — typically a blank
-  // line plus the next function's doc-comment) is preserved
-  // verbatim so subsequent functions don't lose their docs.
-  chunk.name
-  <> "("
-  <> chunk.param_decl
-  <> ") -> "
-  <> chunk.return_type
-  <> " {\n  "
-  <> canonical_name
-  <> "(value)\n}\n"
-  <> chunk.trailing
-}
-
 /// Track which constraint types exist in the schema set.
 type ConstraintTypes {
   ConstraintTypes(
@@ -503,889 +596,6 @@ fn collect_schema_constraint_types_inner(
   }
 }
 
-/// Generate guard functions for a single schema's constrained fields.
-fn generate_guards_for_schema(
-  sb: se.StringBuilder,
-  name: String,
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> se.StringBuilder {
-  case schema_ref {
-    Inline(schema) -> generate_guards_for_schema_object(sb, name, schema, ctx)
-    Reference(name:, ..) -> {
-      let resolved_name = name
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
-        Ok(schema) ->
-          generate_guards_for_schema_object(sb, resolved_name, schema, ctx)
-        _ -> sb
-      }
-    }
-  }
-}
-
-/// Generate guard functions for fields within a schema object.
-fn generate_guards_for_schema_object(
-  sb: se.StringBuilder,
-  name: String,
-  schema: SchemaObject,
-  ctx: Context,
-) -> se.StringBuilder {
-  case schema {
-    ObjectSchema(properties:, min_properties:, max_properties:, ..) -> {
-      let sb =
-        generate_properties_count_guard(
-          sb,
-          name,
-          "",
-          min_properties,
-          max_properties,
-        )
-      let props = ir_build.sorted_entries(properties)
-      list.fold(props, sb, fn(sb, entry) {
-        let #(prop_name, prop_ref) = entry
-        generate_field_guard(sb, name, prop_name, prop_ref, ctx)
-      })
-    }
-    AllOfSchema(schemas:, ..) -> {
-      let props =
-        ir_build.sorted_entries(
-          allof_merge.merge_allof_schemas(schemas, ctx).properties,
-        )
-      list.fold(props, sb, fn(sb, entry) {
-        let #(prop_name, prop_ref) = entry
-        generate_field_guard(sb, name, prop_name, prop_ref, ctx)
-      })
-    }
-    // Top-level string/integer constraints (type aliases with constraints)
-    StringSchema(min_length:, max_length:, pattern:, ..) -> {
-      let sb = generate_string_guard(sb, name, "", min_length, max_length)
-      generate_string_pattern_guard(sb, name, "", pattern)
-    }
-    IntegerSchema(
-      minimum:,
-      maximum:,
-      exclusive_minimum:,
-      exclusive_maximum:,
-      multiple_of:,
-      ..,
-    ) -> {
-      let sb = generate_integer_guard(sb, name, "", minimum, maximum)
-      let sb =
-        generate_integer_exclusive_guard(
-          sb,
-          name,
-          "",
-          exclusive_minimum,
-          exclusive_maximum,
-        )
-      generate_integer_multiple_of_guard(sb, name, "", multiple_of)
-    }
-    NumberSchema(
-      minimum:,
-      maximum:,
-      exclusive_minimum:,
-      exclusive_maximum:,
-      multiple_of:,
-      ..,
-    ) -> {
-      let sb = generate_float_guard(sb, name, "", minimum, maximum)
-      let sb =
-        generate_float_exclusive_guard(
-          sb,
-          name,
-          "",
-          exclusive_minimum,
-          exclusive_maximum,
-        )
-      generate_float_multiple_of_guard(sb, name, "", multiple_of)
-    }
-    ArraySchema(min_items:, max_items:, unique_items:, ..) -> {
-      let sb = generate_list_guard(sb, name, "", min_items, max_items)
-      generate_unique_items_guard(sb, name, "", unique_items)
-    }
-    _ -> sb
-  }
-}
-
-/// Generate a guard for a specific field based on its schema type and constraints.
-fn generate_field_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  prop_ref: SchemaRef,
-  ctx: Context,
-) -> se.StringBuilder {
-  let resolved = case prop_ref {
-    Inline(schema) -> Ok(schema)
-    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
-  }
-  case resolved {
-    Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
-      let sb =
-        generate_string_guard(
-          sb,
-          schema_name,
-          prop_name,
-          min_length,
-          max_length,
-        )
-      generate_string_pattern_guard(sb, schema_name, prop_name, pattern)
-    }
-    Ok(IntegerSchema(
-      minimum:,
-      maximum:,
-      exclusive_minimum:,
-      exclusive_maximum:,
-      multiple_of:,
-      ..,
-    )) -> {
-      let sb =
-        generate_integer_guard(sb, schema_name, prop_name, minimum, maximum)
-      let sb =
-        generate_integer_exclusive_guard(
-          sb,
-          schema_name,
-          prop_name,
-          exclusive_minimum,
-          exclusive_maximum,
-        )
-      generate_integer_multiple_of_guard(
-        sb,
-        schema_name,
-        prop_name,
-        multiple_of,
-      )
-    }
-    Ok(NumberSchema(
-      minimum:,
-      maximum:,
-      exclusive_minimum:,
-      exclusive_maximum:,
-      multiple_of:,
-      ..,
-    )) -> {
-      let sb =
-        generate_float_guard(sb, schema_name, prop_name, minimum, maximum)
-      let sb =
-        generate_float_exclusive_guard(
-          sb,
-          schema_name,
-          prop_name,
-          exclusive_minimum,
-          exclusive_maximum,
-        )
-      generate_float_multiple_of_guard(sb, schema_name, prop_name, multiple_of)
-    }
-    Ok(ArraySchema(min_items:, max_items:, unique_items:, ..)) -> {
-      let sb =
-        generate_list_guard(sb, schema_name, prop_name, min_items, max_items)
-      generate_unique_items_guard(sb, schema_name, prop_name, unique_items)
-    }
-    _ -> sb
-  }
-}
-
-/// Generate a string pattern validation guard.
-fn generate_string_pattern_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  pattern: Option(String),
-) -> se.StringBuilder {
-  case pattern {
-    None -> sb
-    Some(pattern) -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "pattern")
-      let pattern_literal = gleam_string_literal(pattern)
-      let invalid_pattern_prefix =
-        gleam_string_literal("invalid pattern: " <> pattern <> ": ")
-      let mismatch_failure =
-        validation_failure_literal(
-          prop_name,
-          "pattern",
-          "must match pattern: " <> pattern,
-        )
-      let invalid_pattern_failure =
-        validation_failure_dynamic(
-          prop_name,
-          "invalidPattern",
-          invalid_pattern_prefix <> " <> error",
-        )
-      sb
-      |> se.line(
-        "/// Validate string pattern for "
-        <> schema_name
-        <> field_label(prop_name)
-        <> ".",
-      )
-      |> se.line(
-        "pub fn "
-        <> fn_name
-        <> "(value: String) -> Result(String, ValidationFailure) {",
-      )
-      |> se.indent(1, "case regexp.from_string(" <> pattern_literal <> ") {")
-      |> se.indent(2, "Ok(re) -> case regexp.check(re, value) {")
-      |> se.indent(3, "True -> Ok(value)")
-      |> se.indent(3, "False -> " <> mismatch_failure)
-      |> se.indent(2, "}")
-      |> se.indent(
-        2,
-        "Error(regexp.CompileError(error:, ..)) -> " <> invalid_pattern_failure,
-      )
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Word used in minLength/maxLength error messages.
-/// Singular when the bound is exactly one; plural otherwise.
-fn character_word(n: Int) -> String {
-  case n {
-    1 -> "character"
-    _ -> "characters"
-  }
-}
-
-/// Generate a string length validation guard.
-fn generate_string_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  min_length: Option(Int),
-  max_length: Option(Int),
-) -> se.StringBuilder {
-  case min_length, max_length {
-    None, None -> sb
-    _, _ -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "length")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "minLength",
-          "must be at least "
-            <> int.to_string(min)
-            <> " "
-            <> character_word(min),
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "maxLength",
-          "must be at most " <> int.to_string(max) <> " " <> character_word(max),
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate string length for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: String) -> Result(String, ValidationFailure) {",
-        )
-      let sb = sb |> se.indent(1, "let len = string.length(value)")
-      let sb = case min_length, max_length {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False ->")
-          |> se.indent(3, "case len > " <> int.to_string(max) <> " {")
-          |> se.indent(4, "True -> " <> max_failure(max))
-          |> se.indent(4, "False -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
-          |> se.indent(2, "True -> " <> max_failure(max))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate an integer range validation guard.
-fn generate_integer_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  minimum: Option(Int),
-  maximum: Option(Int),
-) -> se.StringBuilder {
-  case minimum, maximum {
-    None, None -> sb
-    _, _ -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "range")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "minimum",
-          "must be at least " <> int.to_string(min),
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "maximum",
-          "must be at most " <> int.to_string(max),
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate integer range for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Int) -> Result(Int, ValidationFailure) {",
-        )
-      let sb = case minimum, maximum {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False ->")
-          |> se.indent(3, "case value > " <> int.to_string(max) <> " {")
-          |> se.indent(4, "True -> " <> max_failure(max))
-          |> se.indent(4, "False -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case value < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case value > " <> int.to_string(max) <> " {")
-          |> se.indent(2, "True -> " <> max_failure(max))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate a float range validation guard.
-fn generate_float_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  minimum: Option(Float),
-  maximum: Option(Float),
-) -> se.StringBuilder {
-  case minimum, maximum {
-    None, None -> sb
-    _, _ -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "range")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "minimum",
-          "must be at least " <> float.to_string(min),
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "maximum",
-          "must be at most " <> float.to_string(max),
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate float range for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Float) -> Result(Float, ValidationFailure) {",
-        )
-      let sb = case minimum, maximum {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case value <. " <> float.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False ->")
-          |> se.indent(3, "case value >. " <> float.to_string(max) <> " {")
-          |> se.indent(4, "True -> " <> max_failure(max))
-          |> se.indent(4, "False -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case value <. " <> float.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case value >. " <> float.to_string(max) <> " {")
-          |> se.indent(2, "True -> " <> max_failure(max))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate an integer exclusive range validation guard.
-fn generate_integer_exclusive_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  exclusive_minimum: Option(Int),
-  exclusive_maximum: Option(Int),
-) -> se.StringBuilder {
-  case exclusive_minimum, exclusive_maximum {
-    None, None -> sb
-    _, _ -> {
-      let fn_name =
-        guard_function_name(schema_name, prop_name, "exclusive_range")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "exclusiveMinimum",
-          "must be greater than " <> int.to_string(min),
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "exclusiveMaximum",
-          "must be less than " <> int.to_string(max),
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate integer exclusive range for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Int) -> Result(Int, ValidationFailure) {",
-        )
-      let sb = case exclusive_minimum, exclusive_maximum {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case value > " <> int.to_string(min) <> " {")
-          |> se.indent(2, "False -> " <> min_failure(min))
-          |> se.indent(2, "True ->")
-          |> se.indent(3, "case value < " <> int.to_string(max) <> " {")
-          |> se.indent(4, "False -> " <> max_failure(max))
-          |> se.indent(4, "True -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case value > " <> int.to_string(min) <> " {")
-          |> se.indent(2, "False -> " <> min_failure(min))
-          |> se.indent(2, "True -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case value < " <> int.to_string(max) <> " {")
-          |> se.indent(2, "False -> " <> max_failure(max))
-          |> se.indent(2, "True -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate an integer multipleOf validation guard.
-fn generate_integer_multiple_of_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  multiple_of: Option(Int),
-) -> se.StringBuilder {
-  case multiple_of {
-    None -> sb
-    Some(m) -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "multiple_of")
-      let failure =
-        validation_failure_literal(
-          prop_name,
-          "multipleOf",
-          "must be a multiple of " <> int.to_string(m),
-        )
-      sb
-      |> se.line(
-        "/// Validate integer multipleOf for "
-        <> schema_name
-        <> field_label(prop_name)
-        <> ".",
-      )
-      |> se.line(
-        "pub fn "
-        <> fn_name
-        <> "(value: Int) -> Result(Int, ValidationFailure) {",
-      )
-      |> se.indent(1, "case value % " <> int.to_string(m) <> " == 0 {")
-      |> se.indent(2, "False -> " <> failure)
-      |> se.indent(2, "True -> Ok(value)")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate a float exclusive range validation guard.
-fn generate_float_exclusive_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  exclusive_minimum: Option(Float),
-  exclusive_maximum: Option(Float),
-) -> se.StringBuilder {
-  case exclusive_minimum, exclusive_maximum {
-    None, None -> sb
-    _, _ -> {
-      let fn_name =
-        guard_function_name(schema_name, prop_name, "exclusive_range")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "exclusiveMinimum",
-          "must be greater than " <> float.to_string(min),
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "exclusiveMaximum",
-          "must be less than " <> float.to_string(max),
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate float exclusive range for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Float) -> Result(Float, ValidationFailure) {",
-        )
-      let sb = case exclusive_minimum, exclusive_maximum {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case value >. " <> float.to_string(min) <> " {")
-          |> se.indent(2, "False -> " <> min_failure(min))
-          |> se.indent(2, "True ->")
-          |> se.indent(3, "case value <. " <> float.to_string(max) <> " {")
-          |> se.indent(4, "False -> " <> max_failure(max))
-          |> se.indent(4, "True -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case value >. " <> float.to_string(min) <> " {")
-          |> se.indent(2, "False -> " <> min_failure(min))
-          |> se.indent(2, "True -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case value <. " <> float.to_string(max) <> " {")
-          |> se.indent(2, "False -> " <> max_failure(max))
-          |> se.indent(2, "True -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate a float multipleOf validation guard.
-fn generate_float_multiple_of_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  multiple_of: Option(Float),
-) -> se.StringBuilder {
-  case multiple_of {
-    None -> sb
-    Some(m) -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "multiple_of")
-      let failure =
-        validation_failure_literal(
-          prop_name,
-          "multipleOf",
-          "must be a multiple of " <> float.to_string(m),
-        )
-      sb
-      |> se.line(
-        "/// Validate float multipleOf for "
-        <> schema_name
-        <> field_label(prop_name)
-        <> ".",
-      )
-      |> se.line(
-        "pub fn "
-        <> fn_name
-        <> "(value: Float) -> Result(Float, ValidationFailure) {",
-      )
-      |> se.indent(
-        1,
-        "let remainder = value -. float.truncate(value /. "
-          <> float.to_string(m)
-          <> " |> int.to_float) *. "
-          <> float.to_string(m),
-      )
-      |> se.indent(1, "case remainder == 0.0 || remainder == -0.0 {")
-      |> se.indent(2, "False -> " <> failure)
-      |> se.indent(2, "True -> Ok(value)")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate a list length validation guard.
-fn generate_list_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  min_items: Option(Int),
-  max_items: Option(Int),
-) -> se.StringBuilder {
-  case min_items, max_items {
-    None, None -> sb
-    _, _ -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "length")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "minItems",
-          "must have at least " <> int.to_string(min) <> " items",
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "maxItems",
-          "must have at most " <> int.to_string(max) <> " items",
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate list length for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-      let sb =
-        sb
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: List(a)) -> Result(List(a), ValidationFailure) {",
-        )
-      let sb =
-        sb
-        |> se.indent(1, "let len = list.length(value)")
-      let sb = case min_items, max_items {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False ->")
-          |> se.indent(3, "case len > " <> int.to_string(max) <> " {")
-          |> se.indent(4, "True -> " <> max_failure(max))
-          |> se.indent(4, "False -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case len < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case len > " <> int.to_string(max) <> " {")
-          |> se.indent(2, "True -> " <> max_failure(max))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
-/// Generate a uniqueItems validation guard.
-fn generate_unique_items_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  unique_items: Bool,
-) -> se.StringBuilder {
-  use <- bool.guard(!unique_items, sb)
-  let fn_name = guard_function_name(schema_name, prop_name, "unique")
-  let failure =
-    validation_failure_literal(prop_name, "uniqueItems", "items must be unique")
-  sb
-  |> se.line(
-    "/// Validate unique items for "
-    <> schema_name
-    <> field_label(prop_name)
-    <> ".",
-  )
-  |> se.line(
-    "pub fn "
-    <> fn_name
-    <> "(value: List(a)) -> Result(List(a), ValidationFailure) {",
-  )
-  |> se.indent(
-    1,
-    "case list.length(value) == list.length(list.unique(value)) {",
-  )
-  |> se.indent(2, "True -> Ok(value)")
-  |> se.indent(2, "False -> " <> failure)
-  |> se.indent(1, "}")
-  |> se.line("}")
-  |> se.blank_line()
-}
-
-/// Generate a minProperties/maxProperties validation guard for objects.
-fn generate_properties_count_guard(
-  sb: se.StringBuilder,
-  schema_name: String,
-  prop_name: String,
-  min_properties: Option(Int),
-  max_properties: Option(Int),
-) -> se.StringBuilder {
-  case min_properties, max_properties {
-    None, None -> sb
-    _, _ -> {
-      let fn_name = guard_function_name(schema_name, prop_name, "properties")
-      let min_failure = fn(min) {
-        validation_failure_literal(
-          prop_name,
-          "minProperties",
-          "must have at least " <> int.to_string(min) <> " properties",
-        )
-      }
-      let max_failure = fn(max) {
-        validation_failure_literal(
-          prop_name,
-          "maxProperties",
-          "must have at most " <> int.to_string(max) <> " properties",
-        )
-      }
-      let sb =
-        sb
-        |> se.line(
-          "/// Validate property count for "
-          <> schema_name
-          <> field_label(prop_name)
-          <> ".",
-        )
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: Dict(k, v)) -> Result(Dict(k, v), ValidationFailure) {",
-        )
-        |> se.indent(1, "let count = dict.size(value)")
-      let sb = case min_properties, max_properties {
-        Some(min), Some(max) ->
-          sb
-          |> se.indent(1, "case count < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False ->")
-          |> se.indent(3, "case count > " <> int.to_string(max) <> " {")
-          |> se.indent(4, "True -> " <> max_failure(max))
-          |> se.indent(4, "False -> Ok(value)")
-          |> se.indent(3, "}")
-          |> se.indent(1, "}")
-        Some(min), None ->
-          sb
-          |> se.indent(1, "case count < " <> int.to_string(min) <> " {")
-          |> se.indent(2, "True -> " <> min_failure(min))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, Some(max) ->
-          sb
-          |> se.indent(1, "case count > " <> int.to_string(max) <> " {")
-          |> se.indent(2, "True -> " <> max_failure(max))
-          |> se.indent(2, "False -> Ok(value)")
-          |> se.indent(1, "}")
-        None, None -> sb
-      }
-      sb
-      |> se.line("}")
-      |> se.blank_line()
-    }
-  }
-}
-
 /// Build the guard function name from schema name, property name, and constraint type.
 fn guard_function_name(
   schema_name: String,
@@ -1491,69 +701,713 @@ fn validation_failure_dynamic(
   <> "))"
 }
 
-/// Generate a composite validate function for a schema that calls all
-/// individual field validators. This enables auto-validation by calling
-/// a single function rather than individual field guards.
-fn generate_composite_validator(
-  sb: se.StringBuilder,
+fn build_composite_guard_function(
   name: String,
   schema_ref: SchemaRef,
   ctx: Context,
-) -> se.StringBuilder {
+) -> Option(GuardFunction) {
   let guard_calls = collect_guard_calls(name, schema_ref, ctx)
   case list.is_empty(guard_calls) {
-    True -> sb
+    True -> None
     False -> {
       let fn_name = "validate_" <> naming.to_snake_case(name)
       let type_name = naming.schema_to_type_name(name)
       let gleam_type = composite_validator_type(name, schema_ref, ctx)
-      let sb =
-        sb
-        |> se.doc_comment("Validate all constraints for " <> type_name <> ".")
-        |> se.doc_comment(
-          "Auto-calls all field validators and collects failures.",
-        )
-        |> se.line(
-          "pub fn "
-          <> fn_name
-          <> "(value: "
-          <> gleam_type
-          <> ") -> Result("
-          <> gleam_type
-          <> ", List(ValidationFailure)) {",
-        )
-        |> se.indent(1, "let errors = []")
-      let sb =
-        list.fold(guard_calls, sb, fn(sb, call) {
+      let call_lines =
+        list.flat_map(guard_calls, fn(call) {
           let #(guard_fn, accessor, is_required) = call
           case is_required {
-            True ->
-              sb
-              |> se.indent(
-                1,
-                "let errors = case " <> guard_fn <> "(" <> accessor <> ") {",
-              )
-              |> se.indent(2, "Ok(_) -> errors")
-              |> se.indent(2, "Error(failure) -> [failure, ..errors]")
-              |> se.indent(1, "}")
-            False ->
-              sb
-              |> se.indent(1, "let errors = case " <> accessor <> " {")
-              |> se.indent(2, "option.Some(v) -> case " <> guard_fn <> "(v) {")
-              |> se.indent(3, "Ok(_) -> errors")
-              |> se.indent(3, "Error(failure) -> [failure, ..errors]")
-              |> se.indent(2, "}")
-              |> se.indent(2, "option.None -> errors")
-              |> se.indent(1, "}")
+            True -> [
+              "  let errors = case " <> guard_fn <> "(" <> accessor <> ") {",
+              "    Ok(_) -> errors",
+              "    Error(failure) -> [failure, ..errors]",
+              "  }",
+            ]
+            False -> [
+              "  let errors = case " <> accessor <> " {",
+              "    option.Some(v) -> case " <> guard_fn <> "(v) {",
+              "      Ok(_) -> errors",
+              "      Error(failure) -> [failure, ..errors]",
+              "    }",
+              "    option.None -> errors",
+              "  }",
+            ]
           }
         })
-      sb
-      |> se.indent(1, "case errors {")
-      |> se.indent(2, "[] -> Ok(value)")
-      |> se.indent(2, "_ -> Error(errors)")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate all constraints for " <> type_name <> ".",
+          "Auto-calls all field validators and collects failures.",
+        ],
+        param_decl: "value: " <> gleam_type,
+        return_type: "Result(" <> gleam_type <> ", List(ValidationFailure))",
+        body: string.join(
+          list.flatten([
+            ["  let errors = []"],
+            call_lines,
+            [
+              "  case errors {",
+              "    [] -> Ok(value)",
+              "    _ -> Error(errors)",
+              "  }",
+            ],
+          ]),
+          "\n",
+        ),
+        kind: CompositeValidator,
+      ))
+    }
+  }
+}
+
+fn build_string_pattern_guard_function(
+  schema_name: String,
+  prop_name: String,
+  pattern: Option(String),
+) -> Option(GuardFunction) {
+  case pattern {
+    None -> None
+    Some(pattern) -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "pattern")
+      let pattern_literal = gleam_string_literal(pattern)
+      let invalid_pattern_prefix =
+        gleam_string_literal("invalid pattern: " <> pattern <> ": ")
+      let mismatch_failure =
+        validation_failure_literal(
+          prop_name,
+          "pattern",
+          "must match pattern: " <> pattern,
+        )
+      let invalid_pattern_failure =
+        validation_failure_dynamic(
+          prop_name,
+          "invalidPattern",
+          invalid_pattern_prefix <> " <> error",
+        )
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate string pattern for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: String",
+        return_type: "Result(String, ValidationFailure)",
+        body: string.join(
+          [
+            "  case regexp.from_string(" <> pattern_literal <> ") {",
+            "    Ok(re) -> case regexp.check(re, value) {",
+            "      True -> Ok(value)",
+            "      False -> " <> mismatch_failure,
+            "    }",
+            "    Error(regexp.CompileError(error:, ..)) -> "
+              <> invalid_pattern_failure,
+            "  }",
+          ],
+          "\n",
+        ),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn character_word(n: Int) -> String {
+  case n {
+    1 -> "character"
+    _ -> "characters"
+  }
+}
+
+fn build_string_guard_function(
+  schema_name: String,
+  prop_name: String,
+  min_length: Option(Int),
+  max_length: Option(Int),
+) -> Option(GuardFunction) {
+  case min_length, max_length {
+    None, None -> None
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "length")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "minLength",
+          "must be at least "
+            <> int.to_string(min)
+            <> " "
+            <> character_word(min),
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "maxLength",
+          "must be at most " <> int.to_string(max) <> " " <> character_word(max),
+        )
+      }
+      let lines = case min_length, max_length {
+        Some(min), Some(max) -> [
+          "  let len = string.length(value)",
+          "  case len < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False ->",
+          "      case len > " <> int.to_string(max) <> " {",
+          "        True -> " <> max_failure(max),
+          "        False -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  let len = string.length(value)",
+          "  case len < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  let len = string.length(value)",
+          "  case len > " <> int.to_string(max) <> " {",
+          "    True -> " <> max_failure(max),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate string length for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: String",
+        return_type: "Result(String, ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_integer_guard_function(
+  schema_name: String,
+  prop_name: String,
+  minimum: Option(Int),
+  maximum: Option(Int),
+) -> Option(GuardFunction) {
+  case minimum, maximum {
+    None, None -> None
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "range")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "minimum",
+          "must be at least " <> int.to_string(min),
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "maximum",
+          "must be at most " <> int.to_string(max),
+        )
+      }
+      let lines = case minimum, maximum {
+        Some(min), Some(max) -> [
+          "  case value < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False ->",
+          "      case value > " <> int.to_string(max) <> " {",
+          "        True -> " <> max_failure(max),
+          "        False -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  case value < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  case value > " <> int.to_string(max) <> " {",
+          "    True -> " <> max_failure(max),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate integer range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Int",
+        return_type: "Result(Int, ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_float_guard_function(
+  schema_name: String,
+  prop_name: String,
+  minimum: Option(Float),
+  maximum: Option(Float),
+) -> Option(GuardFunction) {
+  case minimum, maximum {
+    None, None -> None
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "range")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "minimum",
+          "must be at least " <> float.to_string(min),
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "maximum",
+          "must be at most " <> float.to_string(max),
+        )
+      }
+      let lines = case minimum, maximum {
+        Some(min), Some(max) -> [
+          "  case value <. " <> float.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False ->",
+          "      case value >. " <> float.to_string(max) <> " {",
+          "        True -> " <> max_failure(max),
+          "        False -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  case value <. " <> float.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  case value >. " <> float.to_string(max) <> " {",
+          "    True -> " <> max_failure(max),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate float range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Float",
+        return_type: "Result(Float, ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_integer_exclusive_guard_function(
+  schema_name: String,
+  prop_name: String,
+  exclusive_minimum: Option(Int),
+  exclusive_maximum: Option(Int),
+) -> Option(GuardFunction) {
+  case exclusive_minimum, exclusive_maximum {
+    None, None -> None
+    _, _ -> {
+      let fn_name =
+        guard_function_name(schema_name, prop_name, "exclusive_range")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "exclusiveMinimum",
+          "must be greater than " <> int.to_string(min),
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "exclusiveMaximum",
+          "must be less than " <> int.to_string(max),
+        )
+      }
+      let lines = case exclusive_minimum, exclusive_maximum {
+        Some(min), Some(max) -> [
+          "  case value > " <> int.to_string(min) <> " {",
+          "    False -> " <> min_failure(min),
+          "    True ->",
+          "      case value < " <> int.to_string(max) <> " {",
+          "        False -> " <> max_failure(max),
+          "        True -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  case value > " <> int.to_string(min) <> " {",
+          "    False -> " <> min_failure(min),
+          "    True -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  case value < " <> int.to_string(max) <> " {",
+          "    False -> " <> max_failure(max),
+          "    True -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate integer exclusive range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Int",
+        return_type: "Result(Int, ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_integer_multiple_of_guard_function(
+  schema_name: String,
+  prop_name: String,
+  multiple_of: Option(Int),
+) -> Option(GuardFunction) {
+  case multiple_of {
+    None -> None
+    Some(m) ->
+      Some(GuardFunction(
+        name: guard_function_name(schema_name, prop_name, "multiple_of"),
+        docs: [
+          "Validate integer multipleOf for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Int",
+        return_type: "Result(Int, ValidationFailure)",
+        body: string.join(
+          [
+            "  case value % " <> int.to_string(m) <> " == 0 {",
+            "    False -> "
+              <> validation_failure_literal(
+              prop_name,
+              "multipleOf",
+              "must be a multiple of " <> int.to_string(m),
+            ),
+            "    True -> Ok(value)",
+            "  }",
+          ],
+          "\n",
+        ),
+        kind: FieldValidator,
+      ))
+  }
+}
+
+fn build_float_exclusive_guard_function(
+  schema_name: String,
+  prop_name: String,
+  exclusive_minimum: Option(Float),
+  exclusive_maximum: Option(Float),
+) -> Option(GuardFunction) {
+  case exclusive_minimum, exclusive_maximum {
+    None, None -> None
+    _, _ -> {
+      let fn_name =
+        guard_function_name(schema_name, prop_name, "exclusive_range")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "exclusiveMinimum",
+          "must be greater than " <> float.to_string(min),
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "exclusiveMaximum",
+          "must be less than " <> float.to_string(max),
+        )
+      }
+      let lines = case exclusive_minimum, exclusive_maximum {
+        Some(min), Some(max) -> [
+          "  case value >. " <> float.to_string(min) <> " {",
+          "    False -> " <> min_failure(min),
+          "    True ->",
+          "      case value <. " <> float.to_string(max) <> " {",
+          "        False -> " <> max_failure(max),
+          "        True -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  case value >. " <> float.to_string(min) <> " {",
+          "    False -> " <> min_failure(min),
+          "    True -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  case value <. " <> float.to_string(max) <> " {",
+          "    False -> " <> max_failure(max),
+          "    True -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate float exclusive range for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Float",
+        return_type: "Result(Float, ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_float_multiple_of_guard_function(
+  schema_name: String,
+  prop_name: String,
+  multiple_of: Option(Float),
+) -> Option(GuardFunction) {
+  case multiple_of {
+    None -> None
+    Some(m) ->
+      Some(GuardFunction(
+        name: guard_function_name(schema_name, prop_name, "multiple_of"),
+        docs: [
+          "Validate float multipleOf for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Float",
+        return_type: "Result(Float, ValidationFailure)",
+        body: string.join(
+          [
+            "  let remainder = value -. float.truncate(value /. "
+              <> float.to_string(m)
+              <> " |> int.to_float) *. "
+              <> float.to_string(m),
+            "  case remainder == 0.0 || remainder == -0.0 {",
+            "    False -> "
+              <> validation_failure_literal(
+              prop_name,
+              "multipleOf",
+              "must be a multiple of " <> float.to_string(m),
+            ),
+            "    True -> Ok(value)",
+            "  }",
+          ],
+          "\n",
+        ),
+        kind: FieldValidator,
+      ))
+  }
+}
+
+fn build_list_guard_function(
+  schema_name: String,
+  prop_name: String,
+  min_items: Option(Int),
+  max_items: Option(Int),
+) -> Option(GuardFunction) {
+  case min_items, max_items {
+    None, None -> None
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "length")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "minItems",
+          "must have at least " <> int.to_string(min) <> " items",
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "maxItems",
+          "must have at most " <> int.to_string(max) <> " items",
+        )
+      }
+      let lines = case min_items, max_items {
+        Some(min), Some(max) -> [
+          "  let len = list.length(value)",
+          "  case len < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False ->",
+          "      case len > " <> int.to_string(max) <> " {",
+          "        True -> " <> max_failure(max),
+          "        False -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  let len = list.length(value)",
+          "  case len < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  let len = list.length(value)",
+          "  case len > " <> int.to_string(max) <> " {",
+          "    True -> " <> max_failure(max),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate list length for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: List(a)",
+        return_type: "Result(List(a), ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
+    }
+  }
+}
+
+fn build_unique_items_guard_function(
+  schema_name: String,
+  prop_name: String,
+  unique_items: Bool,
+) -> Option(GuardFunction) {
+  case unique_items {
+    False -> None
+    True ->
+      Some(GuardFunction(
+        name: guard_function_name(schema_name, prop_name, "unique"),
+        docs: [
+          "Validate unique items for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: List(a)",
+        return_type: "Result(List(a), ValidationFailure)",
+        body: string.join(
+          [
+            "  case list.length(value) == list.length(list.unique(value)) {",
+            "    True -> Ok(value)",
+            "    False -> "
+              <> validation_failure_literal(
+              prop_name,
+              "uniqueItems",
+              "items must be unique",
+            ),
+            "  }",
+          ],
+          "\n",
+        ),
+        kind: FieldValidator,
+      ))
+  }
+}
+
+fn build_properties_count_guard_function(
+  schema_name: String,
+  prop_name: String,
+  min_properties: Option(Int),
+  max_properties: Option(Int),
+) -> Option(GuardFunction) {
+  case min_properties, max_properties {
+    None, None -> None
+    _, _ -> {
+      let fn_name = guard_function_name(schema_name, prop_name, "properties")
+      let min_failure = fn(min) {
+        validation_failure_literal(
+          prop_name,
+          "minProperties",
+          "must have at least " <> int.to_string(min) <> " properties",
+        )
+      }
+      let max_failure = fn(max) {
+        validation_failure_literal(
+          prop_name,
+          "maxProperties",
+          "must have at most " <> int.to_string(max) <> " properties",
+        )
+      }
+      let lines = case min_properties, max_properties {
+        Some(min), Some(max) -> [
+          "  let count = dict.size(value)",
+          "  case count < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False ->",
+          "      case count > " <> int.to_string(max) <> " {",
+          "        True -> " <> max_failure(max),
+          "        False -> Ok(value)",
+          "      }",
+          "  }",
+        ]
+        Some(min), None -> [
+          "  let count = dict.size(value)",
+          "  case count < " <> int.to_string(min) <> " {",
+          "    True -> " <> min_failure(min),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, Some(max) -> [
+          "  let count = dict.size(value)",
+          "  case count > " <> int.to_string(max) <> " {",
+          "    True -> " <> max_failure(max),
+          "    False -> Ok(value)",
+          "  }",
+        ]
+        None, None -> []
+      }
+      Some(GuardFunction(
+        name: fn_name,
+        docs: [
+          "Validate property count for "
+          <> schema_name
+          <> field_label(prop_name)
+          <> ".",
+        ],
+        param_decl: "value: Dict(k, v)",
+        return_type: "Result(Dict(k, v), ValidationFailure)",
+        body: string.join(lines, "\n"),
+        kind: FieldValidator,
+      ))
     }
   }
 }

--- a/src/oaspec/internal/codegen/router_ir.gleam
+++ b/src/oaspec/internal/codegen/router_ir.gleam
@@ -1,0 +1,585 @@
+import gleam/dict
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import oaspec/config
+import oaspec/internal/codegen/context.{type Context}
+import oaspec/internal/codegen/guards
+import oaspec/internal/codegen/import_analysis
+import oaspec/internal/codegen/server_request_decode as decode_helpers
+import oaspec/internal/openapi/schema.{Inline, Reference}
+import oaspec/internal/openapi/spec.{type Resolved, Value}
+import oaspec/internal/util/content_type
+import oaspec/internal/util/naming
+
+/// Structured requirements for router generation.
+pub type RouterRequirements {
+  RouterRequirements(
+    has_deep_object: Bool,
+    has_deep_object_with_ap: Bool,
+    needs_deep_object_present: Bool,
+    has_deep_object_untyped_ap: Bool,
+    has_form_urlencoded_body: Bool,
+    has_multipart_body: Bool,
+    has_nested_form_urlencoded_body: Bool,
+    needs_int: Bool,
+    needs_float: Bool,
+    needs_bool: Bool,
+    needs_string: Bool,
+    needs_cookie_lookup: Bool,
+    needs_list_import: Bool,
+    needs_uri_import: Bool,
+    needs_option: Bool,
+    needs_json: Bool,
+    needs_json_for_guards: Bool,
+    needs_decode: Bool,
+    needs_encode: Bool,
+    uses_query: Bool,
+    uses_headers: Bool,
+    uses_body: Bool,
+    has_params_ops: Bool,
+    has_enum_ref_params: Bool,
+    needs_guards: Bool,
+  )
+}
+
+/// Compute semantic requirements for the generated router module.
+pub fn analyze(ctx: Context) -> RouterRequirements {
+  let operations = context.operations(ctx)
+
+  let has_deep_object =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) -> decode_helpers.is_deep_object_param(p, ctx)
+          _ -> False
+        }
+      })
+    })
+  let has_deep_object_with_ap =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            decode_helpers.is_deep_object_param(p, ctx)
+            && decode_helpers.deep_object_has_additional_properties(p, ctx)
+          _ -> False
+        }
+      })
+    })
+  let needs_deep_object_present =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            decode_helpers.is_deep_object_param(p, ctx)
+            && !p.required
+            && !decode_helpers.deep_object_has_untyped_additional_properties(
+              p,
+              ctx,
+            )
+          _ -> False
+        }
+      })
+    })
+  let has_deep_object_untyped_ap =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            decode_helpers.is_deep_object_param(p, ctx)
+            && decode_helpers.deep_object_has_untyped_additional_properties(
+              p,
+              ctx,
+            )
+          _ -> False
+        }
+      })
+    })
+  let has_form_urlencoded_body =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      decode_helpers.operation_uses_form_urlencoded_body(operation)
+    })
+  let has_multipart_body =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      decode_helpers.operation_uses_multipart_body(operation)
+    })
+  let has_nested_form_urlencoded_body =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.form_urlencoded_body_has_nested_object(rb, ctx)
+        _ -> False
+      }
+    })
+
+  let needs_int =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            decode_helpers.query_schema_needs_int(spec.parameter_schema(p))
+            || decode_helpers.deep_object_param_needs_int(p, ctx)
+          _ -> False
+        }
+      })
+      || case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.form_urlencoded_body_needs_int(rb, ctx)
+        _ -> False
+      }
+      || case operation.request_body {
+        Some(Value(rb)) -> decode_helpers.multipart_body_needs_int(rb, ctx)
+        _ -> False
+      }
+    })
+    || operations_have_response_header_of_type(operations, "Int")
+
+  let needs_float =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            decode_helpers.query_schema_needs_float(spec.parameter_schema(p))
+            || decode_helpers.deep_object_param_needs_float(p, ctx)
+          _ -> False
+        }
+      })
+      || case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.form_urlencoded_body_needs_float(rb, ctx)
+        _ -> False
+      }
+      || case operation.request_body {
+        Some(Value(rb)) -> decode_helpers.multipart_body_needs_float(rb, ctx)
+        _ -> False
+      }
+    })
+    || operations_have_response_header_of_type(operations, "Float")
+
+  let needs_bool = operations_have_response_header_of_type(operations, "Bool")
+
+  let needs_string =
+    has_form_urlencoded_body
+    || has_multipart_body
+    || has_deep_object_with_ap
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            case p.in_ {
+              spec.InCookie -> True
+              spec.InQuery | spec.InHeader ->
+                decode_helpers.query_schema_needs_string(spec.parameter_schema(
+                  p,
+                ))
+                || decode_helpers.deep_object_param_needs_string(p, ctx)
+              spec.InPath ->
+                decode_helpers.query_schema_needs_string(spec.parameter_schema(
+                  p,
+                ))
+            }
+          _ -> False
+        }
+      })
+      || case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.form_urlencoded_body_needs_string(rb, ctx)
+        _ -> False
+      }
+    })
+
+  let needs_cookie_lookup =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) -> p.in_ == spec.InCookie
+          _ -> False
+        }
+      })
+    })
+
+  let needs_list_import =
+    needs_cookie_lookup
+    || has_deep_object
+    || has_form_urlencoded_body
+    || has_multipart_body
+    || operations_have_response_headers(operations)
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) ->
+            case p.in_, spec.parameter_schema(p) {
+              spec.InQuery, Some(Inline(schema.ArraySchema(..))) -> True
+              spec.InHeader, Some(Inline(schema.ArraySchema(..))) -> True
+              _, _ -> False
+            }
+          _ -> False
+        }
+      })
+    })
+  let needs_uri_import = needs_cookie_lookup || has_form_urlencoded_body
+
+  let needs_option =
+    import_analysis.operations_have_optional_params(operations)
+    || import_analysis.operations_have_optional_body(operations)
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      let has_optional_deep_object_fields =
+        list.any(operation.parameters, fn(ref_p) {
+          case ref_p {
+            Value(p) ->
+              decode_helpers.deep_object_param_has_optional_fields(p, ctx)
+            _ -> False
+          }
+        })
+      let has_optional_form_urlencoded_fields = case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.form_urlencoded_body_has_optional_fields(rb, ctx)
+        _ -> False
+      }
+      let has_optional_multipart_fields = case operation.request_body {
+        Some(Value(rb)) ->
+          decode_helpers.multipart_body_has_optional_fields(rb, ctx)
+        _ -> False
+      }
+      has_optional_deep_object_fields
+      || has_optional_form_urlencoded_fields
+      || has_optional_multipart_fields
+    })
+    || operations_have_optional_response_header(operations)
+
+  let needs_json =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) -> {
+            let content_entries = dict.to_list(response.content)
+            case content_entries {
+              [#(media_type_name, media_type)] ->
+                case content_type.is_json_compatible(media_type_name) {
+                  True ->
+                    case media_type.schema {
+                      Some(_) -> True
+                      None -> False
+                    }
+                  False -> False
+                }
+              _ -> False
+            }
+          }
+          _ -> False
+        }
+      })
+    })
+
+  let needs_decode =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          list.any(dict.to_list(rb.content), fn(entry) {
+            let #(content_type_name, _) = entry
+            content_type.is_json_compatible(content_type_name)
+          })
+        _ -> False
+      }
+    })
+
+  let uses_query =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) -> p.in_ == spec.InQuery
+          _ -> False
+        }
+      })
+    })
+
+  let uses_headers =
+    has_multipart_body
+    || list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(ref_p) {
+        case ref_p {
+          Value(p) -> p.in_ == spec.InHeader || p.in_ == spec.InCookie
+          _ -> False
+        }
+      })
+    })
+
+  let uses_body =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      option.is_some(operation.request_body)
+    })
+
+  let has_params_ops =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      !list.is_empty(operation.parameters)
+      || option.is_some(operation.request_body)
+    })
+
+  let has_enum_ref_params =
+    decode_helpers.operations_have_enum_ref_params(operations, ctx)
+
+  let needs_guards =
+    config.validate(context.config(ctx))
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      operation_needs_guard_validation(operation, ctx)
+    })
+  let needs_json_for_guards = needs_guards
+
+  RouterRequirements(
+    has_deep_object: has_deep_object,
+    has_deep_object_with_ap: has_deep_object_with_ap,
+    needs_deep_object_present: needs_deep_object_present,
+    has_deep_object_untyped_ap: has_deep_object_untyped_ap,
+    has_form_urlencoded_body: has_form_urlencoded_body,
+    has_multipart_body: has_multipart_body,
+    has_nested_form_urlencoded_body: has_nested_form_urlencoded_body,
+    needs_int: needs_int,
+    needs_float: needs_float,
+    needs_bool: needs_bool,
+    needs_string: needs_string,
+    needs_cookie_lookup: needs_cookie_lookup,
+    needs_list_import: needs_list_import,
+    needs_uri_import: needs_uri_import,
+    needs_option: needs_option,
+    needs_json: needs_json,
+    needs_json_for_guards: needs_json_for_guards,
+    needs_decode: needs_decode,
+    needs_encode: needs_json,
+    uses_query: uses_query,
+    uses_headers: uses_headers,
+    uses_body: uses_body,
+    has_params_ops: has_params_ops,
+    has_enum_ref_params: has_enum_ref_params,
+    needs_guards: needs_guards,
+  )
+}
+
+/// Render the final import list from structured requirements.
+pub fn imports(requirements: RouterRequirements, ctx: Context) -> List(String) {
+  let std_imports = ["gleam/dict.{type Dict}"]
+  let std_imports = case requirements.needs_list_import {
+    True -> list.append(std_imports, ["gleam/list"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_uri_import {
+    True -> list.append(std_imports, ["gleam/uri"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_int {
+    True -> list.append(std_imports, ["gleam/int"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_float {
+    True -> list.append(std_imports, ["gleam/float"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_bool {
+    True -> list.append(std_imports, ["gleam/bool"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_option {
+    True -> list.append(std_imports, ["gleam/option.{None, Some}"])
+    False -> std_imports
+  }
+  let std_imports = case
+    requirements.needs_json || requirements.needs_json_for_guards
+  {
+    True -> list.append(std_imports, ["gleam/json"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.needs_string {
+    True -> list.append(std_imports, ["gleam/string"])
+    False -> std_imports
+  }
+  let std_imports = case requirements.has_deep_object_untyped_ap {
+    True -> list.append(std_imports, ["gleam/dynamic"])
+    False -> std_imports
+  }
+
+  let pkg_imports = [
+    config.package(context.config(ctx)) <> "/handlers",
+    config.package(context.config(ctx)) <> "/handlers_generated",
+  ]
+  let pkg_imports = case
+    requirements.has_deep_object
+    || requirements.has_form_urlencoded_body
+    || requirements.has_multipart_body
+    || requirements.has_enum_ref_params
+  {
+    True ->
+      list.append(pkg_imports, [config.package(context.config(ctx)) <> "/types"])
+    False -> pkg_imports
+  }
+  let pkg_imports = case requirements.needs_decode {
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/decode",
+      ])
+    False -> pkg_imports
+  }
+  let pkg_imports = case requirements.needs_encode {
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/encode",
+      ])
+    False -> pkg_imports
+  }
+  let pkg_imports = case requirements.has_params_ops {
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/request_types",
+        config.package(context.config(ctx)) <> "/response_types",
+      ])
+    False ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/response_types",
+      ])
+  }
+  let pkg_imports = case requirements.needs_guards {
+    True ->
+      list.append(pkg_imports, [
+        config.package(context.config(ctx)) <> "/guards",
+      ])
+    False -> pkg_imports
+  }
+
+  list.append(std_imports, pkg_imports)
+}
+
+fn operation_needs_guard_validation(
+  operation: spec.Operation(Resolved),
+  ctx: Context,
+) -> Bool {
+  let needs_body_guard = case operation.request_body {
+    Some(Value(rb)) -> {
+      let content_entries = dict.to_list(rb.content)
+      case content_entries {
+        [#(_, mt)] ->
+          case mt.schema {
+            Some(Inline(schema.ObjectSchema(..)))
+            | Some(Inline(schema.AllOfSchema(..))) -> True
+            Some(Reference(name:, ..)) -> guards.schema_has_validator(name, ctx)
+            _ -> False
+          }
+        _ -> False
+      }
+    }
+    _ -> False
+  }
+  config.validate(context.config(ctx)) && needs_body_guard
+}
+
+fn operations_have_response_headers(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) -> !dict.is_empty(response.headers)
+        _ -> False
+      }
+    })
+  })
+}
+
+fn operations_have_response_header_of_type(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  type_name: String,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) ->
+          list.any(sorted_header_specs(response.headers), fn(spec) {
+            spec.field_type == type_name
+          })
+        _ -> False
+      }
+    })
+  })
+}
+
+fn operations_have_optional_response_header(
+  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(dict.to_list(operation.responses), fn(entry) {
+      let #(_, ref_or) = entry
+      case ref_or {
+        Value(response) ->
+          list.any(sorted_header_specs(response.headers), fn(spec) {
+            !spec.required
+          })
+        _ -> False
+      }
+    })
+  })
+}
+
+type HeaderSpec {
+  HeaderSpec(
+    header_name: String,
+    field_name: String,
+    field_type: String,
+    required: Bool,
+  )
+}
+
+fn sorted_header_specs(
+  headers: dict.Dict(String, spec.Header),
+) -> List(HeaderSpec) {
+  headers
+  |> dict.to_list
+  |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+  |> list.map(fn(entry) {
+    let #(header_name, header) = entry
+    let field_name = naming.to_snake_case(header_name)
+    let field_type = response_header_field_type(header.schema)
+    HeaderSpec(
+      header_name: header_name,
+      field_name: field_name,
+      field_type: field_type,
+      required: header.required,
+    )
+  })
+}
+
+fn response_header_field_type(
+  schema_opt: option.Option(schema.SchemaRef),
+) -> String {
+  case schema_opt {
+    Some(Inline(schema.IntegerSchema(..))) -> "Int"
+    Some(Inline(schema.NumberSchema(..))) -> "Float"
+    Some(Inline(schema.BooleanSchema(..))) -> "Bool"
+    Some(Inline(schema.StringSchema(..))) -> "String"
+    Some(Reference(name:, ..)) -> "types." <> naming.schema_to_type_name(name)
+    _ -> "String"
+  }
+}

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -9,7 +9,7 @@ import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/guards
-import oaspec/internal/codegen/import_analysis
+import oaspec/internal/codegen/router_ir
 import oaspec/internal/codegen/server_request_decode as decode_helpers
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/schema.{Inline, Reference}
@@ -240,431 +240,8 @@ fn generate_router(
   ctx: Context,
   operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
 ) -> String {
-  let has_deep_object =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> decode_helpers.is_deep_object_param(p, ctx)
-          _ -> False
-        }
-      })
-    })
-  // Whether any deep object param has additional_properties (Untyped or Typed)
-  let has_deep_object_with_ap =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            decode_helpers.is_deep_object_param(p, ctx)
-            && decode_helpers.deep_object_has_additional_properties(p, ctx)
-          _ -> False
-        }
-      })
-    })
-  // Whether any optional deep object param does NOT use deep_object_present_any.
-  // deep_object_present_any is only used for Untyped AP; all other optional
-  // deep object params (no AP or Typed AP) use deep_object_present.
-  let needs_deep_object_present =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            decode_helpers.is_deep_object_param(p, ctx)
-            && !p.required
-            && !decode_helpers.deep_object_has_untyped_additional_properties(
-              p,
-              ctx,
-            )
-          _ -> False
-        }
-      })
-    })
-  // Whether any deep object param has Untyped additional_properties (needs dynamic import)
-  let has_deep_object_untyped_ap =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            decode_helpers.is_deep_object_param(p, ctx)
-            && decode_helpers.deep_object_has_untyped_additional_properties(
-              p,
-              ctx,
-            )
-          _ -> False
-        }
-      })
-    })
-  let has_form_urlencoded_body =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      decode_helpers.operation_uses_form_urlencoded_body(operation)
-    })
-  let has_multipart_body =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      decode_helpers.operation_uses_multipart_body(operation)
-    })
-  let has_nested_form_urlencoded_body =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.form_urlencoded_body_has_nested_object(rb, ctx)
-        _ -> False
-      }
-    })
-
-  // Determine which imports are needed based on operations.
-  // Dict is always needed for the route signature, so we skip a conditional
-  // check here.
-
-  let needs_int =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            decode_helpers.query_schema_needs_int(spec.parameter_schema(p))
-            || decode_helpers.deep_object_param_needs_int(p, ctx)
-          _ -> False
-        }
-      })
-      || case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.form_urlencoded_body_needs_int(rb, ctx)
-        _ -> False
-      }
-      || case operation.request_body {
-        Some(Value(rb)) -> decode_helpers.multipart_body_needs_int(rb, ctx)
-        _ -> False
-      }
-    })
-    // Issue #306: integer response headers stringify via int.to_string.
-    || operations_have_response_header_of_type(operations, "Int")
-
-  let needs_float =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            decode_helpers.query_schema_needs_float(spec.parameter_schema(p))
-            || decode_helpers.deep_object_param_needs_float(p, ctx)
-          _ -> False
-        }
-      })
-      || case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.form_urlencoded_body_needs_float(rb, ctx)
-        _ -> False
-      }
-      || case operation.request_body {
-        Some(Value(rb)) -> decode_helpers.multipart_body_needs_float(rb, ctx)
-        _ -> False
-      }
-    })
-    // Issue #306: float response headers stringify via float.to_string.
-    || operations_have_response_header_of_type(operations, "Float")
-
-  // Issue #306: boolean response headers stringify via bool.to_string —
-  // generated routers had no prior need for `gleam/bool`, so this is a
-  // brand new import condition.
-  let needs_bool = operations_have_response_header_of_type(operations, "Bool")
-
-  let needs_string =
-    has_form_urlencoded_body
-    || has_multipart_body
-    || has_deep_object_with_ap
-    || list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            case p.in_ {
-              spec.InCookie -> True
-              spec.InQuery | spec.InHeader ->
-                decode_helpers.query_schema_needs_string(spec.parameter_schema(
-                  p,
-                ))
-                || decode_helpers.deep_object_param_needs_string(p, ctx)
-              spec.InPath ->
-                decode_helpers.query_schema_needs_string(spec.parameter_schema(
-                  p,
-                ))
-            }
-          _ -> False
-        }
-      })
-      || case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.form_urlencoded_body_needs_string(rb, ctx)
-        _ -> False
-      }
-    })
-
-  let needs_cookie_lookup =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> p.in_ == spec.InCookie
-          _ -> False
-        }
-      })
-    })
-
-  let needs_list_import =
-    needs_cookie_lookup
-    || has_deep_object
-    || has_form_urlencoded_body
-    || has_multipart_body
-    // Issue #306: responses that declare headers materialise the
-    // ServerResponse `headers:` slot via `list.flatten([...])`.
-    || operations_have_response_headers(operations)
-    || list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) ->
-            case p.in_, spec.parameter_schema(p) {
-              spec.InQuery, Some(Inline(schema.ArraySchema(..))) -> True
-              spec.InHeader, Some(Inline(schema.ArraySchema(..))) -> True
-              _, _ -> False
-            }
-          _ -> False
-        }
-      })
-    })
-  let needs_uri_import = needs_cookie_lookup || has_form_urlencoded_body
-
-  let needs_option =
-    import_analysis.operations_have_optional_params(operations)
-    || import_analysis.operations_have_optional_body(operations)
-    || list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      let has_optional_deep_object_fields =
-        list.any(operation.parameters, fn(ref_p) {
-          case ref_p {
-            Value(p) ->
-              decode_helpers.deep_object_param_has_optional_fields(p, ctx)
-            _ -> False
-          }
-        })
-      let has_optional_form_urlencoded_fields = case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.form_urlencoded_body_has_optional_fields(rb, ctx)
-        _ -> False
-      }
-      let has_optional_multipart_fields = case operation.request_body {
-        Some(Value(rb)) ->
-          decode_helpers.multipart_body_has_optional_fields(rb, ctx)
-        _ -> False
-      }
-      has_optional_deep_object_fields
-      || has_optional_form_urlencoded_fields
-      || has_optional_multipart_fields
-    })
-    // Issue #306: optional response headers pattern-match `Some(v) | None`,
-    // which needs `gleam/option` even on operations whose request side
-    // has no Option-typed parameters.
-    || operations_have_optional_response_header(operations)
-
-  let needs_json =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      let responses = dict.to_list(operation.responses)
-      list.any(responses, fn(entry) {
-        let #(_, ref_or) = entry
-        case ref_or {
-          Value(response) -> {
-            let content_entries = dict.to_list(response.content)
-            case content_entries {
-              [#(media_type_name, media_type)] ->
-                case content_type.is_json_compatible(media_type_name) {
-                  True ->
-                    case media_type.schema {
-                      Some(_) -> True
-                      None -> False
-                    }
-                  False -> False
-                }
-              _ -> False
-            }
-          }
-          _ -> False
-        }
-      })
-    })
-
-  let needs_decode =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      case operation.request_body {
-        Some(Value(rb)) ->
-          list.any(dict.to_list(rb.content), fn(entry) {
-            let #(content_type, _) = entry
-            content_type.is_json_compatible(content_type)
-          })
-        _ -> False
-      }
-    })
-
-  let needs_encode = needs_json
-
-  let uses_query =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> p.in_ == spec.InQuery
-          _ -> False
-        }
-      })
-    })
-
-  let uses_headers =
-    has_multipart_body
-    || list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      list.any(operation.parameters, fn(ref_p) {
-        case ref_p {
-          Value(p) -> p.in_ == spec.InHeader || p.in_ == spec.InCookie
-          _ -> False
-        }
-      })
-    })
-
-  let uses_body =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      option.is_some(operation.request_body)
-    })
-
-  let has_params_ops =
-    list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      !list.is_empty(operation.parameters)
-      || option.is_some(operation.request_body)
-    })
-
-  // Build imports list (Dict always needed for route signature)
-  let std_imports = ["gleam/dict.{type Dict}"]
-  let std_imports = case needs_list_import {
-    True -> list.append(std_imports, ["gleam/list"])
-    False -> std_imports
-  }
-  let std_imports = case needs_uri_import {
-    True -> list.append(std_imports, ["gleam/uri"])
-    False -> std_imports
-  }
-  let std_imports = case needs_int {
-    True -> list.append(std_imports, ["gleam/int"])
-    False -> std_imports
-  }
-  let std_imports = case needs_float {
-    True -> list.append(std_imports, ["gleam/float"])
-    False -> std_imports
-  }
-  let std_imports = case needs_bool {
-    True -> list.append(std_imports, ["gleam/bool"])
-    False -> std_imports
-  }
-  let std_imports = case needs_option {
-    True -> list.append(std_imports, ["gleam/option.{None, Some}"])
-    False -> std_imports
-  }
-  // json is also needed when guard validation is enabled (for 422 error responses)
-  let needs_json_for_guards =
-    config.validate(context.config(ctx))
-    && list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      operation_needs_guard_validation(operation, ctx)
-    })
-  let std_imports = case needs_json || needs_json_for_guards {
-    True -> list.append(std_imports, ["gleam/json"])
-    False -> std_imports
-  }
-  let std_imports = case needs_string {
-    True -> list.append(std_imports, ["gleam/string"])
-    False -> std_imports
-  }
-  let std_imports = case has_deep_object_untyped_ap {
-    True -> list.append(std_imports, ["gleam/dynamic"])
-    False -> std_imports
-  }
-
-  // Issue #247: router imports the sealed delegator, not the user-owned
-  // handlers module. handlers_generated.gleam forwards every call to
-  // handlers.<op_name>, so the router stays in lock-step with the spec
-  // without ever touching user code.
-  // Issue #264: also import handlers itself so the route signature can
-  // reference `handlers.State` for the threaded application state.
-  let pkg_imports = [
-    config.package(context.config(ctx)) <> "/handlers",
-    config.package(context.config(ctx)) <> "/handlers_generated",
-  ]
-  // Issue #318: enum query / header / cookie parameters resolved through
-  // `$ref` cause the router body to emit `types.<EnumType><Variant>`
-  // references (see decode_helpers.enum_match_result_expr and
-  // enum_match_option_expr). The `types` import must be present in
-  // those cases too, not just for deep object / form / multipart.
-  let has_enum_ref_params =
-    decode_helpers.operations_have_enum_ref_params(operations, ctx)
-  let pkg_imports = case
-    has_deep_object
-    || has_form_urlencoded_body
-    || has_multipart_body
-    || has_enum_ref_params
-  {
-    True ->
-      list.append(pkg_imports, [config.package(context.config(ctx)) <> "/types"])
-    False -> pkg_imports
-  }
-  let pkg_imports = case needs_decode {
-    True ->
-      list.append(pkg_imports, [
-        config.package(context.config(ctx)) <> "/decode",
-      ])
-    False -> pkg_imports
-  }
-  let pkg_imports = case needs_encode {
-    True ->
-      list.append(pkg_imports, [
-        config.package(context.config(ctx)) <> "/encode",
-      ])
-    False -> pkg_imports
-  }
-  let pkg_imports = case has_params_ops {
-    True ->
-      list.append(pkg_imports, [
-        config.package(context.config(ctx)) <> "/request_types",
-        config.package(context.config(ctx)) <> "/response_types",
-      ])
-    False ->
-      list.append(pkg_imports, [
-        config.package(context.config(ctx)) <> "/response_types",
-      ])
-  }
-  // Import guards module when validation is enabled and any operation body has validators
-  let needs_guards =
-    config.validate(context.config(ctx))
-    && list.any(operations, fn(op) {
-      let #(_, operation, _, _) = op
-      operation_needs_guard_validation(operation, ctx)
-    })
-  let pkg_imports = case needs_guards {
-    True ->
-      list.append(pkg_imports, [
-        config.package(context.config(ctx)) <> "/guards",
-      ])
-    False -> pkg_imports
-  }
-
-  let all_imports = list.append(std_imports, pkg_imports)
+  let requirements = router_ir.analyze(ctx)
+  let all_imports = router_ir.imports(requirements, ctx)
 
   let sb =
     se.file_header(context.version)
@@ -701,7 +278,7 @@ String.",
     |> se.blank_line()
 
   // deep_object_present: only when optional deep object params without AP exist
-  let sb = case needs_deep_object_present {
+  let sb = case requirements.needs_deep_object_present {
     True ->
       sb
       |> se.line(
@@ -718,7 +295,7 @@ String.",
 
   // deep_object_present_any and deep_object_additional_properties:
   // only when deep object params with additional_properties exist
-  let sb = case has_deep_object_with_ap {
+  let sb = case requirements.has_deep_object_with_ap {
     True ->
       sb
       |> se.line(
@@ -761,7 +338,7 @@ String.",
 
   // coerce_dict: type-safe identity for converting Dict value types at compile time
   // Only needed when deepObject params with Untyped additional_properties exist
-  let sb = case has_deep_object_untyped_ap {
+  let sb = case requirements.has_deep_object_untyped_ap {
     True ->
       sb
       |> se.line("@external(erlang, \"gleam_stdlib\", \"identity\")")
@@ -772,7 +349,7 @@ String.",
     False -> sb
   }
 
-  let sb = case has_form_urlencoded_body {
+  let sb = case requirements.has_form_urlencoded_body {
     True ->
       sb
       |> se.line("fn form_url_decode(value: String) -> String {")
@@ -824,7 +401,7 @@ String.",
     False -> sb
   }
 
-  let sb = case has_multipart_body {
+  let sb = case requirements.has_multipart_body {
     True ->
       sb
       |> se.line(
@@ -921,7 +498,7 @@ String.",
     False -> sb
   }
 
-  let sb = case has_nested_form_urlencoded_body {
+  let sb = case requirements.has_nested_form_urlencoded_body {
     True ->
       sb
       |> se.line(
@@ -946,11 +523,11 @@ String.",
     |> se.doc_comment("Route an incoming request to the appropriate handler.")
     |> se.line(
       "pub fn route(app_state: handlers.State, method: String, path: List(String), "
-      <> route_arg_name("query", uses_query)
+      <> route_arg_name("query", requirements.uses_query)
       <> ": Dict(String, List(String)), "
-      <> route_arg_name("headers", uses_headers)
+      <> route_arg_name("headers", requirements.uses_headers)
       <> ": Dict(String, String), "
-      <> route_arg_name("body", uses_body)
+      <> route_arg_name("body", requirements.uses_body)
       <> ": String) -> ServerResponse {",
     )
     |> se.indent(1, "case method, path {")
@@ -979,7 +556,7 @@ String.",
     |> se.line("}")
     |> se.blank_line()
 
-  let sb = case needs_cookie_lookup {
+  let sb = case requirements.needs_cookie_lookup {
     True -> generate_cookie_lookup(sb)
     False -> sb
   }
@@ -1680,40 +1257,6 @@ fn close_lookup_case(sb: se.StringBuilder) -> se.StringBuilder {
   |> se.indent(3, "}")
 }
 
-/// Check if an operation's request body needs guard validation.
-/// True when the body is required, JSON-compatible, references a named schema,
-/// and that schema has constraint-based validators.
-///
-/// Issue #292: inline request body schemas with constraints are NOT covered
-/// here because guards.gleam only generates validators for named component
-/// schemas. Extending guard generation to anonymous inline schemas is
-/// tracked as a follow-up.
-fn operation_needs_guard_validation(
-  operation: spec.Operation(Resolved),
-  ctx: Context,
-) -> Bool {
-  case operation.request_body {
-    Some(Value(rb)) ->
-      rb.required
-      && {
-        let content_entries = dict.to_list(rb.content)
-        list.any(content_entries, fn(entry) {
-          content_type.is_json_compatible(entry.0)
-        })
-        && case content_entries {
-          [#(_, mt)] ->
-            case mt.schema {
-              Some(schema.Reference(name:, ..)) ->
-                guards.schema_has_validator(name, ctx)
-              _ -> False
-            }
-          _ -> False
-        }
-      }
-    _ -> False
-  }
-}
-
 // Parameter parsing, body decoding, and request construction helpers
 // have been extracted to server_request_decode.gleam
 
@@ -1902,64 +1445,6 @@ fn generate_response_conversion(
       sb |> se.indent(3, "}")
     }
   }
-}
-
-/// True if any response of any operation declares at least one header.
-fn operations_have_response_headers(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_, operation, _, _) = op
-    list.any(dict.to_list(operation.responses), fn(entry) {
-      let #(_, ref_or) = entry
-      case ref_or {
-        Value(response) -> !dict.is_empty(response.headers)
-        _ -> False
-      }
-    })
-  })
-}
-
-/// True if any response header field has the given Gleam type.
-/// Used to decide which primitive `gleam/<type>` import the generated
-/// router needs for header value stringification (issue #306).
-fn operations_have_response_header_of_type(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-  type_name: String,
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_, operation, _, _) = op
-    list.any(dict.to_list(operation.responses), fn(entry) {
-      let #(_, ref_or) = entry
-      case ref_or {
-        Value(response) ->
-          list.any(sorted_header_specs(response.headers), fn(spec) {
-            spec.field_type == type_name
-          })
-        _ -> False
-      }
-    })
-  })
-}
-
-/// True if any response header is optional. Optional headers emit
-/// `case hdrs.<field> { Some(v) -> ... None -> [] }` and need `gleam/option`.
-fn operations_have_optional_response_header(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
-) -> Bool {
-  list.any(operations, fn(op) {
-    let #(_, operation, _, _) = op
-    list.any(dict.to_list(operation.responses), fn(entry) {
-      let #(_, ref_or) = entry
-      case ref_or {
-        Value(response) ->
-          list.any(sorted_header_specs(response.headers), fn(spec) {
-            !spec.required
-          })
-        _ -> False
-      }
-    })
-  })
 }
 
 /// Compact spec for a single declared response header, used to render

--- a/test/structured_codegen_ir_test.gleam
+++ b/test/structured_codegen_ir_test.gleam
@@ -1,0 +1,157 @@
+import gleam/list
+import gleeunit/should
+import oaspec/config
+import oaspec/internal/codegen/client_ir
+import oaspec/internal/codegen/context
+import oaspec/internal/codegen/guards
+import oaspec/internal/codegen/router_ir
+import oaspec/internal/openapi/dedup
+import oaspec/internal/openapi/hoist
+import oaspec/internal/openapi/resolve
+import oaspec/openapi/parser
+
+const guard_integration_spec = "
+openapi: 3.0.3
+info:
+  title: Guard Integration Test
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePetRequest'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    CreatePetRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+"
+
+const duplicate_guard_spec = "
+openapi: 3.0.3
+info:
+  title: Guard Dedup Test
+  version: 1.0.0
+paths:
+  /uploads:
+    post:
+      operationId: createUpload
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InlineUpload'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    UploadCommon:
+      type: object
+      required: [title]
+      properties:
+        title:
+          type: string
+          minLength: 3
+          maxLength: 100
+    InlineUpload:
+      allOf:
+        - $ref: '#/components/schemas/UploadCommon'
+        - type: object
+          required: [content_b64]
+          properties:
+            content_b64: { type: string }
+    ReferencedUpload:
+      allOf:
+        - $ref: '#/components/schemas/UploadCommon'
+        - type: object
+          required: [source_url]
+          properties:
+            source_url: { type: string }
+"
+
+fn make_ctx_from_yaml(yaml: String, validate: Bool) -> context.Context {
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: validate,
+    )
+  context.new(resolved, cfg)
+}
+
+pub fn client_ir_tracks_guard_import_requirements_test() {
+  let ctx = make_ctx_from_yaml(guard_integration_spec, True)
+  let requirements = client_ir.analyze(ctx)
+
+  requirements.needs_guards |> should.be_true()
+  client_ir.imports(requirements, ctx)
+  |> list.contains("api/guards")
+  |> should.be_true()
+}
+
+pub fn router_ir_tracks_guard_import_requirements_test() {
+  let ctx = make_ctx_from_yaml(guard_integration_spec, True)
+  let requirements = router_ir.analyze(ctx)
+  let imports = router_ir.imports(requirements, ctx)
+
+  requirements.needs_guards |> should.be_true()
+  requirements.needs_json_for_guards |> should.be_true()
+  imports |> list.contains("gleam/json") |> should.be_true()
+  imports |> list.contains("api/guards") |> should.be_true()
+}
+
+pub fn guards_build_module_dedupes_structurally_test() {
+  let ctx = make_ctx_from_yaml(duplicate_guard_spec, False)
+  let module = guards.build_module(ctx)
+  let target_names = [
+    "validate_inline_upload_title_length",
+    "validate_referenced_upload_title_length",
+    "validate_upload_common_title_length",
+  ]
+  let matching =
+    list.filter(module.functions, fn(function) {
+      list.contains(target_names, function.name)
+    })
+  let delegators =
+    list.filter(matching, fn(function) {
+      case function.kind {
+        guards.DelegatingFieldValidator(_) -> True
+        _ -> False
+      }
+    })
+  let canonical =
+    list.filter(matching, fn(function) {
+      case function.kind {
+        guards.FieldValidator -> True
+        _ -> False
+      }
+    })
+
+  list.length(matching) |> should.equal(3)
+  list.length(delegators) |> should.equal(2)
+  list.length(canonical) |> should.equal(1)
+}


### PR DESCRIPTION
## Summary
Refactor client, router, and guard generation to build structured requirements and validator definitions before rendering source text.
This removes guard source reparsing, keeps import decisions on dedicated requirement data, and adds semantic tests for the new IR-style layers.

## Changes
- add `client_ir` and `router_ir` modules that compute structured generation requirements and derive imports from them
- refactor `client.gleam` and `server.gleam` to consume those structured requirements instead of large local boolean/import blocks
- refactor `guards.gleam` to build structured validator definitions, dedupe field validators before rendering, and expose `build_module/1` for semantic tests
- add unit tests that assert structured requirements and guard dedupe behavior without relying on full generated source strings

## Design Decisions
- keep rendering as the final step while moving semantic analysis into dedicated data structures
- preserve existing generated output behavior and coverage, then add direct semantic assertions on the structured layer

## Limitations
- `guards.build_module/1` currently focuses on the generated validator surface rather than introducing a generic shared IR used by every codegen pass

Closes #373
