### PR TITLE
feat(config): accept nested package values like a/b/c

### DIFF
--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -568,6 +568,66 @@ EOF
 End
 
 # ===================================================================
+# Nested package paths (Issue #387)
+# ===================================================================
+
+Describe 'oaspec nested package'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_nested_pkg() {
+    rm -rf "$PROJECT_ROOT/test_nested_pkg"
+    cat > "$PROJECT_ROOT/test_nested_pkg.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+package: dco_check/github
+output:
+  dir: ./test_nested_pkg
+EOF
+    # Match `generate_petstore_once` in spec_helper.sh: silence both
+    # streams so the BeforeAll hook produces no output (shellspec
+    # treats stdout from BeforeAll as a hook error).
+    cd "$PROJECT_ROOT" && gleam run -- generate --config=./test_nested_pkg.yaml >/dev/null 2>&1
+  }
+
+  cleanup_nested_pkg() {
+    rm -rf "$PROJECT_ROOT/test_nested_pkg" "$PROJECT_ROOT/test_nested_pkg.yaml"
+  }
+
+  BeforeAll 'setup_nested_pkg'
+  AfterAll 'cleanup_nested_pkg'
+
+  # Server tree: <dir>/dco_check/github/...
+  It 'writes server files under <dir>/<a>/<b>'
+    The path "$PROJECT_ROOT/test_nested_pkg/dco_check/github/types.gleam" should be file
+    The path "$PROJECT_ROOT/test_nested_pkg/dco_check/github/router.gleam" should be file
+  End
+
+  # Client tree: <dir>/dco_check/github_client/... — `_client` suffix
+  # attaches to the LAST package segment only.
+  It 'writes client files under <dir>/<a>/<b>_client'
+    The path "$PROJECT_ROOT/test_nested_pkg/dco_check/github_client/types.gleam" should be file
+    The path "$PROJECT_ROOT/test_nested_pkg/dco_check/github_client/client.gleam" should be file
+  End
+
+  # Regression guard: the pre-#387 single-segment fallback
+  # `<dir>/dco_check_github` (slashes stripped) must NOT be written.
+  It 'does not write the slashes-stripped fallback path'
+    The path "$PROJECT_ROOT/test_nested_pkg/dco_check_github" should not be exist
+  End
+
+  # Generated code must import the full `<a>/<b>` module path so the
+  # Gleam compiler resolves it against `<dir>/<a>/<b>/...`. #387 was
+  # reported precisely because the validator rejected the layout that
+  # makes these imports compilable.
+  It 'client imports reference the nested package'
+    The contents of file "$PROJECT_ROOT/test_nested_pkg/dco_check/github_client/client.gleam" should include 'import dco_check/github/types'
+  End
+
+  It 'router imports reference the nested package'
+    The contents of file "$PROJECT_ROOT/test_nested_pkg/dco_check/github/router.gleam" should include 'import dco_check/github/handlers_generated'
+  End
+End
+
+# ===================================================================
 # generate --check tests
 # ===================================================================
 

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -430,12 +430,16 @@ fn misplaced_src_error(field: String, path: String) -> ConfigError {
 
 fn path_has_misplaced_src(path: String, package_segment_count: Int) -> Bool {
   let parent_segments = drop_last_n(path_segments(path), package_segment_count)
+  let earlier_parents = drop_last_n(parent_segments, 1)
   case list.last(parent_segments) {
     // 'src' is the immediate parent of the package's top-level
-    // directory — correct shape.
-    Ok("src") -> False
+    // directory. Still a foot-gun if `src` ALSO appears earlier in
+    // the parent chain (e.g. `./src/foo/src/<pkg>`), because Gleam
+    // resolves imports against the outermost `src/` and the inner
+    // copy ends up baked into the module path.
+    Ok("src") -> list.any(earlier_parents, fn(s) { s == "src" })
     // No parent segment, or some other parent: foot-gun iff 'src'
-    // appears anywhere earlier in the path.
+    // appears anywhere in the parent chain.
     _ -> list.any(parent_segments, fn(s) { s == "src" })
   }
 }

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -254,56 +254,119 @@ pub fn with_output(config: Config, output: Option(String)) -> Config {
 /// (the new default since Issue #248 — both server and client share the same
 /// `<dir>` and need distinct basenames). Anything else is a misconfigured
 /// package/output mismatch the user should be told about.
+///
+/// Nested packages (Issue #387): a `package` containing `/` such as
+/// `dco_check/github` declares an N-segment Gleam module path. The path
+/// tail compared against the package is N segments deep — the LAST N
+/// segments of the output path must equal the package's segments. The
+/// `_client` suffix attaches to the LAST package segment only, matching
+/// the single-segment behaviour (`dco_check/github` →
+/// `dco_check/github_client`, never `dco_check_client/github`).
 pub fn validate_output_package_match(config: Config) -> Result(Nil, ConfigError) {
-  case config.mode {
-    Server | Both ->
-      case basename(config.output_server) == config.package {
-        True -> Ok(Nil)
-        False ->
-          Error(InvalidValue(
-            field: "output.server",
-            detail: "Directory basename '"
-              <> basename(config.output_server)
-              <> "' must match package '"
-              <> config.package
-              <> "'",
-          ))
+  let pkg = package_segments(config.package)
+  case pkg {
+    // Empty package would make the rule vacuously true; bail out
+    // explicitly so a stray `package: ""` does not silently disable
+    // the validation.
+    [] -> Ok(Nil)
+    _ ->
+      case config.mode {
+        Server | Both ->
+          validate_path_tail_matches_package(
+            "output.server",
+            config.output_server,
+            pkg,
+            False,
+          )
+        Client -> Ok(Nil)
       }
-    Client -> Ok(Nil)
-  }
-  |> result.try(fn(_) {
-    case config.mode {
-      Client | Both -> {
-        let client_basename = basename(config.output_client)
-        let client_suffix = config.package <> "_client"
-        case
-          client_basename == config.package || client_basename == client_suffix
-        {
-          True -> Ok(Nil)
-          False ->
-            Error(InvalidValue(
-              field: "output.client",
-              detail: "Directory basename '"
-                <> client_basename
-                <> "' must match package '"
-                <> config.package
-                <> "' or '"
-                <> client_suffix
-                <> "'",
-            ))
+      |> result.try(fn(_) {
+        case config.mode {
+          Client | Both ->
+            validate_path_tail_matches_package(
+              "output.client",
+              config.output_client,
+              pkg,
+              True,
+            )
+          Server -> Ok(Nil)
         }
-      }
-      Server -> Ok(Nil)
-    }
-  })
+      })
+  }
 }
 
-/// Get the basename of a path (last segment after /).
-fn basename(path: String) -> String {
+fn validate_path_tail_matches_package(
+  field: String,
+  path: String,
+  pkg: List(String),
+  allow_client_suffix: Bool,
+) -> Result(Nil, ConfigError) {
+  let tail = last_n(path_segments(path), list.length(pkg))
+  let pkg_with_suffix = suffix_last_segment(pkg, "_client")
+  case tail == pkg, allow_client_suffix && tail == pkg_with_suffix {
+    True, _ | _, True -> Ok(Nil)
+    False, False ->
+      Error(
+        InvalidValue(field: field, detail: case allow_client_suffix {
+          True ->
+            "Output path tail '"
+            <> string.join(tail, "/")
+            <> "' must match package '"
+            <> string.join(pkg, "/")
+            <> "' or '"
+            <> string.join(pkg_with_suffix, "/")
+            <> "'"
+          False ->
+            "Output path tail '"
+            <> string.join(tail, "/")
+            <> "' must match package '"
+            <> string.join(pkg, "/")
+            <> "'"
+        }),
+      )
+  }
+}
+
+/// Split a package name into its slash-separated segments. Empty
+/// entries are dropped so trailing slashes and accidental double
+/// slashes are tolerated. `"api"` → `["api"]`,
+/// `"dco_check/github"` → `["dco_check", "github"]`.
+fn package_segments(package: String) -> List(String) {
+  package
+  |> string.split("/")
+  |> list.filter(fn(s) { s != "" })
+}
+
+/// Split a filesystem path into its segments, dropping `.` and empty
+/// entries so `./src/foo/`, `src/foo`, and `./src//foo` all yield
+/// `["src", "foo"]`.
+fn path_segments(path: String) -> List(String) {
   path
   |> string.split("/")
-  |> list.last
-  |> result.unwrap("")
+  |> list.filter(fn(s) { s != "" && s != "." })
+}
+
+/// Return the last `n` entries of `items`, preserving order. If
+/// `items` has fewer than `n` entries, returns `items` unchanged.
+fn last_n(items: List(a), n: Int) -> List(a) {
+  items |> list.reverse |> list.take(n) |> list.reverse
+}
+
+/// Drop the last `n` entries of `items`, preserving order. If
+/// `items` has fewer than `n` entries, returns `[]`.
+fn drop_last_n(items: List(a), n: Int) -> List(a) {
+  items |> list.reverse |> list.drop(n) |> list.reverse
+}
+
+/// Append `suffix` to the LAST segment of `segments`. Empty input
+/// stays empty. `["a","b"]` + `"_client"` → `["a","b_client"]`. Used
+/// to derive the client-output spelling for nested packages while
+/// keeping all but the leaf intact.
+fn suffix_last_segment(segments: List(String), suffix: String) -> List(String) {
+  case list.reverse(segments) {
+    [] -> []
+    [last, ..rest] -> list.reverse([last <> suffix, ..rest])
+  }
 }
 
 /// Validate the on-disk layout implied by `output.dir`.
@@ -315,31 +378,45 @@ fn basename(path: String) -> String {
 /// clear error instead of a wall of `Unknown module ...` from
 /// `gleam build`.
 ///
-/// Heuristic: in the path leading up to the package directory, `src`
-/// must either be the immediate parent of the package (the "<dir> is
-/// the project's src/" pattern) or be absent (the standalone-Gleam-
-/// project pattern). `src` in any other position is the foot-gun.
+/// Heuristic: in the path leading up to the package's top-level
+/// directory, `src` must either be the immediate parent (the "<dir>
+/// is the project's src/" pattern) or be absent (the standalone-
+/// Gleam-project pattern). `src` in any other position is the
+/// foot-gun.
+///
+/// Nested packages (Issue #387): for a package like `dco_check/github`
+/// the "package directory" is the last 2 path segments, and the rule
+/// applies to whatever sits BEFORE that pair. So `./src/dco_check/github`
+/// has parent chain `[src]` (immediate parent `src` → ok), and
+/// `./pkg/src/foo/dco_check/github` has parent chain
+/// `[pkg, src, foo]` (last is `foo` and `src` appears earlier → bad).
 pub fn validate_output_dir_layout(config: Config) -> Result(Nil, ConfigError) {
-  case config.mode {
-    Server | Both ->
-      case path_has_misplaced_src(config.output_server) {
-        False -> Ok(Nil)
-        True ->
-          Error(misplaced_src_error("output.server", config.output_server))
+  let segment_count = list.length(package_segments(config.package))
+  case segment_count {
+    // Empty package: nothing to peel; skip the layout rule entirely.
+    0 -> Ok(Nil)
+    _ ->
+      case config.mode {
+        Server | Both ->
+          case path_has_misplaced_src(config.output_server, segment_count) {
+            False -> Ok(Nil)
+            True ->
+              Error(misplaced_src_error("output.server", config.output_server))
+          }
+        Client -> Ok(Nil)
       }
-    Client -> Ok(Nil)
-  }
-  |> result.try(fn(_) {
-    case config.mode {
-      Client | Both ->
-        case path_has_misplaced_src(config.output_client) {
-          False -> Ok(Nil)
-          True ->
-            Error(misplaced_src_error("output.client", config.output_client))
+      |> result.try(fn(_) {
+        case config.mode {
+          Client | Both ->
+            case path_has_misplaced_src(config.output_client, segment_count) {
+              False -> Ok(Nil)
+              True ->
+                Error(misplaced_src_error("output.client", config.output_client))
+            }
+          Server -> Ok(Nil)
         }
-      Server -> Ok(Nil)
-    }
-  })
+      })
+  }
 }
 
 fn misplaced_src_error(field: String, path: String) -> ConfigError {
@@ -351,25 +428,15 @@ fn misplaced_src_error(field: String, path: String) -> ConfigError {
   )
 }
 
-fn path_has_misplaced_src(path: String) -> Bool {
-  let segments =
-    path
-    |> string.split("/")
-    |> list.filter(fn(s) { s != "" && s != "." })
-  case list.reverse(segments) {
-    // Strip the final segment (the package directory). Inspect what's
-    // left — the "directory chain" leading up to the package.
-    [_pkg, ..rest_reversed] -> {
-      let parent_segments = list.reverse(rest_reversed)
-      case list.last(parent_segments) {
-        // 'src' is the immediate parent of the package — correct shape.
-        Ok("src") -> False
-        // No parent segment, or some other parent: foot-gun iff 'src'
-        // appears anywhere earlier in the path.
-        _ -> list.any(parent_segments, fn(s) { s == "src" })
-      }
-    }
-    [] -> False
+fn path_has_misplaced_src(path: String, package_segment_count: Int) -> Bool {
+  let parent_segments = drop_last_n(path_segments(path), package_segment_count)
+  case list.last(parent_segments) {
+    // 'src' is the immediate parent of the package's top-level
+    // directory — correct shape.
+    Ok("src") -> False
+    // No parent segment, or some other parent: foot-gun iff 'src'
+    // appears anywhere earlier in the path.
+    _ -> list.any(parent_segments, fn(s) { s == "src" })
   }
 }
 

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -44,6 +44,13 @@ pub fn config_output_paths_test() {
   let _ = support.config_output_dir_deep_under_src_is_rejected_case()
   let _ =
     support.config_output_dir_client_only_under_src_subdir_is_rejected_case()
+  let _ = support.config_nested_package_dir_match_case()
+  let _ = support.config_nested_package_wrong_middle_segment_rejected_case()
+  let _ = support.config_nested_package_wrong_last_segment_rejected_case()
+  let _ = support.config_nested_package_client_no_suffix_accepted_case()
+  let _ = support.config_nested_package_layout_under_src_accepted_case()
+  let _ = support.config_nested_package_layout_under_src_subdir_rejected_case()
+  let _ = support.config_nested_package_layout_outside_src_accepted_case()
 }
 
 pub fn content_type_helpers_test() {

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -51,6 +51,10 @@ pub fn config_output_paths_test() {
   let _ = support.config_nested_package_layout_under_src_accepted_case()
   let _ = support.config_nested_package_layout_under_src_subdir_rejected_case()
   let _ = support.config_nested_package_layout_outside_src_accepted_case()
+  let _ = support.config_nested_package_three_segments_match_case()
+  let _ = support.config_nested_package_trailing_slash_match_case()
+  let _ =
+    support.config_output_dir_double_src_with_immediate_parent_rejected_case()
 }
 
 pub fn content_type_helpers_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -295,6 +295,109 @@ pub fn config_output_dir_client_only_under_src_subdir_is_rejected_case() {
   should.be_error(result)
 }
 
+// Issue #387: nested package paths. A `package` containing slashes is a
+// multi-segment Gleam module path; the layout validator must compare the
+// LAST N segments of the output path against the package's segments and
+// peel them off before applying the `src/` placement rule.
+
+pub fn config_nested_package_dir_match_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/dco_check/github",
+      output_client: "./gen/dco_check/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_package_match(cfg)
+  should.be_ok(result)
+}
+
+pub fn config_nested_package_wrong_middle_segment_rejected_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/wrong/github",
+      output_client: "./gen/wrong/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_package_match(cfg)
+  should.be_error(result)
+}
+
+pub fn config_nested_package_wrong_last_segment_rejected_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/dco_check/wrong",
+      output_client: "./gen/dco_check/wrong_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_package_match(cfg)
+  should.be_error(result)
+}
+
+pub fn config_nested_package_client_no_suffix_accepted_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/dco_check/github",
+      output_client: "./gen/dco_check/github",
+      package: "dco_check/github",
+      mode: config.Client,
+      validate: False,
+    )
+  let result = config.validate_output_package_match(cfg)
+  should.be_ok(result)
+}
+
+pub fn config_nested_package_layout_under_src_accepted_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/dco_check/github",
+      output_client: "./src/dco_check/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_ok(result)
+}
+
+pub fn config_nested_package_layout_under_src_subdir_rejected_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/foo/dco_check/github",
+      output_client: "./src/foo/dco_check/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_error(result)
+}
+
+pub fn config_nested_package_layout_outside_src_accepted_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/dco_check/github",
+      output_client: "./gen/dco_check/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_ok(result)
+}
+
 // --- Parser Tests ---
 
 pub fn parse_petstore_case() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -398,6 +398,58 @@ pub fn config_nested_package_layout_outside_src_accepted_case() {
   should.be_ok(result)
 }
 
+// Three-segment package path (`a/b/c`) — exercises the generalized
+// last_n / drop_last_n helpers beyond the two-segment happy path.
+pub fn config_nested_package_three_segments_match_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/dco_check/internal/github",
+      output_client: "./src/dco_check/internal/github_client",
+      package: "dco_check/internal/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let pkg_match = config.validate_output_package_match(cfg)
+  should.be_ok(pkg_match)
+  let layout = config.validate_output_dir_layout(cfg)
+  should.be_ok(layout)
+}
+
+// A trailing slash on `package` should be tolerated by `package_segments`.
+pub fn config_nested_package_trailing_slash_match_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./gen/dco_check/github",
+      output_client: "./gen/dco_check/github_client",
+      package: "dco_check/github/",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_package_match(cfg)
+  should.be_ok(result)
+}
+
+// Even when the immediate parent IS `src`, a second `src` earlier in
+// the chain is still a foot-gun: Gleam resolves imports against the
+// outermost `src/`, so the inner one ends up baked into the module
+// path. Pre-existing footgun in the validator surfaced by CodeRabbit
+// review on PR #443.
+pub fn config_output_dir_double_src_with_immediate_parent_rejected_case() {
+  let cfg =
+    config.new(
+      input: "openapi.yaml",
+      output_server: "./src/foo/src/dco_check/github",
+      output_client: "./src/foo/src/dco_check/github_client",
+      package: "dco_check/github",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = config.validate_output_dir_layout(cfg)
+  should.be_error(result)
+}
+
 // --- Parser Tests ---
 
 pub fn parse_petstore_case() {


### PR DESCRIPTION
## Summary

Accepts nested `package` values such as `dco_check/github` so users
can land generated code at a sub-package path inside an existing
Gleam project (Issue #387). The two validators that hard-coded a
single-segment package — `validate_output_package_match` and
`validate_output_dir_layout` — are rewritten in terms of the package
split on `/`.

The owner's reply on #387 split the design into two phases:

- **Phase 1 — nested `package` (this PR).** Lift the single-segment
  assumption out of the validators and document the new contract.
- **Phase 2 — multi-target / `targets:` array with `include:` filters
  (intentionally NOT this PR).** That is a larger surface (config
  schema change, multiple output trees per run) and tracked
  separately.

## Changes

- `src/oaspec/config.gleam`:
  - New private helpers `package_segments`, `path_segments`,
    `last_n`, `drop_last_n`, `suffix_last_segment`.
  - `validate_output_package_match` now compares the LAST N segments
    of each output path against the package's segments, where N is
    the number of slash-separated package segments. Client side
    additionally accepts the package with `_client` appended to the
    final segment only (so `dco_check/github` →
    `dco_check/github_client`, never `dco_check_client/github`).
  - `validate_output_dir_layout` peels off the last N segments
    (the package's directory tree) before applying the existing
    `src/`-must-be-immediate-parent rule.
  - The basename helper is gone; doc comments above the two
    validators spell out the new nested-package contract.
  - **Pre-existing foot-gun fixed (CodeRabbit review):**
    `path_has_misplaced_src` now also rejects paths where `src` is
    the immediate parent of the package directory **but another
    `src` appears earlier in the chain** (`./src/foo/src/<pkg>`),
    since Gleam resolves imports against the outermost `src/` and
    the inner copy ends up baked into the module path.

- `test/oaspec_support.gleam` + wiring in
  `test/oaspec_core_test.gleam`: ten new validator cases covering
  nested-package match success, wrong middle / wrong last segment,
  client `_client` suffix and no-suffix paths, the layout rule
  (`./src/a/b` accepted, `./src/foo/a/b` rejected, `./gen/a/b`
  accepted), a 3-segment package
  (`dco_check/internal/github`), a trailing-slash variant, and the
  double-`src` regression.

- `spec/generate_spec.sh`: new `Describe 'oaspec nested package'`
  block that runs `oaspec generate` against a temporary config with
  `package: dco_check/github` and asserts (a) server tree at
  `<dir>/dco_check/github/...`, (b) client tree at
  `<dir>/dco_check/github_client/...`, (c) no slashes-stripped
  `<dir>/dco_check_github` fallback exists, and (d) generated
  `import dco_check/github/...` lines reach the right module path.
  This replaces the manual end-to-end check originally noted in the
  PR description with an automated shellspec run.

## Design decisions

- **`_client` always attaches to the leaf segment.** This matches the
  single-segment behaviour and keeps the config diff minimal — no
  new keys, no breaking change. Users who want a different layout
  can still set `output.client` explicitly.
- **Empty package short-circuits to `Ok`.** A stray `package: ""`
  would otherwise make the rule vacuously true (zero-length tail
  always equals zero-length package). Bailing out explicitly keeps
  the behaviour deliberate; if we later want a stricter empty-package
  error it can be added without re-touching the segment logic.
- **No codegen / writer changes.** Both already handle slashes
  correctly (string concatenation propagates them, and
  `simplifile.create_directory_all` creates intermediate dirs).
  Verified end-to-end via the new shellspec block.

## Out of scope

The multi-target / `targets:` config feature sketched by the owner
in their reply on #387 is intentionally not included. It involves a
new top-level config shape (an array of targets each with
`package` / `output` / `include`) and substantial codegen plumbing
to scope a generation run to a tag/path filter — worth its own
issue and PR.

Closes #387