### PR TITLE
docs(readme): document version subcommand and init --output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ includes the path it attempted to read.
 | `oaspec generate` | Generate Gleam code from an OpenAPI specification |
 | `oaspec validate` | Validate an OpenAPI specification without generating code |
 | `oaspec init` | Create a default `oaspec.yaml` config file |
+| `oaspec version` | Print the installed `oaspec` version (also available as `--version`) |
+
+### CLI options for `init`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output=<path>` | `./oaspec.yaml` | Output path for the generated config file |
 
 ### CLI options for `generate`
 


### PR DESCRIPTION
## Summary

`oaspec` registers four subcommands — `init`, `generate`, `validate`,
and `version` — and the `version` subcommand has been part of the CLI
help since #252, but the README's *CLI commands* table only listed the
first three. The README also did not document `oaspec init`'s
`--output` flag.

## Changes

- Add a `oaspec version` row to the *CLI commands* table, noting the
  `--version` alias.
- Add a *CLI options for `init`* table that covers `--output=<path>`
  with its default `./oaspec.yaml`.

Closes #406