### PR TITLE
tests(cli/parser): cover generate/validate failure exits, init subcommand, --output flag, parse error shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Added
 
+- tests: ShellSpec coverage for `oaspec generate --output=DIR` /
+  `--output DIR` (space form), parse-failure exit codes on
+  `error_missing_info.yaml`, the same parse-failure path through
+  `oaspec validate`, and `--mode=client` override on the validator.
+  (#398, #399, #433)
+- tests: a dedicated `oaspec init` ShellSpec block covering default
+  output (`./oaspec.yaml`), `--output=PATH` override, and the
+  overwrite-refusal exit-status / stderr contract. (#400)
+- tests: `parse_json_string_malformed_has_diagnostic_shape_case`
+  pins the parse-phase diagnostic shape (severity, phase, non-empty
+  code/message) so a regression that returned a bare-`String` error
+  or dropped the structured fields surfaces immediately. (#431)
 - community files: a Contributor Covenant `CODE_OF_CONDUCT.md`, plus
   minimal issue templates (bug report, feature request) and a pull
   request template under `.github/`. The templates only ask for what

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -74,6 +74,54 @@ Describe 'oaspec generate'
       The status should be failure
       The output should include 'Error'
     End
+
+    # Issue #398: a spec with parse-level breakage (`error_missing_info.yaml`
+    # has no `info:` key, which the parser requires) must surface as a
+    # non-zero exit with a diagnostic, not as silent success or a panic.
+    It 'exits non-zero when the spec fails to parse'
+      setup_missing_info_config() {
+        rm -rf "$PROJECT_ROOT/test_missing_info"
+        cat > "$PROJECT_ROOT/test_missing_info.yaml" <<EOF
+input: test/fixtures/error_missing_info.yaml
+package: api
+output:
+  dir: ./test_missing_info
+EOF
+      }
+      cleanup_missing_info_config() {
+        rm -rf "$PROJECT_ROOT/test_missing_info" "$PROJECT_ROOT/test_missing_info.yaml"
+      }
+      setup_missing_info_config
+      When run generate --config=./test_missing_info.yaml
+      The status should be failure
+      The output should include 'Error'
+      cleanup_missing_info_config
+    End
+  End
+
+  Describe '--output flag (Issue #433)'
+    setup_output_flag_dir() {
+      rm -rf "$PROJECT_ROOT/test_output_flag_eq" "$PROJECT_ROOT/test_output_flag_sp"
+    }
+    cleanup_output_flag_dir() {
+      rm -rf "$PROJECT_ROOT/test_output_flag_eq" "$PROJECT_ROOT/test_output_flag_sp"
+    }
+    Before 'setup_output_flag_dir'
+    After 'cleanup_output_flag_dir'
+
+    It 'writes generated files under --output=DIR'
+      When run generate --config=test/fixtures/oaspec.yaml --output=./test_output_flag_eq
+      The status should be success
+      The output should include 'Successfully generated'
+      The path "$PROJECT_ROOT/test_output_flag_eq" should be directory
+    End
+
+    It 'writes generated files under --output DIR (space form)'
+      When run generate --config=test/fixtures/oaspec.yaml --output ./test_output_flag_sp
+      The status should be success
+      The output should include 'Successfully generated'
+      The path "$PROJECT_ROOT/test_output_flag_sp" should be directory
+    End
   End
 
   Describe 'successful generation'
@@ -527,6 +575,97 @@ Describe 'oaspec validate'
       The status should be failure
       The output should include 'Error'
     End
+
+    # Issue #399: validate must exit non-zero when the spec fails to
+    # parse (no info field). Without this, a regression that swallowed
+    # parse errors and returned 0 would defeat validate's CI value.
+    It 'exits non-zero when the underlying spec fails to parse'
+      setup_validate_missing_info_config() {
+        cat > "$PROJECT_ROOT/test_validate_missing_info.yaml" <<EOF
+input: test/fixtures/error_missing_info.yaml
+package: api
+output:
+  dir: ./test_validate_missing_info
+EOF
+      }
+      cleanup_validate_missing_info_config() {
+        rm -f "$PROJECT_ROOT/test_validate_missing_info.yaml"
+      }
+      setup_validate_missing_info_config
+      When run validate_spec --config=./test_validate_missing_info.yaml
+      The status should be failure
+      The output should include 'Error'
+      cleanup_validate_missing_info_config
+    End
+
+    # Issue #399: --mode=client must be accepted on the CLI surface.
+    # Whether the fixture ultimately passes depends on the spec; the
+    # test pins that the flag is parsed (no usage error) and the CLI
+    # produces typed output instead of crashing.
+    It 'accepts the --mode=client override flag without crashing'
+      When run validate_spec --config=test/fixtures/oaspec.yaml --mode=client
+      The status should be success
+      The output should include 'Validation passed'
+    End
+  End
+End
+
+# ===================================================================
+# Issue #400: oaspec init subcommand
+# ===================================================================
+#
+# Pin the init subcommand's three documented behaviors:
+# default-output write, --output PATH override, and overwrite refusal.
+
+Describe 'oaspec init'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_init_dir() {
+    rm -rf "$PROJECT_ROOT/test_init_dir"
+    mkdir -p "$PROJECT_ROOT/test_init_dir"
+  }
+
+  cleanup_init_dir() {
+    rm -rf "$PROJECT_ROOT/test_init_dir"
+  }
+
+  init_default_output() {
+    ( cd "$PROJECT_ROOT/test_init_dir" \
+      && gleam run --no-print-progress -- init )
+  }
+
+  init_with_output_path() {
+    ( cd "$PROJECT_ROOT/test_init_dir" \
+      && gleam run --no-print-progress -- init --output=./custom.yaml )
+  }
+
+  init_twice() {
+    ( cd "$PROJECT_ROOT/test_init_dir" \
+      && gleam run --no-print-progress -- init > /dev/null \
+      && gleam run --no-print-progress -- init )
+  }
+
+  Before 'setup_init_dir'
+  After 'cleanup_init_dir'
+
+  It 'writes ./oaspec.yaml by default and reports the path'
+    When run init_default_output
+    The status should be success
+    The output should include 'Created'
+    The path "$PROJECT_ROOT/test_init_dir/oaspec.yaml" should be file
+  End
+
+  It 'writes to the location given via --output=PATH'
+    When run init_with_output_path
+    The status should be success
+    The output should include 'Created'
+    The path "$PROJECT_ROOT/test_init_dir/custom.yaml" should be file
+  End
+
+  It 'refuses to overwrite an existing target'
+    When run init_twice
+    The status should be failure
+    The stderr should include 'already exists'
   End
 End
 

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -9,6 +9,7 @@ pub fn parser_smoke_test() {
   let _ = support.parse_json_string_preserves_required_array_order_case()
   let _ = support.parse_json_string_handles_many_paths_case()
   let _ = support.parse_json_string_rejects_malformed_case()
+  let _ = support.parse_json_string_malformed_has_diagnostic_shape_case()
   let _ = support.parse_file_dispatches_json_path_for_json_extension_case()
   let _ = support.oss_oai_petstore_expanded_yaml_and_json_agree_case()
   let _ = support.oss_oai_petstore_expanded_yaml_path_count_pinned_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -771,6 +771,21 @@ pub fn parse_json_string_rejects_malformed_case() {
   should.be_error(result)
 }
 
+pub fn parse_json_string_malformed_has_diagnostic_shape_case() {
+  // Issue #431: the `should.be_error` check above only verified that an
+  // error was produced. Here we pin the diagnostic shape (parse-phase
+  // error severity, non-empty message) for any malformed-or-rejected
+  // JSON input, so a regression that returned a bare `String` error or
+  // dropped the severity/phase fields surfaces as a failing test
+  // instead of a silent contract drift.
+  let bad_json = "::: not really json"
+  let assert Error(d) = parser.parse_json_string(bad_json)
+  d.phase |> should.equal(diagnostic.PhaseParse)
+  d.severity |> should.equal(diagnostic.SeverityError)
+  d.message |> should.not_equal("")
+  d.code |> should.not_equal("")
+}
+
 pub fn parse_file_dispatches_json_path_for_json_extension_case() {
   // Call `parse_file` end-to-end so the `.json` extension dispatch
   // is what's under test — if the routing regressed and `.json`


### PR DESCRIPTION
## Summary

Bundles five test-coverage issues into one PR.

- #398 — ShellSpec scenarios for `oaspec generate` failure paths: a spec whose underlying OpenAPI fails to parse (missing `info` field) must exit non-zero and surface `Error`.
- #399 — ShellSpec scenarios for `oaspec validate`: same parse-failure exit-status contract through the validator, plus a smoke test that the `--mode=client` override is wired through to `filter_by_mode` without crashing.
- #400 — A dedicated `Describe 'oaspec init'` block pinning the three documented behaviors: default `./oaspec.yaml` write, `--output=PATH` override, and the overwrite-refusal stderr / non-zero exit contract.
- #433 — ShellSpec scenarios for `--output=DIR` and `--output DIR` (space form) so a regression in the value-flag normalization path would fail the suite instead of only surfacing for users.
- #431 — `parse_json_string_malformed_has_diagnostic_shape_case`: pins the parse-phase Diagnostic shape (phase, severity, non-empty code / message) for a clearly malformed JSON input. The existing `should.be_error`-only case would still pass if the error shape regressed.

## Out of scope (intentional)

The companion `parse_string` YAML source-loc test originally planned under #431 is not included — exercising the yamerl error path triggers a `CaseClause` panic in `parser.parse_to_node` because not every `yay` error variant is matched in the wrapper. That is a parser-side bug worth its own PR.

## Test plan

- [x] `gleam test` — 336 passing, no failures
- [x] `bash scripts/check_sync.sh` — versions and counts in sync
- [x] `shellspec spec/generate_spec.sh` — 93 examples, 0 failures
- [ ] CI green

Closes #398, closes #399, closes #400, closes #431, closes #433.
