### PR TITLE
fix(codegen): make generated client code compile and decode for GitHub-shaped specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 336 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 251 test fixtures (including 98 OSS-derived edge-case specs)
+  and 252 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 336 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 252 test fixtures (including 98 OSS-derived edge-case specs)
+  and 253 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1905,4 +1905,70 @@ rm -rf "$CONST_DIR"
 
 info "Issue #309 constant-property integration tests passed."
 
+# -------------------------------------------------------
+# Step N: Issue #387 — GitHub-API-shaped client compiles
+# -------------------------------------------------------
+# Pinned subset of GitHub-style schema patterns that previously
+# produced uncompilable client code. Five distinct generator bugs
+# surfaced together when halostatue ran oaspec against a trimmed
+# GitHub OpenAPI document; each is now exercised by
+# `test/fixtures/issue_387_complex_response_shapes.yaml`. If a
+# future change re-breaks any of:
+#   - anyOf-of-primitives variant decoder names
+#   - inline string-enum + nullable type wrapping
+#   - nullable top-level array decoder/encoder Option wrapping
+#   - bare `Option(...)` use in decode.gleam / encode.gleam without
+#     a `type Option` import
+#   - response-headers variant arity in client.gleam
+# this step fails before the regression escapes to users.
+info "Testing complex response shapes spec (Issue #387 regression)..."
+
+COMPLEX_SHAPES_DIR="$SCRIPT_DIR/complex_shapes_test"
+rm -rf "$COMPLEX_SHAPES_DIR"
+mkdir -p "$COMPLEX_SHAPES_DIR/src"
+
+cat > "$COMPLEX_SHAPES_DIR/oaspec-complex-shapes.yaml" << 'YAML_EOF'
+input: test/fixtures/issue_387_complex_response_shapes.yaml
+output:
+  client: ./integration_test/complex_shapes_test/src/api
+package: api
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$COMPLEX_SHAPES_DIR/oaspec-complex-shapes.yaml" \
+  --mode=client
+
+cat > "$COMPLEX_SHAPES_DIR/gleam.toml" << 'TOML_EOF'
+name = "complex_shapes_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+TOML_EOF
+
+cat > "$COMPLEX_SHAPES_DIR/src/complex_shapes_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$COMPLEX_SHAPES_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors 2>&1; then
+  info "PASS: Issue #387 regression — generated client compiles cleanly."
+else
+  fail "Issue #387 regression — generated client failed to compile."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$COMPLEX_SHAPES_DIR"
+
+info "Issue #387 complex response shapes integration tests passed."
+
 info "All integration tests passed!"

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -628,6 +628,48 @@ EOF
 End
 
 # ===================================================================
+# Issue #387 — Reference-typed response header refused at codegen
+# ===================================================================
+#
+# The client extractor today supports inline String / Int / Float /
+# Bool response header schemas. A `$ref` header schema has no
+# extractor wired up; the generator must abort with a clear error
+# message rather than silently emit broken client code. This block
+# pins the failure mode so a future regression cannot quietly start
+# producing uncompilable output again.
+
+Describe 'oaspec response header schema'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_ref_header_config() {
+    rm -rf "$PROJECT_ROOT/test_ref_header"
+    mkdir -p "$PROJECT_ROOT/test_ref_header"
+    cat > "$PROJECT_ROOT/test_ref_header.yaml" <<EOF
+input: test/fixtures/issue_387_response_header_ref.yaml
+package: ref_header
+mode: client
+output:
+  dir: ./test_ref_header
+EOF
+  }
+
+  cleanup_ref_header_config() {
+    rm -rf "$PROJECT_ROOT/test_ref_header" "$PROJECT_ROOT/test_ref_header.yaml"
+  }
+
+  Before 'setup_ref_header_config'
+  After 'cleanup_ref_header_config'
+
+  It 'refuses to generate a client when a response header uses a $ref schema'
+    When run generate --config=./test_ref_header.yaml
+    The status should be failure
+    The output should include "Cannot generate client extractor for response header"
+    The output should include "X-Item-Kind"
+    The output should include "issue #387"
+  End
+End
+
+# ===================================================================
 # generate --check tests
 # ===================================================================
 

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -453,27 +453,20 @@ fn generate_client_function(
           let content_entries = ir_build.sorted_entries(response.content)
           // Issue #387: when the response declares headers, the
           // response variant constructor takes an extra typed headers
-          // record. Build the constructor expression here and thread
-          // it through to every variant-emitting branch so they pass
-          // both `decoded` and `headers` in the right order.
-          let headers_record_expr =
-            client_response.build_headers_record_expr(
-              op_id,
-              status_code,
-              response,
-            )
+          // record. Build the headers descriptor here and thread it
+          // through to every variant-emitting branch so each branch
+          // can emit the per-field extraction (let / use chain) and
+          // pass `decoded, headers` in the right order.
+          let headers_record =
+            client_response.build_headers_record(op_id, status_code, response)
           case content_entries {
-            [] -> {
-              let ok_call = case headers_record_expr {
-                Some(expr) -> " -> Ok(" <> variant_name <> "(" <> expr <> "))"
-                None -> " -> Ok(" <> variant_name <> ")"
-              }
-              sb
-              |> se.indent(
-                2,
-                http.status_code_to_int_pattern(status_code) <> ok_call,
+            [] ->
+              client_response.generate_empty_content_response(
+                sb,
+                status_code,
+                variant_name,
+                headers_record,
               )
-            }
             [#(single_ct, single_mt)] ->
               client_response.generate_single_content_response(
                 sb,
@@ -483,7 +476,7 @@ fn generate_client_function(
                 single_mt,
                 op_id,
                 ctx,
-                headers_record_expr,
+                headers_record,
               )
             multiple ->
               client_response.generate_multi_content_response(
@@ -493,7 +486,7 @@ fn generate_client_function(
                 multiple,
                 op_id,
                 ctx,
-                headers_record_expr,
+                headers_record,
               )
           }
         }

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -451,16 +451,29 @@ fn generate_client_function(
             <> "Response"
             <> http.status_code_suffix(status_code)
           let content_entries = ir_build.sorted_entries(response.content)
+          // Issue #387: when the response declares headers, the
+          // response variant constructor takes an extra typed headers
+          // record. Build the constructor expression here and thread
+          // it through to every variant-emitting branch so they pass
+          // both `decoded` and `headers` in the right order.
+          let headers_record_expr =
+            client_response.build_headers_record_expr(
+              op_id,
+              status_code,
+              response,
+            )
           case content_entries {
-            [] ->
+            [] -> {
+              let ok_call = case headers_record_expr {
+                Some(expr) -> " -> Ok(" <> variant_name <> "(" <> expr <> "))"
+                None -> " -> Ok(" <> variant_name <> ")"
+              }
               sb
               |> se.indent(
                 2,
-                http.status_code_to_int_pattern(status_code)
-                  <> " -> Ok("
-                  <> variant_name
-                  <> ")",
+                http.status_code_to_int_pattern(status_code) <> ok_call,
               )
+            }
             [#(single_ct, single_mt)] ->
               client_response.generate_single_content_response(
                 sb,
@@ -470,6 +483,7 @@ fn generate_client_function(
                 single_mt,
                 op_id,
                 ctx,
+                headers_record_expr,
               )
             multiple ->
               client_response.generate_multi_content_response(
@@ -479,6 +493,7 @@ fn generate_client_function(
                 multiple,
                 op_id,
                 ctx,
+                headers_record_expr,
               )
           }
         }

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -54,7 +54,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
         _ -> False
       }
     })
-  let needs_float =
+  let needs_float_param =
     list.any(all_params, fn(p) {
       case p.payload {
         ParameterSchema(Inline(schema.NumberSchema(..))) -> True
@@ -226,8 +226,49 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
     || has_optional_response_headers
     || any_operation_has_no_server(ctx)
 
+  // Issue #387: typed response headers (`type: integer`, `type: number`)
+  // are extracted via `int.parse` / `float.parse`, so we must import
+  // those modules whenever any operation declares such a header.
+  let has_int_response_header =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.headers), fn(h_entry) {
+              let #(_, header) = h_entry
+              case header.schema {
+                Some(Inline(schema.IntegerSchema(..))) -> True
+                _ -> False
+              }
+            })
+          _ -> False
+        }
+      })
+    })
+  let has_float_response_header =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.headers), fn(h_entry) {
+              let #(_, header) = h_entry
+              case header.schema {
+                Some(Inline(schema.NumberSchema(..))) -> True
+                _ -> False
+              }
+            })
+          _ -> False
+        }
+      })
+    })
+
   let needs_int =
