### PR TITLE
fix(codegen): resolve $ref when checking nullability in encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 328 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 331 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 251 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -526,7 +526,8 @@ fn generate_object_decoder(
       let is_write_only = type_gen.schema_ref_is_write_only(prop_ref, ctx)
       let is_required = list.contains(required, prop_name) && !is_write_only
       let field_decoder = schema_ref_to_decoder(prop_ref, name, prop_name)
-      let is_nullable_schema = schema_ref_is_nullable(prop_ref, ctx)
+      let is_nullable_schema =
+        schema_utils.schema_ref_is_nullable(prop_ref, ctx)
 
       // For nullable schemas, the Gleam type is Option(T),
       // so the decoder must be decode.optional(inner_decoder).
@@ -1325,14 +1326,6 @@ fn schema_ref_to_decoder(
       "decode.list(" <> inner <> ")"
     }
     _ -> schema_dispatch.decoder_expr(ref)
-  }
-}
-
-/// Check if a SchemaRef has nullable: true.
-fn schema_ref_is_nullable(ref: SchemaRef, ctx: Context) -> Bool {
-  case context.schema_metadata(ref, ctx) {
-    Some(metadata) -> metadata.nullable
-    None -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -109,7 +109,7 @@ fn generate_encoders(
           |> list.any(fn(p) {
             let #(prop_name, prop_ref) = p
             !list.contains(required, prop_name)
-            && !schema_ref_is_nullable(prop_ref)
+            && !schema_utils.schema_ref_is_nullable(prop_ref, ctx)
           })
         _ -> False
       }
@@ -353,7 +353,7 @@ fn generate_encoder(
         list.any(props_with_names, fn(entry) {
           let #(prop_name, prop_ref, _) = entry
           !list.contains(required, prop_name)
-          && !schema_ref_is_nullable(prop_ref)
+          && !schema_utils.schema_ref_is_nullable(prop_ref, ctx)
         })
 
       let sb = case has_ap, has_omittable {
@@ -404,7 +404,7 @@ fn generate_encoder(
 
           // Issue #296: required+nullable properties have Gleam type
           // Option(T) and must use json.nullable, not the bare encoder.
-          let is_nullable = schema_ref_is_nullable(prop_ref)
+          let is_nullable = schema_utils.schema_ref_is_nullable(prop_ref, ctx)
           let is_omittable = !is_required && !is_nullable
           case has_omittable, is_required, is_nullable, is_omittable {
             // No optional-non-nullable in the schema → static list, current shape.
@@ -908,16 +908,6 @@ fn schema_ref_to_json_encoder_fn(
       "fn(items) { json.array(items, " <> inner <> ") }"
     }
     _ -> schema_dispatch.json_encoder_fn(ref)
-  }
-}
-
-/// Check if a SchemaRef is nullable (inline schemas only — references are
-/// assumed non-nullable here since the ref target's nullability is baked
-/// into the generated type elsewhere).
-fn schema_ref_is_nullable(ref: SchemaRef) -> Bool {
-  case ref {
-    Inline(inline_schema) -> schema.is_nullable(inline_schema)
-    Reference(..) -> False
   }
 }
 

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -1299,6 +1299,140 @@ components:
 }
 
 // ===================================================================
+// $ref + nullable encode/decode parity (issue #389)
+// ===================================================================
+
+/// A `$ref` property whose target schema has `nullable: true` must be
+/// treated as nullable on both sides: the decoder wraps the field in
+/// `decode.optional` and the encoder wraps the value in `json.nullable`.
+/// Issue #389: prior to the fix, the encoder helper returned `False` for
+/// any `Reference(..)` without resolving it, so the encoder emitted the
+/// bare encoder for a field whose Gleam type was already `Option(T)`.
+pub fn encoders_required_ref_to_nullable_uses_json_nullable_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    NullableInt:
+      type: integer
+      nullable: true
+    Wrapper:
+      type: object
+      required: [value]
+      properties:
+        value:
+          $ref: '#/components/schemas/NullableInt'
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { f.path == "encode.gleam" })
+
+  // Required + $ref-to-nullable must wrap with json.nullable, NOT call
+  // the bare encoder on a value that is actually Option(Int).
+  string.contains(
+    encode_file.content,
+    "json.nullable(value.value, encode_nullable_int_json)",
+  )
+  |> should.be_true()
+
+  // The buggy fallback would emit a bare encoder call instead.
+  string.contains(
+    encode_file.content,
+    "#(\"value\", encode_nullable_int_json(value.value))",
+  )
+  |> should.be_false()
+}
+
+/// Optional + `$ref` to nullable schema must use the omit-on-None list
+/// shape with `json.nullable` (None → wire null is permitted because the
+/// referenced schema is nullable).
+pub fn encoders_optional_ref_to_nullable_uses_json_nullable_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    NullableInt:
+      type: integer
+      nullable: true
+    Wrapper:
+      type: object
+      required: []
+      properties:
+        value:
+          $ref: '#/components/schemas/NullableInt'
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(files, fn(f) { f.path == "encode.gleam" })
+
+  // Optional + $ref-to-nullable: emit json.nullable wrapping (the entire
+  // property keeps wire-format null on None because the ref target
+  // declares `nullable: true`).
+  string.contains(
+    encode_file.content,
+    "json.nullable(value.value, encode_nullable_int_json)",
+  )
+  |> should.be_true()
+
+  // It must NOT fall into the optional+non-nullable case-omit shape.
+  string.contains(encode_file.content, "case value.value {")
+  |> should.be_false()
+}
+
+/// A `$ref` to a nullable schema must produce `decode.optional(...)` in
+/// the decoder so the decoded record holds `Option(T)` (matching the
+/// generated Gleam type for a nullable field).
+pub fn decoders_ref_to_nullable_uses_decode_optional_test() {
+  let assert Ok(spec) =
+    parser.parse_string(
+      "
+openapi: '3.0.3'
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    NullableInt:
+      type: integer
+      nullable: true
+    Wrapper:
+      type: object
+      required: [value]
+      properties:
+        value:
+          $ref: '#/components/schemas/NullableInt'
+",
+    )
+  let spec = hoist.hoist(spec)
+  let ctx = test_helpers.make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+  let assert Ok(decode_file) =
+    list.find(files, fn(f) { f.path == "decode.gleam" })
+
+  string.contains(decode_file.content, "decode.optional(")
+  |> should.be_true()
+}
+
+// ===================================================================
 // Enum query parameter codegen (issue #305)
 // ===================================================================
 


