### PR TITLE
cleanup: drop unused context.analyzed_schemas + validate pass-through wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+
+- **codegen**: dropped the unused `context.analyzed_schemas/1` accessor
+  and its backing `AnalyzedSchema` type. Production codegen consumes
+  the schema cache through `resolve_schema_ref/2`, and the snapshot
+  test that backed `analyzed_schemas/1` was the only reader. The
+  internal `build_schema_cache` is now a one-shot fold over the spec's
+  components dict instead of going through an intermediary list. (#429)
+- **codegen**: dropped the `validate.errors_only` /
+  `validate.warnings_only` / `validate.filter_by_mode` pass-through
+  wrappers. Callers (`generate.gleam` and the test suite) now import
+  `oaspec/openapi/diagnostic` and call those functions directly, which
+  removes the prior two-name confusion (`generate.gleam` had been
+  mixing both forms). (#430)
+
 ### Changed
 
 - **codegen**: extracted shared codec helpers

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 337 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 336 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 257 test fixtures (including 98 OSS-derived edge-case specs)
 
 ## Install

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -94,14 +94,14 @@ fn prepare_context(
   let #(elapsed, capability_issues) =
     progress.timed(fn() {
       capability_check.check(spec)
-      |> validate.filter_by_mode(config.mode(cfg))
+      |> diagnostic.filter_by_mode(config.mode(cfg))
     })
   progress.report(
     reporter,
     "capability check (took " <> progress.format_ms(elapsed) <> ")",
   )
-  let capability_errors = validate.errors_only(capability_issues)
-  let capability_warnings = validate.warnings_only(capability_issues)
+  let capability_errors = diagnostic.errors_only(capability_issues)
+  let capability_warnings = diagnostic.warnings_only(capability_issues)
   use _ <- result.try(case list.is_empty(capability_errors) {
     False -> Error(ValidationErrors(errors: capability_errors))
     True -> Ok(Nil)
@@ -139,7 +139,7 @@ fn prepare_context(
   let #(elapsed, validation_issues) =
     progress.timed(fn() {
       validate.validate(ctx)
-      |> validate.filter_by_mode(config.mode(cfg))
+      |> diagnostic.filter_by_mode(config.mode(cfg))
     })
   progress.report(
     reporter,
@@ -147,8 +147,8 @@ fn prepare_context(
       <> progress.format_ms(elapsed)
       <> ")",
   )
-  let blocking_errors = validate.errors_only(validation_issues)
-  let validation_warnings = validate.warnings_only(validation_issues)
+  let blocking_errors = diagnostic.errors_only(validation_issues)
+  let validation_warnings = diagnostic.warnings_only(validation_issues)
   use _ <- result.try(case list.is_empty(blocking_errors) {
     False -> Error(ValidationErrors(errors: blocking_errors))
     True -> Ok(Nil)

--- a/src/oaspec/internal/codegen/context.gleam
+++ b/src/oaspec/internal/codegen/context.gleam
@@ -1,7 +1,6 @@
 import gleam/dict
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/string
 import oaspec/config.{type Config}
 import oaspec/internal/openapi/operations
 import oaspec/internal/openapi/resolver
@@ -21,16 +20,6 @@ pub const version = "0.41.0"
 pub type AnalyzedOperation =
   #(String, Operation(Resolved), String, HttpMethod)
 
-/// One analyzed component schema: the component name, its canonical local
-/// `$ref`, and the pre-resolved schema object (or the resolution error).
-pub type AnalyzedSchema {
-  AnalyzedSchema(
-    name: String,
-    ref: String,
-    resolved: Result(SchemaObject, resolver.ResolveError),
-  )
-}
-
 /// Context for code generation, carrying all needed state.
 /// Only accepts a resolved spec — codegen must not operate on unresolved ASTs.
 ///
@@ -44,7 +33,6 @@ pub opaque type Context {
     config: Config,
     operations: List(AnalyzedOperation),
     schema_cache: dict.Dict(String, Result(SchemaObject, resolver.ResolveError)),
-    analyzed_schemas: List(AnalyzedSchema),
   )
 }
 
@@ -55,14 +43,11 @@ pub opaque type Context {
 /// read them via `operations/1` / `resolve_schema_ref/2` instead of
 /// rebuilding the same analysis at unrelated call sites (issue #371).
 pub fn new(spec: OpenApiSpec(Resolved), config: Config) -> Context {
-  let analyzed_schemas = collect_analyzed_schemas(spec)
-  let schema_cache = build_schema_cache(analyzed_schemas)
   Context(
     spec:,
     config:,
     operations: operations.collect_operations(spec),
-    schema_cache:,
-    analyzed_schemas:,
+    schema_cache: build_schema_cache(spec),
   )
 }
 
@@ -81,12 +66,6 @@ pub fn config(ctx: Context) -> Config {
 /// `operations.collect_operations` directly.
 pub fn operations(ctx: Context) -> List(AnalyzedOperation) {
   ctx.operations
-}
-
-/// The analyzed component schemas, sorted by schema name. This is a
-/// debug-friendly inspectable view over the schema-resolution cache.
-pub fn analyzed_schemas(ctx: Context) -> List(AnalyzedSchema) {
-  ctx.analyzed_schemas
 }
 
 /// Resolve a schema ref through the shared analyzed cache.
@@ -121,30 +100,22 @@ pub fn schema_metadata(
   }
 }
 
-fn collect_analyzed_schemas(spec: OpenApiSpec(Resolved)) -> List(AnalyzedSchema) {
+fn build_schema_cache(
+  spec: OpenApiSpec(Resolved),
+) -> dict.Dict(String, Result(SchemaObject, resolver.ResolveError)) {
   case spec.components {
     Some(components) ->
-      dict.to_list(components.schemas)
-      |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
-      |> list.map(fn(entry) {
+      list.fold(dict.to_list(components.schemas), dict.new(), fn(acc, entry) {
         let #(name, _schema_ref) = entry
         let ref = component_schema_ref(name)
-        AnalyzedSchema(
-          name: name,
-          ref: ref,
-          resolved: resolver.resolve_schema_ref(Reference(ref:, name:), spec),
+        dict.insert(
+          acc,
+          ref,
+          resolver.resolve_schema_ref(Reference(ref:, name:), spec),
         )
       })
-    None -> []
+    None -> dict.new()
   }
-}
-
-fn build_schema_cache(
-  analyzed_schemas: List(AnalyzedSchema),
-) -> dict.Dict(String, Result(SchemaObject, resolver.ResolveError)) {
-  list.fold(analyzed_schemas, dict.new(), fn(acc, entry) {
-    dict.insert(acc, entry.ref, entry.resolved)
-  })
 }
 
 fn component_schema_ref(name: String) -> String {

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -193,24 +193,6 @@ fn duplicate_function_name_diagnostic(
   )
 }
 
-/// Filter to only errors (not warnings).
-pub fn errors_only(issues: List(Diagnostic)) -> List(Diagnostic) {
-  diagnostic.errors_only(issues)
-}
-
-/// Filter to only warnings (not errors).
-pub fn warnings_only(issues: List(Diagnostic)) -> List(Diagnostic) {
-  diagnostic.warnings_only(issues)
-}
-
-/// Filter validation issues to those relevant for the selected generation mode.
-pub fn filter_by_mode(
-  issues: List(Diagnostic),
-  mode: config.GenerateMode,
-) -> List(Diagnostic) {
-  diagnostic.filter_by_mode(issues, mode)
-}
-
 /// Convert a validation error to a human-readable string.
 pub fn error_to_string(error: Diagnostic) -> String {
   diagnostic.to_string(error)

--- a/test/context_test.gleam
+++ b/test/context_test.gleam
@@ -95,36 +95,6 @@ pub fn operations_petstore_snapshot_test() {
   ])
 }
 
-pub fn analyzed_schemas_snapshot_test() {
-  let ctx = test_helpers.make_ctx(readonly_writeonly)
-  let snapshot =
-    context.analyzed_schemas(ctx)
-    |> list.map(fn(entry) {
-      #(entry.name, entry.ref, case entry.resolved {
-        Ok(schema.ObjectSchema(..)) -> "object"
-        Ok(schema.AllOfSchema(..)) -> "allOf"
-        Ok(schema.OneOfSchema(..)) -> "oneOf"
-        Ok(schema.AnyOfSchema(..)) -> "anyOf"
-        Ok(schema.ArraySchema(..)) -> "array"
-        Ok(schema.StringSchema(..)) -> "string"
-        Ok(schema.IntegerSchema(..)) -> "integer"
-        Ok(schema.NumberSchema(..)) -> "number"
-        Ok(schema.BooleanSchema(..)) -> "boolean"
-        Error(resolver.UnresolvedRef(..)) -> "unresolved"
-        Error(resolver.CircularRef(..)) -> "circular"
-      })
-    })
-
-  snapshot
-  |> should.equal([
-    #("AccountBase", "#/components/schemas/AccountBase", "object"),
-    #("AccountRead", "#/components/schemas/AccountRead", "allOf"),
-    #("AccountReadPart1", "#/components/schemas/AccountReadPart1", "object"),
-    #("AccountWrite", "#/components/schemas/AccountWrite", "allOf"),
-    #("AccountWritePart1", "#/components/schemas/AccountWritePart1", "object"),
-  ])
-}
-
 pub fn schema_cache_matches_direct_resolver_test() {
   let ctx = test_helpers.make_ctx(readonly_writeonly)
   let account_read_ref =

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6350,11 +6350,11 @@ paths:
     )
   let issues = validate.validate(ctx)
   // No blocking errors — codegen would proceed.
-  validate.errors_only(issues)
+  diagnostic.errors_only(issues)
   |> list.is_empty
   |> should.be_true()
   // But there's exactly one warning, pointing at the filter param.
-  let warnings = validate.warnings_only(issues)
+  let warnings = diagnostic.warnings_only(issues)
   list.length(warnings) |> should.equal(1)
   let assert [Diagnostic(message: msg, ..)] = warnings
   string.contains(msg, "no explicit 'style'")
@@ -6404,7 +6404,7 @@ paths:
       ),
     )
   let issues = validate.validate(ctx)
-  validate.errors_only(issues)
+  diagnostic.errors_only(issues)
   |> list.is_empty
   |> should.be_true()
 }
@@ -9039,7 +9039,7 @@ pub fn filter_by_mode_drops_server_errors_for_client_case() {
       hint: None,
     ),
   ]
-  let filtered = validate.filter_by_mode(issues, config.Client)
+  let filtered = diagnostic.filter_by_mode(issues, config.Client)
   list.length(filtered)
   |> should.equal(1)
 }
@@ -9061,7 +9061,7 @@ pub fn filter_by_mode_drops_client_errors_for_server_case() {
       hint: None,
     ),
   ]
-  let filtered = validate.filter_by_mode(issues, config.Server)
+  let filtered = diagnostic.filter_by_mode(issues, config.Server)
   list.length(filtered)
   |> should.equal(1)
 }
@@ -9090,7 +9090,7 @@ pub fn filter_by_mode_keeps_all_errors_for_both_case() {
       hint: None,
     ),
   ]
-  let filtered = validate.filter_by_mode(issues, config.Both)
+  let filtered = diagnostic.filter_by_mode(issues, config.Both)
   list.length(filtered)
   |> should.equal(3)
 }
@@ -10441,7 +10441,7 @@ pub fn oss_libopenapi_all_components_validates_security_case() {
     parser.parse_file("test/fixtures/oss_libopenapi_all_components.yaml")
   let ctx = make_ctx_from_spec(spec)
   let errors = validate.validate(ctx)
-  let blocking = validate.errors_only(errors)
+  let blocking = diagnostic.errors_only(errors)
   let has_security_error =
     list.any(blocking, fn(e) {
       string.contains(diagnostic.to_string(e), "api_key")
@@ -10523,7 +10523,7 @@ pub fn oss_oapi_codegen_nullable_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      let blocking = validate.errors_only(errors)
+      let blocking = diagnostic.errors_only(errors)
       list.length(blocking) |> should.equal(0)
     }
   }
@@ -10552,7 +10552,7 @@ pub fn oss_oapi_codegen_allof_additional_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      let blocking = validate.errors_only(errors)
+      let blocking = diagnostic.errors_only(errors)
       list.length(blocking) |> should.equal(0)
     }
   }