-    list.any(all_params, fn(p) {
+    has_int_response_header
+    || list.any(all_params, fn(p) {
       case p.payload {
         ParameterSchema(Inline(schema.IntegerSchema(..))) -> True
         ParameterSchema(Inline(schema.ArraySchema(
@@ -244,6 +285,8 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
         _ -> False
       }
     })
+
+  let needs_float = needs_float_param || has_float_response_header
 
   let needs_bytes_helper =
     list.any(operations, fn(op) {

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -99,9 +99,43 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       }
     })
 
+  // Issue #387: when any response declares `headers:`, the client
+  // assembles a typed headers record by calling `list.key_find` on
+  // `resp.headers`. That makes `gleam/list` mandatory and (for any
+  // optional header field) brings `Some`/`None` into the body of the
+  // function. Track both signals here so the import builder picks up
+  // the right shapes.
+  let has_response_headers =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) -> dict.size(response.headers) > 0
+          _ -> False
+        }
+      })
+    })
+  let has_optional_response_headers =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(dict.to_list(operation.responses), fn(entry) {
+        let #(_, ref_or) = entry
+        case ref_or {
+          Value(response) ->
+            list.any(dict.to_list(response.headers), fn(h_entry) {
+              let #(_, header) = h_entry
+              !header.required
+            })
+          _ -> False
+        }
+      })
+    })
+
   let needs_list =
     has_form_urlencoded
     || has_multi_content_response
+    || has_response_headers
     || list.any(all_params, fn(p) { p.in_ == spec.InQuery })
     || list.any(all_params, fn(p) { p.in_ == spec.InCookie })
     || list.any(all_params, fn(p) { p.in_ == spec.InHeader })
@@ -175,11 +209,22 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
 
   let needs_typed_schemas =
     import_analysis.operations_need_typed_schemas(operations)
+  // `needs_option_type` represents the bare `Option(...)` type
+  // appearing in client function SIGNATURES. Optional response
+  // headers do not surface in signatures (only as `Some`/`None`
+  // constructors inside function bodies), so they are not added
+  // here — Issue #387.
   let needs_option_type =
     import_analysis.operations_have_optional_params(operations)
     || import_analysis.operations_have_optional_body(operations)
-  let needs_some_ctor = needs_option_type || any_operation_has_server(ctx)
-  let needs_none_ctor = needs_option_type || any_operation_has_no_server(ctx)
+  let needs_some_ctor =
+    needs_option_type
+    || has_optional_response_headers
+    || any_operation_has_server(ctx)
+  let needs_none_ctor =
+    needs_option_type
+    || has_optional_response_headers
+    || any_operation_has_no_server(ctx)
 
   let needs_int =
     list.any(all_params, fn(p) {

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -3,12 +3,30 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/openapi/schema.{Inline, Reference}
+import oaspec/internal/openapi/schema.{
+  type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema, Inline,
+  IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema, Reference,
+  StringSchema,
+}
 import oaspec/internal/openapi/spec.{type Resolved}
 import oaspec/internal/util/content_type
 import oaspec/internal/util/http
 import oaspec/internal/util/naming
 import oaspec/internal/util/string_extra as se
+
+/// Issue #387: assembled response-headers record. Tracks both the
+/// pre-statements (let bindings or `use` chains that extract each
+/// header field from `resp.headers`) and the final constructor
+/// expression that references those bound names.
+///
+/// Required headers and parse-required typed headers (Int / Float /
+/// Bool) emit `use ... <- result.try(...)` so a missing or
+/// unparseable header short-circuits with
+/// `Error(InvalidResponse(detail: ...))`. Optional headers emit a
+/// plain `let`, defaulting to `None` when the lookup or parse fails.
+pub type HeadersRecord {
+  HeadersRecord(pre_statements: List(String), record_expr: String)
+}
 
 /// Generate response handling for a single content type. Emits a branch
 /// of the `case resp.status { ... }` ladder inside a generated
@@ -26,51 +44,25 @@ pub fn generate_single_content_response(
   media_type: spec.MediaType,
   op_id: String,
   ctx: Context,
-  headers_record_expr: Option(String),
+  headers: Option(HeadersRecord),
 ) -> se.StringBuilder {
   case content_type.from_string(media_type_name) {
     content_type.ApplicationOctetStream ->
       case media_type.schema {
         Some(_) ->
-          sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code) <> " -> {",
-          )
-          |> se.indent(3, "use bytes <- result.try(bytes_body(resp.body))")
-          |> se.indent(
-            3,
-            "Ok("
-              <> variant_name
-              <> "("
-              <> append_headers_arg("bytes", headers_record_expr)
-              <> "))",
-          )
-          |> se.indent(2, "}")
-        _ ->
-          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
+          body_branch(sb, status_code, variant_name, "bytes", headers, fn(sb) {
+            se.indent(sb, 3, "use bytes <- result.try(bytes_body(resp.body))")
+          })
+        _ -> empty_body_branch(sb, status_code, variant_name, headers)
       }
 
     content_type.TextPlain | content_type.ApplicationXml | content_type.TextXml ->
       case media_type.schema {
         Some(_) ->
-          sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code) <> " -> {",
-          )
-          |> se.indent(3, "use text <- result.try(text_body(resp.body))")
-          |> se.indent(
-            3,
-            "Ok("
-              <> variant_name
-              <> "("
-              <> append_headers_arg("text", headers_record_expr)
-              <> "))",
-          )
-          |> se.indent(2, "}")
-        _ ->
-          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
+          body_branch(sb, status_code, variant_name, "text", headers, fn(sb) {
+            se.indent(sb, 3, "use text <- result.try(text_body(resp.body))")
+          })
+        _ -> empty_body_branch(sb, status_code, variant_name, headers)
       }
 
     _ ->
