### PR TITLE
refactor(codegen): extract codec_helpers, slim types.gleam, use AnalyzedOperation alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **codegen**: extracted shared codec helpers
+  (`escape_for_string_literal`, `list_at_or`, `qualified_schema_ref_type`,
+  `schema_ref_has_bare_option_type`) into a new
+  `oaspec/internal/codegen/codec_helpers` module. Both `encoders.gleam`
+  and `decoders.gleam` import from there now; the prior copy-pasted
+  duplicates (and the divergent `schema_ref_has_bare_option_*_type`
+  pair) are gone. Closes the follow-up flagged in #212. (#402)
+- **codegen**: `oaspec/internal/codegen/types` is now a thin module
+  that owns only `generate/1` and its private rendering helpers. The
+  dozen passthrough re-exports (`schema_to_gleam_type`,
+  `schema_has_*`, `filter_*_properties`, `merge_allof_schemas`, …) are
+  removed; callers (`encoders`, `decoders`, `guards`, `codec_helpers`)
+  now import `schema_utils` / `schema_dispatch` / `allof_merge`
+  directly. (#419)
+- **codegen**: function signatures across `decoders`, `encoders`,
+  `ir_build`, `router_ir`, `server`, `server_request_decode`, and
+  `validate` standardise on `List(context.AnalyzedOperation)` instead
+  of the inline 4-tuple shape `List(#(String, spec.Operation(Resolved),
+  String, spec.HttpMethod))`. The `AnalyzedOperation` alias already
+  existed; this PR finishes wiring callers through it so future field
+  additions on the alias don't ripple across 19 signatures. (#421)
+
 ### Performance
 
 - **transport**: `with_default_headers` no longer rebuilds `req.headers`

--- a/src/oaspec/internal/codegen/codec_helpers.gleam
+++ b/src/oaspec/internal/codegen/codec_helpers.gleam
@@ -1,0 +1,66 @@
+//// Helpers shared between `encoders.gleam` and `decoders.gleam`.
+////
+//// Issue #402: prior to extraction these four helpers were duplicated
+//// in both modules, with the doc comment on `encoders.gleam` flagging
+//// the duplication as a follow-up to #212. The bodies were
+//// byte-identical (modulo function names for the bare-Option pair), so
+//// keeping them in lock-step manually was a maintenance trap. This
+//// module owns the canonical implementations now.
+
+import gleam/string
+import oaspec/internal/codegen/context.{type Context}
+import oaspec/internal/codegen/schema_dispatch
+import oaspec/internal/openapi/schema.{
+  type SchemaRef, ArraySchema, BooleanSchema, Inline, IntegerSchema,
+  NumberSchema, StringSchema,
+}
+
+/// Escape a spec-derived string so it can be safely interpolated
+/// inside a generated Gleam string literal (e.g. `json.string("...")`).
+/// Constant property values from issue #309 land here — practical
+/// values are simple identifiers (`text`, `media`, …) but a spec
+/// could in principle declare an enum value containing `"` or `\`.
+pub fn escape_for_string_literal(value: String) -> String {
+  value
+  |> string.replace(each: "\\", with: "\\\\")
+  |> string.replace(each: "\"", with: "\\\"")
+}
+
+/// Get element at index from a list, or return a default.
+pub fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
+  case lst, idx {
+    [], _ -> default
+    [head, ..], 0 -> head
+    [_, ..rest], n -> list_at_or(rest, n - 1, default)
+  }
+}
+
+/// Convert a SchemaRef to a qualified Gleam type string (with `types.`
+/// prefix for component refs). `_ctx` is currently unused but kept on
+/// the signature so future ref-resolving variants don't change the
+/// caller surface.
+pub fn qualified_schema_ref_type(ref: SchemaRef, _ctx: Context) -> String {
+  case ref {
+    Inline(schema) -> schema_dispatch.schema_type(schema)
+    _ -> schema_dispatch.schema_ref_qualified_type(ref)
+  }
+}
+
+/// Issue #387: True when the top-level codec for this schema would
+/// emit a bare `Option(...)` wrapper at the surface (decoder declares
+/// `decode.Decoder(Option(...))`, encoder takes a bare `Option(...)`
+/// parameter). Only primitive / array component schemas with
+/// `nullable: true` reach this shape; object / allOf / oneOf / anyOf /
+/// enum schemas wrap optionality through `decode.optional` /
+/// `json.nullable` inside their bodies and never declare `Option(...)`
+/// as the outer type.
+pub fn schema_ref_has_bare_option_type(ref: SchemaRef) -> Bool {
+  case ref {
+    Inline(StringSchema(metadata:, enum_values: [], ..)) -> metadata.nullable
+    Inline(IntegerSchema(metadata:, ..)) -> metadata.nullable
+    Inline(NumberSchema(metadata:, ..)) -> metadata.nullable
+    Inline(BooleanSchema(metadata:)) -> metadata.nullable
+    Inline(ArraySchema(metadata:, ..)) -> metadata.nullable
+    _ -> False
+  }
+}

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -5,13 +5,13 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/config
 import oaspec/internal/codegen/allof_merge
