### PR TITLE
feat(config): include filter and targets array (Issue #387)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 336 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 253 test fixtures (including 98 OSS-derived edge-case specs)
+- Backed by 337 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+  and 254 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 337 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 254 test fixtures (including 98 OSS-derived edge-case specs)
+  and 257 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -256,23 +256,24 @@ include:
     - "/repos/**"
 ```
 
-- Both lists are optional. Empty or omitted = no filter on that
-  axis. Both empty = no filtering applied.
-- Operations pass when their tag list intersects `include.tags`
-  **OR** their path matches one of `include.paths` (the two lists
-  are unioned, not intersected).
-- Path patterns ending in `/**` match any path that extends the
-  prefix with a `/<rest>` segment (`"/repos/**"` matches
-  `/repos/foo` and `/repos/foo/bar`, but **not** the bare
-  `/repos` — list it explicitly when needed). Other patterns are
-  compared by exact equality.
+Both lists are optional; omitting one means there is no constraint on
+that axis, and omitting both leaves the filter inactive. An operation
+is kept when its tag list intersects `include.tags` or its path matches
+one of `include.paths`; the two lists are unioned rather than
+intersected, so adding entries to either list widens the result.
+
+Path patterns ending in `/**` match any path that extends the prefix
+with a `/<rest>` segment, so `"/repos/**"` matches `/repos/foo` and
+`/repos/foo/bar` but does not match the bare `/repos` — list `/repos`
+explicitly when you also need it. Other patterns are compared by exact
+equality.
 
 ### Splitting one spec into multiple packages with `targets:`
 
-`targets:` is an array of per-target overrides. The same input
-spec gets generated once per entry, each with its own
-`package` / `output` / `include`. The top-level `input`, `mode`,
-and `validate` are shared across every target.
+`targets:` is an array of per-target overrides. The same input spec is
+generated once per entry, each with its own `package`, `output`, and
+`include`. The top-level `input`, `mode`, and `validate` are shared
+across every target.
 
 ```yaml
 input: github.yaml
@@ -288,21 +289,19 @@ targets:
       paths: ["/repos/**"]
 ```
 
-Above, one `oaspec generate` run produces two packages:
-`./src/dco_check/github/issues/...` and
+The example above produces two packages from one `oaspec generate` run,
+at `./src/dco_check/github/issues/...` and
 `./src/dco_check/github/repos/...`. Callers consume them as
 `import dco_check/github/issues/client` and
 `import dco_check/github/repos/client`.
 
-Notes:
-- Each target must declare its own `package` — there is no
-  fallback default for multi-target configs (otherwise two
-  targets without a package would overwrite each other).
-- The CLI rejects configs whose targets resolve to overlapping
-  output paths, before any file is written.
-- `--output` cannot be used with multi-target configs (each target
-  already declares its own per-package output directory). Use the
-  per-target `output:` blocks instead.
+Each target must declare its own `package`; there is no fallback default
+for multi-target configs because two targets sharing the same default
+would overwrite each other. The CLI rejects configs whose targets
+resolve to overlapping output directories before writing any file. The
+`--output` CLI flag is also rejected with multi-target configs because
+each target already declares its own per-package output directory; use
+per-target `output:` blocks instead.
 
 ### Configuration paths
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,73 @@ Generated server code is written to `<dir>/<package>` and generated client code 
 | `output.dir` | no | `./gen` | Base output directory |
 | `output.server` | no | `<dir>/<package>` | Server output path |
 | `output.client` | no | `<dir>/<package>_client` | Client output path |
+| `include.tags` | no | `[]` | Operation tag allowlist (filter) |
+| `include.paths` | no | `[]` | Operation path allowlist (filter, supports `/foo/**` glob) |
+| `targets` | no | - | Array of per-target overrides (multi-target codegen) |
+
+### Filtering operations with `include:`
+
+To generate code for a subset of a large spec without modifying the
+spec file, set `include.tags` and / or `include.paths`:
+
+```yaml
+input: github.yaml
+package: github
+mode: client
+include:
+  tags: [issues, repos]
+  paths:
+    - "/users/{username}"
+    - "/repos/**"
+```
+
+- Both lists are optional. Empty or omitted = no filter on that
+  axis. Both empty = no filtering applied.
+- Operations pass when their tag list intersects `include.tags`
+  **OR** their path matches one of `include.paths` (the two lists
+  are unioned, not intersected).
+- Path patterns ending in `/**` match any path that extends the
+  prefix with a `/<rest>` segment (`"/repos/**"` matches
+  `/repos/foo` and `/repos/foo/bar`, but **not** the bare
+  `/repos` — list it explicitly when needed). Other patterns are
+  compared by exact equality.
+
+### Splitting one spec into multiple packages with `targets:`
+
+`targets:` is an array of per-target overrides. The same input
+spec gets generated once per entry, each with its own
+`package` / `output` / `include`. The top-level `input`, `mode`,
+and `validate` are shared across every target.
+
+```yaml
+input: github.yaml
+mode: client
+targets:
+  - package: dco_check/github/issues
+    output: { dir: ./src }
+    include:
+      tags: [issues]
+  - package: dco_check/github/repos
+    output: { dir: ./src }
+    include:
+      paths: ["/repos/**"]
+```
+
+Above, one `oaspec generate` run produces two packages:
+`./src/dco_check/github/issues/...` and
+`./src/dco_check/github/repos/...`. Callers consume them as
+`import dco_check/github/issues/client` and
+`import dco_check/github/repos/client`.
+
+Notes:
+- Each target must declare its own `package` — there is no
+  fallback default for multi-target configs (otherwise two
+  targets without a package would overwrite each other).
+- The CLI rejects configs whose targets resolve to overlapping
+  output paths, before any file is written.
+- `--output` cannot be used with multi-target configs (each target
+  already declares its own per-package output directory). Use the
+  per-target `output:` blocks instead.
 
 ### Configuration paths
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -2050,4 +2050,99 @@ rm -rf "$INCLUDE_DIR"
 
 info "Issue #387 include-filter integration tests passed."
 
+# -------------------------------------------------------
+# Step N+2: Issue #387 — `targets:` array (multi-target codegen)
+# -------------------------------------------------------
+# Splits the petstore spec into two Gleam packages
+# (`petshop/listing` for `/pets`, `petshop/details` for
+# `/pets/**`) in one `oaspec generate` run, then verifies BOTH
+# packages compile cleanly. If the multi-target pipeline ever
+# generates code that fails to compile (e.g. a target's filter
+# orphans a referenced component), this build catches it.
+info "Testing Issue #387 multi-target codegen (two packages compile)..."
+
+MULTI_DIR="$SCRIPT_DIR/multi_target_test"
+rm -rf "$MULTI_DIR"
+mkdir -p "$MULTI_DIR/src"
+
+cat > "$MULTI_DIR/oaspec-multi-target.yaml" << 'YAML_EOF'
+input: test/fixtures/petstore.yaml
+mode: client
+targets:
+  - package: petshop/listing
+    output:
+      dir: ./integration_test/multi_target_test/src
+    include:
+      paths:
+        - "/pets"
+  - package: petshop/details
+    output:
+      dir: ./integration_test/multi_target_test/src
+    include:
+      paths:
+        - "/pets/**"
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$MULTI_DIR/oaspec-multi-target.yaml"
+
+# Sanity: each target's client.gleam carries only its filtered
+# operations.
+if grep -q "pub fn list_pets" "$MULTI_DIR/src/petshop/listing/client.gleam"; then
+  info "PASS: listing target carries list_pets."
+else
+  fail "multi-target: listing target dropped list_pets, which should have been kept"
+fi
+if grep -q "pub fn get_pet" "$MULTI_DIR/src/petshop/listing/client.gleam"; then
+  fail "multi-target: listing target kept get_pet, which should have been filtered out"
+else
+  info "PASS: listing target excludes get_pet."
+fi
+if grep -q "pub fn get_pet" "$MULTI_DIR/src/petshop/details/client.gleam"; then
+  info "PASS: details target carries get_pet."
+else
+  fail "multi-target: details target dropped get_pet, which should have been kept"
+fi
+if grep -q "pub fn list_pets" "$MULTI_DIR/src/petshop/details/client.gleam"; then
+  fail "multi-target: details target kept list_pets, which should have been filtered out"
+else
+  info "PASS: details target excludes list_pets."
+fi
+
+cat > "$MULTI_DIR/gleam.toml" << 'TOML_EOF'
+name = "multi_target_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$MULTI_DIR/src/multi_target_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$MULTI_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors 2>&1; then
+  info "PASS: both targets compile cleanly under one project."
+else
+  fail "Issue #387 multi-target — combined build failed to compile."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$MULTI_DIR"
+
+info "Issue #387 multi-target integration tests passed."
+
 info "All integration tests passed!"

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1971,4 +1971,83 @@ rm -rf "$COMPLEX_SHAPES_DIR"
 
 info "Issue #387 complex response shapes integration tests passed."
 
+# -------------------------------------------------------
+# Step N+1: Issue #387 — `include:` filter compiles a strict subset
+# -------------------------------------------------------
+# Generates from the petstore fixture with `include.paths: ["/pets"]`
+# and verifies (a) only `/pets` operations appear in the generated
+# code, AND (b) the result still compiles with
+# `--warnings-as-errors`. If the filter accidentally drops something
+# the remaining code references — say, a component schema only used
+# by `listPets` — the build fails here before users ever see broken
+# output.
+info "Testing Issue #387 include filter (subset client compiles)..."
+
+INCLUDE_DIR="$SCRIPT_DIR/include_filter_test"
+rm -rf "$INCLUDE_DIR"
+mkdir -p "$INCLUDE_DIR/src"
+
+cat > "$INCLUDE_DIR/oaspec-include.yaml" << 'YAML_EOF'
+input: test/fixtures/petstore.yaml
+output:
+  client: ./integration_test/include_filter_test/src/api
+package: api
+mode: client
+include:
+  paths:
+    - "/pets"
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$INCLUDE_DIR/oaspec-include.yaml" \
+  --mode=client
+
+# Sanity check: handlers / client only carry the included operations.
+if grep -q "pub fn list_pets" "$INCLUDE_DIR/src/api/client.gleam"; then
+  info "PASS: included operation list_pets is present in client.gleam"
+else
+  fail "include filter dropped list_pets, which should have been kept"
+fi
+if grep -q "pub fn get_pet" "$INCLUDE_DIR/src/api/client.gleam"; then
+  fail "include filter kept get_pet, which should have been filtered out"
+else
+  info "PASS: filtered-out operation get_pet absent from client.gleam"
+fi
+
+cat > "$INCLUDE_DIR/gleam.toml" << 'TOML_EOF'
+name = "include_filter_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$INCLUDE_DIR/src/include_filter_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$INCLUDE_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors 2>&1; then
+  info "PASS: subset client (path filter) compiles cleanly."
+else
+  fail "Issue #387 include filter — subset client failed to compile."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$INCLUDE_DIR"
+
+info "Issue #387 include-filter integration tests passed."
+
 info "All integration tests passed!"

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -749,6 +749,148 @@ EOF
 End
 
 # ===================================================================
+# Issue #387 — `targets:` array (multi-target codegen)
+# ===================================================================
+#
+# Splits a single spec into multiple Gleam packages in one
+# `oaspec generate` run. Each `targets:` entry has its own
+# `package`, `output`, and `include`, but all entries share the
+# top-level `input`, `mode`, and `validate`. The CLI parses the
+# spec once and runs the per-target pipeline (filter → capability
+# check → hoist → dedup → validate → codegen → write) for each
+# target in order.
+
+Describe 'oaspec multi-target generate'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_multi_target_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets"
+    cat > "$PROJECT_ROOT/test_multi_targets.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+mode: client
+targets:
+  - package: petshop/listing
+    output:
+      dir: ./test_multi_targets
+    include:
+      paths:
+        - "/pets"
+  - package: petshop/details
+    output:
+      dir: ./test_multi_targets
+    include:
+      paths:
+        - "/pets/**"
+EOF
+  }
+
+  cleanup_multi_target_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets" \
+           "$PROJECT_ROOT/test_multi_targets.yaml"
+  }
+
+  Before 'setup_multi_target_config'
+  After 'cleanup_multi_target_config'
+
+  It 'writes one package per target with its filtered subset'
+    When run generate --config=./test_multi_targets.yaml
+    The status should be success
+    The output should include 'Successfully generated'
+    The output should include '[target: petshop/listing]'
+    The output should include '[target: petshop/details]'
+    # listing target: only the /pets operations land in its client.
+    The path "$PROJECT_ROOT/test_multi_targets/petshop/listing/client.gleam" should be file
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/listing/client.gleam" should include 'pub fn list_pets'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/listing/client.gleam" should include 'pub fn create_pet'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/listing/client.gleam" should not include 'pub fn get_pet'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/listing/client.gleam" should not include 'pub fn delete_pet'
+    # details target: only the /pets/** operations land in its client.
+    The path "$PROJECT_ROOT/test_multi_targets/petshop/details/client.gleam" should be file
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/details/client.gleam" should include 'pub fn get_pet'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/details/client.gleam" should include 'pub fn delete_pet'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/details/client.gleam" should not include 'pub fn list_pets'
+    The contents of file "$PROJECT_ROOT/test_multi_targets/petshop/details/client.gleam" should not include 'pub fn create_pet'
+  End
+
+  setup_multi_target_overlap_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets_overlap"
+    # Two targets with the same package would write to the same
+    # directory. The CLI must reject this before any file is written.
+    cat > "$PROJECT_ROOT/test_multi_targets_overlap.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+mode: client
+targets:
+  - package: shared/api
+    output:
+      dir: ./test_multi_targets_overlap
+    include:
+      paths:
+        - "/pets"
+  - package: shared/api
+    output:
+      dir: ./test_multi_targets_overlap
+    include:
+      paths:
+        - "/pets/**"
+EOF
+  }
+
+  cleanup_multi_target_overlap_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets_overlap" \
+           "$PROJECT_ROOT/test_multi_targets_overlap.yaml"
+  }
+
+  Describe 'overlap detection'
+    Before 'setup_multi_target_overlap_config'
+    After 'cleanup_multi_target_overlap_config'
+
+    It 'rejects configs whose targets resolve to the same output dir'
+      When run generate --config=./test_multi_targets_overlap.yaml
+      The status should be failure
+      The output should include 'two targets resolve to the same output directory'
+      The path "$PROJECT_ROOT/test_multi_targets_overlap" should not be exist
+    End
+  End
+
+  setup_multi_target_with_output_override_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets_override"
+    cat > "$PROJECT_ROOT/test_multi_targets_override.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+mode: client
+targets:
+  - package: foo/listing
+    output:
+      dir: ./test_multi_targets_override
+    include:
+      paths:
+        - "/pets"
+  - package: foo/details
+    output:
+      dir: ./test_multi_targets_override
+    include:
+      paths:
+        - "/pets/**"
+EOF
+  }
+
+  cleanup_multi_target_with_output_override_config() {
+    rm -rf "$PROJECT_ROOT/test_multi_targets_override" \
+           "$PROJECT_ROOT/test_multi_targets_override.yaml"
+  }
+
+  Describe 'CLI --output override'
+    Before 'setup_multi_target_with_output_override_config'
+    After 'cleanup_multi_target_with_output_override_config'
+
+    It 'rejects --output override on a multi-target config'
+      When run generate --config=./test_multi_targets_override.yaml --output=./somewhere_else
+      The status should be failure
+      The output should include 'cannot override the output directory for a multi-target config'
+    End
+  End
+End
+
+# ===================================================================
 # Issue #387 — Reference-typed response header refused at codegen
 # ===================================================================
 #

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -628,6 +628,55 @@ EOF
 End
 
 # ===================================================================
+# `oaspec init` round-trip — Issue #387 follow-up
+# ===================================================================
+#
+# `init` creates a default oaspec.yaml. After Issue #387 added
+# `include:` and `targets:` to the schema, the template grew new
+# commented-out blocks documenting both. The parser must still load
+# the shipped template cleanly (the new blocks are comments, but a
+# stray colon or indent slip would only surface in a CI run).
+
+Describe 'oaspec init round-trip'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_init_round_trip() {
+    rm -rf "$PROJECT_ROOT/test_init_round_trip"
+    mkdir -p "$PROJECT_ROOT/test_init_round_trip"
+    cp "$PROJECT_ROOT/test/fixtures/petstore.yaml" \
+       "$PROJECT_ROOT/test_init_round_trip/openapi.yaml"
+  }
+
+  cleanup_init_round_trip() {
+    rm -rf "$PROJECT_ROOT/test_init_round_trip"
+  }
+
+  Before 'setup_init_round_trip'
+  After 'cleanup_init_round_trip'
+
+  It 'creates an oaspec.yaml that the validator can load and parse'
+    cd "$PROJECT_ROOT/test_init_round_trip" || exit 1
+    # `oaspec init` writes ./oaspec.yaml in the current directory.
+    When run gleam run --no-print-progress -- init --output=./oaspec.yaml
+    The status should be success
+    The output should include 'Created'
+    The path "$PROJECT_ROOT/test_init_round_trip/oaspec.yaml" should be file
+  End
+
+  It 'validates against a real spec without parse errors'
+    cd "$PROJECT_ROOT/test_init_round_trip" || exit 1
+    # Generate the template via init, then run validate against
+    # the petstore stub copied as openapi.yaml above. If the
+    # template's commented include / targets blocks broke the
+    # YAML parser, this would fail before any validation logic ran.
+    gleam run --no-print-progress -- init --output=./oaspec.yaml > /dev/null 2>&1
+    When run gleam run --no-print-progress -- validate --config=./oaspec.yaml
+    The status should be success
+    The output should include 'Validation passed'
+  End
+End
+
+# ===================================================================
 # Issue #387 — `include:` filter (subset of operations)
 # ===================================================================
 #

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -651,26 +651,40 @@ Describe 'oaspec init round-trip'
     rm -rf "$PROJECT_ROOT/test_init_round_trip"
   }
 
+  # Shellspec evaluates the It body in the host shell, so any
+  # `cd` inside it leaks across cases and outlives `After`.
+  # Wrap the steps in subshell helpers (`( cd ...; ... )`) so the
+  # working directory only changes inside `When run`'s subprocess
+  # — cleanup can then `rm -rf` the test dir without yanking the
+  # parent shell's cwd.
+  init_in_test_dir() {
+    ( cd "$PROJECT_ROOT/test_init_round_trip" \
+      && gleam run --no-print-progress -- init --output=./oaspec.yaml )
+  }
+
+  init_then_validate_in_test_dir() {
+    ( cd "$PROJECT_ROOT/test_init_round_trip" \
+      && gleam run --no-print-progress -- init --output=./oaspec.yaml \
+           > /dev/null \
+      && gleam run --no-print-progress -- validate --config=./oaspec.yaml )
+  }
+
   Before 'setup_init_round_trip'
   After 'cleanup_init_round_trip'
 
   It 'creates an oaspec.yaml that the validator can load and parse'
-    cd "$PROJECT_ROOT/test_init_round_trip" || exit 1
-    # `oaspec init` writes ./oaspec.yaml in the current directory.
-    When run gleam run --no-print-progress -- init --output=./oaspec.yaml
+    When run init_in_test_dir
     The status should be success
     The output should include 'Created'
     The path "$PROJECT_ROOT/test_init_round_trip/oaspec.yaml" should be file
   End
 
   It 'validates against a real spec without parse errors'
-    cd "$PROJECT_ROOT/test_init_round_trip" || exit 1
-    # Generate the template via init, then run validate against
+    # Generates the template via init, then runs validate against
     # the petstore stub copied as openapi.yaml above. If the
     # template's commented include / targets blocks broke the
     # YAML parser, this would fail before any validation logic ran.
-    gleam run --no-print-progress -- init --output=./oaspec.yaml > /dev/null 2>&1
-    When run gleam run --no-print-progress -- validate --config=./oaspec.yaml
+    When run init_then_validate_in_test_dir
     The status should be success
     The output should include 'Validation passed'
   End

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -628,6 +628,127 @@ EOF
 End
 
 # ===================================================================
+# Issue #387 — `include:` filter (subset of operations)
+# ===================================================================
+#
+# `include.tags` and `include.paths` let users generate code for a
+# subset of the spec without modifying the spec itself. Operations
+# pass when their tag list intersects `include.tags` OR their path
+# matches one of `include.paths` (`/foo/**` matches anything under
+# `/foo/`). Both lists empty == no filter.
+
+Describe 'oaspec include filter'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_path_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_path"
+    cat > "$PROJECT_ROOT/test_include_path.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+package: api
+output:
+  dir: ./test_include_path
+include:
+  paths:
+    - "/pets"
+EOF
+  }
+
+  cleanup_path_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_path" \
+           "$PROJECT_ROOT/test_include_path.yaml"
+  }
+
+  Describe 'path filter'
+    Before 'setup_path_filter_config'
+    After 'cleanup_path_filter_config'
+
+    It 'keeps only the operations on the matched path'
+      When run generate --config=./test_include_path.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      # /pets stays (listPets, createPet) but /pets/{petId} is filtered
+      # out, so its operations must NOT appear in handlers.gleam.
+      The contents of file "$PROJECT_ROOT/test_include_path/api/handlers.gleam" should include 'pub fn list_pets'
+      The contents of file "$PROJECT_ROOT/test_include_path/api/handlers.gleam" should include 'pub fn create_pet'
+      The contents of file "$PROJECT_ROOT/test_include_path/api/handlers.gleam" should not include 'pub fn get_pet'
+      The contents of file "$PROJECT_ROOT/test_include_path/api/handlers.gleam" should not include 'pub fn delete_pet'
+    End
+  End
+
+  setup_glob_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_glob"
+    cat > "$PROJECT_ROOT/test_include_glob.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+package: api
+output:
+  dir: ./test_include_glob
+include:
+  paths:
+    - "/pets/**"
+EOF
+  }
+
+  cleanup_glob_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_glob" \
+           "$PROJECT_ROOT/test_include_glob.yaml"
+  }
+
+  Describe 'path glob filter'
+    Before 'setup_glob_filter_config'
+    After 'cleanup_glob_filter_config'
+
+    It 'keeps only operations under the glob prefix'
+      When run generate --config=./test_include_glob.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      # `/pets/**` matches `/pets/{petId}` (getPet, deletePet) but
+      # NOT the bare `/pets` path itself (which has listPets and
+      # createPet) — that is the documented strict-prefix glob
+      # behaviour.
+      The contents of file "$PROJECT_ROOT/test_include_glob/api/handlers.gleam" should include 'pub fn get_pet'
+      The contents of file "$PROJECT_ROOT/test_include_glob/api/handlers.gleam" should include 'pub fn delete_pet'
+      The contents of file "$PROJECT_ROOT/test_include_glob/api/handlers.gleam" should not include 'pub fn list_pets'
+      The contents of file "$PROJECT_ROOT/test_include_glob/api/handlers.gleam" should not include 'pub fn create_pet'
+    End
+  End
+
+  setup_tag_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_tag"
+    cat > "$PROJECT_ROOT/test_include_tag.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+package: api
+output:
+  dir: ./test_include_tag
+include:
+  tags:
+    - pets
+EOF
+  }
+
+  cleanup_tag_filter_config() {
+    rm -rf "$PROJECT_ROOT/test_include_tag" \
+           "$PROJECT_ROOT/test_include_tag.yaml"
+  }
+
+  Describe 'tag filter'
+    Before 'setup_tag_filter_config'
+    After 'cleanup_tag_filter_config'
+
+    It 'keeps every operation tagged with the listed tag'
+      When run generate --config=./test_include_tag.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      # All petstore operations are tagged `pets`, so the tag
+      # filter is a no-op for this fixture — but the run still
+      # demonstrates that tag-based filtering parses and applies
+      # without error.
+      The contents of file "$PROJECT_ROOT/test_include_tag/api/handlers.gleam" should include 'pub fn list_pets'
+      The contents of file "$PROJECT_ROOT/test_include_tag/api/handlers.gleam" should include 'pub fn get_pet'
+    End
+  End
+End
+
+# ===================================================================
 # Issue #387 — Reference-typed response header refused at codegen
 # ===================================================================
 #

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -141,7 +142,38 @@ pub fn parse_mode(mode: String) -> Result(GenerateMode, ConfigError) {
 }
 
 /// Load config from a YAML file.
+///
+/// Returns the single target the YAML declares. When the YAML has a
+/// `targets:` array with more than one entry, this errors out with
+/// a multi-target hint — callers that need to handle the multi-
+/// target case must use `load_all/1` instead. For ordinary
+/// single-target configs (no `targets:` key, or a `targets:` array
+/// with exactly one entry) the result is the same as before.
 pub fn load(path: String) -> Result(Config, ConfigError) {
+  use targets <- result.try(load_all(path))
+  case targets {
+    [single] -> Ok(single)
+    [_, _, ..] ->
+      Error(InvalidValue(
+        field: "targets",
+        detail: "config declares multiple targets; use config.load_all/1 to retrieve the full list",
+      ))
+    [] ->
+      Error(InvalidValue(
+        field: "targets",
+        detail: "must declare at least one target",
+      ))
+  }
+}
+
+/// Load every target declared by an oaspec.yaml. A config without a
+/// `targets:` key is treated as a single implicit target whose
+/// fields come from the top-level `package:`, `output:`, and
+/// `include:` keys (the legacy single-target shape). A config with
+/// a `targets:` sequence yields one `Config` per element, each
+/// carrying its own `package` / `output_*` / `include` while
+/// sharing the top-level `input:`, `mode:`, and `validate:` values.
+pub fn load_all(path: String) -> Result(List(Config), ConfigError) {
   use content <- result.try(
     simplifile.read(path)
     |> result.map_error(fn(e) {
@@ -176,11 +208,6 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     |> result.map_error(fn(_) { MissingField(field: "input") }),
   )
 
-  let package =
-    yay.extract_optional_string(root, "package")
-    |> result.unwrap(None)
-    |> option.unwrap("api")
-
   use mode <- result.try(
     case yay.extract_optional_string(root, "mode") |> result.unwrap(None) {
       Some("server") -> Ok(Server)
@@ -194,37 +221,6 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
         ))
     },
   )
-
-  // Determine output base directory, then derive mode-aware server/client
-  // defaults. Priority: output.server/client (explicit) > output.dir (base)
-  // > default "./gen".
-  //
-  // The `_client` suffix is only needed in `Both` mode to disambiguate the
-  // two output trees inside a single `<dir>`. In client-only mode there is
-  // no server output to clash with, so the default client output is just
-  // `<dir>/<package>` and the generated `import <package>/...` lines
-  // resolve correctly (Issue #262).
-  //
-  // The unused field in single-mode configs (e.g. `output_server` in
-  // client-only mode) is set to a sensible-looking placeholder for
-  // diagnostics; it is never read by the writer or codegen.
-  let output_dir =
-    extract_nested_string(root, "output", "dir")
-    |> option.unwrap("./gen")
-
-  let server_default = output_dir <> "/" <> package
-  let client_default = case mode {
-    Client -> output_dir <> "/" <> package
-    Server | Both -> output_dir <> "/" <> package <> "_client"
-  }
-
-  let output_server =
-    extract_nested_string(root, "output", "server")
-    |> option.unwrap(server_default)
-
-  let output_client =
-    extract_nested_string(root, "output", "client")
-    |> option.unwrap(client_default)
 
   // When `validate:` is omitted, the default is mode-dependent (issue #268).
   // Server-mode codegen with `validate: false` lets schema-invalid input
@@ -253,11 +249,88 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     },
   )
 
-  // Issue #387: optional `include:` block selects a subset of
-  // operations to generate. Either list (tags / paths) may be omitted
-  // or empty, in which case no filtering is applied along that axis.
-  // Both omitted == match everything.
-  use include <- result.try(parse_include(root))
+  // Issue #387: when `targets:` is present, walk the sequence and
+  // build one `Config` per item, each inheriting the shared
+  // input/mode/validate values from the root. When absent, the root
+  // itself is the implicit single target (legacy single-target
+  // shape: top-level package / output / include).
+  case yay.select_sugar(from: root, selector: "targets") {
+    // nolint: thrown_away_error -- absent `targets:` is the documented default for single-target configs.
+    Error(_) -> {
+      use cfg <- result.try(parse_target_node(root, input, mode, validate))
+      Ok([cfg])
+    }
+    Ok(yay.NodeSeq(items)) ->
+      case items {
+        [] ->
+          Error(InvalidValue(
+            field: "targets",
+            detail: "must declare at least one target",
+          ))
+        _ ->
+          items
+          |> list.index_map(fn(item, idx) {
+            parse_target_item(item, idx, input, mode, validate)
+          })
+          |> result.all
+      }
+    Ok(_) ->
+      Error(InvalidValue(
+        field: "targets",
+        detail: "must be a sequence of target objects",
+      ))
+  }
+}
+
+/// Parse a single target node — either the YAML root (legacy
+/// single-target config) or one element of the `targets:` sequence
+/// — into a fully-formed `Config`. The shared `input` / `mode` /
+/// `validate` come from the top-level YAML and are baked into the
+/// returned value.
+fn parse_target_node(
+  node: yay.Node,
+  input: String,
+  mode: GenerateMode,
+  validate: Bool,
+) -> Result(Config, ConfigError) {
+  let package =
+    yay.extract_optional_string(node, "package")
+    |> result.unwrap(None)
+    |> option.unwrap("api")
+
+  // Determine output base directory, then derive mode-aware
+  // server/client defaults. Priority: output.server/client
+  // (explicit) > output.dir (base) > default "./gen".
+  //
+  // The `_client` suffix is only needed in `Both` mode to
+  // disambiguate the two output trees inside a single `<dir>`. In
+  // client-only mode there is no server output to clash with, so
+  // the default client output is just `<dir>/<package>` and the
+  // generated `import <package>/...` lines resolve correctly
+  // (Issue #262).
+  //
+  // The unused field in single-mode configs (e.g. `output_server`
+  // in client-only mode) is set to a sensible-looking placeholder
+  // for diagnostics; it is never read by the writer or codegen.
+  let output_dir =
+    extract_nested_string(node, "output", "dir")
+    |> option.unwrap("./gen")
+
+  let server_default = output_dir <> "/" <> package
+  let client_default = case mode {
+    Client -> output_dir <> "/" <> package
+    Server | Both -> output_dir <> "/" <> package <> "_client"
+  }
+
+  let output_server =
+    extract_nested_string(node, "output", "server")
+    |> option.unwrap(server_default)
+
+  let output_client =
+    extract_nested_string(node, "output", "client")
+    |> option.unwrap(client_default)
+
+  use include <- result.try(parse_include(node))
 
   Ok(Config(
     input:,
@@ -268,6 +341,28 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     validate:,
     include:,
   ))
+}
+
+fn parse_target_item(
+  node: yay.Node,
+  idx: Int,
+  input: String,
+  mode: GenerateMode,
+  validate: Bool,
+) -> Result(Config, ConfigError) {
+  // Each entry in `targets:` MUST declare its own `package:` —
+  // unlike the single-target shape (which falls back to "api"),
+  // multiple targets sharing the default package would clobber each
+  // other on disk and via Gleam imports. Reject early with a clear
+  // index-tagged error.
+  case yay.extract_optional_string(node, "package") |> result.unwrap(None) {
+    None ->
+      Error(InvalidValue(
+        field: "targets[" <> int.to_string(idx) <> "].package",
+        detail: "each target must declare a package name",
+      ))
+    Some(_) -> parse_target_node(node, input, mode, validate)
+  }
 }
 
 /// Parse the optional `include:` block. Returns `empty_include()`

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -9,8 +9,8 @@ import yay
 ///
 /// Opaque: external callers construct via `new/6` and read fields via
 /// the accessors below. Mutators (`with_mode`, `with_validate`,
-/// `with_output`) live in this module too, so every change to a
-/// `Config` value goes through an explicit function.
+/// `with_output`, `with_include`) live in this module too, so every
+/// change to a `Config` value goes through an explicit function.
 pub opaque type Config {
   Config(
     input: String,
@@ -19,12 +19,43 @@ pub opaque type Config {
     package: String,
     mode: GenerateMode,
     validate: Bool,
+    include: Include,
   )
 }
 
-/// Construct a new `Config` from its six fields. Prefer `load/1` in
-/// production code; `new/6` is primarily for tests and ad-hoc tooling
-/// that assembles a config in memory.
+/// Issue #387: subset filter for codegen. When non-empty, only
+/// operations matching at least one of the listed `tags` or `paths`
+/// are kept; the others are dropped before capability check, hoist,
+/// and validate.
+///
+/// Path patterns may end in `/**` to match any path under a prefix
+/// (`"/repos/**"` matches `/repos/foo`, `/repos/foo/bar`, …);
+/// otherwise the pattern is compared by exact string equality.
+///
+/// `tags` and `paths` combine with OR semantics — an operation is
+/// kept if EITHER its tag list intersects `Include.tags` OR its path
+/// matches one of `Include.paths`. With both lists empty (the
+/// default), no filtering is applied.
+pub type Include {
+  Include(tags: List(String), paths: List(String))
+}
+
+/// The default include filter — matches everything. Equivalent to
+/// `oaspec.yaml` omitting the `include:` key entirely.
+pub fn empty_include() -> Include {
+  Include(tags: [], paths: [])
+}
+
+/// True when no filter is active (both tag and path lists empty).
+pub fn include_is_empty(include: Include) -> Bool {
+  list.is_empty(include.tags) && list.is_empty(include.paths)
+}
+
+/// Construct a new `Config` from its six required fields. Prefer
+/// `load/1` in production code; `new/6` is primarily for tests and
+/// ad-hoc tooling that assembles a config in memory. The include
+/// filter defaults to `empty_include()` (match everything); use
+/// `with_include/2` to override.
 pub fn new(
   input input: String,
   output_server output_server: String,
@@ -33,7 +64,15 @@ pub fn new(
   mode mode: GenerateMode,
   validate validate: Bool,
 ) -> Config {
-  Config(input:, output_server:, output_client:, package:, mode:, validate:)
+  Config(
+    input:,
+    output_server:,
+    output_client:,
+    package:,
+    mode:,
+    validate:,
+    include: empty_include(),
+  )
 }
 
 /// Path to the OpenAPI spec this config was built for.
@@ -64,6 +103,11 @@ pub fn mode(cfg: Config) -> GenerateMode {
 /// Whether guard-based runtime validation is enabled.
 pub fn validate(cfg: Config) -> Bool {
   cfg.validate
+}
+
+/// Operation include filter (tags / paths). Issue #387.
+pub fn include(cfg: Config) -> Include {
+  cfg.include
 }
 
 /// Generation mode.
@@ -209,7 +253,67 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
     },
   )
 
-  Ok(Config(input:, output_server:, output_client:, package:, mode:, validate:))
+  // Issue #387: optional `include:` block selects a subset of
+  // operations to generate. Either list (tags / paths) may be omitted
+  // or empty, in which case no filtering is applied along that axis.
+  // Both omitted == match everything.
+  use include <- result.try(parse_include(root))
+
+  Ok(Config(
+    input:,
+    output_server:,
+    output_client:,
+    package:,
+    mode:,
+    validate:,
+    include:,
+  ))
+}
+
+/// Parse the optional `include:` block. Returns `empty_include()`
+/// when the key is absent so the absence path stays cheap.
+fn parse_include(root: yay.Node) -> Result(Include, ConfigError) {
+  case yay.select_sugar(from: root, selector: "include") {
+    // nolint: thrown_away_error -- absent `include:` key is the documented default; the empty-include filter matches everything.
+    Error(_) -> Ok(empty_include())
+    Ok(include_node) -> {
+      use tags <- result.try(extract_optional_string_list(
+        include_node,
+        "include.tags",
+        "tags",
+      ))
+      use paths <- result.try(extract_optional_string_list(
+        include_node,
+        "include.paths",
+        "paths",
+      ))
+      Ok(Include(tags: tags, paths: paths))
+    }
+  }
+}
+
+/// Read a list-of-strings YAML field that may be absent, in which
+/// case an empty list is returned. `field_path` is the dotted name
+/// shown in any `InvalidValue` diagnostic.
+fn extract_optional_string_list(
+  node: yay.Node,
+  field_path: String,
+  key: String,
+) -> Result(List(String), ConfigError) {
+  case yay.extract_string_list(node, key) {
+    Ok(values) -> Ok(values)
+    // nolint: thrown_away_error -- yay's distinction between "key absent" and "key present but not a list" is squashed here; absent → empty list, type-mismatch → InvalidValue with a specific detail string is emitted by the existence check below.
+    Error(_) ->
+      case yay.select_sugar(from: node, selector: key) {
+        // nolint: thrown_away_error -- key truly absent: the documented default of an empty list applies.
+        Error(_) -> Ok([])
+        Ok(_) ->
+          Error(InvalidValue(
+            field: field_path,
+            detail: "must be a list of strings",
+          ))
+      }
+  }
 }
 
 /// Apply CLI overrides to a config.
@@ -220,6 +324,12 @@ pub fn with_mode(config: Config, mode: GenerateMode) -> Config {
 /// Apply validation mode override.
 pub fn with_validate(config: Config, validate: Bool) -> Config {
   Config(..config, validate:)
+}
+
+/// Apply include-filter override (Issue #387). Useful for tests
+/// that build a `Config` in memory.
+pub fn with_include(config: Config, include: Include) -> Config {
+  Config(..config, include:)
 }
 
 /// Apply output base directory override.

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -11,6 +11,7 @@ import oaspec/internal/codegen/types
 import oaspec/internal/codegen/validate
 import oaspec/internal/openapi/capability_check
 import oaspec/internal/openapi/dedup
+import oaspec/internal/openapi/filter
 import oaspec/internal/openapi/hoist
 import oaspec/internal/openapi/normalize
 import oaspec/internal/openapi/resolve
@@ -77,6 +78,16 @@ fn prepare_context(
   use spec <- result.try(
     resolved
     |> result.map_error(fn(errors) { ValidationErrors(errors:) }),
+  )
+
+  // Issue #387: apply the include filter (if any) before capability
+  // check / hoist / validate so every downstream stage sees only the
+  // operations the user asked for. Empty filter is a no-op.
+  let #(elapsed, spec) =
+    progress.timed(fn() { filter.apply(spec, config.include(cfg)) })
+  progress.report(
+    reporter,
+    "apply include filter (took " <> progress.format_ms(elapsed) <> ")",
   )
 
   // Check for unsupported features using capability registry

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -229,6 +229,37 @@ package: api
 #                                 # picks up both.
 #   server: ./gen/api             # Override server output path
 #   client: ./gen/api_client      # Override client output path
+
+# Operation filter (optional, Issue #387). When set, codegen only
+# emits operations whose tag list intersects `tags` OR whose path
+# matches one of `paths` (the two lists are unioned, not
+# intersected). Path patterns ending in `/**` match any path that
+# extends the prefix with a `/<rest>` segment. Both lists empty /
+# both keys omitted = no filter.
+# include:
+#   tags:
+#     - issues
+#   paths:
+#     - \"/users/{username}\"
+#     - \"/repos/**\"
+
+# Multi-target codegen (optional, Issue #387). When `targets:` is
+# set, the same input spec is generated once per entry, each with
+# its own `package`, `output`, and `include`. The top-level
+# `input`, `mode`, and `validate` are shared across every target.
+# Targets whose output paths overlap are rejected at config-load
+# time. `--output` cannot be used with multi-target configs.
+# targets:
+#   - package: my_app/issues
+#     output:
+#       dir: ./src
+#     include:
+#       tags: [issues]
+#   - package: my_app/repos
+#     output:
+#       dir: ./src
+#     include:
+#       paths: [\"/repos/**\"]
 "
 
   case simplifile.is_file(path) {

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -267,41 +267,195 @@ fn run_generate(
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
 
-  use cfg <- require(
-    load_config(config_path, mode_opt, output_opt),
+  // Issue #387: a config may declare multiple `targets:`. Each target
+  // produces its own package + output tree from the same input spec.
+  // The single-target legacy shape returns a 1-element list here.
+  use cfgs <- require(
+    load_configs(config_path, mode_opt, output_opt),
     load_config_error_to_string,
   )
-  let cfg = case validate_mode {
-    True -> config.with_validate(cfg, True)
-    False -> cfg
-  }
+  let cfgs =
+    list.map(cfgs, fn(c) {
+      case validate_mode {
+        True -> config.with_validate(c, True)
+        False -> c
+      }
+    })
 
-  print_resolved_paths(config_path, cfg)
-  io.println("Parsing OpenAPI spec: " <> config.input(cfg))
+  // Reject configs where two targets would write to the same
+  // directory — generated files would clobber each other and there
+  // is no sensible default order.
+  use _ <- require(
+    validate_no_target_overlap(cfgs),
+    load_config_error_to_string,
+  )
+
+  print_resolved_paths_for_all(config_path, cfgs)
+
+  // The input spec is shared across every target, so parse it once.
+  // `load_configs` already guarantees `cfgs` is non-empty.
+  let shared_input = case cfgs {
+    [first, ..] -> config.input(first)
+    [] -> ""
+  }
+  io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
   use spec <- require(
-    parser.parse_file_with_progress(config.input(cfg), reporter),
+    parser.parse_file_with_progress(shared_input, reporter),
     fn(e) { "Error: " <> parser.parse_error_to_string(e) },
   )
 
-  use summary <- require(
-    generate.generate_with_progress(spec, cfg, reporter),
-    format_generate_error,
-  )
-
-  io.println("Spec loaded: " <> summary.spec_title)
-  print_warnings(summary.warnings)
-  case fail_on_warnings && summary.warnings != [] {
-    True -> {
-      io.println_error("")
-      io.println_error("Error: warnings present and --fail-on-warnings is set.")
-      halt(1)
-    }
-    False -> Nil
+  // Run codegen once per target. `generate_with_progress` re-runs
+  // every per-target stage (filter / hoist / dedup / validate /
+  // codegen) so each target sees only the operations its filter
+  // keeps. `parse` and `normalize` would be re-run too if we passed
+  // the same `OpenApiSpec(Unresolved)` value through the pipeline,
+  // but those stages are pure and cheap relative to codegen.
+  let multi_target = case cfgs {
+    [_, _, ..] -> True
+    _ -> False
   }
-  case check_mode {
-    True -> run_check(summary.files, cfg)
-    False -> write_files(summary.files, cfg)
+  list.each(cfgs, fn(cfg) {
+    case multi_target {
+      True -> {
+        io.println("")
+        io.println("[target: " <> config.package(cfg) <> "]")
+      }
+      False -> Nil
+    }
+    use summary <- require(
+      generate.generate_with_progress(spec, cfg, reporter),
+      format_generate_error,
+    )
+    io.println("Spec loaded: " <> summary.spec_title)
+    print_warnings(summary.warnings)
+    case fail_on_warnings && summary.warnings != [] {
+      True -> {
+        io.println_error("")
+        io.println_error(
+          "Error: warnings present and --fail-on-warnings is set.",
+        )
+        halt(1)
+      }
+      False -> Nil
+    }
+    case check_mode {
+      True -> run_check(summary.files, cfg)
+      False -> write_files(summary.files, cfg)
+    }
+  })
+}
+
+fn print_resolved_paths_for_all(
+  config_path: String,
+  cfgs: List(config.Config),
+) -> Nil {
+  case cfgs {
+    [single] -> print_resolved_paths(config_path, single)
+    multiple -> {
+      case simplifile.current_directory() {
+        Ok(cwd) -> {
+          io.println("Resolved paths:")
+          io.println("  config: " <> resolve_path_from_cwd(config_path, cwd))
+          let inputs =
+            multiple
+            |> list.map(fn(c) { config.input(c) })
+            |> list.unique
+          list.each(inputs, fn(p) {
+            io.println("  input: " <> resolve_path_from_cwd(p, cwd))
+          })
+          list.each(multiple, fn(cfg) {
+            io.println("  target [" <> config.package(cfg) <> "]:")
+            print_target_outputs(cfg, cwd, "    ")
+          })
+        }
+        // nolint: thrown_away_error -- path printing is best-effort.
+        Error(_) -> Nil
+      }
+    }
+  }
+}
+
+fn print_target_outputs(cfg: config.Config, cwd: String, prefix: String) -> Nil {
+  case config.mode(cfg) {
+    config.Server -> {
+      io.println(
+        prefix
+        <> "output.server: "
+        <> resolve_path_from_cwd(config.output_server(cfg), cwd),
+      )
+    }
+    config.Client -> {
+      io.println(
+        prefix
+        <> "output.client: "
+        <> resolve_path_from_cwd(config.output_client(cfg), cwd),
+      )
+    }
+    config.Both -> {
+      io.println(
+        prefix
+        <> "output.server: "
+        <> resolve_path_from_cwd(config.output_server(cfg), cwd),
+      )
+      io.println(
+        prefix
+        <> "output.client: "
+        <> resolve_path_from_cwd(config.output_client(cfg), cwd),
+      )
+    }
+  }
+}
+
+/// Issue #387: every active output path across every target must be
+/// unique. Two targets writing to the same directory would clobber
+/// each other on disk and surface random "wrong package" errors at
+/// the Gleam compiler level depending on which generate ran second.
+fn validate_no_target_overlap(
+  cfgs: List(config.Config),
+) -> Result(Nil, LoadConfigError) {
+  let paths =
+    cfgs
+    |> list.flat_map(fn(cfg) { active_output_paths(cfg) })
+  find_duplicate_path(paths, [])
+  |> result.map_error(fn(err) {
+    let DuplicateOutputPath(path) = err
+    OutputValidationError(error: config.InvalidValue(
+      field: "targets",
+      detail: "two targets resolve to the same output directory '"
+        <> path
+        <> "' — give them distinct package or output paths so generated files do not clobber each other",
+    ))
+  })
+}
+
+fn active_output_paths(cfg: config.Config) -> List(String) {
+  case config.mode(cfg) {
+    config.Server -> [config.output_server(cfg)]
+    config.Client -> [config.output_client(cfg)]
+    config.Both -> [config.output_server(cfg), config.output_client(cfg)]
+  }
+}
+
+/// Internal error from `find_duplicate_path/2`. Wrapping the offending
+/// path in a named record (rather than a bare String) keeps the
+/// linter happy and makes the failure mode explicit for any future
+/// caller that wants the path on its own.
+type DuplicateOutputPathError {
+  DuplicateOutputPath(path: String)
+}
+
+fn find_duplicate_path(
+  remaining: List(String),
+  seen: List(String),
+) -> Result(Nil, DuplicateOutputPathError) {
+  case remaining {
+    [] -> Ok(Nil)
+    [path, ..rest] ->
+      case list.contains(seen, path) {
+        True -> Error(DuplicateOutputPath(path: path))
+        False -> find_duplicate_path(rest, [path, ..seen])
+      }
   }
 }
 
@@ -581,30 +735,48 @@ fn unique_id() -> String {
   }
 }
 
-/// Execute the validation-only pipeline.
+/// Execute the validation-only pipeline. With a multi-target
+/// config, every target is validated against the same parsed spec
+/// and the run only succeeds when each target validates cleanly.
 fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
   io.println("oaspec v" <> context.version)
   io.println("Loading config from: " <> config_path)
 
-  use cfg <- require(
-    load_config(config_path, mode_opt, None),
+  use cfgs <- require(
+    load_configs(config_path, mode_opt, None),
     load_config_error_to_string,
   )
 
-  io.println("Parsing OpenAPI spec: " <> config.input(cfg))
+  let shared_input = case cfgs {
+    [first, ..] -> config.input(first)
+    [] -> ""
+  }
+  io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
   use spec <- require(
-    parser.parse_file_with_progress(config.input(cfg), reporter),
+    parser.parse_file_with_progress(shared_input, reporter),
     fn(e) { "Error: " <> parser.parse_error_to_string(e) },
   )
 
-  use summary <- require(
-    generate.validate_only_with_progress(spec, cfg, reporter),
-    format_generate_error,
-  )
-
-  io.println("Spec loaded: " <> summary.spec_title)
-  print_warnings(summary.warnings)
+  let multi_target = case cfgs {
+    [_, _, ..] -> True
+    _ -> False
+  }
+  list.each(cfgs, fn(cfg) {
+    case multi_target {
+      True -> {
+        io.println("")
+        io.println("[target: " <> config.package(cfg) <> "]")
+      }
+      False -> Nil
+    }
+    use summary <- require(
+      generate.validate_only_with_progress(spec, cfg, reporter),
+      format_generate_error,
+    )
+    io.println("Spec loaded: " <> summary.spec_title)
+    print_warnings(summary.warnings)
+  })
   io.println("")
   io.println("Validation passed.")
 }
@@ -628,33 +800,65 @@ fn load_config_error_to_string(error: LoadConfigError) -> String {
   "Error: " <> detail
 }
 
-/// Pure config loading and validation pipeline.
-fn load_config(
+/// Pure config loading and validation pipeline. Issue #387: returns
+/// every target the config declares (1 for legacy single-target,
+/// N for multi-target). CLI overrides (`--mode`, `--output`) are
+/// applied uniformly to every target; `--output` over a multi-
+/// target config is rejected because each target already declares
+/// its own per-package output directory.
+fn load_configs(
   config_path: String,
   mode_opt: Option(String),
   output_opt: Option(String),
-) -> Result(config.Config, LoadConfigError) {
-  use cfg <- result.try(
-    config.load(config_path)
+) -> Result(List(config.Config), LoadConfigError) {
+  use cfgs <- result.try(
+    config.load_all(config_path)
     |> result.map_error(ConfigLoadError),
   )
-  use cfg <- result.try(case mode_opt {
-    None -> Ok(cfg)
+  use cfgs <- result.try(case mode_opt {
+    None -> Ok(cfgs)
     Some(mode_str) ->
       config.parse_mode(mode_str)
-      |> result.map(fn(parsed) { config.with_mode(cfg, parsed) })
+      |> result.map(fn(parsed) {
+        list.map(cfgs, fn(c) { config.with_mode(c, parsed) })
+      })
       |> result.map_error(ModeParseError)
   })
-  let cfg = case output_opt {
-    None -> cfg
-    Some(path) -> config.with_output(cfg, Some(path))
-  }
+  use cfgs <- result.try(case output_opt, cfgs {
+    None, _ -> Ok(cfgs)
+    Some(path), [single] -> Ok([config.with_output(single, Some(path))])
+    Some(_), [_, _, ..] ->
+      Error(
+        OutputValidationError(error: config.InvalidValue(
+          field: "--output",
+          detail: "cannot override the output directory for a multi-target config; each target already declares its own output (set per-target output: in oaspec.yaml or drop the --output flag)",
+        )),
+      )
+    Some(_), [] ->
+      Error(
+        OutputValidationError(error: config.InvalidValue(
+          field: "targets",
+          detail: "must declare at least one target",
+        )),
+      )
+  })
+  // Each target's own server/client paths must satisfy the per-
+  // target invariants (basename matches package, src placement is
+  // safe). Run both validators on every target.
+  use _ <- result.try(
+    cfgs
+    |> list.try_map(fn(cfg) { validate_target_paths(cfg) })
+    |> result.map(fn(_) { Nil }),
+  )
+  Ok(cfgs)
+}
+
+fn validate_target_paths(cfg: config.Config) -> Result(Nil, LoadConfigError) {
   use _ <- result.try(
     config.validate_output_package_match(cfg)
     |> result.map_error(OutputValidationError),
   )
   config.validate_output_dir_layout(cfg)
-  |> result.map(fn(_) { cfg })
   |> result.map_error(OutputValidationError)
 }
 

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -293,11 +293,11 @@ fn run_generate(
   print_resolved_paths_for_all(config_path, cfgs)
 
   // The input spec is shared across every target, so parse it once.
-  // `load_configs` already guarantees `cfgs` is non-empty.
-  let shared_input = case cfgs {
-    [first, ..] -> config.input(first)
-    [] -> ""
-  }
+  // `load_configs` rejects empty target lists at config-load time,
+  // so `cfgs` is guaranteed non-empty by the time we get here.
+  // nolint: assert_ok_pattern -- `load_configs` rejects empty target lists; reaching the empty branch would be an internal invariant violation.
+  let assert [first_cfg, ..] = cfgs
+  let shared_input = config.input(first_cfg)
   io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
   use spec <- require(
@@ -747,10 +747,11 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
     load_config_error_to_string,
   )
 
-  let shared_input = case cfgs {
-    [first, ..] -> config.input(first)
-    [] -> ""
-  }
+  // `load_configs` rejects empty target lists; the destructure
+  // documents that invariant for any future reader.
+  // nolint: assert_ok_pattern -- `load_configs` rejects empty target lists; reaching the empty branch would be an internal invariant violation.
+  let assert [first_cfg, ..] = cfgs
+  let shared_input = config.input(first_cfg)
   io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
   use spec <- require(

--- a/src/oaspec/internal/openapi/filter.gleam
+++ b/src/oaspec/internal/openapi/filter.gleam
@@ -1,0 +1,152 @@
+//// Subset filter for the OpenAPI generation pipeline (Issue #387).
+////
+//// Applies the user's `include:` config (`tags` and / or `paths`)
+//// to a Resolved OpenApiSpec by keeping only operations whose tag
+//// list intersects `include.tags` OR whose path matches one of
+//// `include.paths`. Paths whose every operation gets dropped are
+//// removed from `spec.paths`. Components, webhooks, security
+//// schemes, and other top-level fields are left untouched —
+//// component pruning is a separate optimisation.
+
+import gleam/bool
+import gleam/dict.{type Dict}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import oaspec/config.{type Include}
+import oaspec/internal/openapi/spec.{
+  type OpenApiSpec, type Operation, type PathItem, type RefOr, type Resolved,
+  OpenApiSpec, PathItem, Ref, Value,
+}
+
+/// Apply the include filter to a Resolved spec. When the filter is
+/// empty (`include_is_empty == True`), the spec is returned
+/// unchanged. Otherwise paths are walked, each operation is checked
+/// against tag and path criteria, and operations / paths that fail
+/// are dropped.
+pub fn apply(
+  spec: OpenApiSpec(Resolved),
+  include: Include,
+) -> OpenApiSpec(Resolved) {
+  use <- bool.guard(config.include_is_empty(include), spec)
+  let new_paths = filter_paths(spec.paths, include)
+  OpenApiSpec(..spec, paths: new_paths)
+}
+
+fn filter_paths(
+  paths: Dict(String, RefOr(PathItem(Resolved))),
+  include: Include,
+) -> Dict(String, RefOr(PathItem(Resolved))) {
+  paths
+  |> dict.to_list
+  |> list.filter_map(fn(entry) {
+    let #(path, ref_or_item) = entry
+    case ref_or_item {
+      Value(item) -> {
+        let filtered_item = filter_path_item(path, item, include)
+        case path_item_has_operations(filtered_item) {
+          True -> Ok(#(path, Value(filtered_item)))
+          False -> Error(Nil)
+        }
+      }
+      // Resolve eliminates `Ref(_)` before this filter runs; if one
+      // somehow survives we leave it alone rather than silently
+      // dropping it, which would mask a deeper bug.
+      Ref(_) -> Ok(entry)
+    }
+  })
+  |> dict.from_list
+}
+
+fn filter_path_item(
+  path: String,
+  item: PathItem(Resolved),
+  include: Include,
+) -> PathItem(Resolved) {
+  let keep = fn(op) { keep_operation(path, op, include) }
+  PathItem(
+    ..item,
+    get: filter_op(item.get, keep),
+    post: filter_op(item.post, keep),
+    put: filter_op(item.put, keep),
+    delete: filter_op(item.delete, keep),
+    patch: filter_op(item.patch, keep),
+    head: filter_op(item.head, keep),
+    options: filter_op(item.options, keep),
+    trace: filter_op(item.trace, keep),
+  )
+}
+
+fn filter_op(
+  op: Option(Operation(Resolved)),
+  keep: fn(Operation(Resolved)) -> Bool,
+) -> Option(Operation(Resolved)) {
+  case op {
+    None -> None
+    Some(o) ->
+      case keep(o) {
+        True -> Some(o)
+        False -> None
+      }
+  }
+}
+
+fn path_item_has_operations(item: PathItem(Resolved)) -> Bool {
+  is_some(item.get)
+  || is_some(item.post)
+  || is_some(item.put)
+  || is_some(item.delete)
+  || is_some(item.patch)
+  || is_some(item.head)
+  || is_some(item.options)
+  || is_some(item.trace)
+}
+
+fn is_some(opt: Option(a)) -> Bool {
+  case opt {
+    Some(_) -> True
+    None -> False
+  }
+}
+
+fn keep_operation(
+  path: String,
+  op: Operation(Resolved),
+  include: Include,
+) -> Bool {
+  // OR semantics across the two axes: an operation passes if its
+  // tags intersect `include.tags` OR its path matches one of
+  // `include.paths`. With a single axis active, the other is "no
+  // restriction"; with both empty the caller short-circuits via
+  // `apply/2`'s `include_is_empty` check.
+  case include.tags, include.paths {
+    [], [] -> True
+    [], _ -> path_matches(path, include.paths)
+    _, [] -> tags_match(op.tags, include.tags)
+    _, _ ->
+      tags_match(op.tags, include.tags) || path_matches(path, include.paths)
+  }
+}
+
+fn tags_match(op_tags: List(String), include_tags: List(String)) -> Bool {
+  list.any(op_tags, fn(t) { list.contains(include_tags, t) })
+}
+
+/// Match a path string against a list of include patterns. A pattern
+/// ending in `/**` matches any path that has the prefix-up-to-`/**`
+/// followed by a `/` segment. Otherwise the pattern is compared by
+/// exact equality.
+pub fn path_matches(path: String, patterns: List(String)) -> Bool {
+  list.any(patterns, fn(pattern) {
+    case string.ends_with(pattern, "/**") {
+      True -> {
+        // Drop the trailing 3 characters (`/**`) to recover the
+        // prefix; require the path to extend the prefix with `/<rest>`
+        // so `/repos/**` matches `/repos/foo` but not `/repository`.
+        let prefix = string.drop_end(pattern, 3)
+        string.starts_with(path, prefix <> "/")
+      }
+      False -> path == pattern
+    }
+  })
+}

--- a/src/oaspec/internal/openapi/filter.gleam
+++ b/src/oaspec/internal/openapi/filter.gleam
@@ -92,21 +92,14 @@ fn filter_op(
 }
 
 fn path_item_has_operations(item: PathItem(Resolved)) -> Bool {
-  is_some(item.get)
-  || is_some(item.post)
-  || is_some(item.put)
-  || is_some(item.delete)
-  || is_some(item.patch)
-  || is_some(item.head)
-  || is_some(item.options)
-  || is_some(item.trace)
-}
-
-fn is_some(opt: Option(a)) -> Bool {
-  case opt {
-    Some(_) -> True
-    None -> False
-  }
+  option.is_some(item.get)
+  || option.is_some(item.post)
+  || option.is_some(item.put)
+  || option.is_some(item.delete)
+  || option.is_some(item.patch)
+  || option.is_some(item.head)
+  || option.is_some(item.options)
+  || option.is_some(item.trace)
 }
 
 fn keep_operation(

--- a/test/fixtures/oaspec_include_filter.yaml
+++ b/test/fixtures/oaspec_include_filter.yaml
@@ -1,0 +1,9 @@
+input: petstore.yaml
+package: api
+mode: client
+include:
+  tags:
+    - pets
+  paths:
+    - "/pets"
+    - "/pets/**"

--- a/test/fixtures/oaspec_targets_empty.yaml
+++ b/test/fixtures/oaspec_targets_empty.yaml
@@ -1,0 +1,3 @@
+input: petstore.yaml
+mode: client
+targets: []

--- a/test/fixtures/oaspec_targets_missing_package.yaml
+++ b/test/fixtures/oaspec_targets_missing_package.yaml
@@ -1,0 +1,8 @@
+input: petstore.yaml
+mode: client
+targets:
+  - output:
+      dir: ./gen
+    include:
+      tags:
+        - pets

--- a/test/fixtures/oaspec_targets_multi.yaml
+++ b/test/fixtures/oaspec_targets_multi.yaml
@@ -1,0 +1,15 @@
+input: petstore.yaml
+mode: client
+targets:
+  - package: petshop/listing
+    output:
+      dir: ./gen
+    include:
+      paths:
+        - "/pets"
+  - package: petshop/details
+    output:
+      dir: ./gen
+    include:
+      paths:
+        - "/pets/**"

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -57,6 +57,19 @@ pub fn config_output_paths_test() {
     support.config_output_dir_double_src_with_immediate_parent_rejected_case()
 }
 
+pub fn include_filter_test() {
+  let _ = support.config_load_parses_include_block_case()
+  let _ = support.config_load_omitted_include_is_empty_case()
+  let _ = support.config_default_include_is_empty_case()
+  let _ = support.config_with_include_round_trip_case()
+  let _ = support.filter_apply_empty_filter_returns_spec_unchanged_case()
+  let _ = support.filter_apply_path_glob_keeps_matching_paths_case()
+  let _ = support.filter_apply_unknown_path_drops_everything_case()
+  let _ = support.filter_apply_tag_membership_keeps_tagged_operations_case()
+  let _ = support.filter_apply_tags_or_paths_unions_case()
+  let _ = support.filter_path_matches_exact_and_glob_case()
+}
+
 pub fn content_type_helpers_test() {
   let _ = support.content_type_from_string_case()
   let _ = support.content_type_x_ndjson_is_supported_response_case()

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -58,6 +58,13 @@ pub fn config_output_paths_test() {
 }
 
 pub fn include_filter_test() {
+  let _ = support.config_load_all_single_target_case()
+  let _ = support.config_load_all_multi_target_case()
+  let _ = support.config_load_targets_per_target_include_case()
+  let _ = support.config_load_targets_per_target_output_case()
+  let _ = support.config_load_target_missing_package_rejected_case()
+  let _ = support.config_load_targets_empty_rejected_case()
+  let _ = support.config_load_multi_target_via_load_returns_error_case()
   let _ = support.config_load_parses_include_block_case()
   let _ = support.config_load_omitted_include_is_empty_case()
   let _ = support.config_default_include_is_empty_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -461,10 +461,21 @@ pub fn config_output_dir_double_src_with_immediate_parent_rejected_case() {
 
 pub fn config_load_all_single_target_case() {
   // Legacy single-target shape (no `targets:` key) yields a
-  // 1-element list whose values match the legacy `load/1`.
-  let assert Ok(cfgs) =
-    config.load_all("test/fixtures/oaspec_include_filter.yaml")
-  list.length(cfgs) |> should.equal(1)
+  // 1-element list whose sole config is field-equal to what the
+  // legacy `load/1` returns. Asserting field-by-field catches
+  // drift between the two entry points if either one changes its
+  // parsing rules.
+  let path = "test/fixtures/oaspec_include_filter.yaml"
+  let assert Ok(cfgs) = config.load_all(path)
+  let assert [cfg] = cfgs
+  let assert Ok(legacy) = config.load(path)
+  config.input(cfg) |> should.equal(config.input(legacy))
+  config.mode(cfg) |> should.equal(config.mode(legacy))
+  config.validate(cfg) |> should.equal(config.validate(legacy))
+  config.package(cfg) |> should.equal(config.package(legacy))
+  config.output_server(cfg) |> should.equal(config.output_server(legacy))
+  config.output_client(cfg) |> should.equal(config.output_client(legacy))
+  config.include(cfg) |> should.equal(config.include(legacy))
 }
 
 pub fn config_load_all_multi_target_case() {
@@ -497,6 +508,12 @@ pub fn config_load_targets_per_target_include_case() {
   let assert [details, listing] = by_package
   config.include(details).paths |> should.equal(["/pets/**"])
   config.include(listing).paths |> should.equal(["/pets"])
+  // No `tags:` declared in this fixture, so each target should
+  // default to an empty tag list. Asserting this catches any
+  // regression where tag defaulting silently leaks state across
+  // targets or fails to parse omitted tag lists as `[]`.
+  config.include(details).tags |> should.equal([])
+  config.include(listing).tags |> should.equal([])
 }
 
 pub fn config_load_targets_per_target_output_case() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -457,6 +457,79 @@ pub fn config_output_dir_double_src_with_immediate_parent_rejected_case() {
 // filter module's `apply` is a no-op when the filter is empty and
 // otherwise drops operations whose tags / paths do not match.
 
+// Issue #387 follow-up: multi-target configs.
+
+pub fn config_load_all_single_target_case() {
+  // Legacy single-target shape (no `targets:` key) yields a
+  // 1-element list whose values match the legacy `load/1`.
+  let assert Ok(cfgs) =
+    config.load_all("test/fixtures/oaspec_include_filter.yaml")
+  list.length(cfgs) |> should.equal(1)
+}
+
+pub fn config_load_all_multi_target_case() {
+  let assert Ok(cfgs) =
+    config.load_all("test/fixtures/oaspec_targets_multi.yaml")
+  list.length(cfgs) |> should.equal(2)
+  // Each target has its own package and output paths, but the
+  // shared input/mode/validate are baked into both.
+  let packages =
+    cfgs
+    |> list.map(fn(c) { config.package(c) })
+    |> list.sort(string.compare)
+  packages |> should.equal(["petshop/details", "petshop/listing"])
+  list.each(cfgs, fn(c) {
+    config.input(c) |> should.equal("petstore.yaml")
+    config.mode(c) |> should.equal(config.Client)
+  })
+}
+
+pub fn config_load_targets_per_target_include_case() {
+  let assert Ok(cfgs) =
+    config.load_all("test/fixtures/oaspec_targets_multi.yaml")
+  // Sort by package so the assertion below matches the spec
+  // regardless of dict iteration order.
+  let by_package =
+    cfgs
+    |> list.sort(fn(a, b) {
+      string.compare(config.package(a), config.package(b))
+    })
+  let assert [details, listing] = by_package
+  config.include(details).paths |> should.equal(["/pets/**"])
+  config.include(listing).paths |> should.equal(["/pets"])
+}
+
+pub fn config_load_targets_per_target_output_case() {
+  let assert Ok(cfgs) =
+    config.load_all("test/fixtures/oaspec_targets_multi.yaml")
+  // `output.dir: ./gen` + `package: petshop/<leaf>` resolves to
+  // `./gen/petshop/<leaf>` for each target; client mode means no
+  // `_client` suffix.
+  let outputs =
+    cfgs
+    |> list.map(fn(c) { config.output_client(c) })
+    |> list.sort(string.compare)
+  outputs |> should.equal(["./gen/petshop/details", "./gen/petshop/listing"])
+}
+
+pub fn config_load_target_missing_package_rejected_case() {
+  let result =
+    config.load_all("test/fixtures/oaspec_targets_missing_package.yaml")
+  should.be_error(result)
+}
+
+pub fn config_load_targets_empty_rejected_case() {
+  let result = config.load_all("test/fixtures/oaspec_targets_empty.yaml")
+  should.be_error(result)
+}
+
+pub fn config_load_multi_target_via_load_returns_error_case() {
+  // The legacy `load/1` only handles single-target configs; multi-
+  // target callers must use `load_all/1` explicitly.
+  let result = config.load("test/fixtures/oaspec_targets_multi.yaml")
+  should.be_error(result)
+}
+
 pub fn config_load_parses_include_block_case() {
   let assert Ok(cfg) = config.load("test/fixtures/oaspec_include_filter.yaml")
   let inc = config.include(cfg)

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -20,6 +20,7 @@ import oaspec/internal/codegen/types
 import oaspec/internal/codegen/validate
 import oaspec/internal/openapi/capability_check
 import oaspec/internal/openapi/dedup
+import oaspec/internal/openapi/filter
 import oaspec/internal/openapi/hoist
 import oaspec/internal/openapi/location_index
 import oaspec/internal/openapi/normalize
@@ -448,6 +449,114 @@ pub fn config_output_dir_double_src_with_immediate_parent_rejected_case() {
     )
   let result = config.validate_output_dir_layout(cfg)
   should.be_error(result)
+}
+
+// --- Issue #387: include filter ---
+// Default `Config` has an empty include filter; only `load`-loaded
+// or `with_include`-applied configs ever carry a non-empty one. The
+// filter module's `apply` is a no-op when the filter is empty and
+// otherwise drops operations whose tags / paths do not match.
+
+pub fn config_load_parses_include_block_case() {
+  let assert Ok(cfg) = config.load("test/fixtures/oaspec_include_filter.yaml")
+  let inc = config.include(cfg)
+  config.include_is_empty(inc) |> should.be_false
+  inc.tags |> should.equal(["pets"])
+  inc.paths |> should.equal(["/pets", "/pets/**"])
+}
+
+pub fn config_load_omitted_include_is_empty_case() {
+  let assert Ok(cfg) = config.load("test/fixtures/oaspec.yaml")
+  config.include(cfg) |> config.include_is_empty |> should.be_true
+}
+
+pub fn config_default_include_is_empty_case() {
+  let cfg = make_default_cfg()
+  config.include(cfg) |> config.include_is_empty |> should.be_true
+}
+
+pub fn config_with_include_round_trip_case() {
+  let include = config.Include(tags: ["a", "b"], paths: ["/x", "/y/**"])
+  let cfg = make_default_cfg() |> config.with_include(include)
+  config.include(cfg) |> should.equal(include)
+}
+
+pub fn filter_apply_empty_filter_returns_spec_unchanged_case() {
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let before = dict.size(resolved.paths)
+  let after =
+    filter.apply(resolved, config.empty_include())
+    |> fn(s) { dict.size(s.paths) }
+  after |> should.equal(before)
+}
+
+pub fn filter_apply_path_glob_keeps_matching_paths_case() {
+  // petstore declares /pets and /pets/{petId}; both must survive a
+  // `/pets/**` filter (glob matches everything under `/pets/`) AND
+  // an exact `/pets` filter via the union semantics.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: [], paths: ["/pets", "/pets/**"])
+  let filtered = filter.apply(resolved, include)
+  let kept = dict.keys(filtered.paths) |> list.sort(string.compare)
+  kept |> should.equal(["/pets", "/pets/{petId}"])
+}
+
+pub fn filter_apply_unknown_path_drops_everything_case() {
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: [], paths: ["/no-such-path"])
+  let filtered = filter.apply(resolved, include)
+  dict.size(filtered.paths) |> should.equal(0)
+}
+
+pub fn filter_apply_tag_membership_keeps_tagged_operations_case() {
+  // petstore tags every operation `pets`; including that tag keeps
+  // both paths, and including a non-existent tag drops everything.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  filter.apply(resolved, config.Include(tags: ["pets"], paths: []))
+  |> fn(s) { dict.size(s.paths) }
+  |> should.equal(2)
+  filter.apply(resolved, config.Include(tags: ["nope"], paths: []))
+  |> fn(s) { dict.size(s.paths) }
+  |> should.equal(0)
+}
+
+pub fn filter_apply_tags_or_paths_unions_case() {
+  // OR semantics: an operation passes if EITHER its tags intersect
+  // include.tags OR its path matches include.paths. Setting one
+  // matching list and one mismatching list still keeps the
+  // matching subset.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: ["pets"], paths: ["/no-such-path"])
+  filter.apply(resolved, include)
+  |> fn(s) { dict.size(s.paths) }
+  |> should.equal(2)
+}
+
+pub fn filter_path_matches_exact_and_glob_case() {
+  filter.path_matches("/repos/foo", ["/repos/**"]) |> should.be_true
+  filter.path_matches("/repos/foo/bar", ["/repos/**"]) |> should.be_true
+  // `/repos/**` requires an extending segment; `/repos` itself does
+  // NOT match the glob form (callers list it explicitly when needed).
+  filter.path_matches("/repos", ["/repos/**"]) |> should.be_false
+  filter.path_matches("/repository/foo", ["/repos/**"]) |> should.be_false
+  filter.path_matches("/repos", ["/repos"]) |> should.be_true
+  filter.path_matches("/repos/foo", ["/repos"]) |> should.be_false
+}
+
+fn make_default_cfg() -> config.Config {
+  config.new(
+    input: "openapi.yaml",
+    output_server: "./gen/api",
+    output_client: "./gen/api_client",
+    package: "api",
+    mode: config.Both,
+    validate: False,
+  )
 }
 
 // --- Parser Tests ---


### PR DESCRIPTION
## Summary

Issue #387's owner reply sketched two related config features. This
PR ships **both** of them so a single `oaspec generate` run can
carve out a subset of a spec (`include:`) AND split that subset
across multiple Gleam packages (`targets:`).

### Patterns now supported

```yaml
# Pattern A — single target with subset filter (already on the
#             single-target schema before targets: existed).
input: github.yaml
package: dco_check/github
mode: client
output: { dir: ./src }
include:
  paths: [\"/repos/**\"]
```

```yaml
# Pattern B — split a spec into multiple Gleam packages in one run.
input: github.yaml
mode: client
targets:
  - package: dco_check/github/issues
    output: { dir: ./src }
    include: { tags: [issues] }
  - package: dco_check/github/repos
    output: { dir: ./src }
    include: { paths: [\"/repos/**\"] }
```

```yaml
# Pattern C — single target wrapped inside targets: (consistent
#             schema for tooling that always uses the array form).
input: github.yaml
mode: client
targets:
  - package: dco_check/github
    output: { dir: ./src }
    include: { tags: [repos, issues] }
```

## Filter semantics (`include:`)

- \`include.tags\` and \`include.paths\` are both optional. Empty or
  omitted = no filter on that axis.
- The two lists combine with **OR** semantics: an operation passes
  when its tag list intersects \`include.tags\` OR its path matches
  one of \`include.paths\`.
- Path patterns ending in \`/**\` match any path that extends the
  prefix with a \`/<rest>\` segment (\`\"/repos/**\"\` matches
  \`/repos/foo\` and \`/repos/foo/bar\`, but **not** the bare
  \`/repos\` — list it explicitly when needed). Other patterns are
  compared by exact equality.
- Both lists empty / both keys omitted = filter short-circuits to
  a no-op.

## Multi-target semantics (`targets:`)

- Each entry declares its own \`package\`, \`output\`, and
  \`include\`. Top-level \`input\`, \`mode\`, and \`validate\` are
  shared across every target.
- Legacy single-target configs (no \`targets:\` key) keep working —
  the parser treats the root as an implicit single target.
- \`--mode\` overrides apply uniformly to every target. \`--output\`
  is rejected for multi-target configs (each target already
  declares its own per-package output dir; a single CLI override
  cannot meaningfully apply to all of them).
- Targets whose active output paths overlap (same
  \`output_server\` or \`output_client\`) are rejected at config-
  load time with a clear "two targets resolve to the same output
  directory" message — the CLI exits before writing any file.

## Pipeline placement

\`filter.apply/2\` runs in \`generate.prepare_context\` between
\`resolve.resolve\` and \`capability_check.check\`. With multi-
target, the CLI parses the spec once and runs the per-target
pipeline (filter → capability check → hoist → dedup → validate →
codegen → write/check) for each target in order. Components,
webhooks, and other top-level fields are left untouched per target
— component pruning is a follow-up.

## Tests

### Unit tests (\`test/oaspec_support.gleam\` + wiring)

- **Filter logic (8 cases)**: YAML parse of the \`include:\` block,
  \`with_include\` round-trip, no-op behaviour with an empty
  filter, path glob and exact match, tag membership, OR semantics
  across both axes, "unknown path drops everything", and the
  \`path_matches/2\` helper.
- **Multi-target parsing (7 cases)**: \`load_all\` on single-target,
  two-target, missing \`package\`, empty \`targets:\`, the legacy
  \`load/1\` rejecting multi-target, per-target \`include:\`
  parsing, per-target \`output:\` resolution.

### ShellSpec (\`spec/generate_spec.sh\`)

- **\`Describe 'oaspec include filter'\`** — path filter, path
  glob, tag filter end-to-end against petstore.
- **\`Describe 'oaspec multi-target generate'\`** —
  - happy path: 2 targets each carry only their filtered
    operations,
  - overlap detection: identical output dirs rejected before any
    file is written,
  - \`--output\` override on multi-target rejected with a clear
    error.

### Integration tests (\`integration_test/run.sh\`)

- **Single-target subset**: generate with \`include.paths\` and
  build with \`gleam build --warnings-as-errors\`.
- **Multi-target**: generate two packages (\`petshop/listing\` and
  \`petshop/details\`) in one run, grep each \`client.gleam\` to
  confirm operation membership matches the filter, then run
  \`gleam build --warnings-as-errors\` over a single project that
  imports both packages — catches any case where a filter orphans
  a referenced component.

## Out of scope

- **Component pruning.** Components are kept verbatim per target;
  the generated code may include schemas no kept operation
  references (correct but suboptimal). Worth a separate issue.
- **Cross-target component sharing.** Two targets that reference
  the same component schema each emit their own copy. Shared-
  component dedup is also a follow-up.
- **Per-target \`mode:\`.** Every target inherits the shared
  top-level \`mode:\`. A hypothetical override would let one target
  emit a server and another a client off the same spec, but that
  has not surfaced as a use case.

Refs #387