### PR TITLE
refactor(codegen): share analyzed schema queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal: add shared schema queries to `Context` and route codegen /
+  validation through them.** `Context` now precomputes an inspectable
+  `analyzed_schemas` view plus a cached component-schema resolver, exposed
+  through `context.resolve_schema_ref/2` and `context.schema_metadata/2`.
+  The repeated ad hoc `$ref` resolution logic in `schema_dispatch`,
+  `schema_utils`, `client_request`, `server_request_decode`, `guards`,
+  `validate`, and related helpers now goes through that shared query layer
+  instead of each module resolving component refs independently. Adds
+  context-level tests for analyzed schema snapshots and nested property
+  metadata flags, completing the deferred schema-query follow-up for #371.
+
 ## [0.40.0] - 2026-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate usable Gleam code from OpenAPI 3.x specifications.
 - Generate client and server-side modules from a single spec
 - Produce readable Gleam types, encoders, decoders, request types, and response types
 - Handle real-world OpenAPI patterns: unions, nullable fields, `additionalProperties`, form bodies, multipart, and security
-- Backed by 314 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 317 unit tests, ShellSpec CLI tests, 40 integration compile tests, and 240 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Why oaspec?
 

--- a/src/oaspec/internal/codegen/allof_merge.gleam
+++ b/src/oaspec/internal/codegen/allof_merge.gleam
@@ -2,10 +2,9 @@ import gleam/dict
 import gleam/int
 import gleam/list
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type AdditionalProperties, type SchemaRef, Forbidden, Inline, ObjectSchema,
-  Reference, Typed, Unspecified, Untyped,
+  Typed, Unspecified, Untyped,
 }
 
 /// Result of merging allOf sub-schemas.
