### PR TITLE
docs(examples): scope petstore_client as decoder-demo + document real-HTTP swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Documentation
 
+- examples: `petstore_client` is now scoped (in title, README header,
+  and program preamble) as a generated-client / decoder roundtrip demo
+  against a stub transport, not a real-HTTP example. Adds a "Hooking
+  up real HTTP" section showing the one-liner swap to the
+  `oaspec_httpc` adapter so the BEAM HTTP path is documented in code
+  even though no sibling runnable example ships yet. The top-level
+  README's examples list reflects the same scoping. (#425)
 - changelog: adopted a dedicated `Breaking` subsection convention for
   future releases — older `BREAKING:`-prefixed entries within
   `Changed` / `Fixed` stay as historical record. The README pointer

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ with the capability registry at
 
 Working examples live under [`examples/`](./examples):
 
-- [`examples/petstore_client`](./examples/petstore_client) — minimal client usage against a canned HTTP transport. Run it from the repo root with `just example-petstore`.
+- [`examples/petstore_client`](./examples/petstore_client) — generated client / decoder roundtrip demo against a stub transport (no network). The example's README shows the one-liner swap to `oaspec_httpc` for real BEAM HTTP. Run it from the repo root with `just example-petstore`.
 - [`examples/petstore_client_fetch`](./examples/petstore_client_fetch) — JavaScript-target client usage through the first-party fetch adapter. Run it from the repo root with `just example-petstore-fetch`.
 - [`examples/server_adapter`](./examples/server_adapter) — wires the generated `router.route/5` to a framework-free adapter. Run it from the repo root with `just example-server-adapter`.
 

--- a/examples/petstore_client/README.md
+++ b/examples/petstore_client/README.md
@@ -1,17 +1,27 @@
-# petstore_client — runnable client example
+# petstore_client — generated client / decoder roundtrip demo
 
 A minimal Gleam project that uses an oaspec-generated client for the
 Petstore OpenAPI spec at `test/fixtures/petstore.yaml`.
+
+This example is intentionally framework-free: it does not hit a real
+HTTP endpoint. The transport is a stub built with `oaspec/mock` that
+returns a canned JSON body, so the example runs without a live server,
+without network access, and without any HTTP adapter dependency. The
+focus is the contract between oaspec-generated code and `oaspec/transport`
+— request building, response decoding, and the typed response variants.
+
+For a parallel example that calls a live JavaScript fetch endpoint, see
+[`examples/petstore_client_fetch`](../petstore_client_fetch/). For a
+BEAM example that issues real HTTP, see "Hooking up real HTTP" below
+for the exact swap.
 
 ## What it shows
 
 - Generating a client from an OpenAPI 3.x spec via `oaspec.yaml`.
 - Importing the generated client and response types.
 - Building a `transport.Send` value with `mock.from(...)` and a custom
-  request handler (here a stub that returns a canned JSON body — swap
-  in the [`oaspec_httpc`](../../adapters/httpc/) adapter for real
-  BEAM-side traffic, or the [`oaspec_fetch`](../../adapters/fetch/)
-  adapter for the JavaScript target).
+  request handler — the stub is the only piece swapped out when moving
+  to a real adapter.
 - Handling the typed response variants that oaspec generates for each
   operation.
 
@@ -79,6 +89,38 @@ examples/petstore_client/
   src/api/                   — generated client code (checked in)
   src/petstore_client_example.gleam  — the program you run
 ```
+
+## Hooking up real HTTP
+
+To run the same client against a live BEAM HTTP backend, swap the
+stub for the `oaspec_httpc` adapter from
+[`adapters/httpc/`](../../adapters/httpc/). The change is a one-liner
+on the transport: everything else (the typed `list_pets/3` call, the
+`response_types.ListPetsResponseOk(pets)` match, the
+`ClientError` handling) stays the same.
+
+```gleam
+// before — stubbed, no network
+import oaspec/mock
+let send = mock.from(stub_handler)
+
+// after — real BEAM HTTP via gleam_httpc
+import oaspec/httpc
+import oaspec/transport
+let send =
+  httpc.send
+  |> transport.with_base_url("https://petstore3.swagger.io/api/v3")
+```
+
+`oaspec_httpc` is not yet on Hex; depend on it from a path or git
+dependency in your project's `gleam.toml` (see the
+[oaspec_fetch example layout](../petstore_client_fetch/gleam.toml) for
+the canonical pattern).
+
+A self-contained runnable real-HTTP sibling example
+(`petstore_client_httpc`) can be added later once the `oaspec_httpc`
+adapter ships on Hex; the swap above is small enough that it doesn't
+need its own directory in the meantime.
 
 ## Related examples
 

--- a/examples/petstore_client/src/petstore_client_example.gleam
+++ b/examples/petstore_client/src/petstore_client_example.gleam
@@ -1,9 +1,12 @@
-//// Runnable example: using the oaspec-generated Petstore client.
+//// Runnable example: oaspec-generated Petstore client against a stub
+//// transport. This is a decoder / transport-contract demo, not a real
+//// HTTP example — see this example's README for the
+//// `oaspec/httpc` swap when you want live BEAM HTTP, or
+//// `examples/petstore_client_fetch/` for the JavaScript fetch path.
 ////
-//// This program calls `list_pets` against a fake transport built with
-//// `oaspec/mock`, then prints the result. Replace `mock.from(...)` with
-//// a real transport adapter (e.g. `oaspec/httpc`) to talk to a live
-//// Petstore.
+//// The program calls `list_pets` against a `mock.from(...)` transport
+//// that returns a canned 200 response, then prints the typed
+//// `ListPetsResponseOk(...)` payload.
 
 import api/client
 import api/response_types


### PR DESCRIPTION
## Summary

#425 noted that `petstore_client` uses a stub mock transport that returns canned JSON, but the example's framing made it look like a real-HTTP client example — a user running `just example-petstore` would reasonably wonder if oaspec actually does HTTP at all.

Going with the first option from the Issue's two-option suggestion (rename / re-position so the scope is clear), without yet adding the `petstore_client_httpc` sibling:

- `examples/petstore_client/README.md` leads with "generated client / decoder roundtrip demo against a stub transport (no network)" and adds a "Hooking up real HTTP" section showing the one-liner swap from `mock.from(stub_handler)` to `httpc.send |> transport.with_base_url(...)`.
- `examples/petstore_client/src/petstore_client_example.gleam` preamble is rephrased to match.
- Top-level `README.md` examples list now describes `petstore_client` as a stub / decoder demo and points at `oaspec_httpc` for real BEAM HTTP.

The runnable real-HTTP sibling (option 2 from #425) can land later once `oaspec_httpc` ships on Hex; the swap is small enough that an in-place note suffices in the meantime.

## Test plan

- [x] `bash scripts/check_sync.sh`
- [x] `bash scripts/check_readme_examples.sh`
- [x] `gleam format src/ test/`
- [ ] CI green

Closes #425.
