### PR TITLE
docs(cli): clarify --validate as one-way override that cannot disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ includes the path it attempted to read.
 | `--output=<path>` | - | Override output base directory |
 | `--check` | `false` | Check that generated code matches existing files without writing |
 | `--fail-on-warnings` | `false` | Treat warnings as errors |
-| `--validate` | `false` | Enable guard validation in generated server/client code |
+| `--validate` | `false` | Force-enable guard validation in generated server/client code. One-way override — passing this flag turns validation **on**, but it cannot turn it off. To disable validation when the config sets `validate: true` (the default for `server` / `both` modes), edit `validate: false` in `oaspec.yaml`. |
 
 ### CLI options for `validate`
 

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -105,7 +105,7 @@ fn generate_command() -> glint.Command(Nil) {
       glint.bool_flag("validate")
       |> glint.flag_default(False)
       |> glint.flag_help(
-        "Enable guard validation in generated server/client code",
+        "Force-enable guard validation in generated server/client code. One-way override: cannot disable validation set by oaspec.yaml. Set validate: false in the config to turn it off.",
       ),
     )
 


### PR DESCRIPTION
## Summary

The README's *CLI options for `generate`* table presented `--validate`
as a normal toggle (default `false`, "Enable guard validation"), and
the CLI's own `--help` output said the same. In reality the flag only
force-enables: passing `--validate=false` (or omitting it) does not
override `validate: true` from `oaspec.yaml`, which is the default
for `server` / `both` modes. Users hitting this rightly find it
surprising (Issue #409).

## Changes

- README *CLI options for `generate`* table: rewrite the `--validate`
  description to say it is a one-way override and point at the config
  file as the way to disable validation.
- `src/oaspec/internal/cli.gleam`: update the `glint.flag_help` string
  for `--validate` so `oaspec generate --help` matches the README.

## Design Decisions

- Picked option (b) from the issue (document the one-way semantics)
  rather than option (a) (make the flag a true override). Switching to
  a true override would change CLI behaviour and risks turning off
  validation for users who currently rely on the YAML setting alone;
  that should be a deliberate change, not bundled into a docs fix.

Closes #409