@@ -10581,7 +10581,7 @@ pub fn oss_oapi_codegen_multi_content_rejects_unsupported_types_case() {
     parser.parse_file("test/fixtures/oss_oapi_codegen_multi_content.yaml")
   let ctx = make_ctx_from_spec(spec)
   let errors = validate.validate(ctx)
-  let blocking = validate.errors_only(errors)
+  let blocking = diagnostic.errors_only(errors)
   // Should have blocking errors for unsupported content types
   list.length(blocking) |> should.not_equal(0)
 }
@@ -10604,7 +10604,7 @@ pub fn oss_oapi_codegen_issue_312_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10634,7 +10634,7 @@ pub fn oss_oapi_codegen_issue_52_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10683,7 +10683,7 @@ pub fn oss_oapi_codegen_issue_579_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10704,7 +10704,7 @@ pub fn oss_oapi_codegen_issue_2185_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10735,7 +10735,7 @@ pub fn oss_openapi_gen_issue_9719_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10754,7 +10754,7 @@ pub fn oss_openapi_gen_issue_13917_rejects_json_patch_content_case() {
     parser.parse_file("test/fixtures/oss_openapi_gen_issue_13917.yaml")
   let ctx = make_ctx_from_spec(spec)
   let errors = validate.validate(ctx)
-  let blocking = validate.errors_only(errors)
+  let blocking = diagnostic.errors_only(errors)
   list.length(blocking) |> should.not_equal(0)
 }
 