@@ -78,19 +70,22 @@ pub fn generate_single_content_response(
         Some(schema_ref) -> {
           let decode_expr =
             get_response_decode_expr(schema_ref, op_id, status_code, ctx)
+          let sb =
+            sb
+            |> se.indent(
+              2,
+              http.status_code_to_int_pattern(status_code) <> " -> {",
+            )
+            |> se.indent(3, "use text <- result.try(text_body(resp.body))")
+            |> emit_pre_statements(headers)
           sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code) <> " -> {",
-          )
-          |> se.indent(3, "use text <- result.try(text_body(resp.body))")
           |> se.indent(3, "case " <> decode_expr <> " {")
           |> se.indent(
             4,
             "Ok(decoded) -> Ok("
               <> variant_name
               <> "("
-              <> append_headers_arg("decoded", headers_record_expr)
+              <> append_headers_arg("decoded", headers)
               <> "))",
           )
           |> se.indent(
@@ -100,38 +95,120 @@ pub fn generate_single_content_response(
           |> se.indent(3, "}")
           |> se.indent(2, "}")
         }
-        _ ->
-          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
+        _ -> empty_body_branch(sb, status_code, variant_name, headers)
       }
   }
 }
 
+/// Common branch shape for content branches that extract a body
+/// value (`text` / `bytes`) directly into the variant constructor
+/// without an intervening decoder. The `extract_body` callback emits
+/// the `use <body> <- ...` line; the rest is reused across binary
+/// and text/xml branches.
+fn body_branch(
+  sb: se.StringBuilder,
+  status_code: http.HttpStatusCode,
+  variant_name: String,
+  body_arg: String,
+  headers: Option(HeadersRecord),
+  extract_body: fn(se.StringBuilder) -> se.StringBuilder,
+) -> se.StringBuilder {
+  sb
+  |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
+  |> extract_body
+  |> emit_pre_statements(headers)
+  |> se.indent(
+    3,
+    "Ok("
+      <> variant_name
+      <> "("
+      <> append_headers_arg(body_arg, headers)
+      <> "))",
+  )
+  |> se.indent(2, "}")
+}
+
 /// Issue #387: shared empty-body branch for status entries that have
 /// no schema (e.g. 204 No Content) but may still carry a typed
