### PR TITLE
docs(contributing): point at internal/ paths after the source layout move

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,9 @@ just check        # format check, typecheck, build, unit tests
 
 When changing how code is generated:
 
-1. Make your changes in `src/oaspec/codegen/`
+1. Make your changes in `src/oaspec/internal/codegen/` (the only module
+   directly under `src/oaspec/codegen/` is `writer.gleam`, which writes
+   files to disk; everything else lives under `internal/codegen/`)
 2. Run `just check` to verify the generator compiles
 3. Run `just shellspec` to verify generated file structure and content
 4. Run `just integration` to verify generated code compiles and works correctly
@@ -98,10 +100,13 @@ When changing how code is generated:
 
 When adding support for a new OpenAPI feature:
 
-1. Add types to `src/oaspec/openapi/spec.gleam` or `schema.gleam`
-2. Add parsing logic in `src/oaspec/openapi/parser.gleam`
-3. Add resolution logic in `src/oaspec/openapi/resolver.gleam` if needed
-4. Update code generation in the relevant `src/oaspec/codegen/` module
+1. Add types to `src/oaspec/internal/openapi/spec.gleam` or `schema.gleam`
+2. Add parsing logic in `src/oaspec/openapi/parser.gleam` (public surface)
+   or its internal helpers under `src/oaspec/internal/openapi/`
+3. Add resolution logic in `src/oaspec/internal/openapi/resolver.gleam`
+   if needed
+4. Update code generation in the relevant `src/oaspec/internal/codegen/`
+   module
 5. Add a test case to the petstore fixture (`test/fixtures/petstore.yaml`)
 6. Add unit tests, ShellSpec checks, and integration tests
 


### PR DESCRIPTION
## Summary

After #328 moved most modules under `src/oaspec/internal/`, the
*Modifying Code Generation* and *Adding OpenAPI Feature Support*
sections of `CONTRIBUTING.md` still pointed at `src/oaspec/codegen/`
and `src/oaspec/openapi/spec.gleam` / `schema.gleam` / `resolver.gleam`,
none of which actually hold those modules anymore. New contributors
following the guide were sent to the wrong directories.

## Changes

- *Modifying Code Generation*: send readers to
  `src/oaspec/internal/codegen/` and call out that `writer.gleam` is
  the only module remaining at `src/oaspec/codegen/`.
- *Adding OpenAPI Feature Support*: route type / parser / resolver /
  codegen steps to their current locations under
  `src/oaspec/internal/openapi/` and `src/oaspec/internal/codegen/`,
  while preserving the public surface (`src/oaspec/openapi/parser.gleam`)
  as the entry point for parsing logic.

Closes #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with clarified development guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->