@@ -10808,7 +10808,7 @@ pub fn oss_kiota_discriminator_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10828,7 +10828,7 @@ pub fn oss_kiota_derived_types_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -10849,7 +10849,7 @@ pub fn oss_kiota_multi_security_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
     }
   }
 }
@@ -11002,7 +11002,7 @@ pub fn oss_openapi_gen_issue_11897_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
   }
 }
 
@@ -11028,7 +11028,7 @@ pub fn oss_openapi_gen_issue_1666_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
   }
 }
 
@@ -11054,7 +11054,7 @@ pub fn oss_openapi_gen_issue_18516_generates_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) ->
-      list.length(validate.errors_only(errors)) |> should.equal(0)
+      list.length(diagnostic.errors_only(errors)) |> should.equal(0)
   }
 }
 
@@ -11386,7 +11386,7 @@ pub fn oss_openapi_dotnet_dollar_id_parses_case() {
 /// actionable hint.
 pub fn validate_rejects_id_backed_url_ref_with_dedicated_diagnostic_case() {
   let ctx = make_ctx("test/fixtures/oss_openapi_dotnet_dollar_id.yaml")
-  let errors = validate.validate(ctx) |> validate.errors_only
+  let errors = validate.validate(ctx) |> diagnostic.errors_only
   let messages = list.map(errors, validate.error_to_string)
   list.any(messages, fn(s) {
     string.contains(s, "URL-style $ref")
@@ -11535,7 +11535,7 @@ pub fn capability_check_warns_on_callbacks_case() {
   let ctx = make_ctx("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
   let warnings =
     capability_check.check_preserved(ctx)
-    |> validate.warnings_only
+    |> diagnostic.warnings_only
   let messages = list.map(warnings, validate.error_to_string)
   list.any(messages, fn(s) {
     string.contains(s, "Operation-level callbacks")
@@ -12380,7 +12380,7 @@ pub fn pipeline_end_to_end_case() {
   case result {
     Ok(summary) -> list.length(summary.files) |> should.not_equal(0)
     Error(generate.ValidationErrors(errors:)) -> {
-      let blocking = validate.errors_only(errors)
+      let blocking = diagnostic.errors_only(errors)
       list.length(blocking) |> should.equal(0)
     }
   }
@@ -12855,7 +12855,7 @@ pub fn error_missing_path_param_case() {
         )
       let ctx = context.new(resolved, cfg)
       let diagnostics = validate.validate(ctx)
-      let errors = validate.errors_only(diagnostics)
+      let errors = diagnostic.errors_only(diagnostics)
       { list.length(errors) >= 1 } |> should.be_true()
       Nil
     }
@@ -13017,42 +13017,42 @@ pub fn server_default_response_only_generates_case() {
 pub fn validate_wildcard_status_codes_case() {
   let ctx = make_ctx("test/fixtures/wildcard_status_codes.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 
 pub fn validate_format_types_case() {
   let ctx = make_ctx("test/fixtures/format_types.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 
 pub fn validate_enum_edge_cases_case() {
   let ctx = make_ctx("test/fixtures/enum_edge_cases.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 
 pub fn validate_mixed_param_locations_case() {
   let ctx = make_ctx("test/fixtures/mixed_param_locations.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 
 pub fn validate_complex_discriminator_case() {
   let ctx = make_ctx("test/fixtures/complex_discriminator.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 
 pub fn validate_optional_required_combinations_case() {
   let ctx = make_ctx("test/fixtures/optional_required_combinations.yaml")
   let diagnostics = validate.validate(ctx)
-  let errors = validate.errors_only(diagnostics)
+  let errors = diagnostic.errors_only(diagnostics)
   list.length(errors) |> should.equal(0)
 }
 


### PR DESCRIPTION
## Summary

Bundles two small cleanup issues into one PR.

- **#429** Removed `context.analyzed_schemas/1` and the `AnalyzedSchema` type. Production codegen consumed the cache via `resolve_schema_ref/2` already; the `analyzed_schemas` accessor was only read by one snapshot test. The internal `build_schema_cache` now folds directly over the spec components dict, dropping the intermediate `AnalyzedSchema` list.
- **#430** Removed the `validate.errors_only` / `validate.warnings_only` / `validate.filter_by_mode` pass-through wrappers around the same-named functions in `oaspec/openapi/diagnostic`. `generate.gleam` had been mixing both forms (`validate.filter_by_mode` in one place, `diagnostic.filter_by_mode` in another); callers now consistently go through `diagnostic` directly.

## Out of scope (deferred)

- **#390** (codegen panic → `Result`) is not included — that one needs a function-signature change rippling through `schema_dispatch` callers and warrants its own PR.

## Test plan

- [x] `gleam build`
- [x] `gleam format --check src/ test/`
- [x] `gleam test` — 336 passed (one snapshot test removed alongside `analyzed_schemas`)
- [x] `gleam run -m glinter` — 0 errors
- [ ] CI green

Closes #429, closes #430.
