### PR TITLE
docs(examples): replace ClientConfig with transport.Send + mock.from

### DIFF
--- a/examples/petstore_client/README.md
+++ b/examples/petstore_client/README.md
@@ -7,9 +7,11 @@ Petstore OpenAPI spec at `test/fixtures/petstore.yaml`.
 
 - Generating a client from an OpenAPI 3.x spec via `oaspec.yaml`.
 - Importing the generated client and response types.
-- Building a `ClientConfig` with a custom `send` function (here a stub
-  that returns a canned JSON body — swap in `gleam_httpc`, `mist`, or
-  `wisp` for real traffic).
+- Building a `transport.Send` value with `mock.from(...)` and a custom
+  request handler (here a stub that returns a canned JSON body — swap
+  in the [`oaspec_httpc`](../../adapters/httpc/) adapter for real
+  BEAM-side traffic, or the [`oaspec_fetch`](../../adapters/fetch/)
+  adapter for the JavaScript target).
 - Handling the typed response variants that oaspec generates for each
   operation.
 


### PR DESCRIPTION
## Summary

The petstore_client README's *What it shows* section talked about
"Building a `ClientConfig` with a custom `send` function" and pointed
at `gleam_httpc`, `mist`, and `wisp` as drop-in replacements. There is
no `ClientConfig` type in the codebase — the example program itself
uses `transport.Send` together with `mock.from(...)`, and `mist` /
`wisp` are server frameworks, not client transports.

## Changes

- Update the bullet in
  `examples/petstore_client/README.md` to describe the actual public
  API (`transport.Send`, `mock.from`) and link to the real client
  adapters (`oaspec_httpc` for BEAM, `oaspec_fetch` for JS) instead of
  unrelated server frameworks.

Closes #394