### PR DESCRIPTION
## Summary

Three private `schema_ref_is_nullable` helpers existed with different
semantics. The encoder copy returned `False` for any `Reference(..)`
without resolving it, while the decoder and `schema_utils` copies
properly resolved the ref through `context.schema_metadata`.

As a result, a property whose type is a `$ref` to a schema with
`nullable: true` was decoded as `Option(T)` but encoded by the bare
encoder (no `json.nullable` wrapping). On a record with `option.None`,
the encoder emitted the wrong shape or failed to compile.

## Changes

- Drop the private `schema_ref_is_nullable` in
  `src/oaspec/internal/codegen/encoders.gleam` and route the three call
  sites through the canonical
  `schema_utils.schema_ref_is_nullable(prop_ref, ctx)`.
- Drop the equivalent private helper in
  `src/oaspec/internal/codegen/decoders.gleam` (semantics already
  matched the canonical helper) and route the call site through
  `schema_utils` for consistency.
- Add three unit tests in `test/codegen_unit_test.gleam`:
  - required `$ref`-to-nullable emits `json.nullable(...)` (regression
    test for the bug);
  - optional `$ref`-to-nullable emits `json.nullable(...)` and does
    not fall into the optional+non-nullable case-omit shape;
  - decoder for `$ref`-to-nullable emits `decode.optional(...)`.

## Design Decisions

- The canonical helper already lives in `schema_utils` and is `pub`,
  so no new public API is introduced.
- No fixture file was added — the bug is reproducible with a tiny
  inline OpenAPI string, which keeps the regression contained next to
  related tests in `codegen_unit_test.gleam`.

Closes #389