+import oaspec/internal/codegen/codec_helpers
 import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
-import oaspec/internal/codegen/types as type_gen
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema.{
@@ -49,7 +49,7 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 /// Generate JSON decoders for all component schemas and anonymous types.
 fn generate_decoders(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> String {
   let schemas = case context.spec(ctx).components {
     Some(components) ->
@@ -63,7 +63,7 @@ fn generate_decoders(
   let needs_option =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      type_gen.schema_has_optional_fields(schema_ref, ctx)
+      schema_utils.schema_has_optional_fields(schema_ref, ctx)
     })
 
   // Check if dict module is needed (any schema with typed/untyped
@@ -78,13 +78,19 @@ fn generate_decoders(
   let component_needs_dict =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      type_gen.schema_has_additional_properties(schema_ref, ctx)
-      || type_gen.schema_has_forbidden_additional_properties(schema_ref, ctx)
+      schema_utils.schema_has_additional_properties(schema_ref, ctx)
+      || schema_utils.schema_has_forbidden_additional_properties(
+        schema_ref,
+        ctx,
+      )
     })
   let operation_needs_dict =
     list.any(operation_inline_schemas, fn(schema_ref) {
-      type_gen.schema_has_additional_properties(schema_ref, ctx)
-      || type_gen.schema_has_forbidden_additional_properties(schema_ref, ctx)
+      schema_utils.schema_has_additional_properties(schema_ref, ctx)
+      || schema_utils.schema_has_forbidden_additional_properties(
+        schema_ref,
+        ctx,
+      )
     })
   let needs_dict = component_needs_dict || operation_needs_dict
 
@@ -94,10 +100,10 @@ fn generate_decoders(
   let needs_strict_oneof_runtime =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      type_gen.schema_has_non_discriminator_oneof(schema_ref, ctx)
+      schema_utils.schema_has_non_discriminator_oneof(schema_ref, ctx)
     })
     || list.any(operation_inline_schemas, fn(schema_ref) {
-      type_gen.schema_has_non_discriminator_oneof(schema_ref, ctx)
+      schema_utils.schema_has_non_discriminator_oneof(schema_ref, ctx)
     })
 
   // Check if types module is needed (any non-primitive schema)
@@ -139,7 +145,7 @@ fn generate_decoders(
   let needs_bare_option_type =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      schema_ref_has_bare_option_decoder_type(schema_ref)
+      codec_helpers.schema_ref_has_bare_option_type(schema_ref)
     })
   let imports = case needs_option, needs_bare_option_type {
     True, True -> list.append(base_imports, ["gleam/option.{type Option}"])
@@ -184,7 +190,7 @@ fn generate_decoders(
 fn generate_anonymous_decoders(
   sb: se.StringBuilder,
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> se.StringBuilder {
   list.fold(operations, sb, fn(sb, op) {
     let #(op_id, operation, _path, _method) = op
@@ -212,7 +218,7 @@ fn generate_anonymous_response_decoders(
               Some(Inline(schema_obj)) -> {
                 // Filter out writeOnly properties from response decoders
                 let filtered_schema =
-                  type_gen.filter_write_only_properties(schema_obj, ctx)
+                  schema_utils.filter_write_only_properties(schema_obj, ctx)
                 let suffix = "Response" <> http.status_code_suffix(status_code)
                 generate_anonymous_schema_decoder(
                   sb,
@@ -248,7 +254,7 @@ fn generate_anonymous_request_body_decoder(
             Some(Inline(schema_obj)) -> {
               // Filter out readOnly properties from request body decoders
               let filtered_schema =
-                type_gen.filter_read_only_properties(schema_obj, ctx)
+                schema_utils.filter_read_only_properties(schema_obj, ctx)
               generate_anonymous_schema_decoder(
                 sb,
                 op_id,
@@ -273,7 +279,7 @@ fn generate_anonymous_request_body_decoder(
 /// leave `gleam/dict` un-imported when the body of the generated decoder
 /// references it.
 fn collect_operation_inline_schemas(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> List(SchemaRef) {
   list.flat_map(operations, fn(op) {
     let #(_op_id, operation, _path, _method) = op
@@ -404,7 +410,7 @@ fn generate_decoder(
       )
 
     Inline(AllOfSchema(metadata:, schemas:)) -> {
-      let merged = type_gen.merge_allof_schemas(schemas, ctx)
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
       let merged_schema =
         Inline(ObjectSchema(
           metadata:,
@@ -541,10 +547,14 @@ fn generate_object_decoder(
     list.index_fold(props, sb, fn(sb, entry, idx) {
       let #(prop_name, prop_ref) = entry
       let field_name =
-        list_at_or(deduped_names, idx, naming.to_snake_case(prop_name))
+        codec_helpers.list_at_or(
+          deduped_names,
+          idx,
+          naming.to_snake_case(prop_name),
+        )
       // writeOnly fields may not appear in responses, so treat them
       // as optional even if listed in required
-      let is_write_only = type_gen.schema_ref_is_write_only(prop_ref, ctx)
+      let is_write_only = schema_utils.schema_ref_is_write_only(prop_ref, ctx)
       let is_required = list.contains(required, prop_name) && !is_write_only
       let field_decoder = schema_ref_to_decoder(prop_ref, name, prop_name)
       let is_nullable_schema =
@@ -708,7 +718,11 @@ fn generate_object_decoder(
     list.index_map(props, fn(entry, idx) {
       let #(prop_name, prop_ref) = entry
       let field_name =
-        list_at_or(deduped_names, idx, naming.to_snake_case(prop_name))
+        codec_helpers.list_at_or(
+          deduped_names,
+          idx,
+          naming.to_snake_case(prop_name),
+        )
       #(prop_name, prop_ref, field_name)
     })
     // Issue #309: constant properties are elided from the record, so
@@ -817,7 +831,11 @@ fn generate_enum_decoder(
   let sb =
     list.index_fold(enum_values, sb, fn(sb, value, idx) {
       let variant_suffix =
-        list_at_or(deduped_variants, idx, naming.to_pascal_case(value))
+        codec_helpers.list_at_or(
+          deduped_variants,
+          idx,
+          naming.to_pascal_case(value),
+        )
       let variant = naming.schema_to_type_name(type_name) <> variant_suffix
       sb
       |> se.indent(
@@ -828,7 +846,7 @@ fn generate_enum_decoder(
 
   // Unknown enum values → decode failure, not silent fallback
   let first_variant_suffix =
-    list_at_or(deduped_variants, 0, case enum_values {
+    codec_helpers.list_at_or(deduped_variants, 0, case enum_values {
       [first, ..] -> naming.to_pascal_case(first)
       [] -> "Unknown"
     })
@@ -991,7 +1009,7 @@ fn generate_array_decoder(
   ctx: Context,
 ) -> se.StringBuilder {
   let inner_decoder = schema_ref_to_decoder(items, name, "")
-  let inner_type = qualified_schema_ref_type(items, ctx)
+  let inner_type = codec_helpers.qualified_schema_ref_type(items, ctx)
   let list_type = "List(" <> inner_type <> ")"
   let list_decoder = "decode.list(" <> inner_decoder <> ")"
   let #(gleam_type, decoder_expr) = case nullable {
@@ -1369,42 +1387,6 @@ fn schema_ref_to_decoder(
   }
 }
 
-/// Get element at index from a list, or return a default.
-fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
-  case lst, idx {
-    [], _ -> default
-    [head, ..], 0 -> head
-    [_, ..rest], n -> list_at_or(rest, n - 1, default)
-  }
-}
-
-/// Convert a SchemaRef to a qualified Gleam type string (with types. prefix for refs).
-fn qualified_schema_ref_type(ref: SchemaRef, ctx: Context) -> String {
-  case ref {
-    Inline(schema) -> type_gen.schema_to_gleam_type(schema, ctx)
-    _ -> schema_dispatch.schema_ref_qualified_type(ref)
-  }
-}
-
-/// Issue #387: True when the top-level decoder for this schema would
-/// emit a bare `decode.Decoder(Option(...))` annotation. That happens
-/// only for primitive / array component schemas with `nullable: true`,
-/// since those produce a top-level type alias wrapped in `Option(...)`
-/// and the matching decoder declares the same type. Object / allOf /
-/// oneOf / anyOf / enum schemas wrap any optionality through
-/// `decode.optional(...)` inside `decode.field`, so the bare `Option`
-/// type never appears in their decoder bodies.
-fn schema_ref_has_bare_option_decoder_type(ref: SchemaRef) -> Bool {
-  case ref {
-    Inline(StringSchema(metadata:, enum_values: [], ..)) -> metadata.nullable
-    Inline(IntegerSchema(metadata:, ..)) -> metadata.nullable
-    Inline(NumberSchema(metadata:, ..)) -> metadata.nullable
-    Inline(BooleanSchema(metadata:)) -> metadata.nullable
-    Inline(ArraySchema(metadata:, ..)) -> metadata.nullable
-    _ -> False
-  }
-}
-
 /// Add a doc comment if description is present.
 fn maybe_doc_comment(
   sb: se.StringBuilder,
@@ -1430,7 +1412,7 @@ fn emit_constant_field_decoder(
   prop_name: String,
   constant_value: String,
 ) -> se.StringBuilder {
-  let escaped = escape_for_string_literal(constant_value)
+  let escaped = codec_helpers.escape_for_string_literal(constant_value)
   sb
   |> se.indent(
     1,
@@ -1450,14 +1432,4 @@ fn emit_constant_field_decoder(
   )
   |> se.indent(2, "}")
   |> se.indent(1, "}))")
-}
-
-/// Escape a spec-derived string so it can be safely interpolated
-/// inside a generated Gleam string literal. Mirrors the helper in
-/// `encoders.gleam` — extracted here to keep the decoder module
-/// self-contained for issue #309.
-fn escape_for_string_literal(value: String) -> String {
-  value
-  |> string.replace(each: "\\", with: "\\\\")
-  |> string.replace(each: "\"", with: "\\\"")
 }

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -2,11 +2,10 @@
 ////
 //// Split out of `decoders.gleam` so each module owns one direction of
 //// the codec pipeline — decoders produces `decode.gleam`, encoders
-//// produces `encode.gleam`. Shared traversal helpers (`list_at_or`,
-//// `qualified_schema_ref_type`) are intentionally duplicated rather
-//// than lifted into a third module; the helpers are small, the
-//// duplication is stable, and extracting a shared dispatch module is
-//// tracked as follow-up to #212.
+//// produces `encode.gleam`. The shared traversal helpers
+//// (`escape_for_string_literal`, `list_at_or`, `qualified_schema_ref_type`,
+//// `schema_ref_has_bare_option_type`) live in `codec_helpers.gleam` —
+//// extracted in #402 to close the follow-up flagged by #212.
 
 import gleam/bool
 import gleam/dict
@@ -15,13 +14,13 @@ import gleam/option.{None, Some}
 import gleam/string
 import oaspec/config
 import oaspec/internal/codegen/allof_merge
+import oaspec/internal/codegen/codec_helpers
 import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
-import oaspec/internal/codegen/types as type_gen
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/schema.{
   type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema,
@@ -49,7 +48,7 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 /// Generate JSON encoders for all component schemas and anonymous types.
 fn generate_encoders(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> String {
   let schemas = case context.spec(ctx).components {
     Some(components) ->
@@ -134,7 +133,7 @@ fn generate_encoders(
   let needs_bare_option_type =
     list.any(schemas, fn(entry) {
       let #(_, schema_ref) = entry
-      schema_ref_has_bare_option_encoder_type(schema_ref)
+      codec_helpers.schema_ref_has_bare_option_type(schema_ref)
     })
   let option_import_line = case needs_bare_option_type {
     True -> "gleam/option.{type Option}"
@@ -264,7 +263,7 @@ fn generate_inline_enum_encoders(
 fn generate_anonymous_encoders(
   sb: se.StringBuilder,
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> se.StringBuilder {
   list.fold(operations, sb, fn(sb, op) {
     let #(op_id, operation, _path, _method) = op
@@ -289,7 +288,7 @@ fn generate_anonymous_request_body_encoder(
             Some(Inline(schema_obj)) -> {
               // Filter out readOnly properties from request body encoders
               let filtered_schema =
-                type_gen.filter_read_only_properties(schema_obj, ctx)
+                schema_utils.filter_read_only_properties(schema_obj, ctx)
               let name = naming.to_snake_case(op_id) <> "_request_body"
               generate_encoder(sb, name, Inline(filtered_schema), ctx)
             }
@@ -347,12 +346,16 @@ fn generate_encoder(
         list.index_map(all_props, fn(entry, idx) {
           let #(prop_name, prop_ref) = entry
           let field_name =
-            list_at_or(all_deduped_names, idx, naming.to_snake_case(prop_name))
+            codec_helpers.list_at_or(
+              all_deduped_names,
+              idx,
+              naming.to_snake_case(prop_name),
+            )
           #(prop_name, prop_ref, field_name)
         })
         |> list.filter(fn(entry) {
           let #(_, prop_ref, _) = entry
-          !type_gen.schema_ref_is_read_only(prop_ref, ctx)
+          !schema_utils.schema_ref_is_read_only(prop_ref, ctx)
         })
 
       // Issue #303: a property that is in `properties` but not in `required`
@@ -405,7 +408,7 @@ fn generate_encoder(
           {
             Some(constant_value) ->
               "json.string(\""
-              <> escape_for_string_literal(constant_value)
+              <> codec_helpers.escape_for_string_literal(constant_value)
               <> "\")"
             None ->
               schema_ref_to_json_encoder(
@@ -567,7 +570,11 @@ fn generate_encoder(
       let sb =
         list.index_fold(enum_values, sb, fn(sb, value, idx) {
           let variant_suffix =
-            list_at_or(enc_deduped_variants, idx, naming.to_pascal_case(value))
+            codec_helpers.list_at_or(
+              enc_deduped_variants,
+              idx,
+              naming.to_pascal_case(value),
+            )
           let variant = naming.schema_to_type_name(type_name) <> variant_suffix
           sb
           |> se.indent(2, "types." <> variant <> " -> \"" <> value <> "\"")
@@ -610,7 +617,11 @@ fn generate_encoder(
       let sb =
         list.index_fold(enum_values, sb, fn(sb, value, idx) {
           let variant_suffix =
-            list_at_or(enc_deduped_variants, idx, naming.to_pascal_case(value))
+            codec_helpers.list_at_or(
+              enc_deduped_variants,
+              idx,
+              naming.to_pascal_case(value),
+            )
           let variant = naming.schema_to_type_name(type_name) <> variant_suffix
           sb
           |> se.indent(2, "types." <> variant <> " -> \"" <> value <> "\"")
@@ -623,7 +634,7 @@ fn generate_encoder(
     }
 
     Inline(AllOfSchema(metadata:, schemas:)) -> {
-      let merged = type_gen.merge_allof_schemas(schemas, ctx)
+      let merged = allof_merge.merge_allof_schemas(schemas, ctx)
       let merged_schema =
         Inline(ObjectSchema(
           metadata:,
@@ -838,7 +849,7 @@ fn generate_encoder(
       // alias rendered as `Option(List(T))`, so the encoder must accept
       // `Option(List(T))` and use `json.nullable(value, ...)` instead
       // of the bare `json.array(...)` it had been emitting.
-      let inner_type = qualified_schema_ref_type(items, ctx)
+      let inner_type = codec_helpers.qualified_schema_ref_type(items, ctx)
       let list_type = "List(" <> inner_type <> ")"
       let inner_encoder = schema_ref_to_json_encoder_fn(items, name, "")
       let array_expr = "json.array(value, " <> inner_encoder <> ")"
@@ -945,50 +956,4 @@ fn schema_ref_to_json_encoder_fn(
 fn ensure_import(imports: List(String), name: String) -> List(String) {
   use <- bool.guard(list.contains(imports, name), imports)
   list.append(imports, [name])
-}
-
-/// Issue #387: True when the top-level encoder for this schema would
-/// emit a bare `Option(...)` parameter type. Mirrors the decoder
-/// counterpart in `decoders.gleam`. Only primitive / array component
-/// schemas with `nullable: true` reach this shape; object / allOf /
-/// oneOf / anyOf / enum schemas wrap optionality through
-/// `json.nullable(...)` inside their encoder bodies and never declare
-/// `Option(...)` as the outer parameter type.
-fn schema_ref_has_bare_option_encoder_type(ref: SchemaRef) -> Bool {
-  case ref {
-    Inline(StringSchema(metadata:, enum_values: [], ..)) -> metadata.nullable
-    Inline(IntegerSchema(metadata:, ..)) -> metadata.nullable
-    Inline(NumberSchema(metadata:, ..)) -> metadata.nullable
-    Inline(BooleanSchema(metadata:)) -> metadata.nullable
-    Inline(ArraySchema(metadata:, ..)) -> metadata.nullable
-    _ -> False
-  }
-}
-
-/// Escape a spec-derived string so it can be safely interpolated
-/// inside a generated Gleam string literal (e.g. `json.string("...")`).
-/// Constant property values from issue #309 land here — practical
-/// values are simple identifiers (`text`, `media`, …) but a spec
-/// could in principle declare an enum value containing `"` or `\`.
-fn escape_for_string_literal(value: String) -> String {
-  value
-  |> string.replace(each: "\\", with: "\\\\")
-  |> string.replace(each: "\"", with: "\\\"")
-}
-
-/// Get element at index from a list, or return a default.
-fn list_at_or(lst: List(String), idx: Int, default: String) -> String {
-  case lst, idx {
-    [], _ -> default
-    [head, ..], 0 -> head
-    [_, ..rest], n -> list_at_or(rest, n - 1, default)
-  }
-}
-
-/// Convert a SchemaRef to a qualified Gleam type string (with types. prefix for refs).
-fn qualified_schema_ref_type(ref: SchemaRef, ctx: Context) -> String {
-  case ref {
-    Inline(schema) -> type_gen.schema_to_gleam_type(schema, ctx)
-    _ -> schema_dispatch.schema_ref_qualified_type(ref)
-  }
 }

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -13,7 +13,7 @@ import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/ir_build
-import oaspec/internal/codegen/types as type_gen
+import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, ArraySchema, Inline,
   IntegerSchema, NumberSchema, ObjectSchema, Reference, StringSchema,
@@ -1410,7 +1410,7 @@ fn composite_validator_type(
     Ok(ObjectSchema(..)) | Ok(AllOfSchema(..)) ->
       "types." <> naming.schema_to_type_name(name)
     Ok(s) -> {
-      type_gen.schema_to_gleam_type(s, ctx)
+      schema_dispatch.schema_type(s)
     }
     _ -> "types." <> naming.schema_to_type_name(name)
   }

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -82,7 +82,7 @@ pub fn build_request_types_module(ctx: Context) -> Module {
 }
 
 fn compute_request_type_imports(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
   ctx: Context,
 ) -> List(String) {
   let needs_option =
@@ -237,7 +237,7 @@ pub fn build_response_types_module(ctx: Context) -> Module {
 
 /// Build ResponseHeaderRecord list from all operations.
 fn build_response_header_records(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> List(ir.ResponseHeaderRecord) {
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, _path, _method) = op
@@ -296,7 +296,7 @@ fn response_headers_need_option(records: List(ir.ResponseHeaderRecord)) -> Bool 
 }
 
 fn responses_need_types_import(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> Bool {
   list.any(operations, fn(op) {
     let #(_op_id, operation, _path, _method) = op

--- a/src/oaspec/internal/codegen/router_ir.gleam
+++ b/src/oaspec/internal/codegen/router_ir.gleam
@@ -492,7 +492,7 @@ fn operation_needs_guard_validation(
 }
 
 fn operations_have_response_headers(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> Bool {
   list.any(operations, fn(op) {
     let #(_, operation, _, _) = op
@@ -507,7 +507,7 @@ fn operations_have_response_headers(
 }
 
 fn operations_have_response_header_of_type(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
   type_name: String,
 ) -> Bool {
   list.any(operations, fn(op) {
@@ -526,7 +526,7 @@ fn operations_have_response_header_of_type(
 }
 
 fn operations_have_optional_response_header(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> Bool {
   list.any(operations, fn(op) {
     let #(_, operation, _, _) = op

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -65,7 +65,7 @@ pub fn generate(ctx: Context) -> List(GeneratedFile) {
 /// banner is intentionally absent — the user owns this file.
 fn generate_handlers(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> String {
   let sb =
     se.line(
@@ -112,7 +112,7 @@ fn generate_handlers(
 /// spec without touching the user's `handlers.gleam`.
 fn generate_handlers_generated(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> String {
   let pkg = config.package(context.config(ctx))
   let sb =
@@ -238,7 +238,7 @@ fn generate_handler(
 /// Generate a router module that dispatches requests.
 fn generate_router(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> String {
   let requirements = router_ir.analyze(ctx)
   let all_imports = router_ir.imports(requirements, ctx)

--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -330,7 +330,7 @@ pub fn schema_ref_string_enum(
 /// of my emitted code reference `types`?" without re-implementing the
 /// per-param dispatch.
 pub fn operations_have_enum_ref_params(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
   ctx: Context,
 ) -> Bool {
   list.any(operations, fn(op) {

--- a/src/oaspec/internal/codegen/types.gleam
+++ b/src/oaspec/internal/codegen/types.gleam
@@ -1,20 +1,23 @@
-import oaspec/internal/codegen/allof_merge
+//// Type-module generation entry point.
+////
+//// Issue #419: previously this module also re-exported a dozen
+//// `schema_utils` / `schema_dispatch` / `allof_merge` helpers as
+//// passthrough wrappers, which made "where does this helper live?" a
+//// guessing game (`schema_ref_is_read_only` was exported from both
+//// `schema_utils` and `types`, etc.). Callers now import the
+//// underlying modules directly; only `generate/1` lives here.
+
 import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/ir_build
 import oaspec/internal/codegen/ir_render
-import oaspec/internal/codegen/schema_dispatch
-import oaspec/internal/codegen/schema_utils
-import oaspec/internal/openapi/schema.{type SchemaObject, type SchemaRef}
-import oaspec/internal/openapi/spec.{type Resolved}
 
 /// Generate type definitions from OpenAPI schemas.
 pub fn generate(ctx: Context) -> List(GeneratedFile) {
-  let operations = context.operations(ctx)
   let types_content = generate_types(ctx)
-  let request_types_content = generate_request_types(ctx, operations)
-  let response_types_content = generate_response_types(ctx, operations)
+  let request_types_content = generate_request_types(ctx)
+  let response_types_content = generate_response_types(ctx)
 
   [
     GeneratedFile(
@@ -45,109 +48,16 @@ fn generate_types(ctx: Context) -> String {
   |> ir_render.render()
 }
 
-/// Convert a schema object to a Gleam type string.
-/// Delegates to schema_dispatch for the centralized type mapping.
-pub fn schema_to_gleam_type(schema: SchemaObject, _ctx: Context) -> String {
-  schema_dispatch.schema_type(schema)
-}
-
 /// Generate request types for all operations via the IR pipeline.
-/// Shape of each RecordType matches the former string-builder output;
-/// `gleam format` normalizes whitespace either way so the final on-disk
-/// content is unchanged.
-fn generate_request_types(
-  ctx: Context,
-  _operations: List(
-    #(String, spec.Operation(Resolved), String, spec.HttpMethod),
-  ),
-) -> String {
+fn generate_request_types(ctx: Context) -> String {
   ir_build.build_request_types_module(ctx)
   |> ir_render.render()
 }
 
 /// Generate response types for all operations via the IR pipeline.
 /// Each operation becomes one `UnionType` with status-code-named
-/// variants. Payload rules (empty / String / qualified schema type) are
-/// preserved from the former string-builder output.
-fn generate_response_types(
-  ctx: Context,
-  _operations: List(
-    #(String, spec.Operation(Resolved), String, spec.HttpMethod),
-  ),
-) -> String {
+/// variants.
+fn generate_response_types(ctx: Context) -> String {
   ir_build.build_response_types_module(ctx)
   |> ir_render.render()
-}
-
-/// Result of merging allOf sub-schemas.
-/// Re-export from allof_merge for backward compatibility.
-pub type MergedAllOf =
-  allof_merge.MergedAllOf
-
-/// Re-export merge_allof_schemas.
-pub fn merge_allof_schemas(
-  schemas: List(SchemaRef),
-  ctx: Context,
-) -> MergedAllOf {
-  allof_merge.merge_allof_schemas(schemas, ctx)
-}
-
-/// Check if a schema has typed or untyped additionalProperties that would need Dict.
-pub fn schema_has_additional_properties(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
-  schema_utils.schema_has_additional_properties(schema_ref, ctx)
-}
-
-/// Check if a schema has `additionalProperties: false` (needs Dict for the
-/// closed-schema unknown-key check at decode time).
-pub fn schema_has_forbidden_additional_properties(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
-  schema_utils.schema_has_forbidden_additional_properties(schema_ref, ctx)
-}
-
-/// Check if a schema is — or contains — a non-discriminator `oneOf` whose
-/// strict decoder needs `gleam/list` + `gleam/result` imported in
-/// `decode.gleam`.
-pub fn schema_has_non_discriminator_oneof(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
-  schema_utils.schema_has_non_discriminator_oneof(schema_ref, ctx)
-}
-
-/// Check if a schema has any optional or nullable fields that would need Option.
-pub fn schema_has_optional_fields(schema_ref: SchemaRef, ctx: Context) -> Bool {
-  schema_utils.schema_has_optional_fields(schema_ref, ctx)
-}
-
-/// Check if a SchemaRef has readOnly metadata, resolving $ref if needed.
-pub fn schema_ref_is_read_only(ref: SchemaRef, ctx: Context) -> Bool {
-  schema_utils.schema_ref_is_read_only(ref, ctx)
-}
-
-/// Check if a SchemaRef has writeOnly metadata, resolving $ref if needed.
-pub fn schema_ref_is_write_only(ref: SchemaRef, ctx: Context) -> Bool {
-  schema_utils.schema_ref_is_write_only(ref, ctx)
-}
-
-/// Filter readOnly properties from an ObjectSchema for request body context.
-/// Returns a new schema with readOnly properties removed.
-pub fn filter_read_only_properties(
-  schema_obj: SchemaObject,
-  ctx: Context,
-) -> SchemaObject {
-  schema_utils.filter_read_only_properties(schema_obj, ctx)
-}
-
-/// Filter writeOnly properties from an ObjectSchema for response body context.
-/// Returns a new schema with writeOnly properties removed.
-pub fn filter_write_only_properties(
-  schema_obj: SchemaObject,
-  ctx: Context,
-) -> SchemaObject {
-  schema_utils.filter_write_only_properties(schema_obj, ctx)
 }

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -99,7 +99,7 @@ fn validate_decode_list_collisions(ctx: Context) -> List(Diagnostic) {
 /// name. Returns one diagnostic per distinct colliding name, listing all
 /// `METHOD /path` sites that claimed it.
 fn validate_unique_operation_ids(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> List(Diagnostic) {
   let literal = group_operations_by_id(operations, fn(op_id) { op_id })
   let by_function =
@@ -139,7 +139,7 @@ fn validate_unique_operation_ids(
 }
 
 fn group_operations_by_id(
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
   key_fn: fn(String) -> String,
 ) -> Dict(String, List(String)) {
   // Accumulate site lists in reverse (prepend is O(1)) then reverse each
@@ -219,7 +219,7 @@ pub fn error_to_string(error: Diagnostic) -> String {
 /// Validate all operations for unsupported patterns.
 fn validate_operations(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> List(Diagnostic) {
   list.flat_map(operations, fn(op) {
     let #(op_id, operation, path, _method) = op
@@ -1280,7 +1280,7 @@ fn validate_schema_recursive(
 /// security requirements point to schemes defined in components.securitySchemes.
 fn validate_security_schemes(
   ctx: Context,
-  operations: List(#(String, spec.Operation(Resolved), String, spec.HttpMethod)),
+  operations: List(context.AnalyzedOperation),
 ) -> List(Diagnostic) {
   let scheme_names = case context.spec(ctx).components {
     Some(components) -> dict.keys(components.security_schemes)


### PR DESCRIPTION
## Summary

Bundles three codegen-cleanup issues into one PR.

- **#402** Extracted `src/oaspec/internal/codegen/codec_helpers.gleam` owning the four helpers copy-pasted between `encoders.gleam` and `decoders.gleam` (`escape_for_string_literal`, `list_at_or`, `qualified_schema_ref_type`, plus the unified `schema_ref_has_bare_option_type` — the encoder/decoder copies were byte-identical apart from the function suffix). Closes the follow-up flagged in #212.
- **#419** `types.gleam` reduced to the single real entry point (`generate/1` + its private renderer helpers). The dozen passthrough re-exports that wrapped `schema_utils` / `schema_dispatch` / `allof_merge` are gone; callers (`encoders`, `decoders`, `guards`, `codec_helpers`) now import the underlying modules directly, so "where does this helper live?" stops being a guessing game and there is no longer a duplicate `schema_ref_is_read_only` export across two modules.
- **#421** Function signatures in `decoders`, `encoders`, `ir_build`, `router_ir`, `server`, `server_request_decode`, and `validate` now use `List(context.AnalyzedOperation)` instead of the bare 4-tuple `List(#(String, spec.Operation(Resolved), String, spec.HttpMethod))`. The alias already existed but most call sites had ignored it; future field additions on `AnalyzedOperation` are now non-breaking on these 19 signatures.

## Out of scope (deferred)

The remaining refactor issues from the project review (#403, #416, #417, #418, #420) are larger structural changes and are tracked as follow-up PRs.

## Test plan

- [x] `gleam build`
- [x] `gleam format --check src/ test/`
- [x] `gleam test` — 337 passed, no failures
- [x] `gleam run -m glinter` — 0 errors
- [ ] CI green

Closes #402, closes #419, closes #421.
