### PR TITLE
docs(readme): correct generated files tree to use gen/<package>_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ gen/my_api/
   handlers_generated.gleam
   router.gleam
 
-gen_client/my_api/
+gen/my_api_client/
   types.gleam
   decode.gleam
   encode.gleam


### PR DESCRIPTION
## Summary

The README's `## Generated files` section illustrated the client output
as `gen_client/my_api/`, but the actual default is
`<output_dir>/<package>_client`, i.e. `./gen/my_api_client/`. That
matches the README's own configuration table and what
`src/oaspec/config.gleam` implements; the `gen_client/...` layout was
retired by #262.

## Changes

- Update the tree in `README.md` so the second block reads
  `gen/my_api_client/` instead of `gen_client/my_api/`.

Closes #393