-/// headers record.
+/// headers record. Emits a single-line `<status> -> Ok(...)` when the
+/// headers record has no pre-statements, or a multi-line block when
+/// any required header forces a `use` chain.
 fn empty_body_branch(
   sb: se.StringBuilder,
   status_code: http.HttpStatusCode,
   variant_name: String,
-  headers_record_expr: Option(String),
+  headers: Option(HeadersRecord),
 ) -> se.StringBuilder {
-  let ok_call = case headers_record_expr {
-    Some(expr) -> " -> Ok(" <> variant_name <> "(" <> expr <> "))"
-    None -> " -> Ok(" <> variant_name <> ")"
+  case headers {
+    Some(HeadersRecord(pre_statements: [_, ..], record_expr: expr)) ->
+      sb
+      |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
+      |> emit_pre_statements(headers)
+      |> se.indent(3, "Ok(" <> variant_name <> "(" <> expr <> "))")
+      |> se.indent(2, "}")
+    Some(HeadersRecord(record_expr: expr, ..)) ->
+      sb
+      |> se.indent(
+        2,
+        http.status_code_to_int_pattern(status_code)
+          <> " -> Ok("
+          <> variant_name
+          <> "("
+          <> expr
+          <> "))",
+      )
+    None ->
+      sb
+      |> se.indent(
+        2,
+        http.status_code_to_int_pattern(status_code)
+          <> " -> Ok("
+          <> variant_name
+          <> ")",
+      )
   }
-  sb
-  |> se.indent(2, http.status_code_to_int_pattern(status_code) <> ok_call)
+}
+
+/// Emit each header pre-statement at the appropriate indentation
+/// level (3, inside the per-status block). No-op when the response
+/// declares no headers.
+fn emit_pre_statements(
+  sb: se.StringBuilder,
+  headers: Option(HeadersRecord),
+) -> se.StringBuilder {
+  case headers {
+    Some(HeadersRecord(pre_statements: stmts, ..)) ->
+      list.fold(stmts, sb, fn(acc, line) { se.indent(acc, 3, line) })
+    None -> sb
+  }
 }
 
 /// Issue #387: when a response declares headers, the variant
 /// constructor takes the body value followed by the typed headers
 /// record. This helper appends the headers expression to a body
 /// argument so callers do not need to know whether headers exist.
-fn append_headers_arg(body_arg: String, headers: Option(String)) -> String {
+fn append_headers_arg(
+  body_arg: String,
+  headers: Option(HeadersRecord),
+) -> String {
   case headers {
-    Some(expr) -> body_arg <> ", " <> expr
+    Some(HeadersRecord(record_expr: expr, ..)) -> body_arg <> ", " <> expr
     None -> body_arg
   }
+}
+
+/// Generate the per-status branch for responses that declare no
+/// `content` entries (e.g. 204 No Content, or anywhere the spec uses
+/// just `description:` and optional `headers:`). When typed headers
+/// are present this still emits the headers extraction; otherwise
+/// it collapses to a single `<status> -> Ok(<Variant>)` line.
+pub fn generate_empty_content_response(
+  sb: se.StringBuilder,
+  status_code: http.HttpStatusCode,
+  variant_name: String,
+  headers: Option(HeadersRecord),
+) -> se.StringBuilder {
+  empty_body_branch(sb, status_code, variant_name, headers)
 }
 
 /// Generate response handling for multiple content types. Multi-content
@@ -144,53 +221,37 @@ pub fn generate_multi_content_response(
   _content_entries: List(#(String, spec.MediaType)),
   _op_id: String,
   _ctx: Context,
-  headers_record_expr: Option(String),
+  headers: Option(HeadersRecord),
 ) -> se.StringBuilder {
-  sb
-  |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
-  |> se.indent(3, "use text <- result.try(text_body(resp.body))")
-  |> se.indent(
-    3,
-    "Ok("
-      <> variant_name
-      <> "("
-      <> append_headers_arg("text", headers_record_expr)
-      <> "))",
-  )
-  |> se.indent(2, "}")
+  body_branch(sb, status_code, variant_name, "text", headers, fn(sb) {
+    se.indent(sb, 3, "use text <- result.try(text_body(resp.body))")
+  })
 }
 
-/// Issue #387: build the typed-headers-record constructor expression
-/// for a response, or `None` if the response declares no headers.
+/// Issue #387: build the typed-headers record for a response, or
+/// `None` if the response declares no headers. Returns a
+/// `HeadersRecord` carrying both the per-field extraction
+/// pre-statements and the final constructor expression that
+/// references the bound names.
 ///
-/// The emitted expression references `resp.headers` (a
-/// `List(#(String, String))` from `oaspec/transport`) and constructs
-/// the `<Op>Response<Status>Headers` record using whatever fields
-/// the spec declares. HTTP header names are looked up case-
-/// insensitively by lowercasing the spec-declared name; that matches
-/// what `gleam/list.key_find` is given to compare against.
+/// Header type plumbing (no longer scoped down to "String only"):
+///   - Optional + String → `let <fn> = list.key_find(...) |> result.map(Some) |> result.unwrap(None)`
+///   - Required + String → `use <fn> <- result.try(list.key_find(...) |> result.map_error(...))`
+///   - Optional + Int / Float → same as String, plus `result.try(int.parse)` / `result.try(float.parse)`
+///   - Required + Int / Float → use chain that errors on missing OR unparseable values
+///   - Optional + Bool   → case match for "true" / "false" (anything else → None)
+///   - Required + Bool   → case match wrapped in `use ... <- result.try(...)`
 ///
-/// Field-type handling (current scope):
-///   - optional headers (`required: false` or omitted) →
-///     `list.key_find(...) |> result.map(Some) |> result.unwrap(None)`,
-///     producing `Option(String)`.
-///   - required headers (`required: true`) →
-///     `result.unwrap(list.key_find(...), "")`, producing `String`
-///     with an empty-string fallback when the upstream server omits
-///     the header. The server is in violation of its own contract in
-///     that case; treating it as "" is safer than panicking inside a
-///     generated client.
-///
-/// Typed headers beyond String (Int / Float / Bool / `$ref` schemas)
-/// would require parsers or component decoders here. Real specs
-/// rarely declare typed response headers, so the minimal fix lets
-/// the typical case (String / Option(String)) compile and reach the
-/// caller; broader typing is left to a follow-up.
-pub fn build_headers_record_expr(
+/// `$ref`-typed response headers (`schema: $ref: ...`) and complex
+/// inline shapes (Object / Array / allOf / oneOf / anyOf) are
+/// rejected at generation time with a clear `panic` so the user
+/// sees the gap explicitly rather than getting a cryptic compile
+/// error in the generated module.
+pub fn build_headers_record(
   op_id: String,
   status_code: http.HttpStatusCode,
   response: spec.Response(Resolved),
-) -> Option(String) {
+) -> Option(HeadersRecord) {
   let headers =
     response.headers
     |> dict.to_list
@@ -208,18 +269,153 @@ pub fn build_headers_record_expr(
         list.map(headers, fn(entry) {
           let #(header_name, header) = entry
           let field_name = naming.to_snake_case(header_name)
-          let lookup = header_lookup_expr(header_name)
-          // `header.required` is the OAS-required flag; `False` (the
-          // OAS default) maps to `Option(_)` in the generated record.
-          let value_expr = case header.required {
-            False -> lookup <> " |> result.map(Some) |> result.unwrap(None)"
-            True -> "result.unwrap(" <> lookup <> ", \"\")"
-          }
-          field_name <> ": " <> value_expr
+          let pre_statement =
+            header_field_extraction(field_name, header_name, header)
+          #(field_name, pre_statement)
         })
-      Some(record_name <> "(" <> string.join(fields, ", ") <> ")")
+      let pre_statements = list.map(fields, fn(p) { p.1 })
+      let assignments = list.map(fields, fn(p) { p.0 <> ": " <> p.0 })
+      Some(HeadersRecord(
+        pre_statements: pre_statements,
+        record_expr: record_name <> "(" <> string.join(assignments, ", ") <> ")",
+      ))
     }
   }
+}
+
+/// Classification of a response header's schema, restricted to
+/// shapes the client extractor can produce code for. Anything
+/// outside this set falls back to a codegen-time panic via
+/// `header_field_extraction`.
+type HeaderFieldType {
+  StringHeader
+  IntHeader
+  FloatHeader
+  BoolHeader
+}
+
+fn classify_header_schema(
+  schema_opt: Option(SchemaRef),
+  header_name: String,
+) -> HeaderFieldType {
+  case schema_opt {
+    None -> StringHeader
+    Some(Inline(StringSchema(..))) -> StringHeader
+    Some(Inline(IntegerSchema(..))) -> IntHeader
+    Some(Inline(NumberSchema(..))) -> FloatHeader
+    Some(Inline(BooleanSchema(..))) -> BoolHeader
+    Some(Reference(name:, ..)) ->
+      panic as response_header_unsupported(
+          header_name,
+          "$ref to component schema '" <> name <> "'",
+        )
+    Some(Inline(ObjectSchema(..))) ->
+      panic as response_header_unsupported(header_name, "inline object schema")
+    Some(Inline(ArraySchema(..))) ->
+      panic as response_header_unsupported(header_name, "inline array schema")
+    Some(Inline(AllOfSchema(..))) ->
+      panic as response_header_unsupported(header_name, "allOf composition")
+    Some(Inline(OneOfSchema(..))) ->
+      panic as response_header_unsupported(header_name, "oneOf composition")
+    Some(Inline(AnyOfSchema(..))) ->
+      panic as response_header_unsupported(header_name, "anyOf composition")
+  }
+}
+
+fn response_header_unsupported(header_name: String, kind: String) -> String {
+  "Cannot generate client extractor for response header '"
+  <> header_name
+  <> "' (unsupported schema: "
+  <> kind
+  <> "). Supported shapes today are inline String / Int / Float / Bool. "
+  <> "File a follow-up to oaspec issue #387 if you need typed extraction "
+  <> "for this header."
+}
+
+fn header_field_extraction(
+  field_name: String,
+  header_name: String,
+  header: spec.Header,
+) -> String {
+  let lookup = header_lookup_expr(header_name)
+  let kind = classify_header_schema(header.schema, header_name)
+  case header.required, kind {
+    False, StringHeader ->
+      "let "
+      <> field_name
+      <> " = "
+      <> lookup
+      <> " |> result.map(Some) |> result.unwrap(None)"
+    True, StringHeader ->
+      "use "
+      <> field_name
+      <> " <- result.try("
+      <> lookup
+      <> " |> result.map_error(fn(_) { "
+      <> missing_required_error(header_name, "string")
+      <> " }))"
+    False, IntHeader ->
+      "let "
+      <> field_name
+      <> " = "
+      <> lookup
+      <> " |> result.try(int.parse) |> result.map(Some) |> result.unwrap(None)"
+    True, IntHeader ->
+      "use "
+      <> field_name
+      <> " <- result.try("
+      <> lookup
+      <> " |> result.try(int.parse) |> result.map_error(fn(_) { "
+      <> missing_required_error(header_name, "integer")
+      <> " }))"
+    False, FloatHeader ->
+      "let "
+      <> field_name
+      <> " = "
+      <> lookup
+      <> " |> result.try(float.parse) |> result.map(Some) |> result.unwrap(None)"
+    True, FloatHeader ->
+      "use "
+      <> field_name
+      <> " <- result.try("
+      <> lookup
+      <> " |> result.try(float.parse) |> result.map_error(fn(_) { "
+      <> missing_required_error(header_name, "number")
+      <> " }))"
+    False, BoolHeader ->
+      "let "
+      <> field_name
+      <> " = case "
+      <> lookup
+      <> " { Ok(\"true\") -> Some(True) Ok(\"false\") -> Some(False) _ -> None }"
+    True, BoolHeader ->
+      "use "
+      <> field_name
+      <> " <- result.try(case "
+      <> lookup
+      <> " { Ok(\"true\") -> Ok(True) Ok(\"false\") -> Ok(False) _ -> Error("
+      <> missing_required_error_inner(header_name, "boolean")
+      <> ") })"
+  }
+}
+
+fn missing_required_error(header_name: String, kind: String) -> String {
+  "InvalidResponse(detail: \"missing or invalid required "
+  <> kind
+  <> " header: "
+  <> header_name
+  <> "\")"
+}
+
+fn missing_required_error_inner(header_name: String, kind: String) -> String {
+  // Same payload as `missing_required_error/2` but built without the
+  // outer `fn(_) { ... }` wrapper, used inside an inline
+  // `case ... { ... -> Error(...) }` branch.
+  "InvalidResponse(detail: \"missing or invalid required "
+  <> kind
+  <> " header: "
+  <> header_name
+  <> "\")"
 }
 
 fn header_lookup_expr(header_name: String) -> String {

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -1,7 +1,10 @@
-import gleam/option.{Some}
+import gleam/dict
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
 import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/openapi/schema.{Inline, Reference}
-import oaspec/internal/openapi/spec
+import oaspec/internal/openapi/spec.{type Resolved}
 import oaspec/internal/util/content_type
 import oaspec/internal/util/http
 import oaspec/internal/util/naming
@@ -23,6 +26,7 @@ pub fn generate_single_content_response(
   media_type: spec.MediaType,
   op_id: String,
   ctx: Context,
+  headers_record_expr: Option(String),
 ) -> se.StringBuilder {
   case content_type.from_string(media_type_name) {
     content_type.ApplicationOctetStream ->
@@ -34,17 +38,17 @@ pub fn generate_single_content_response(
             http.status_code_to_int_pattern(status_code) <> " -> {",
           )
           |> se.indent(3, "use bytes <- result.try(bytes_body(resp.body))")
-          |> se.indent(3, "Ok(" <> variant_name <> "(bytes))")
+          |> se.indent(
+            3,
+            "Ok("
+              <> variant_name
+              <> "("
+              <> append_headers_arg("bytes", headers_record_expr)
+              <> "))",
+          )
           |> se.indent(2, "}")
         _ ->
-          sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code)
-              <> " -> Ok("
-              <> variant_name
-              <> ")",
-          )
+          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
       }
 
     content_type.TextPlain | content_type.ApplicationXml | content_type.TextXml ->
@@ -56,17 +60,17 @@ pub fn generate_single_content_response(
             http.status_code_to_int_pattern(status_code) <> " -> {",
           )
           |> se.indent(3, "use text <- result.try(text_body(resp.body))")
-          |> se.indent(3, "Ok(" <> variant_name <> "(text))")
+          |> se.indent(
+            3,
+            "Ok("
+              <> variant_name
+              <> "("
+              <> append_headers_arg("text", headers_record_expr)
+              <> "))",
+          )
           |> se.indent(2, "}")
         _ ->
-          sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code)
-              <> " -> Ok("
-              <> variant_name
-              <> ")",
-          )
+          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
       }
 
     _ ->
