### PR TITLE
tests: transport async middleware + try_await/map_try, ConfigError formatting, diagnostic to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Added
 
+- tests: complementary `try_await` (Ok-Ok chaining) and `map_try`
+  (error short-circuit) coverage on `oaspec/transport`, plus async-send
+  variants of `with_default_header`, `with_default_headers`, and
+  `with_security` so the polymorphic-transport contract is exercised
+  on `transport.AsyncSend`, not just the sync `Send` surface. (#427, #428)
+- tests: a new `config_error_formatting_test` group asserting the
+  user-facing string produced by `config.error_to_string` for each
+  `ConfigError` variant (FileNotFound, FileReadError, ParseError,
+  MissingField, InvalidValue), plus a regression case pinning that an
+  empty / non-conforming config surfaces as `MissingField` /
+  `InvalidValue` rather than a generic parse failure. (#413)
+- tests: `diagnostic.to_short_string` and `diagnostic.to_string` now
+  have direct shape assertions for the `file_error`, `yaml_error`
+  (with and without source loc), `missing_field`, and `invalid_value`
+  branches. The pointer-to-human stack is already covered by
+  `diagnostic_format_test`; this fills the surrounding format gap. (#414)
 - tests: ShellSpec coverage for `oaspec generate --output=DIR` /
   `--output DIR` (space form), parse-failure exit codes on
   `error_missing_info.yaml`, the same parse-failure path through

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 336 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 349 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 257 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>

--- a/test/diagnostic_format_test.gleam
+++ b/test/diagnostic_format_test.gleam
@@ -1,9 +1,98 @@
+import gleam/string
 import gleeunit
 import gleeunit/should
 import oaspec/internal/openapi/diagnostic_format
+import oaspec/openapi/diagnostic
 
 pub fn main() {
   gleeunit.main()
+}
+
+// ====================================================================
+// Issue #414: pin diagnostic.to_short_string and diagnostic.to_string
+// shape per code variant. These strings leak to the CLI and a format
+// regression was previously invisible to the test suite.
+// ====================================================================
+
+pub fn to_short_string_file_error_test() {
+  let diag = diagnostic.file_error(detail: "file not found: spec.yaml")
+  diagnostic.to_short_string(diag)
+  |> should.equal("file not found: spec.yaml")
+}
+
+pub fn to_short_string_yaml_error_with_loc_test() {
+  let diag =
+    diagnostic.yaml_error(
+      detail: "unexpected token",
+      loc: diagnostic.SourceLoc(line: 4, column: 7),
+    )
+  diagnostic.to_short_string(diag)
+  |> should.equal("unexpected token (line 4, column 7)")
+}
+
+pub fn to_short_string_yaml_error_no_loc_test() {
+  let diag =
+    diagnostic.yaml_error(detail: "empty document", loc: diagnostic.NoSourceLoc)
+  diagnostic.to_short_string(diag)
+  |> should.equal("empty document")
+}
+
+pub fn to_short_string_missing_field_test() {
+  let diag =
+    diagnostic.missing_field(
+      path: "paths.~1pets.get",
+      field: "responses",
+      loc: diagnostic.NoSourceLoc,
+    )
+  let rendered = diagnostic.to_short_string(diag)
+  rendered
+  |> should.equal(
+    "Missing required field 'responses' at GET /pets. Check your OpenAPI spec structure.",
+  )
+}
+
+pub fn to_short_string_invalid_value_test() {
+  let diag =
+    diagnostic.invalid_value(
+      path: "paths.~1pets.post.requestBody",
+      detail: "content type must be a string",
+      loc: diagnostic.NoSourceLoc,
+    )
+  let rendered = diagnostic.to_short_string(diag)
+  rendered
+  |> should.equal(
+    "Invalid value at POST /pets, requestBody: content type must be a string",
+  )
+}
+
+pub fn to_string_yaml_error_full_format_test() {
+  // Full to_string should include phase prefix, severity, message, and
+  // SourceLoc trailer. yaml_error has no pointer so the "at ..." chunk
+  // is absent.
+  let diag =
+    diagnostic.yaml_error(
+      detail: "boom",
+      loc: diagnostic.SourceLoc(line: 1, column: 2),
+    )
+  diagnostic.to_string(diag)
+  |> should.equal("[Parse] Error: boom (line 1, column 2)")
+}
+
+pub fn to_string_missing_field_includes_pointer_and_hint_test() {
+  let diag =
+    diagnostic.missing_field(
+      path: "components.schemas.Pet",
+      field: "type",
+      loc: diagnostic.NoSourceLoc,
+    )
+  let rendered = diagnostic.to_string(diag)
+  // Phase + severity + pointer + message + hint must all appear.
+  rendered |> string.contains("[Parse] Error") |> should.be_true()
+  rendered |> string.contains("at components.schemas.Pet") |> should.be_true()
+  rendered |> string.contains("Missing required field: type") |> should.be_true()
+  rendered
+  |> string.contains("Check your OpenAPI spec structure.")
+  |> should.be_true()
 }
 
 // --- empty / root ---------------------------------------------------

--- a/test/diagnostic_format_test.gleam
+++ b/test/diagnostic_format_test.gleam
@@ -89,7 +89,9 @@ pub fn to_string_missing_field_includes_pointer_and_hint_test() {
   // Phase + severity + pointer + message + hint must all appear.
   rendered |> string.contains("[Parse] Error") |> should.be_true()
   rendered |> string.contains("at components.schemas.Pet") |> should.be_true()
-  rendered |> string.contains("Missing required field: type") |> should.be_true()
+  rendered
+  |> string.contains("Missing required field: type")
+  |> should.be_true()
   rendered
   |> string.contains("Check your OpenAPI spec structure.")
   |> should.be_true()

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -31,6 +31,15 @@ pub fn config_defaults_test() {
   let _ = support.config_validate_default_when_omitted_case()
 }
 
+pub fn config_error_formatting_test() {
+  let _ = support.config_error_to_string_file_not_found_case()
+  let _ = support.config_error_to_string_file_read_error_case()
+  let _ = support.config_error_to_string_parse_error_case()
+  let _ = support.config_error_to_string_missing_field_case()
+  let _ = support.config_error_to_string_invalid_value_case()
+  let _ = support.config_load_missing_input_returns_missing_field_case()
+}
+
 pub fn config_output_paths_test() {
   let _ = support.config_client_only_default_drops_client_suffix_case()
   let _ = support.config_with_output_client_only_drops_suffix_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -111,6 +111,59 @@ pub fn config_not_found_case() {
   }
 }
 
+// Issue #413: pin the user-facing strings produced by
+// `config.error_to_string` for each ConfigError variant. These leak to
+// the CLI surface, so format regressions degrade UX silently.
+
+pub fn config_error_to_string_file_not_found_case() {
+  let s = config.error_to_string(config.FileNotFound(path: "missing.yaml"))
+  s |> string.contains("Config file not found") |> should.be_true()
+  s |> string.contains("missing.yaml") |> should.be_true()
+}
+
+pub fn config_error_to_string_file_read_error_case() {
+  let s =
+    config.error_to_string(config.FileReadError(
+      path: "x.yaml",
+      detail: "permission denied",
+    ))
+  s |> string.contains("Error reading config file") |> should.be_true()
+  s |> string.contains("x.yaml") |> should.be_true()
+  s |> string.contains("permission denied") |> should.be_true()
+}
+
+pub fn config_error_to_string_parse_error_case() {
+  let s = config.error_to_string(config.ParseError(detail: "unexpected token"))
+  s |> string.contains("Config parse error") |> should.be_true()
+  s |> string.contains("unexpected token") |> should.be_true()
+}
+
+pub fn config_error_to_string_missing_field_case() {
+  let s = config.error_to_string(config.MissingField(field: "input"))
+  s |> string.contains("Missing required config field") |> should.be_true()
+  s |> string.contains("input") |> should.be_true()
+}
+
+pub fn config_error_to_string_invalid_value_case() {
+  let s =
+    config.error_to_string(config.InvalidValue(
+      field: "mode",
+      detail: "must be one of: server, client, both",
+    ))
+  s |> string.contains("Invalid value for") |> should.be_true()
+  s |> string.contains("mode") |> should.be_true()
+  s |> string.contains("must be one of") |> should.be_true()
+}
+
+pub fn config_load_missing_input_returns_missing_field_case() {
+  let result = config.load("test/fixtures/oaspec_targets_empty.yaml")
+  case result {
+    Error(config.MissingField(field: _)) | Error(config.InvalidValue(..)) ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
 pub fn parse_mode_case() {
   config.parse_mode("server") |> should.be_ok()
   config.parse_mode("client") |> should.be_ok()

--- a/test/transport_test.gleam
+++ b/test/transport_test.gleam
@@ -488,3 +488,66 @@ pub fn async_try_await_short_circuits_error_test() {
   |> transport.try_await(fn(_value) { transport.resolve(Ok("should not run")) })
   |> transport.run(fn(result) { result |> should.equal(Error("boom")) })
 }
+
+// Issue #427: complementary halves of try_await / map_try.
+
+pub fn async_try_await_chains_ok_test() {
+  // Successful first stage flows into the second stage; both Ok values
+  // are visible to the final continuation.
+  transport.resolve(Ok(1))
+  |> transport.try_await(fn(value) { transport.resolve(Ok(value + 1)) })
+  |> transport.run(fn(result) { result |> should.equal(Ok(2)) })
+}
+
+pub fn async_map_try_short_circuits_error_test() {
+  // Error skips the mapping function entirely.
+  transport.resolve(Error("nope"))
+  |> transport.map_try(fn(_value) { Ok(99) })
+  |> transport.run(fn(result) { result |> should.equal(Error("nope")) })
+}
+
+// Issue #428: middleware composition has to keep working when wired
+// against `AsyncSend`, not just sync `Send`. `with_base_url` is
+// already covered above; mirror the rest.
+
+pub fn with_default_header_async_send_test() {
+  let send =
+    transport.with_default_header(echo_to_async_response(), "x-trace", "abc")
+  transport.run(send(empty_request()), fn(result) {
+    let assert Ok(resp) = result
+    resp.headers
+    |> list.key_find("x-trace")
+    |> should.equal(Ok("abc"))
+  })
+}
+
+pub fn with_default_headers_async_send_test() {
+  let send =
+    transport.with_default_headers(echo_to_async_response(), [
+      #("x-a", "1"),
+      #("x-b", "2"),
+    ])
+  transport.run(send(empty_request()), fn(result) {
+    let assert Ok(resp) = result
+    resp.headers
+    |> list.key_find("x-a")
+    |> should.equal(Ok("1"))
+    resp.headers
+    |> list.key_find("x-b")
+    |> should.equal(Ok("2"))
+  })
+}
+
+pub fn with_security_async_send_test() {
+  let creds =
+    transport.credentials()
+    |> transport.with_bearer_token("BearerAuth", "tok-async")
+  let send = transport.with_security(echo_to_async_response(), creds)
+  let req = with_security_alts([HttpAuthorization("BearerAuth", "Bearer")])
+  transport.run(send(req), fn(result) {
+    let assert Ok(resp) = result
+    resp.headers
+    |> list.key_find("authorization")
+    |> should.equal(Ok("Bearer tok-async"))
+  })
+}


### PR DESCRIPTION
## Summary

Bundles four test-coverage issues into one PR.

- #427 — complementary `try_await` (Ok-Ok chaining) and `map_try` (error short-circuit) coverage. The pre-existing pair only covered the error-then-Ok and Ok-then-Ok halves respectively; the missing two arms could regress a one-line case clause silently.
- #428 — `with_default_header` / `with_default_headers` / `with_security` now have async-send tests using `echo_to_async_response`. `with_base_url` was already covered async; this finishes the polymorphic-transport contract on the rest of the middleware.
- #413 — a `config_error_formatting_test` group asserts the user-facing string `config.error_to_string` produces for each `ConfigError` variant (FileNotFound, FileReadError, ParseError, MissingField, InvalidValue), plus a regression case pinning that an empty / non-conforming config surfaces as `MissingField` / `InvalidValue`.
- #414 — `diagnostic.to_short_string` and `diagnostic.to_string` now have direct shape assertions for `file_error` / `yaml_error` (with and without source loc) / `missing_field` / `invalid_value`. The pointer-to-human stack already had coverage; this fills the surrounding format gap so a CLI string regression fails the suite.

Test count: 336 → 349.

## Out of scope (deferred)

- #401 (`writer.write_all` real-filesystem tests) — needs a temp-directory harness.
- #422 (router / guards exercised from gleeunit instead of `run.sh`) — needs the `integration_test` gleeunit suite wired to the generated runtime helpers.

Both warrant their own PR.

## Test plan

- [x] `gleam test` — 349 passing
- [x] `gleam run -m glinter` — 0 errors
- [x] `bash scripts/check_sync.sh` — versions and counts in sync
- [ ] CI green

Closes #413, closes #414, closes #427, closes #428.
