### PR TITLE
docs(parser): align parse_file docstring with actual external $ref scope

### DIFF
--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -32,10 +32,13 @@ import yay
 
 /// Parse an OpenAPI spec from a file path.
 /// Supports both YAML (.yaml, .yml) and JSON (.json) files.
-/// After parsing, resolves relative-file `$ref` values in
-/// `components.schemas` by loading the referenced files from disk and
-/// merging their schemas. Nested or parameter/response external refs are
-/// left to downstream validation.
+/// After parsing, resolves relative-file `$ref` values across schemas,
+/// parameters, request bodies, responses, and path items — including
+/// nested object/array properties and composition branches — by loading
+/// the referenced files from disk and merging their definitions into the
+/// main spec. Cyclic external ref graphs (`A.yaml → B.yaml → A.yaml`)
+/// fail fast with a dedicated diagnostic. HTTP/HTTPS URLs are not
+/// followed.
 pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
   parse_file_with_progress(path, progress.noop())
 }


### PR DESCRIPTION
## Summary

The public `parse_file` docstring still claimed external refs were
resolved only inside `components.schemas` and that "Nested or
parameter/response external refs are left to downstream validation."
That description has been stale for some time — the loader in
`src/oaspec/internal/openapi/external_loader.gleam` now resolves refs
across schemas (including nested properties, array items,
`additionalProperties`, and composition branches), parameters, request
bodies, responses, and path items, with cycle detection — exactly the
scope the README advertises.

## Changes

- Rewrite the `parse_file` docstring in
  `src/oaspec/openapi/parser.gleam` to match the loader's actual
  behaviour (matching the README's wording) and call out cycle
  detection plus the HTTP/HTTPS-out-of-scope note.

Closes #432