### PR TITLE
docs/community: code of conduct, minimal templates, example snippets, changelog convention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,11 @@
+---
+name: Bug report
+about: Something doesn't work as expected
+labels: bug
+---
+
+oaspec version:
+Gleam / OTP version:
+OS:
+
+What I tried to do / what happened:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest a new feature or change
+labels: enhancement
+---
+
+What I want to do:
+
+Why (use case / context):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What this PR changes and why. -->
+
+## Test
+
+- [ ] `just check` passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
+Going forward, breaking changes are listed under a dedicated `Breaking`
+section per release (issue #434). Older entries inline `BREAKING:` prefixes
+within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- community files: a Contributor Covenant `CODE_OF_CONDUCT.md`, plus
+  minimal issue templates (bug report, feature request) and a pull
+  request template under `.github/`. The templates only ask for what
+  is genuinely useful (version info, what was tried, what happened) —
+  no checklists or boilerplate. (#415)
+
 ### Documentation
 
-- **readme**: top-of-README rewrite — added the `doc/img/gleam-oas-logo.png`
-  logo, Hex / HexDocs / license / CI badges, a 30-second pitch with a
-  runnable 5-line client example, and a HexDocs link near the install
-  section. (#397)
+- changelog: adopted a dedicated `Breaking` subsection convention for
+  future releases — older `BREAKING:`-prefixed entries within
+  `Changed` / `Fixed` stay as historical record. The README pointer
+  to the latest breaking section is added once the first such release
+  ships. (#434)
+- examples: every example README (`petstore_client`,
+  `petstore_client_fetch`, `server_adapter`) now includes a
+  "What the generator produces" section with a short signature
+  excerpt of the generated `client.gleam` / `router.gleam` /
+  `response_types.gleam`, so a reader can preview the shape before
+  cloning. (#424)
+- readme: dropped the inline logo `<img>` from the top-of-README
+  rewrite, collapsed the centered badge block back to inline shields,
+  and removed gratuitous bold-text emphasis to match the project's
+  plain-prose voice.
+- **readme**: top-of-README rewrite — Hex / HexDocs / license / CI
+  badges, a 30-second pitch with a runnable 5-line client example,
+  and a HexDocs link near the install section. (#397)
 - **readme**: install section now leads with the Hex library install
   (`gleam add oaspec`) for consumers of the runtime / generator API,
   and the GitHub-release / build-from-source paths are scoped to the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Contributor Covenant Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1][cc] code of conduct.
+By participating, you agree to abide by its terms.
+
+Report unacceptable behavior to the maintainer at
+<n.chika156@gmail.com>. All reports are reviewed and investigated; the
+reporter's identity will be kept confidential.
+
+[cc]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
 # oaspec
 
-<p align="center">
-  <img src="doc/img/gleam-oas-logo.png" alt="oaspec logo" width="180">
-</p>
+[![Hex package](https://img.shields.io/hexpm/v/oaspec)](https://hex.pm/packages/oaspec)
+[![HexDocs](https://img.shields.io/badge/hexdocs-latest-blue)](https://hexdocs.pm/oaspec/)
+[![License](https://img.shields.io/github/license/nao1215/oaspec)](https://github.com/nao1215/oaspec/blob/main/LICENSE)
+[![CI](https://github.com/nao1215/oaspec/actions/workflows/ci.yml/badge.svg)](https://github.com/nao1215/oaspec/actions)
 
-<p align="center">
-  <a href="https://hex.pm/packages/oaspec"><img src="https://img.shields.io/hexpm/v/oaspec" alt="Hex package"></a>
-  <a href="https://hexdocs.pm/oaspec/"><img src="https://img.shields.io/badge/hexdocs-latest-blue" alt="HexDocs"></a>
-  <a href="https://github.com/nao1215/oaspec/blob/main/LICENSE"><img src="https://img.shields.io/github/license/nao1215/oaspec" alt="License"></a>
-  <a href="https://github.com/nao1215/oaspec/actions"><img src="https://github.com/nao1215/oaspec/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-</p>
-
-**Generate Gleam client and server modules from OpenAPI 3.x specs.**
+Generate Gleam client and server modules from OpenAPI 3.x specs.
 
 OpenAPI in → typed Gleam client and server out, with no per-operation glue
 code to write or maintain. The generator owns request and response types,
@@ -49,9 +43,9 @@ API reference: <https://hexdocs.pm/oaspec/>
 
 `oaspec` ships in two flavors:
 
-- **Library API** (the runtime contract for generated clients, plus the
+- Library API (the runtime contract for generated clients, plus the
   generator itself for in-process use) — install via `gleam add` from Hex.
-- **CLI** (the `oaspec` binary that drives `init` / `generate` / `validate`
+- CLI (the `oaspec` binary that drives `init` / `generate` / `validate`
   on the command line) — install from a GitHub release or build from source.
 
 Most users want both: `gleam add oaspec` in the project that consumes the
@@ -284,8 +278,8 @@ HTTP runtime:
   `gleam_fetch`, with helpers to bridge `transport.Async` and native
   JavaScript promises.
 
-> **Note** — `oaspec_httpc` and `oaspec_fetch` are **not yet published on
-> Hex**. `gleam add oaspec_httpc` / `gleam add oaspec_fetch` will fail
+> Note: `oaspec_httpc` and `oaspec_fetch` are not yet published on
+> Hex. `gleam add oaspec_httpc` / `gleam add oaspec_fetch` will fail
 > with "package not found". Until they are published, depend on them
 > from a local checkout via a path or git dependency in your
 > consumer project's `gleam.toml`:
@@ -453,7 +447,7 @@ includes the path it attempted to read.
 | `--output=<path>` | - | Override output base directory |
 | `--check` | `false` | Check that generated code matches existing files without writing |
 | `--fail-on-warnings` | `false` | Treat warnings as errors |
-| `--validate` | `false` | Force-enable guard validation in generated server/client code. One-way override — passing this flag turns validation **on**, but it cannot turn it off. To disable validation when the config sets `validate: true` (the default for `server` / `both` modes), edit `validate: false` in `oaspec.yaml`. |
+| `--validate` | `false` | Force-enable guard validation in generated server/client code. One-way override — passing this flag turns validation on, but it cannot turn it off. To disable validation when the config sets `validate: true` (the default for `server` / `both` modes), edit `validate: false` in `oaspec.yaml`. |
 
 ### CLI options for `validate`
 

--- a/examples/petstore_client/README.md
+++ b/examples/petstore_client/README.md
@@ -43,6 +43,33 @@ Got 2 pet(s):
   - Whiskers (id=2)
 ```
 
+## What the generator produces
+
+A snippet from the checked-in [`src/api/client.gleam`](./src/api/client.gleam)
+and [`src/api/response_types.gleam`](./src/api/response_types.gleam) — these
+are emitted by `oaspec generate` from [`oaspec.yaml`](./oaspec.yaml):
+
+```gleam
+// src/api/client.gleam
+pub fn list_pets(
+  send send: transport.Send,
+  limit limit: Option(Int),
+  offset offset: Option(Int),
+) -> Result(response_types.ListPetsResponse, ClientError)
+```
+
+```gleam
+// src/api/response_types.gleam
+pub type ListPetsResponse {
+  ListPetsResponseOk(List(types.Pet))
+  ListPetsResponseUnauthorized
+}
+```
+
+The full generated tree (`types.gleam`, `decode.gleam`, `encode.gleam`,
+`request_types.gleam`, `response_types.gleam`, `guards.gleam`,
+`client.gleam`) lives under `src/api/`.
+
 ## File layout
 
 ```text

--- a/examples/petstore_client_fetch/README.md
+++ b/examples/petstore_client_fetch/README.md
@@ -37,3 +37,28 @@ Got 2 pet(s):
   - Fido (id=1)
   - Whiskers (id=2)
 ```
+
+## What the generator produces
+
+The async client and shared response types are emitted by `oaspec generate`
+into [`src/api/`](./src/api/). Excerpt:
+
+```gleam
+// src/api/client.gleam
+pub fn list_pets_async(
+  async_send async_send: transport.AsyncSend,
+  limit limit: Option(Int),
+  offset offset: Option(Int),
+) -> transport.Async(Result(response_types.ListPetsResponse, ClientError))
+```
+
+```gleam
+// src/api/response_types.gleam
+pub type ListPetsResponse {
+  ListPetsResponseOk(List(types.Pet))
+  ListPetsResponseUnauthorized
+}
+```
+
+The non-async `list_pets/3` is generated alongside the async variant, so
+the same module can drive sync BEAM and async JavaScript callers.

--- a/examples/server_adapter/README.md
+++ b/examples/server_adapter/README.md
@@ -6,7 +6,7 @@ A Gleam project that shows how to bridge the oaspec-generated
 ## What it shows
 
 - Generating a server from an OpenAPI 3.x spec via `oaspec.yaml`.
-- A **regeneration-safe handler layout**: domain logic lives in
+- A regeneration-safe handler layout: domain logic lives in
   `src/example_handlers.gleam`, which the generator never touches.
   `src/api/handlers.gleam` is a thin delegator owned by the generator.
 - Calling the generated router with primitive request pieces
@@ -23,6 +23,36 @@ adapter is the same three-step pattern:
 
 This program runs that adapter against a canned request instead of
 spinning up an HTTP server, so the example has no framework dependency.
+
+## What the generator produces
+
+`oaspec generate` writes `src/api/router.gleam`, `handlers_generated.gleam`,
+the request/response types, decoders/encoders, guards, and the first-time
+`handlers.gleam` panic stub. The router entry point looks like:
+
+```gleam
+// src/api/router.gleam (excerpt)
+pub fn route(
+  app_state: handlers.State,
+  method: String,
+  path: List(String),
+  query: Dict(String, List(String)),
+  _headers: Dict(String, String),
+  body: String,
+) -> ServerResponse
+```
+
+```gleam
+// src/api/response_types.gleam (excerpt)
+pub type ListPetsResponse {
+  ListPetsResponseOk(List(types.Pet))
+  ListPetsResponseUnauthorized
+}
+```
+
+Per-operation request types (`ListPetsRequest`, `CreatePetRequest`, …)
+are emitted into `src/api/request_types.gleam` and consumed by the
+delegator pattern below.
 
 ## Recommended handler layout
 


### PR DESCRIPTION
## Summary

Bundles three docs/community items plus a small README follow-up.

- #415 — added `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) and minimal GitHub templates under `.github/`. The bug-report and feature-request templates only ask for what is genuinely useful (version info, what was tried, what happened); no checklists or boilerplate. PR template stays minimal. `SUPPORT.md` intentionally not added.
- #424 — each example README (`petstore_client`, `petstore_client_fetch`, `server_adapter`) gains a "What the generator produces" section with a short signature excerpt of the generated client / async client / router and a representative response type.
- #434 — CHANGELOG header documents the going-forward `### Breaking` subsection convention. Older `BREAKING:` prefixes inside `Changed` / `Fixed` stay as historical record.
- README cleanup (follow-up to the recently-merged #397): dropped the inline logo `<img>`, collapsed the centered badge block back to inline shields, and removed gratuitous bold-text emphasis to match the project's plain-prose voice.

## Out of scope (deferred)

- #411 (capability-check diagnostics source-loc threading) — code change rippling through `capability_check.gleam` plus `diagnostic.gleam`; needs its own PR.

## Test plan

- [x] `bash scripts/check_sync.sh` — versions and counts in sync
- [x] `bash scripts/check_readme_examples.sh` — Library API snippet still compiles
- [ ] CI green

Closes #415, closes #424, closes #434.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct to establish community standards
  * Updated README with improved formatting and badges
  * Added issue and pull request templates to guide community contributions
  * Enhanced example documentation with generated code samples showing expected output
  * Introduced changelog convention for breaking changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->