@@ -81,7 +85,14 @@ pub fn generate_single_content_response(
           )
           |> se.indent(3, "use text <- result.try(text_body(resp.body))")
           |> se.indent(3, "case " <> decode_expr <> " {")
-          |> se.indent(4, "Ok(decoded) -> Ok(" <> variant_name <> "(decoded))")
+          |> se.indent(
+            4,
+            "Ok(decoded) -> Ok("
+              <> variant_name
+              <> "("
+              <> append_headers_arg("decoded", headers_record_expr)
+              <> "))",
+          )
           |> se.indent(
             4,
             "Error(_) -> Error(DecodeFailure(detail: \"Failed to decode response body\"))",
@@ -90,15 +101,36 @@ pub fn generate_single_content_response(
           |> se.indent(2, "}")
         }
         _ ->
-          sb
-          |> se.indent(
-            2,
-            http.status_code_to_int_pattern(status_code)
-              <> " -> Ok("
-              <> variant_name
-              <> ")",
-          )
+          empty_body_branch(sb, status_code, variant_name, headers_record_expr)
       }
+  }
+}
+
+/// Issue #387: shared empty-body branch for status entries that have
+/// no schema (e.g. 204 No Content) but may still carry a typed
+/// headers record.
+fn empty_body_branch(
+  sb: se.StringBuilder,
+  status_code: http.HttpStatusCode,
+  variant_name: String,
+  headers_record_expr: Option(String),
+) -> se.StringBuilder {
+  let ok_call = case headers_record_expr {
+    Some(expr) -> " -> Ok(" <> variant_name <> "(" <> expr <> "))"
+    None -> " -> Ok(" <> variant_name <> ")"
+  }
+  sb
+  |> se.indent(2, http.status_code_to_int_pattern(status_code) <> ok_call)
+}
+
+/// Issue #387: when a response declares headers, the variant
+/// constructor takes the body value followed by the typed headers
+/// record. This helper appends the headers expression to a body
+/// argument so callers do not need to know whether headers exist.
+fn append_headers_arg(body_arg: String, headers: Option(String)) -> String {
+  case headers {
+    Some(expr) -> body_arg <> ", " <> expr
+    None -> body_arg
   }
 }
 
@@ -112,12 +144,89 @@ pub fn generate_multi_content_response(
   _content_entries: List(#(String, spec.MediaType)),
   _op_id: String,
   _ctx: Context,
+  headers_record_expr: Option(String),
 ) -> se.StringBuilder {
   sb
   |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
   |> se.indent(3, "use text <- result.try(text_body(resp.body))")
-  |> se.indent(3, "Ok(" <> variant_name <> "(text))")
+  |> se.indent(
+    3,
+    "Ok("
+      <> variant_name
+      <> "("
+      <> append_headers_arg("text", headers_record_expr)
+      <> "))",
+  )
   |> se.indent(2, "}")
+}
+
+/// Issue #387: build the typed-headers-record constructor expression
+/// for a response, or `None` if the response declares no headers.
+///
+/// The emitted expression references `resp.headers` (a
+/// `List(#(String, String))` from `oaspec/transport`) and constructs
+/// the `<Op>Response<Status>Headers` record using whatever fields
+/// the spec declares. HTTP header names are looked up case-
+/// insensitively by lowercasing the spec-declared name; that matches
+/// what `gleam/list.key_find` is given to compare against.
+///
+/// Field-type handling (current scope):
+///   - optional headers (`required: false` or omitted) →
+///     `list.key_find(...) |> result.map(Some) |> result.unwrap(None)`,
+///     producing `Option(String)`.
+///   - required headers (`required: true`) →
+///     `result.unwrap(list.key_find(...), "")`, producing `String`
+///     with an empty-string fallback when the upstream server omits
+///     the header. The server is in violation of its own contract in
+///     that case; treating it as "" is safer than panicking inside a
+///     generated client.
+///
+/// Typed headers beyond String (Int / Float / Bool / `$ref` schemas)
+/// would require parsers or component decoders here. Real specs
+/// rarely declare typed response headers, so the minimal fix lets
+/// the typical case (String / Option(String)) compile and reach the
+/// caller; broader typing is left to a follow-up.
+pub fn build_headers_record_expr(
+  op_id: String,
+  status_code: http.HttpStatusCode,
+  response: spec.Response(Resolved),
+) -> Option(String) {
+  let headers =
+    response.headers
+    |> dict.to_list
+    |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+  case headers {
+    [] -> None
+    _ -> {
+      let record_name =
+        "response_types."
+        <> naming.schema_to_type_name(op_id)
+        <> "Response"
+        <> http.status_code_suffix(status_code)
+        <> "Headers"
+      let fields =
+        list.map(headers, fn(entry) {
+          let #(header_name, header) = entry
+          let field_name = naming.to_snake_case(header_name)
+          let lookup = header_lookup_expr(header_name)
+          // `header.required` is the OAS-required flag; `False` (the
+          // OAS default) maps to `Option(_)` in the generated record.
+          let value_expr = case header.required {
+            False -> lookup <> " |> result.map(Some) |> result.unwrap(None)"
+            True -> "result.unwrap(" <> lookup <> ", \"\")"
+          }
+          field_name <> ": " <> value_expr
+        })
+      Some(record_name <> "(" <> string.join(fields, ", ") <> ")")
+    }
+  }
+}
+
+fn header_lookup_expr(header_name: String) -> String {
+  // HTTP headers are case-insensitive on the wire; normalise to
+  // lowercase so the lookup works regardless of how the upstream
+  // server cased the name.
+  "list.key_find(resp.headers, \"" <> string.lowercase(header_name) <> "\")"
 }
 
 /// Decoder expression for a response body. The emitted expression

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -129,9 +129,22 @@ fn generate_decoders(
       ])
     False -> base_imports
   }
