### PR TITLE
perf: drop quadratic list.append + add parser_value defaulted helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.41.0] - 2026-05-02
+### Performance
+
+- **transport**: `with_default_headers` no longer rebuilds `req.headers`
+  with `list.append(acc, [...])` on every fold step — the merge now uses
+  prepend + final reverse, dropping the O(N²) shape that showed up on
+  requests with many default headers. Iteration order on the wire is
+  preserved. (#404)
+- **codegen**: `hoist.hoist_parameters` and `validate.group_operations_by_id`
+  switch their inner accumulators from `list.append(acc, [x])` to
+  prepend-and-reverse-once, so traversal of large specs scales linearly
+  with parameter / duplicate-site counts instead of quadratically. (#426)
+- **parser**: new `parser_value.{optional_bool, optional_string,
+  optional_int, optional_float, bool_default, string_default,
+  int_default}` helpers replace the brittle
+  `result.unwrap(None) |> option.unwrap(default)` chains. Migrated the
+  schema-object parser and `config.gleam` over to the helpers; the
+  remaining ~40 mechanical migration sites in `openapi/parser.gleam`
+  are tracked as a follow-up under the same Issue. (#423)
 
 ### Added
 

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
+import oaspec/internal/openapi/parser_value
 import simplifile
 import yay
 
@@ -209,7 +210,7 @@ pub fn load_all(path: String) -> Result(List(Config), ConfigError) {
   )
 
   use mode <- result.try(
-    case yay.extract_optional_string(root, "mode") |> result.unwrap(None) {
+    case parser_value.optional_string(root, "mode") {
       Some("server") -> Ok(Server)
       Some("client") -> Ok(Client)
       Some("both") -> Ok(Both)
@@ -293,10 +294,7 @@ fn parse_target_node(
   mode: GenerateMode,
   validate: Bool,
 ) -> Result(Config, ConfigError) {
-  let package =
-    yay.extract_optional_string(node, "package")
-    |> result.unwrap(None)
-    |> option.unwrap("api")
+  let package = parser_value.string_default(node, "package", "api")
 
   // Determine output base directory, then derive mode-aware
   // server/client defaults. Priority: output.server/client
@@ -355,7 +353,7 @@ fn parse_target_item(
   // multiple targets sharing the default package would clobber each
   // other on disk and via Gleam imports. Reject early with a clear
   // index-tagged error.
-  case yay.extract_optional_string(node, "package") |> result.unwrap(None) {
+  case parser_value.optional_string(node, "package") {
     None ->
       Error(InvalidValue(
         field: "targets[" <> int.to_string(idx) <> "].package",

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -209,19 +209,17 @@ pub fn load_all(path: String) -> Result(List(Config), ConfigError) {
     |> result.map_error(fn(_) { MissingField(field: "input") }),
   )
 
-  use mode <- result.try(
-    case parser_value.optional_string(root, "mode") {
-      Some("server") -> Ok(Server)
-      Some("client") -> Ok(Client)
-      Some("both") -> Ok(Both)
-      None -> Ok(Both)
-      Some(other) ->
-        Error(InvalidValue(
-          field: "mode",
-          detail: "must be one of: server, client, both (got: " <> other <> ")",
-        ))
-    },
-  )
+  use mode <- result.try(case parser_value.optional_string(root, "mode") {
+    Some("server") -> Ok(Server)
+    Some("client") -> Ok(Client)
+    Some("both") -> Ok(Both)
+    None -> Ok(Both)
+    Some(other) ->
+      Error(InvalidValue(
+        field: "mode",
+        detail: "must be one of: server, client, both (got: " <> other <> ")",
+      ))
+  })
 
   // When `validate:` is omitted, the default is mode-dependent (issue #268).
   // Server-mode codegen with `validate: false` lets schema-invalid input

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -142,16 +142,23 @@ fn group_operations_by_id(
   operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
   key_fn: fn(String) -> String,
 ) -> Dict(String, List(String)) {
-  list.fold(operations, dict.new(), fn(acc, entry) {
-    let #(op_id, _operation, path, method) = entry
-    let key = key_fn(op_id)
-    let site = string.uppercase(spec.method_to_string(method)) <> " " <> path
-    case dict.get(acc, key) {
-      Ok(existing) -> dict.insert(acc, key, list.append(existing, [site]))
-      // nolint: thrown_away_error -- dict.get's Error signals absence of key; we start a new list for the first occurrence
-      Error(_) -> dict.insert(acc, key, [site])
-    }
-  })
+  // Accumulate site lists in reverse (prepend is O(1)) then reverse each
+  // value once at the end. The previous `list.append(existing, [site])`
+  // shape was O(N²) on the number of duplicates per key, which matters
+  // when a large spec accidentally collides many operationIds under the
+  // same case-folded form.
+  let reversed =
+    list.fold(operations, dict.new(), fn(acc, entry) {
+      let #(op_id, _operation, path, method) = entry
+      let key = key_fn(op_id)
+      let site = string.uppercase(spec.method_to_string(method)) <> " " <> path
+      case dict.get(acc, key) {
+        Ok(existing) -> dict.insert(acc, key, [site, ..existing])
+        // nolint: thrown_away_error -- dict.get's Error signals absence of key; we start a new list for the first occurrence
+        Error(_) -> dict.insert(acc, key, [site])
+      }
+    })
+  dict.map_values(reversed, fn(_key, sites) { list.reverse(sites) })
 }
 
 fn duplicate_operation_id_diagnostic(

--- a/src/oaspec/internal/openapi/hoist.gleam
+++ b/src/oaspec/internal/openapi/hoist.gleam
@@ -516,34 +516,37 @@ fn hoist_parameters(
   op_id: String,
   state: HoistState,
 ) -> #(List(RefOr(spec.Parameter(stage))), HoistState) {
-  list.fold(params, #([], state), fn(acc, ref_or_param) {
-    let #(params_acc, state) = acc
-    case ref_or_param {
-      Ref(_) -> #(list.append(params_acc, [ref_or_param]), state)
-      Value(param) -> {
-        case param.payload {
-          spec.ParameterSchema(schema_ref) -> {
-            let suffix = "Param" <> naming.to_pascal_case(param.name)
-            let #(hoisted, state) =
-              hoist_schema_ref(
-                schema_ref,
-                op_id,
-                suffix,
-                HoistedParameter(operation_id: op_id, name: param.name),
-                state,
-              )
-            let new_param =
-              spec.Parameter(..param, payload: spec.ParameterSchema(hoisted))
-            #(list.append(params_acc, [Value(new_param)]), state)
+  // Build params_rev with prepend (O(1) per step), reverse once at the
+  // end. Replaces the prior `list.append(acc, [x])` shape that was
+  // O(N²) on the parameter count — observable on operations with many
+  // parameters in large specs.
+  let #(params_rev, state) =
+    list.fold(params, #([], state), fn(acc, ref_or_param) {
+      let #(params_acc, state) = acc
+      case ref_or_param {
+        Ref(_) -> #([ref_or_param, ..params_acc], state)
+        Value(param) -> {
+          case param.payload {
+            spec.ParameterSchema(schema_ref) -> {
+              let suffix = "Param" <> naming.to_pascal_case(param.name)
+              let #(hoisted, state) =
+                hoist_schema_ref(
+                  schema_ref,
+                  op_id,
+                  suffix,
+                  HoistedParameter(operation_id: op_id, name: param.name),
+                  state,
+                )
+              let new_param =
+                spec.Parameter(..param, payload: spec.ParameterSchema(hoisted))
+              #([Value(new_param), ..params_acc], state)
+            }
+            spec.ParameterContent(_) -> #([ref_or_param, ..params_acc], state)
           }
-          spec.ParameterContent(_) -> #(
-            list.append(params_acc, [ref_or_param]),
-            state,
-          )
         }
       }
-    }
-  })
+    })
+  #(list.reverse(params_rev), state)
 }
 
 /// Hoist schemas within a RequestBody.

--- a/src/oaspec/internal/openapi/parser_schema.gleam
+++ b/src/oaspec/internal/openapi/parser_schema.gleam
@@ -40,33 +40,12 @@ fn parse_schema_object(
   path: String,
   index: LocationIndex,
 ) -> Result(SchemaObject, Diagnostic) {
-  let nullable =
-    yay.extract_optional_bool(node, "nullable")
-    |> result.unwrap(None)
-    |> option.unwrap(False)
-
-  let description =
-    yay.extract_optional_string(node, "description")
-    |> result.unwrap(None)
-
-  let deprecated =
-    yay.extract_optional_bool(node, "deprecated")
-    |> result.unwrap(None)
-    |> option.unwrap(False)
-
-  let title =
-    yay.extract_optional_string(node, "title")
-    |> result.unwrap(None)
-
-  let read_only =
-    yay.extract_optional_bool(node, "readOnly")
-    |> result.unwrap(None)
-    |> option.unwrap(False)
-
-  let write_only =
-    yay.extract_optional_bool(node, "writeOnly")
-    |> result.unwrap(None)
-    |> option.unwrap(False)
+  let nullable = parser_value.bool_default(node, "nullable", False)
+  let description = parser_value.optional_string(node, "description")
+  let deprecated = parser_value.bool_default(node, "deprecated", False)
+  let title = parser_value.optional_string(node, "title")
+  let read_only = parser_value.bool_default(node, "readOnly", False)
+  let write_only = parser_value.bool_default(node, "writeOnly", False)
 
   let default = parser_value.extract_optional(node, "default")
 
@@ -289,18 +268,13 @@ fn parse_typed_schema(
         // Unsupported keywords (const, if/then/else, etc.) are already caught
         // by check_unsupported_schema_keywords before reaching this point,
         // so this fallback is safe for legitimate type-less schemas.
-        let type_name =
-          yay.extract_optional_string(node, "type")
-          |> result.unwrap(None)
-          |> option.unwrap("object")
+        let type_name = parser_value.string_default(node, "type", "object")
         Ok(#(type_name, metadata))
       }
     },
   )
 
-  let format =
-    yay.extract_optional_string(node, "format")
-    |> result.unwrap(None)
+  let format = parser_value.optional_string(node, "format")
 
   case type_str {
     "string" -> {
@@ -308,12 +282,9 @@ fn parse_typed_schema(
         Ok(values) -> values
         _ -> []
       }
-      let min_length =
-        yay.extract_optional_int(node, "minLength") |> result.unwrap(None)
-      let max_length =
-        yay.extract_optional_int(node, "maxLength") |> result.unwrap(None)
-      let pattern =
-        yay.extract_optional_string(node, "pattern") |> result.unwrap(None)
+      let min_length = parser_value.optional_int(node, "minLength")
+      let max_length = parser_value.optional_int(node, "maxLength")
+      let pattern = parser_value.optional_string(node, "pattern")
       Ok(StringSchema(
         metadata:,
         format:,
@@ -325,18 +296,13 @@ fn parse_typed_schema(
     }
 
     "integer" -> {
-      let minimum =
-        yay.extract_optional_int(node, "minimum") |> result.unwrap(None)
-      let maximum =
-        yay.extract_optional_int(node, "maximum") |> result.unwrap(None)
+      let minimum = parser_value.optional_int(node, "minimum")
+      let maximum = parser_value.optional_int(node, "maximum")
       let exclusive_minimum =
-        yay.extract_optional_int(node, "exclusiveMinimum")
-        |> result.unwrap(None)
+        parser_value.optional_int(node, "exclusiveMinimum")
       let exclusive_maximum =
-        yay.extract_optional_int(node, "exclusiveMaximum")
-        |> result.unwrap(None)
-      let multiple_of =
-        yay.extract_optional_int(node, "multipleOf") |> result.unwrap(None)
+        parser_value.optional_int(node, "exclusiveMaximum")
+      let multiple_of = parser_value.optional_int(node, "multipleOf")
       Ok(IntegerSchema(
         metadata:,
         format:,
@@ -349,19 +315,13 @@ fn parse_typed_schema(
     }
 
     "number" -> {
-      let minimum =
-        yay.extract_optional_float(node, "minimum") |> result.unwrap(None)
-      let maximum =
-        yay.extract_optional_float(node, "maximum") |> result.unwrap(None)
+      let minimum = parser_value.optional_float(node, "minimum")
+      let maximum = parser_value.optional_float(node, "maximum")
       let exclusive_minimum =
-        yay.extract_optional_float(node, "exclusiveMinimum")
-        |> result.unwrap(None)
+        parser_value.optional_float(node, "exclusiveMinimum")
       let exclusive_maximum =
-        yay.extract_optional_float(node, "exclusiveMaximum")
-        |> result.unwrap(None)
-      let multiple_of =
-        yay.extract_optional_float(node, "multipleOf")
-        |> result.unwrap(None)
+        parser_value.optional_float(node, "exclusiveMaximum")
+      let multiple_of = parser_value.optional_float(node, "multipleOf")
       Ok(NumberSchema(
         metadata:,
         format:,
@@ -388,14 +348,9 @@ fn parse_typed_schema(
             ))
         },
       )
-      let min_items =
-        yay.extract_optional_int(node, "minItems") |> result.unwrap(None)
-      let max_items =
-        yay.extract_optional_int(node, "maxItems") |> result.unwrap(None)
-      let unique_items =
-        yay.extract_optional_bool(node, "uniqueItems")
-        |> result.unwrap(None)
-        |> option.unwrap(False)
+      let min_items = parser_value.optional_int(node, "minItems")
+      let max_items = parser_value.optional_int(node, "maxItems")
+      let unique_items = parser_value.bool_default(node, "uniqueItems", False)
       Ok(ArraySchema(metadata:, items:, min_items:, max_items:, unique_items:))
     }
 
@@ -423,12 +378,8 @@ fn parse_typed_schema(
           _ -> Ok(schema.Unspecified)
         },
       )
-      let min_properties =
-        yay.extract_optional_int(node, "minProperties")
-        |> result.unwrap(None)
-      let max_properties =
-        yay.extract_optional_int(node, "maxProperties")
-        |> result.unwrap(None)
+      let min_properties = parser_value.optional_int(node, "minProperties")
+      let max_properties = parser_value.optional_int(node, "maxProperties")
       Ok(ObjectSchema(
         metadata:,
         properties:,

--- a/src/oaspec/internal/openapi/parser_value.gleam
+++ b/src/oaspec/internal/openapi/parser_value.gleam
@@ -6,7 +6,7 @@
 
 import gleam/dict.{type Dict}
 import gleam/list
-import gleam/option.{type Option}
+import gleam/option.{type Option, None, Some}
 import oaspec/internal/openapi/value.{
   type JsonValue, JsonArray, JsonBool, JsonFloat, JsonInt, JsonNull, JsonObject,
   JsonString,
@@ -44,6 +44,63 @@ pub fn extract_optional(node: yay.Node, key: String) -> Option(JsonValue) {
     Ok(child) -> option.Some(from_node(child))
     // nolint: thrown_away_error -- yay.SelectorError here only signals absent/mismatched key; absence is represented as None
     Error(_) -> option.None
+  }
+}
+
+/// Extract an optional bool, collapsing yay's
+/// `Result(Option(Bool), _)` into a plain `Option(Bool)`. Used by
+/// `bool_default` below — kept private until a defaulted-only caller
+/// genuinely needs `Option(Bool)` outside the helper module.
+fn optional_bool(node: yay.Node, key: String) -> Option(Bool) {
+  case yay.extract_optional_bool(node, key) {
+    Ok(value) -> value
+    // nolint: thrown_away_error -- yay extractor errors collapse to "absent" for these helpers; the explicit Diagnostic surface is a separate concern handled elsewhere
+    Error(_) -> None
+  }
+}
+
+/// Extract an optional string, collapsing yay's nested result/option.
+pub fn optional_string(node: yay.Node, key: String) -> Option(String) {
+  case yay.extract_optional_string(node, key) {
+    Ok(value) -> value
+    // nolint: thrown_away_error -- absence is the only meaningful outcome here; see optional_bool
+    Error(_) -> None
+  }
+}
+
+/// Extract an optional int, collapsing yay's nested result/option.
+pub fn optional_int(node: yay.Node, key: String) -> Option(Int) {
+  case yay.extract_optional_int(node, key) {
+    Ok(value) -> value
+    // nolint: thrown_away_error -- absence is the only meaningful outcome here; see optional_bool
+    Error(_) -> None
+  }
+}
+
+/// Extract an optional float, collapsing yay's nested result/option.
+pub fn optional_float(node: yay.Node, key: String) -> Option(Float) {
+  case yay.extract_optional_float(node, key) {
+    Ok(value) -> value
+    // nolint: thrown_away_error -- absence is the only meaningful outcome here; see optional_bool
+    Error(_) -> None
+  }
+}
+
+/// Extract a bool with a default. Replaces the very common
+/// `extract_optional_bool |> result.unwrap(None) |> option.unwrap(default)`
+/// chain.
+pub fn bool_default(node: yay.Node, key: String, default: Bool) -> Bool {
+  case optional_bool(node, key) {
+    Some(value) -> value
+    None -> default
+  }
+}
+
+/// Extract a string with a default.
+pub fn string_default(node: yay.Node, key: String, default: String) -> String {
+  case optional_string(node, key) {
+    Some(value) -> value
+    None -> default
   }
 }
 

--- a/src/oaspec/transport.gleam
+++ b/src/oaspec/transport.gleam
@@ -239,15 +239,20 @@ pub fn with_default_headers(
   headers headers: List(#(String, String)),
 ) -> fn(Request) -> a {
   fn(req: Request) {
-    let merged =
-      list.fold(headers, req.headers, fn(acc, kv) {
+    // Build with prepend + final reverse so the fold is O(N) over the
+    // header list instead of the O(N²) shape we get from
+    // `list.append(acc, [...])`. has_header is order-independent
+    // (a name lookup), so checking against the reversed accumulator
+    // preserves the original "first-occurrence wins" behavior.
+    let merged_rev =
+      list.fold(headers, list.reverse(req.headers), fn(acc_rev, kv) {
         let #(name, value) = kv
-        case has_header(acc, name) {
-          True -> acc
-          False -> list.append(acc, [#(name, value)])
+        case has_header(acc_rev, name) {
+          True -> acc_rev
+          False -> [#(name, value), ..acc_rev]
         }
       })
-    send(Request(..req, headers: merged))
+    send(Request(..req, headers: list.reverse(merged_rev)))
   }
 }
 


### PR DESCRIPTION
## Summary

Bundles four perf-review issues into one PR.

- **#404** `transport.with_default_headers` rebuilt `req.headers` via `list.append(acc, [...])` on every fold step (O(N²) on the header count). Switched to prepend + final reverse — header order on the wire is preserved.
- **#426** `hoist.hoist_parameters` and `validate.group_operations_by_id` moved off `list.append(acc, [x])` for the same reason. `group_operations_by_id` reverses each per-key site list once at the end so the diagnostic message order is unchanged.
- **#423** Added `parser_value.{optional_string, optional_int, optional_float, bool_default, string_default}` (plus a private `optional_bool` used by `bool_default`) to replace the `result.unwrap(None) |> option.unwrap(default)` idiom that appeared 50+ times across the parser layer. Migrated `parser_schema.gleam` and `config.gleam` onto the helpers; the ~40 mechanical migration sites in `openapi/parser.gleam` are tracked as a follow-up under the same Issue.

## Out of scope (deferred)

- **#405** (regex re-compile in `naming`) — the architectural fix needs an FFI-backed memoized cache (Erlang `persistent_term` / JS module-level singleton) that interacts with the `ffi_usage = "error"` glinter rule. Will land as its own PR.

## Test plan

- [x] `gleam test` — 337 passed, no failures
- [x] `gleam run -m glinter` — 0 errors
- [ ] CI green

Closes #404, closes #426. Partially addresses #423 (parser.gleam migration tracked as follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal configuration parsing patterns to use simplified helper methods for YAML value extraction.
  * Updated internal data accumulation patterns across components for consistency and improved code clarity.

* **Documentation**
  * Updated changelog documenting recent internal technical improvements and refactoring initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->