@@ -32,10 +31,7 @@ pub fn merge_allof_schemas(
       additional_properties: Unspecified,
     ),
     fn(acc, s_ref, idx) {
-      let resolved = case s_ref {
-        Inline(obj) -> Ok(obj)
-        Reference(..) -> resolver.resolve_schema_ref(s_ref, context.spec(ctx))
-      }
+      let resolved = context.resolve_schema_ref(s_ref, ctx)
       case resolved {
         Ok(ObjectSchema(properties:, required:, additional_properties:, ..)) -> {
           let merged_ap = case

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -5,7 +5,6 @@ import oaspec/config
 import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/import_analysis
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{ParameterSchema, Value}
 import oaspec/internal/util/content_type as ct_util
@@ -110,7 +109,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       case p.payload {
         ParameterSchema(Inline(schema.ArraySchema(..))) -> True
         ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+          case context.resolve_schema_ref(sr, ctx) {
             Ok(schema.ArraySchema(..)) -> True
             _ -> False
           }
@@ -191,7 +190,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
           ..,
         ))) -> True
         ParameterSchema(Reference(..) as sr) ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+          case context.resolve_schema_ref(sr, ctx) {
             Ok(schema.IntegerSchema(..)) -> True
             Ok(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..)) ->
               True

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -7,7 +7,6 @@ import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/operation_ir
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/openapi/dedup
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{type Resolved, ParameterSchema, Value}
 import oaspec/internal/util/naming
@@ -147,10 +146,7 @@ pub fn build_param_list(
 /// Convert a parameter to its Gleam type string.
 fn param_to_type(param: spec.Parameter(Resolved), ctx: Context) -> String {
   let base =
-    schema_dispatch.resolve_param_type(
-      spec.parameter_schema(param),
-      context.spec(ctx),
-    )
+    schema_dispatch.resolve_param_type(spec.parameter_schema(param), ctx)
   case param.required {
     True -> base
     False -> "Option(" <> base <> ")"
@@ -165,7 +161,7 @@ pub fn param_to_string_expr(
 ) -> String {
   case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> {
-      let item_to_str = schema_dispatch.to_string_fn(items, context.spec(ctx))
+      let item_to_str = schema_dispatch.to_string_fn(items, ctx)
       "string.join(list.map("
       <> param_name
       <> ", "
@@ -175,10 +171,9 @@ pub fn param_to_string_expr(
     ParameterSchema(Inline(s)) -> schema_dispatch.to_string_expr(s, param_name)
     ParameterSchema(Reference(..) as schema_ref) -> {
       // Resolve the $ref to determine the actual schema type
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema.ArraySchema(items:, ..)) -> {
-          let item_to_str =
-            schema_dispatch.to_string_fn(items, context.spec(ctx))
+          let item_to_str = schema_dispatch.to_string_fn(items, ctx)
           "string.join(list.map("
           <> param_name
           <> ", "
@@ -186,11 +181,7 @@ pub fn param_to_string_expr(
           <> "), \",\")"
         }
         _ ->
-          schema_dispatch.schema_ref_to_string_expr(
-            schema_ref,
-            param_name,
-            context.spec(ctx),
-          )
+          schema_dispatch.schema_ref_to_string_expr(schema_ref, param_name, ctx)
       }
     }
     _ -> param_name
@@ -204,23 +195,17 @@ pub fn to_str_for_optional_value(
 ) -> String {
   case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> {
-      let item_to_str = schema_dispatch.to_string_fn(items, context.spec(ctx))
+      let item_to_str = schema_dispatch.to_string_fn(items, ctx)
       "string.join(list.map(v, " <> item_to_str <> "), \",\")"
     }
     ParameterSchema(Inline(s)) -> schema_dispatch.to_string_expr(s, "v")
     ParameterSchema(Reference(..) as schema_ref) -> {
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema.ArraySchema(items:, ..)) -> {
-          let item_to_str =
-            schema_dispatch.to_string_fn(items, context.spec(ctx))
+          let item_to_str = schema_dispatch.to_string_fn(items, ctx)
           "string.join(list.map(v, " <> item_to_str <> "), \",\")"
         }
-        _ ->
-          schema_dispatch.schema_ref_to_string_expr(
-            schema_ref,
-            "v",
-            context.spec(ctx),
-          )
+        _ -> schema_dispatch.schema_ref_to_string_expr(schema_ref, "v", ctx)
       }
     }
     _ -> "v"
@@ -298,7 +283,7 @@ pub fn generate_multipart_body(
           required,
         )
         Some(Reference(..) as schema_ref) ->
-          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+          case context.resolve_schema_ref(schema_ref, ctx) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
               #(ir_build.sorted_entries(properties), required)
             }
@@ -395,7 +380,7 @@ pub fn multipart_field_is_binary(
   case field_schema {
     Inline(schema.StringSchema(format: Some("binary"), ..)) -> True
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema.StringSchema(format: Some("binary"), ..)) -> True
         _ -> False
       }
@@ -407,7 +392,7 @@ fn multipart_field_to_string_fn(
   field_schema: schema.SchemaRef,
   ctx: Context,
 ) -> String {
-  let result = schema_dispatch.to_string_fn(field_schema, context.spec(ctx))
+  let result = schema_dispatch.to_string_fn(field_schema, ctx)
   // Return "" for identity functions since callers use "" to mean "no conversion"
   case result {
     "fn(x) { x }" -> ""
@@ -423,11 +408,7 @@ fn form_array_item_to_string(
 ) -> String {
   case field_schema {
     Inline(schema.ArraySchema(items:, ..)) ->
-      schema_dispatch.schema_ref_to_string_expr(
-        items,
-        "item",
-        context.spec(ctx),
-      )
+      schema_dispatch.schema_ref_to_string_expr(items, "item", ctx)
     _ -> "string.inspect(item)"
   }
 }
@@ -442,11 +423,7 @@ fn generate_form_nested_object(
   is_required: Bool,
   ctx: Context,
 ) -> se.StringBuilder {
-  let resolved = case field_schema {
-    Inline(s) -> Ok(s)
-    Reference(..) ->
-      resolver.resolve_schema_ref(field_schema, context.spec(ctx))
-  }
+  let resolved = context.resolve_schema_ref(field_schema, ctx)
   let sub_props = case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> #(
       ir_build.sorted_entries(properties),
@@ -485,7 +462,7 @@ fn generate_form_nested_object(
       let is_sub_object = case sub_ref {
         Inline(schema.ObjectSchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+          case context.resolve_schema_ref(sr, ctx) {
             Ok(schema.ObjectSchema(..)) -> True
             _ -> False
           }
@@ -581,11 +558,7 @@ fn generate_form_bracket_fields(
   parts_var: String,
   ctx: Context,
 ) -> se.StringBuilder {
-  let resolved = case field_schema {
-    Inline(s) -> Ok(s)
-    Reference(..) ->
-      resolver.resolve_schema_ref(field_schema, context.spec(ctx))
-  }
+  let resolved = context.resolve_schema_ref(field_schema, ctx)
   case resolved {
     Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
       let props = ir_build.sorted_entries(properties)
@@ -597,7 +570,7 @@ fn generate_form_bracket_fields(
         let is_obj = case prop_ref {
           Inline(schema.ObjectSchema(..)) -> True
           Reference(..) as sr ->
-            case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+            case context.resolve_schema_ref(sr, ctx) {
               Ok(schema.ObjectSchema(..)) -> True
               _ -> False
             }
@@ -689,7 +662,7 @@ pub fn generate_form_urlencoded_body(
           required,
         )
         Some(Reference(..) as schema_ref) ->
-          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+          case context.resolve_schema_ref(schema_ref, ctx) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
               #(ir_build.sorted_entries(properties), required)
             }
@@ -709,7 +682,7 @@ pub fn generate_form_urlencoded_body(
       let is_array = case field_schema {
         Inline(schema.ArraySchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+          case context.resolve_schema_ref(sr, ctx) {
             Ok(schema.ArraySchema(..)) -> True
             _ -> False
           }
@@ -718,7 +691,7 @@ pub fn generate_form_urlencoded_body(
       let is_object = case field_schema {
         Inline(schema.ObjectSchema(..)) -> True
         Reference(..) as sr ->
-          case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+          case context.resolve_schema_ref(sr, ctx) {
             Ok(schema.ObjectSchema(..)) -> True
             _ -> False
           }
@@ -841,7 +814,7 @@ pub fn is_exploded_array_param(
   let is_array = case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(..))) -> True
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+      case context.resolve_schema_ref(sr, ctx) {
         Ok(schema.ArraySchema(..)) -> True
         _ -> False
       }
@@ -863,7 +836,7 @@ pub fn is_delimited_array_param(
   let is_array = case param.payload {
     ParameterSchema(Inline(schema.ArraySchema(..))) -> True
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+      case context.resolve_schema_ref(sr, ctx) {
         Ok(schema.ArraySchema(..)) -> True
         _ -> False
       }
@@ -893,7 +866,7 @@ pub fn generate_delimited_array_query_param(
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
       array_item_to_string_fn(items, ctx)
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+      case context.resolve_schema_ref(sr, ctx) {
         Ok(schema.ArraySchema(items:, ..)) ->
           array_item_to_string_fn(items, ctx)
         _ -> "fn(x) { x }"
@@ -949,7 +922,7 @@ pub fn generate_exploded_array_query_param(
     ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
       array_item_to_string_fn(items, ctx)
     ParameterSchema(Reference(..) as sr) ->
-      case resolver.resolve_schema_ref(sr, context.spec(ctx)) {
+      case context.resolve_schema_ref(sr, ctx) {
         Ok(schema.ArraySchema(items:, ..)) ->
           array_item_to_string_fn(items, ctx)
         _ -> "fn(x) { x }"
@@ -993,5 +966,5 @@ pub fn is_deep_object_param(
 /// Return a function expression that converts an array item to String.
 /// Used in generated code: `list.map(param, <fn>)`.
 fn array_item_to_string_fn(items: schema.SchemaRef, ctx: Context) -> String {
-  schema_dispatch.to_string_fn(items, context.spec(ctx))
+  schema_dispatch.to_string_fn(items, ctx)
 }

--- a/src/oaspec/internal/codegen/context.gleam
+++ b/src/oaspec/internal/codegen/context.gleam
@@ -1,5 +1,13 @@
+import gleam/dict
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
 import oaspec/config.{type Config}
 import oaspec/internal/openapi/operations
+import oaspec/internal/openapi/resolver
+import oaspec/internal/openapi/schema.{
+  type SchemaMetadata, type SchemaObject, type SchemaRef, Inline, Reference,
+}
 import oaspec/internal/openapi/spec.{
   type HttpMethod, type OpenApiSpec, type Operation, type Resolved,
 }
@@ -13,6 +21,16 @@ pub const version = "0.40.0"
 pub type AnalyzedOperation =
   #(String, Operation(Resolved), String, HttpMethod)
 
+/// One analyzed component schema: the component name, its canonical local
+/// `$ref`, and the pre-resolved schema object (or the resolution error).
+pub type AnalyzedSchema {
+  AnalyzedSchema(
+    name: String,
+    ref: String,
+    resolved: Result(SchemaObject, resolver.ResolveError),
+  )
+}
+
 /// Context for code generation, carrying all needed state.
 /// Only accepts a resolved spec — codegen must not operate on unresolved ASTs.
 ///
@@ -25,16 +43,27 @@ pub opaque type Context {
     spec: OpenApiSpec(Resolved),
     config: Config,
     operations: List(AnalyzedOperation),
+    schema_cache: dict.Dict(String, Result(SchemaObject, resolver.ResolveError)),
+    analyzed_schemas: List(AnalyzedSchema),
   )
 }
 
 /// Create a new generation context from a resolved spec. The list of
 /// analyzed operations (with merged path-level params, effective security,
-/// effective servers, and synthesized operationIds) is computed once here
-/// so every codegen pass can read it via `operations/1` instead of
-/// rebuilding the same list at unrelated call sites (issue #371).
+/// effective servers, and synthesized operationIds) plus the component
+/// schema-resolution cache are computed once here so every codegen pass can
+/// read them via `operations/1` / `resolve_schema_ref/2` instead of
+/// rebuilding the same analysis at unrelated call sites (issue #371).
 pub fn new(spec: OpenApiSpec(Resolved), config: Config) -> Context {
-  Context(spec:, config:, operations: operations.collect_operations(spec))
+  let analyzed_schemas = collect_analyzed_schemas(spec)
+  let schema_cache = build_schema_cache(analyzed_schemas)
+  Context(
+    spec:,
+    config:,
+    operations: operations.collect_operations(spec),
+    schema_cache:,
+    analyzed_schemas:,
+  )
 }
 
 /// The resolved OpenAPI spec this context wraps.
@@ -52,6 +81,74 @@ pub fn config(ctx: Context) -> Config {
 /// `operations.collect_operations` directly.
 pub fn operations(ctx: Context) -> List(AnalyzedOperation) {
   ctx.operations
+}
+
+/// The analyzed component schemas, sorted by schema name. This is a
+/// debug-friendly inspectable view over the schema-resolution cache.
+pub fn analyzed_schemas(ctx: Context) -> List(AnalyzedSchema) {
+  ctx.analyzed_schemas
+}
+
+/// Resolve a schema ref through the shared analyzed cache.
+///
+/// Inline schemas are returned directly. Canonical component refs are served
+/// from the cache; anything else falls back to the resolver to preserve the
+/// original error shape for unexpected refs.
+pub fn resolve_schema_ref(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Result(SchemaObject, resolver.ResolveError) {
+  case schema_ref {
+    Inline(schema_obj) -> Ok(schema_obj)
+    Reference(ref:, ..) ->
+      case dict.get(ctx.schema_cache, ref) {
+        Ok(resolved) -> resolved
+        // nolint: thrown_away_error -- cache miss falls back to the resolver so non-canonical refs still get the right error/result
+        Error(_) -> resolver.resolve_schema_ref(schema_ref, ctx.spec)
+      }
+  }
+}
+
+/// Read metadata for any schema ref through the shared analyzed query layer.
+pub fn schema_metadata(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Option(SchemaMetadata) {
+  case resolve_schema_ref(schema_ref, ctx) {
+    Ok(schema_obj) -> Some(schema.get_metadata(schema_obj))
+    // nolint: thrown_away_error -- unresolved refs have no metadata; callers treat this as absence and the validator reports the underlying ref error separately
+    Error(_) -> None
+  }
+}
+
+fn collect_analyzed_schemas(spec: OpenApiSpec(Resolved)) -> List(AnalyzedSchema) {
+  case spec.components {
+    Some(components) ->
+      dict.to_list(components.schemas)
+      |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+      |> list.map(fn(entry) {
+        let #(name, _schema_ref) = entry
+        let ref = component_schema_ref(name)
+        AnalyzedSchema(
+          name: name,
+          ref: ref,
+          resolved: resolver.resolve_schema_ref(Reference(ref:, name:), spec),
+        )
+      })
+    None -> []
+  }
+}
+
+fn build_schema_cache(
+  analyzed_schemas: List(AnalyzedSchema),
+) -> dict.Dict(String, Result(SchemaObject, resolver.ResolveError)) {
+  list.fold(analyzed_schemas, dict.new(), fn(acc, entry) {
+    dict.insert(acc, entry.ref, entry.resolved)
+  })
+}
+
+fn component_schema_ref(name: String) -> String {
+  "#/components/schemas/" <> name
 }
 
 /// Target for a generated file, indicating where it should be written.

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -1330,14 +1330,9 @@ fn schema_ref_to_decoder(
 
 /// Check if a SchemaRef has nullable: true.
 fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(schema) -> schema.is_nullable(schema)
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
-        Ok(resolved_schema) -> schema.is_nullable(resolved_schema)
-        // nolint: thrown_away_error -- unresolved refs are treated as non-nullable here; the spec validator reports the ref error separately
-        Error(_) -> False
-      }
+  case context.schema_metadata(ref, ctx) {
+    Some(metadata) -> metadata.nullable
+    None -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -14,7 +14,6 @@ import oaspec/internal/codegen/context.{
 }
 import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/types as type_gen
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, ArraySchema, Inline,
   IntegerSchema, NumberSchema, ObjectSchema, Reference, StringSchema,
@@ -122,11 +121,7 @@ pub fn build_module(ctx: Context) -> GuardModule {
       case list.is_empty(guard_calls) {
         True -> False
         False -> {
-          let resolved = case schema_ref {
-            Inline(s) -> Ok(s)
-            Reference(..) ->
-              resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
-          }
+          let resolved = context.resolve_schema_ref(schema_ref, ctx)
           case resolved {
             Ok(ObjectSchema(..)) | Ok(AllOfSchema(..)) -> True
             _ -> False
@@ -267,7 +262,7 @@ fn collect_guard_functions_for_schema(
     Inline(schema) ->
       collect_guard_functions_for_schema_object(name, schema, ctx)
     Reference(name:, ..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema) ->
           collect_guard_functions_for_schema_object(name, schema, ctx)
         _ -> []
@@ -372,10 +367,7 @@ fn collect_field_guard_functions(
   prop_ref: SchemaRef,
   ctx: Context,
 ) -> List(GuardFunction) {
-  let resolved = case prop_ref {
-    Inline(schema) -> Ok(schema)
-    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
-  }
+  let resolved = context.resolve_schema_ref(prop_ref, ctx)
   case resolved {
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) ->
       list.flatten([
@@ -545,10 +537,7 @@ fn collect_schema_constraint_types_inner(
   ctx: Context,
   seen: Set(String),
 ) -> ConstraintTypes {
-  let schema = case schema_ref {
-    Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
-  }
+  let schema = context.resolve_schema_ref(schema_ref, ctx)
   case schema {
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
       let acc = case min_length, max_length {
@@ -1416,10 +1405,7 @@ fn composite_validator_type(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> String {
-  let schema = case schema_ref {
-    Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
-  }
+  let schema = context.resolve_schema_ref(schema_ref, ctx)
   case schema {
     Ok(ObjectSchema(..)) | Ok(AllOfSchema(..)) ->
       "types." <> naming.schema_to_type_name(name)
@@ -1441,10 +1427,7 @@ fn collect_guard_calls(
   schema_ref: SchemaRef,
   ctx: Context,
 ) -> List(GuardCall) {
-  let schema = case schema_ref {
-    Inline(s) -> Ok(s)
-    Reference(..) -> resolver.resolve_schema_ref(schema_ref, context.spec(ctx))
-  }
+  let schema = context.resolve_schema_ref(schema_ref, ctx)
   case schema {
     Ok(ObjectSchema(
       properties:,
@@ -1577,10 +1560,7 @@ fn collect_field_guard_calls(
   is_required: Bool,
   ctx: Context,
 ) -> List(GuardCall) {
-  let resolved = case prop_ref {
-    Inline(schema) -> Ok(schema)
-    Reference(..) -> resolver.resolve_schema_ref(prop_ref, context.spec(ctx))
-  }
+  let resolved = context.resolve_schema_ref(prop_ref, ctx)
   let accessor = "value." <> naming.to_snake_case(prop_name)
   case resolved {
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {

--- a/src/oaspec/internal/codegen/operation_ir.gleam
+++ b/src/oaspec/internal/codegen/operation_ir.gleam
@@ -1,6 +1,5 @@
 import gleam/option.{type Option, None, Some}
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema
 import oaspec/internal/openapi/spec
 
@@ -39,7 +38,7 @@ pub fn is_deep_object_param(
       Some(spec.DeepObjectStyle),
       Some(schema.Reference(..) as schema_ref)
     ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema.ObjectSchema(..)) -> True
         _ -> False
       }

--- a/src/oaspec/internal/codegen/schema_dispatch.gleam
+++ b/src/oaspec/internal/codegen/schema_dispatch.gleam
@@ -8,13 +8,12 @@
 /// Previously this logic was duplicated across types.gleam, decoders.gleam,
 /// client.gleam, and guards.gleam (14+ functions with the same dispatch).
 import gleam/option.{type Option, None, Some}
-import oaspec/internal/openapi/resolver
+import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   BooleanSchema, Inline, IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema,
   Reference, StringSchema,
 }
-import oaspec/internal/openapi/spec.{type OpenApiSpec, type Resolved}
 import oaspec/internal/util/naming
 
 /// Map a schema object to its Gleam type string (without nullable wrapping).
@@ -73,12 +72,12 @@ pub fn to_string_expr(schema: SchemaObject, value: String) -> String {
 pub fn schema_ref_to_string_expr(
   ref: SchemaRef,
   value: String,
-  spec: OpenApiSpec(Resolved),
+  ctx: Context,
 ) -> String {
   case ref {
     Inline(schema) -> to_string_expr(schema, value)
     Reference(name:, ..) -> {
-      case resolver.resolve_schema_ref(ref, spec) {
+      case context.resolve_schema_ref(ref, ctx) {
         Ok(StringSchema(enum_values:, ..)) if enum_values != [] ->
           "encode.encode_"
           <> naming.to_snake_case(name)
@@ -156,17 +155,17 @@ pub fn json_encoder_fn(ref: SchemaRef) -> String {
 }
 
 /// Map a schema ref to its to_string function reference (for list.map etc).
-pub fn to_string_fn(ref: SchemaRef, spec: OpenApiSpec(Resolved)) -> String {
+pub fn to_string_fn(ref: SchemaRef, ctx: Context) -> String {
   case ref {
     Inline(StringSchema(..)) -> "fn(x) { x }"
     Inline(IntegerSchema(..)) -> "int.to_string"
     Inline(NumberSchema(..)) -> "float.to_string"
     Inline(BooleanSchema(..)) -> "bool.to_string"
     Reference(name:, ..) -> {
-      case resolver.resolve_schema_ref(ref, spec) {
+      case context.resolve_schema_ref(ref, ctx) {
         Ok(StringSchema(enum_values:, ..)) if enum_values != [] ->
           "encode.encode_" <> naming.to_snake_case(name) <> "_to_string"
-        Ok(resolved) -> to_string_fn(Inline(resolved), spec)
+        Ok(resolved) -> to_string_fn(Inline(resolved), ctx)
         // nolint: thrown_away_error -- unresolved refs fall back to identity; the resolver reports the ref error separately
         Error(_) -> "fn(x) { x }"
       }
@@ -197,14 +196,11 @@ fn schema_kind(schema: SchemaObject) -> String {
 }
 
 /// Resolve a schema ref and return the base type (for parameter type resolution).
-pub fn resolve_param_type(
-  schema_ref: Option(SchemaRef),
-  spec: OpenApiSpec(Resolved),
-) -> String {
+pub fn resolve_param_type(schema_ref: Option(SchemaRef), ctx: Context) -> String {
   case schema_ref {
     Some(Inline(schema)) -> schema_base_type(schema)
     Some(Reference(name:, ..) as ref) -> {
-      case resolver.resolve_schema_ref(ref, spec) {
+      case context.resolve_schema_ref(ref, ctx) {
         Ok(ArraySchema(items:, ..)) -> "List(" <> schema_ref_type(items) <> ")"
         _ -> "types." <> naming.schema_to_type_name(name)
       }

--- a/src/oaspec/internal/codegen/schema_utils.gleam
+++ b/src/oaspec/internal/codegen/schema_utils.gleam
@@ -5,7 +5,6 @@ import gleam/dict
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, Forbidden, Inline,
   ObjectSchema, OneOfSchema, Reference, StringSchema, Typed, Untyped,
@@ -22,7 +21,7 @@ pub fn schema_has_additional_properties(
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_additional_properties(s, ctx) })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) ->
           schema_has_additional_properties(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having additionalProperties; the resolver reports the ref error separately
@@ -46,7 +45,7 @@ pub fn schema_has_forbidden_additional_properties(
         schema_has_forbidden_additional_properties(s, ctx)
       })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) ->
           schema_has_forbidden_additional_properties(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having forbidden additionalProperties; the resolver reports the ref error separately
@@ -78,7 +77,7 @@ pub fn schema_has_non_discriminator_oneof(
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_non_discriminator_oneof(s, ctx) })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) ->
           schema_has_non_discriminator_oneof(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having strict-oneOf needs; the resolver reports the ref error separately
@@ -100,7 +99,7 @@ pub fn schema_has_untyped_additional_properties(
         schema_has_untyped_additional_properties(s, ctx)
       })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) ->
           schema_has_untyped_additional_properties(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having untyped additionalProperties; the resolver reports the ref error separately
@@ -124,7 +123,7 @@ pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
     Inline(AllOfSchema(schemas:, ..)) ->
       list.any(schemas, fn(s) { schema_has_optional_fields(s, ctx) })
     Reference(..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) -> schema_has_optional_fields(Inline(schema_obj), ctx)
         // nolint: thrown_away_error -- unresolved refs are treated as not having optional fields; the resolver reports the ref error separately
         Error(_) -> False
@@ -159,40 +158,25 @@ pub fn constant_property_value(
 
 /// Check if a SchemaRef is nullable, resolving $ref if needed.
 pub fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(inline_schema) -> schema.is_nullable(inline_schema)
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
-        Ok(resolved) -> schema.is_nullable(resolved)
-        // nolint: thrown_away_error -- unresolved refs are treated as non-nullable; the resolver reports the ref error separately
-        Error(_) -> False
-      }
+  case context.schema_metadata(ref, ctx) {
+    Some(metadata) -> metadata.nullable
+    None -> False
   }
 }
 
 /// Check if a SchemaRef has readOnly metadata, resolving $ref if needed.
 pub fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(inline_schema) -> schema.get_metadata(inline_schema).read_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
-        Ok(resolved) -> schema.get_metadata(resolved).read_only
-        // nolint: thrown_away_error -- unresolved refs are treated as not read-only; the resolver reports the ref error separately
-        Error(_) -> False
-      }
+  case context.schema_metadata(ref, ctx) {
+    Some(metadata) -> metadata.read_only
+    None -> False
   }
 }
 
 /// Check if a SchemaRef has writeOnly metadata, resolving $ref if needed.
 pub fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
-  case ref {
-    Inline(inline_schema) -> schema.get_metadata(inline_schema).write_only
-    Reference(..) ->
-      case resolver.resolve_schema_ref(ref, context.spec(ctx)) {
-        Ok(resolved) -> schema.get_metadata(resolved).write_only
-        // nolint: thrown_away_error -- unresolved refs are treated as not write-only; the resolver reports the ref error separately
-        Error(_) -> False
-      }
+  case context.schema_metadata(ref, ctx) {
+    Some(metadata) -> metadata.write_only
+    None -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -6,7 +6,6 @@ import gleam/string
 import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/operation_ir
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type AdditionalProperties, type SchemaRef, Forbidden, Inline, ObjectSchema,
   Reference, Typed, Unspecified, Untyped,
@@ -66,7 +65,7 @@ pub fn body_field_kind(schema_ref: SchemaRef, ctx: Context) -> BodyFieldKind {
         _ -> BodyFieldUnknown
       }
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) -> body_field_kind_from_object(schema_obj, ctx)
         // nolint: thrown_away_error -- unresolved refs map to Unknown; the resolver reports the ref error separately
         Error(_) -> BodyFieldUnknown
@@ -308,7 +307,7 @@ pub fn schema_ref_string_enum(
 ) -> Option(#(String, List(String))) {
   case schema_ref {
     Reference(name: ref_name, ..) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema.StringSchema(enum_values: values, ..)) ->
           case values {
             [_, ..] -> Some(#(naming.schema_to_type_name(ref_name), values))
@@ -519,7 +518,7 @@ fn deep_object_properties(
 ) -> List(DeepObjectProperty) {
   let details = case spec.parameter_schema(param) {
     Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(ObjectSchema(properties:, required:, ..)) -> #(properties, required)
         _ -> #(dict.new(), [])
       }
@@ -656,7 +655,7 @@ pub fn deep_object_has_additional_properties(
 ) -> Bool {
   case spec.parameter_schema(param) {
     Some(Reference(..) as schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(ObjectSchema(additional_properties: schema.Typed(_), ..)) -> True
         Ok(ObjectSchema(additional_properties: schema.Untyped, ..)) -> True
         _ -> False
@@ -759,7 +758,7 @@ fn object_properties_from_schema_ref(
 ) -> List(DeepObjectProperty) {
   let details = case schema_ref {
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(ObjectSchema(properties:, required:, ..)) -> #(properties, required)
         _ -> #(dict.new(), [])
       }
@@ -814,7 +813,7 @@ fn schema_ref_resolves_to_object(schema_ref: SchemaRef, ctx: Context) -> Bool {
   case schema_ref {
     Inline(ObjectSchema(..)) -> True
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(ObjectSchema(..)) -> True
         _ -> False
       }
@@ -829,7 +828,7 @@ fn schema_ref_additional_properties(
   case schema_ref {
     Inline(ObjectSchema(additional_properties:, ..)) -> additional_properties
     Reference(..) as schema_ref ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(ObjectSchema(additional_properties:, ..)) -> additional_properties
         _ -> Forbidden
       }

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -5,7 +5,6 @@ import gleam/regexp
 import gleam/string
 import oaspec/config
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   BooleanSchema, Forbidden, Inline, IntegerSchema, NumberSchema, ObjectSchema,
@@ -658,7 +657,7 @@ fn resolve_schema_object(
   case schema_ref {
     Some(Inline(schema_obj)) -> Some(schema_obj)
     Some(schema_ref) ->
-      case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+      case context.resolve_schema_ref(schema_ref, ctx) {
         Ok(schema_obj) -> Some(schema_obj)
         // nolint: thrown_away_error -- unresolved refs surface as absent; the ref error is reported elsewhere in the validator
         Error(_) -> None
@@ -1191,7 +1190,7 @@ fn validate_schema_ref_recursive(
           },
         ]
         True ->
-          case resolver.resolve_schema_ref(schema_ref, context.spec(ctx)) {
+          case context.resolve_schema_ref(schema_ref, ctx) {
             Ok(_) -> []
             // nolint: thrown_away_error -- resolver error is replaced with a user-facing diagnostic that conveys the same failure
             Error(_) -> [

--- a/test/context_test.gleam
+++ b/test/context_test.gleam
@@ -3,6 +3,7 @@
 //// pass should consume — these tests pin down its shape and ensure it stays
 //// in sync with `operations.collect_operations` (issue #371).
 
+import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
@@ -10,6 +11,8 @@ import gleeunit
 import gleeunit/should
 import oaspec/internal/codegen/context
 import oaspec/internal/openapi/operations
+import oaspec/internal/openapi/resolver
+import oaspec/internal/openapi/schema
 import oaspec/internal/openapi/spec
 import test_helpers
 
@@ -18,6 +21,8 @@ pub fn main() {
 }
 
 const petstore = "test/fixtures/petstore.yaml"
+
+const readonly_writeonly = "test/fixtures/readonly_writeonly_properties.yaml"
 
 pub fn operations_matches_direct_collect_test() {
   let ctx = test_helpers.make_ctx(petstore)
@@ -88,4 +93,99 @@ pub fn operations_petstore_snapshot_test() {
     #("getPet", "get", "/pets/{petId}", 1, False, 0),
     #("deletePet", "delete", "/pets/{petId}", 1, False, 0),
   ])
+}
+
+pub fn analyzed_schemas_snapshot_test() {
+  let ctx = test_helpers.make_ctx(readonly_writeonly)
+  let snapshot =
+    context.analyzed_schemas(ctx)
+    |> list.map(fn(entry) {
+      #(entry.name, entry.ref, case entry.resolved {
+        Ok(schema.ObjectSchema(..)) -> "object"
+        Ok(schema.AllOfSchema(..)) -> "allOf"
+        Ok(schema.OneOfSchema(..)) -> "oneOf"
+        Ok(schema.AnyOfSchema(..)) -> "anyOf"
+        Ok(schema.ArraySchema(..)) -> "array"
+        Ok(schema.StringSchema(..)) -> "string"
+        Ok(schema.IntegerSchema(..)) -> "integer"
+        Ok(schema.NumberSchema(..)) -> "number"
+        Ok(schema.BooleanSchema(..)) -> "boolean"
+        Error(resolver.UnresolvedRef(..)) -> "unresolved"
+        Error(resolver.CircularRef(..)) -> "circular"
+      })
+    })
+
+  snapshot
+  |> should.equal([
+    #("AccountBase", "#/components/schemas/AccountBase", "object"),
+    #("AccountRead", "#/components/schemas/AccountRead", "allOf"),
+    #("AccountReadPart1", "#/components/schemas/AccountReadPart1", "object"),
+    #("AccountWrite", "#/components/schemas/AccountWrite", "allOf"),
+    #("AccountWritePart1", "#/components/schemas/AccountWritePart1", "object"),
+  ])
+}
+
+pub fn schema_cache_matches_direct_resolver_test() {
+  let ctx = test_helpers.make_ctx(readonly_writeonly)
+  let account_read_ref =
+    schema.make_reference("#/components/schemas/AccountRead")
+  context.resolve_schema_ref(account_read_ref, ctx)
+  |> should.equal(resolver.resolve_schema_ref(
+    account_read_ref,
+    context.spec(ctx),
+  ))
+}
+
+pub fn schema_metadata_exposes_nested_property_flags_test() {
+  let ctx = test_helpers.make_ctx(readonly_writeonly)
+  let account_read_ref =
+    schema.make_reference("#/components/schemas/AccountRead")
+  let account_write_ref =
+    schema.make_reference("#/components/schemas/AccountWrite")
+  let assert Some(id_ref) = find_property_ref(account_read_ref, "id", ctx)
+  let assert Some(password_ref) =
+    find_property_ref(account_write_ref, "password", ctx)
+  let assert Some(id_metadata) = context.schema_metadata(id_ref, ctx)
+  let assert Some(password_metadata) =
+    context.schema_metadata(password_ref, ctx)
+
+  id_metadata.read_only
+  |> should.be_true()
+  password_metadata.write_only
+  |> should.be_true()
+}
+
+fn find_property_ref(
+  schema_ref: schema.SchemaRef,
+  prop_name: String,
+  ctx: context.Context,
+) -> option.Option(schema.SchemaRef) {
+  case context.resolve_schema_ref(schema_ref, ctx) {
+    Ok(schema_obj) -> find_property_ref_in_object(schema_obj, prop_name, ctx)
+    // nolint: thrown_away_error -- test helper treats unresolved refs as absence while walking for a known property
+    Error(_) -> None
+  }
+}
+
+fn find_property_ref_in_object(
+  schema_obj: schema.SchemaObject,
+  prop_name: String,
+  ctx: context.Context,
+) -> option.Option(schema.SchemaRef) {
+  case schema_obj {
+    schema.ObjectSchema(properties:, ..) ->
+      case dict.get(properties, prop_name) {
+        Ok(prop_ref) -> Some(prop_ref)
+        // nolint: thrown_away_error -- missing property means keep searching other allOf branches
+        Error(_) -> None
+      }
+    schema.AllOfSchema(schemas:, ..) ->
+      list.fold(schemas, None, fn(found, part_ref) {
+        case found {
+          Some(_) -> found
+          None -> find_property_ref(part_ref, prop_name, ctx)
+        }
+      })
+    _ -> None
+  }
 }


### PR DESCRIPTION
## Summary

Finish issue #371 by moving repeated schema-resolution work onto the shared analyzed generation context. `Context` now precomputes an inspectable analyzed schema view plus a cached component-schema resolver, and downstream codegen / validation modules consume that shared query layer instead of resolving `$ref`s ad hoc.

## Changes

- add `context.analyzed_schemas/1`, `context.resolve_schema_ref/2`, and `context.schema_metadata/2`
- cache component schema resolution once in `Context` and expose the analyzed view for tests/debugging
- migrate `schema_dispatch`, `schema_utils`, `client_request`, `server_request_decode`, `guards`, `validate`, and related helpers onto the shared schema queries
- add context-level tests for analyzed schema snapshots, cached resolution parity, and nested property metadata flags
- update `CHANGELOG.md` and README test counts

## Design Decisions

- keep the new schema analysis on the existing opaque `Context` so downstream modules get the shared queries without a large public API rewrite
- cache canonical component refs once, but fall back to the resolver for non-canonical refs so unexpected error shapes stay intact

## Validation

- `gleam format --check src/ test/`
- `gleam check`
- `gleam run -m glinter -- --stats`
- `gleam build --warnings-as-errors`
- `gleam test`
- `shellspec`
- `bash integration_test/run.sh`
- `gleam run -m gleescript`
- `bash scripts/smoke_escript.sh ./oaspec`
- `just adapter-httpc`
- `just example-petstore`
- `just example-server-adapter`
- `cd examples/js_smoke && gleam deps download && gleam run`
- `bash scripts/check_readme_examples.sh`
- `bash scripts/check_sync.sh`

Closes #371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new context-level tests for analyzed schema snapshots and nested property metadata flags.
  * Increased test suite from 314 to 317 unit tests, improving code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->