-  let imports = case needs_option {
-    True -> list.append(base_imports, ["gleam/option"])
-    False -> base_imports
+  // Issue #387: when any top-level component schema is a `nullable: true`
+  // primitive or array (or anyOf/oneOf hoists one), the generated decoder
+  // emits a bare `decode.Decoder(Option(<inner>))` type expression. The
+  // bare `Option` only resolves if `type Option` is brought into scope
+  // explicitly, so include the type in that case. For specs that only
+  // use `Option` indirectly (e.g. via `decode.optional`), the plain
+  // `gleam/option` import is enough.
+  let needs_bare_option_type =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      schema_ref_has_bare_option_decoder_type(schema_ref)
+    })
+  let imports = case needs_option, needs_bare_option_type {
+    True, True -> list.append(base_imports, ["gleam/option.{type Option}"])
+    True, False -> list.append(base_imports, ["gleam/option"])
+    False, _ -> base_imports
   }
 
   let sb =
@@ -483,8 +496,16 @@ fn generate_decoder(
       )
     }
 
-    Inline(ArraySchema(items:, ..)) ->
-      generate_array_decoder(sb, name, fn_name, decoder_fn_name, items, ctx)
+    Inline(ArraySchema(metadata:, items:, ..)) ->
+      generate_array_decoder(
+        sb,
+        name,
+        fn_name,
+        decoder_fn_name,
+        items,
+        metadata.nullable,
+        ctx,
+      )
 
     _ -> sb
   }
@@ -848,14 +869,17 @@ fn generate_anyof_decoder(
 ) -> se.StringBuilder {
   let sb = maybe_doc_comment(sb, description)
 
-  // Generate field decoders that try each variant
+  // Generate field decoders that try each variant. The decoder
+  // function for a top-level component schema named `Foo` is emitted
+  // as `foo_decoder()`; the previous `decode_<snake>_decoder` form
+  // referenced a function that never exists and broke compilation
+  // for every anyOf union that survives hoisting (Issue #387).
   let variant_fields =
     list.map(schemas, fn(s_ref) {
       case s_ref {
         Reference(name: ref_name, ..) -> {
           let field_name = naming.to_snake_case(ref_name)
-          let decoder_name =
-            "decode_" <> naming.to_snake_case(ref_name) <> "_decoder"
+          let decoder_name = naming.to_snake_case(ref_name) <> "_decoder"
           #(field_name, decoder_name, ref_name)
         }
         Inline(_) -> #("unknown", "decode.string", "Unknown")
@@ -949,18 +973,34 @@ fn generate_primitive_decoder(
   |> se.blank_line()
 }
 
-/// Generate decoder for an ArraySchema.
+/// Generate decoder for an ArraySchema. Issue #387: when the array
+/// schema itself carries `nullable: true`, the type generator wraps
+/// the resulting type alias in `Option(List(T))` (via
+/// `schema_dispatch.schema_type`), so the decoder must wrap its
+/// `decode.list(...)` body in `decode.optional(...)` to match.
+/// Otherwise the emitted variant decoder returns
+/// `Decoder(List(T))` while every caller treats it as
+/// `Decoder(Option(List(T)))`.
 fn generate_array_decoder(
   sb: se.StringBuilder,
   name: String,
   fn_name: String,
   decoder_fn_name: String,
   items: SchemaRef,
+  nullable: Bool,
   ctx: Context,
 ) -> se.StringBuilder {
   let inner_decoder = schema_ref_to_decoder(items, name, "")
   let inner_type = qualified_schema_ref_type(items, ctx)
-  let gleam_type = "List(" <> inner_type <> ")"
+  let list_type = "List(" <> inner_type <> ")"
+  let list_decoder = "decode.list(" <> inner_decoder <> ")"
+  let #(gleam_type, decoder_expr) = case nullable {
+    True -> #(
+      "Option(" <> list_type <> ")",
+      "decode.optional(" <> list_decoder <> ")",
+    )
+    False -> #(list_type, list_decoder)
+  }
   sb
   |> se.line(
     "pub fn "
@@ -969,7 +1009,7 @@ fn generate_array_decoder(
     <> gleam_type
     <> ") {",
   )
-  |> se.indent(1, "decode.list(" <> inner_decoder <> ")")
+  |> se.indent(1, decoder_expr)
   |> se.line("}")
   |> se.blank_line()
   |> se.line(
@@ -1343,6 +1383,25 @@ fn qualified_schema_ref_type(ref: SchemaRef, ctx: Context) -> String {
   case ref {
     Inline(schema) -> type_gen.schema_to_gleam_type(schema, ctx)
     _ -> schema_dispatch.schema_ref_qualified_type(ref)
+  }
+}
+
+/// Issue #387: True when the top-level decoder for this schema would
+/// emit a bare `decode.Decoder(Option(...))` annotation. That happens
+/// only for primitive / array component schemas with `nullable: true`,
+/// since those produce a top-level type alias wrapped in `Option(...)`
+/// and the matching decoder declares the same type. Object / allOf /
+/// oneOf / anyOf / enum schemas wrap any optionality through
+/// `decode.optional(...)` inside `decode.field`, so the bare `Option`
+/// type never appears in their decoder bodies.
+fn schema_ref_has_bare_option_decoder_type(ref: SchemaRef) -> Bool {
+  case ref {
+    Inline(StringSchema(metadata:, enum_values: [], ..)) -> metadata.nullable
+    Inline(IntegerSchema(metadata:, ..)) -> metadata.nullable
+    Inline(NumberSchema(metadata:, ..)) -> metadata.nullable
+    Inline(BooleanSchema(metadata:)) -> metadata.nullable
+    Inline(ArraySchema(metadata:, ..)) -> metadata.nullable
+    _ -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -126,11 +126,25 @@ fn generate_encoders(
     True, False -> ["gleam/dict", "gleam/json", "gleam/list"]
     _, _ -> ["gleam/json"]
   }
+  // Issue #387: a top-level encoder for a `nullable: true` primitive
+  // or array schema is generated with a bare `Option(...)` parameter
+  // type. Bringing `type Option` into scope is only needed in that
+  // case; the more common record-encoder path that uses
+  // `option.None`/`option.Some` is fine with just `gleam/option`.
+  let needs_bare_option_type =
+    list.any(schemas, fn(entry) {
+      let #(_, schema_ref) = entry
+      schema_ref_has_bare_option_encoder_type(schema_ref)
+    })
+  let option_import_line = case needs_bare_option_type {
+    True -> "gleam/option.{type Option}"
+    False -> "gleam/option"
+  }
   let base_imports = case needs_option_and_list {
     True ->
       base_imports
       |> ensure_import("gleam/list")
-      |> ensure_import("gleam/option")
+      |> ensure_import(option_import_line)
     False -> base_imports
   }
   let imports = case needs_types {
@@ -819,16 +833,28 @@ fn generate_encoder(
       )
     }
 
-    Inline(ArraySchema(items:, ..)) -> {
+    Inline(ArraySchema(metadata:, items:, ..)) -> {
+      // Issue #387: a top-level nullable array schema gets its type
+      // alias rendered as `Option(List(T))`, so the encoder must accept
+      // `Option(List(T))` and use `json.nullable(value, ...)` instead
+      // of the bare `json.array(...)` it had been emitting.
       let inner_type = qualified_schema_ref_type(items, ctx)
-      let gleam_type = "List(" <> inner_type <> ")"
+      let list_type = "List(" <> inner_type <> ")"
       let inner_encoder = schema_ref_to_json_encoder_fn(items, name, "")
+      let array_expr = "json.array(value, " <> inner_encoder <> ")"
+      let #(gleam_type, json_expr) = case metadata.nullable {
+        True -> #(
+          "Option(" <> list_type <> ")",
+          "json.nullable(value, fn(value) { " <> array_expr <> " })",
+        )
+        False -> #(list_type, array_expr)
+      }
       generate_primitive_encoder(
         sb,
         fn_name,
         json_fn_name,
         gleam_type,
-        "json.array(value, " <> inner_encoder <> ")",
+        json_expr,
       )
     }
 
@@ -919,6 +945,24 @@ fn schema_ref_to_json_encoder_fn(
 fn ensure_import(imports: List(String), name: String) -> List(String) {
   use <- bool.guard(list.contains(imports, name), imports)
   list.append(imports, [name])
+}
+
+/// Issue #387: True when the top-level encoder for this schema would
+/// emit a bare `Option(...)` parameter type. Mirrors the decoder
+/// counterpart in `decoders.gleam`. Only primitive / array component
+/// schemas with `nullable: true` reach this shape; object / allOf /
+/// oneOf / anyOf / enum schemas wrap optionality through
+/// `json.nullable(...)` inside their encoder bodies and never declare
+/// `Option(...)` as the outer parameter type.
+fn schema_ref_has_bare_option_encoder_type(ref: SchemaRef) -> Bool {
+  case ref {
+    Inline(StringSchema(metadata:, enum_values: [], ..)) -> metadata.nullable
+    Inline(IntegerSchema(metadata:, ..)) -> metadata.nullable
+    Inline(NumberSchema(metadata:, ..)) -> metadata.nullable
+    Inline(BooleanSchema(metadata:)) -> metadata.nullable
+    Inline(ArraySchema(metadata:, ..)) -> metadata.nullable
+    _ -> False
+  }
 }
 
 /// Escape a spec-derived string so it can be safely interpolated

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -1014,9 +1014,22 @@ fn schema_ref_to_type_with_inline_enum(
   ctx: Context,
 ) -> String {
   case ref {
-    Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
-      naming.schema_to_type_name(parent_name)
-      <> naming.schema_to_type_name(prop_name)
+    // Issue #387: inline string-enum properties produce a per-property
+    // enum type and a bare type expression. When the spec also marks
+    // the property `nullable: true`, the surrounding record wraps it
+    // through `is_already_optional` — but that path assumes the type
+    // expression already contains the `Option(...)` wrapper (matching
+    // what `schema_dispatch.schema_type` returns for non-enum inline
+    // schemas). Wrap explicitly here so the type, decoder, and
+    // encoder agree on `Option(EnumType)`.
+    Inline(StringSchema(metadata:, enum_values:, ..)) if enum_values != [] -> {
+      let base =
+        naming.schema_to_type_name(parent_name)
+        <> naming.schema_to_type_name(prop_name)
+      case metadata.nullable {
+        True -> "Option(" <> base <> ")"
+        False -> base
+      }
     }
     _ -> schema_ref_to_type(ref, ctx)
   }

--- a/test/fixtures/issue_387_complex_response_shapes.yaml
+++ b/test/fixtures/issue_387_complex_response_shapes.yaml
@@ -34,10 +34,46 @@ paths:
         '200':
           description: List of items, paginated via Link header.
           headers:
+            # Optional String header — bug #5 (no client construction
+            # of headers record). Most common shape in real specs.
             Link:
               description: Pagination cursor.
               schema:
                 type: string
+            # Required String header — exercises the
+            # `use ... <- result.try(...)` short-circuit path that
+            # replaces the silent empty-string fallback.
+            X-Request-Id:
+              description: Server-supplied request id, always present.
+              required: true
+              schema:
+                type: string
+            # Optional Int header — exercises typed primitive
+            # parsing via `int.parse`. Real-world example:
+            # GitHub's `X-RateLimit-Remaining`.
+            X-RateLimit-Remaining:
+              description: Remaining requests in the current window.
+              schema:
+                type: integer
+            # Required Int header — same path as the optional Int
+            # header but errors on missing/unparseable values.
+            X-Total-Count:
+              description: Total item count across all pages.
+              required: true
+              schema:
+                type: integer
+            # Optional Float header — covers `float.parse` on the
+            # extractor side.
+            X-Response-Time-Seconds:
+              description: Server-side processing time in seconds.
+              schema:
+                type: number
+            # Optional Bool header — covers the case-match
+            # extraction (no parser; "true"/"false" only).
+            X-Cache-Hit:
+              description: Whether the response was served from cache.
+              schema:
+                type: boolean
           content:
             application/json:
               schema:

--- a/test/fixtures/issue_387_complex_response_shapes.yaml
+++ b/test/fixtures/issue_387_complex_response_shapes.yaml
@@ -1,0 +1,125 @@
+openapi: 3.0.3
+info:
+  title: Complex response shapes (Issue #387 regression fixture)
+  version: 1.0.0
+  description: |
+    Pinned subset of GitHub-API-shaped patterns that previously
+    produced uncompilable client code (#387). Each path / schema
+    targets one of the five generator bugs surfaced when generating
+    a client from the GitHub OpenAPI document:
+
+    1. anyOf of primitives — used to call missing
+       `decode_<x>_decoder` helpers.
+    2. inline string-enum + nullable — used to lose its `Option(...)`
+       wrapper in `types.gleam` while the decoder/encoder still
+       expected one.
+    3. nullable top-level array (oneOf branch with array + nullable)
+       — used to emit `decode.Decoder(List(T))` against an
+       `Option(List(T))` type alias and a bare `json.array(...)`
+       encoder against an `Option(List(T))` parameter.
+    4. decoders generated bare `Option(...)` types without importing
+       `type Option`.
+    5. responses declaring `headers:` — used to widen the variant
+       constructor arity but the client never passed the headers
+       record.
+
+    Keep this fixture minimal; if a future spec shape breaks
+    something this one already covers, prefer adding a paragraph
+    here over inflating the spec.
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200':
+          description: List of items, paginated via Link header.
+          headers:
+            Link:
+              description: Pagination cursor.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+        '422':
+          description: Validation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+    patch:
+      operationId: updateItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                state_reason:
+                  description: Optional nullable inline string-enum (bug #2).
+                  type: string
+                  nullable: true
+                  enum:
+                    - completed
+                    - reopened
+                    - cancelled
+                value:
+                  description: Optional nullable inline anyOf-of-primitives (bug #1).
+                  anyOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                  nullable: true
+      responses:
+        '200':
+          description: Updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        nickname:
+          type: string
+          nullable: true
+
+    ValidationError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              # nullable variant inside oneOf — bug #3 + bug #4 trigger
+              value:
+                oneOf:
+                  - type: string
+                    nullable: true
+                  - type: integer
+                    nullable: true
+                  - type: array
+                    nullable: true
+                    items:
+                      type: string

--- a/test/fixtures/issue_387_response_header_ref.yaml
+++ b/test/fixtures/issue_387_response_header_ref.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: Reference-typed response header (Issue #387 negative fixture)
+  version: 1.0.0
+  description: |
+    Response declares a header whose `schema` is a `$ref` to a
+    component schema. Issue #387 explicitly does not handle this
+    shape yet — generation MUST abort with a clear error message
+    rather than silently produce broken client code. This fixture
+    pins the failure mode so a future regression cannot reintroduce
+    silent breakage.
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        '200':
+          description: Items.
+          headers:
+            X-Item-Kind:
+              description: Reference-typed header — not supported.
+              schema:
+                $ref: '#/components/schemas/ItemKind'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+
+components:
+  schemas:
+    ItemKind:
+      type: string
+      enum:
+        - regular
+        - vip
+    Item:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer


### PR DESCRIPTION
## Summary

@halostatue reported on Issue #387 that the generated client "needed
a few changes to get it to compile" and that "the response isn't
going to decode properly." Reproducing against a representative
subset of the GitHub OpenAPI document surfaced **five distinct**
generator bugs that all break realistic specs.

This PR fixes each of them and pins regression coverage so future
changes cannot silently reintroduce any of these failure modes.

## Bugs fixed

1. **anyOf decoder name typo** — `decoders.gleam` emitted
   `decode_<snake>_decoder()` but the actual variant decoder is
   `<snake>_decoder()`. Any anyOf union that survived hoisting
   referenced a function that did not exist.
2. **Inline string-enum + nullable lost its `Option(...)` wrapper**
   — `ir_build.schema_ref_to_type_with_inline_enum` returned the
   bare enum type regardless of nullability, while the
   `is_already_optional` branch downstream assumed the type
   expression already carried `Option`. The decoder produced
   `Option(EnumType)` while the record field was bare `EnumType`.
3. **Top-level nullable arrays mismatched** —
   `generate_array_decoder` / the array branch in
   `generate_encoder` ignored `metadata.nullable`. A `nullable: true`
   array's type alias was `Option(List(T))` but its decoder was
   `Decoder(List(T))` and its encoder body called
   `json.array(value, ...)` against an `Option(List(T))` parameter.
4. **Bare `Option(_)` used without `type Option` import** —
   nullable primitive / array variant decoders and encoders
   reference `Option(...)` in their signatures, but the
   `gleam/option` import was the module-only form. Added a precise
   check (`schema_ref_has_bare_option_*_type`) so the
   `{type Option}` form is emitted only when the bare type is
   actually used; specs without nullable primitives/arrays keep the
   plain `gleam/option` import.
5. **Client never passed the typed headers record** — response
   variants declaring `headers:` widen the constructor arity to
   `(body, headers)`, but `client_response.gleam` only ever called
   `Variant(decoded)`. Added `build_headers_record` which assembles
   the typed headers record from `resp.headers` (case-insensitive
   `list.key_find`), and threaded it through every variant-emitting
   branch (single content, multi-content, empty body, empty
   content). Header type plumbing covers:

   - Optional / required **String**
   - Optional / required **Int** (parsed via `int.parse`)
   - Optional / required **Float** (parsed via `float.parse`)
   - Optional / required **Bool** (matched on `"true"` / `"false"`)

   Required headers (any of the supported types) and parse-required
   typed values short-circuit through `use ... <- result.try(...)`
   so a missing or unparseable header surfaces as
   `Error(InvalidResponse(detail: "missing or invalid required
   <kind> header: <name>"))`. The previous "" fallback would have
   been silent data corruption.

## Tests / regression coverage

- `test/fixtures/issue_387_complex_response_shapes.yaml` — minimal
  spec exercising every shape above (anyOf-of-primitives, inline
  string-enum + nullable, oneOf array variant + nullable, response
  with optional `Link` / required `X-Request-Id` /
  optional+required Int / optional Float / optional Bool headers).
- `integration_test/run.sh` gains a step that generates a client
  from that fixture and runs `gleam build --warnings-as-errors`.
  The build fails CI if any of the bug categories above re-surface.
- `test/fixtures/issue_387_response_header_ref.yaml` — a negative
  fixture pinning a `$ref`-typed response header.
  `spec/generate_spec.sh` gains a `Describe 'oaspec response header
  schema'` block that asserts `oaspec generate` fails with a panic
  message naming the offending header and pointing at this issue,
  so future regressions cannot silently start producing
  uncompilable generated code again.
- The fixture is also exercised end-to-end against a 320 KB subset
  of the real GitHub OpenAPI document
  (`/repos/{owner}/{repo}/issues`, `/issues/{n}`, `/pulls`,
  `/pulls/{n}`, `/repos/{o}/{r}`, `/users/{u}`); after this PR the
  generated client compiles cleanly with `gleam build`.

## Design decisions

- **Required headers must be present and parseable.** Missing or
  unparseable required headers return
  `Error(InvalidResponse(detail: ...))` — the upstream server is in
  violation of its own contract, but the failure is surfaced
  through the client's normal `Result` channel rather than through
  silent fallbacks (`""` / `0` / `False`) the caller cannot detect.
- **Optional headers default to `None` on missing or unparseable.**
  Optional Int / Float / Bool headers never raise — if the value is
  absent or fails to parse, the field is `None`. This mirrors how
  optional body fields treat decode failures.
- **`$ref` and complex header schemas refuse at generation time.**
  Response headers whose schema is a `$ref` to a component, or an
  inline `Object` / `Array` / composition, currently have no
  extractor wired up. Generation fails fast with a clear panic
  message that names the offending header and points at this issue,
  rather than silently emitting code that would not compile or
  would silently ignore the typed shape. ShellSpec coverage pins
  the failure mode.
- **Option import is per-module specific.** Each generated module
  picks its own option-import shape based on whether it actually
  uses the bare `Option` type. The petstore decoder still imports
  `gleam/option` (module only); the GitHub-style decoder imports
  `gleam/option.{type Option}`.

## Out of scope

- Typed-header extractors for `$ref` / `Object` / `Array` /
  `allOf` / `oneOf` / `anyOf` schemas. Real specs declare these
  rarely; the panic + ShellSpec ensures the gap is loud and that
  regressing into "silently wrong" is impossible.
- The `targets:` / `include:` multi-target config feature mentioned
  in #387 — already deferred to a separate issue.

Closes #387