### PR TITLE
docs(codegen): clarify schema_dispatch panic sites as hoist contract tripwires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Documentation
+
+- **codegen**: clarified the four `panic as { ... }` sites in
+  `internal/codegen/schema_dispatch` (`decoder_expr` /
+  `json_encoder_expr` / `json_encoder_fn` / `to_string_fn`) as
+  hoist-contract tripwires rather than user-facing errors. Each panic
+  now points at `oaspec/internal/openapi/hoist` as the post-hoist
+  invariant owner and asks users who hit them to file an issue with
+  the offending spec. The `Result`-based dispatch suggested in #390
+  was investigated but deferred — it would have rippled through 9+
+  caller sites in `decoders` / `encoders` / `client_request` and
+  would have masked the contract that hoist is responsible for. (#390)
+
 ## [0.44.0] - 2026-05-04
 
 ### Changed

--- a/src/oaspec/internal/codegen/schema_dispatch.gleam
+++ b/src/oaspec/internal/codegen/schema_dispatch.gleam
@@ -107,12 +107,25 @@ pub fn decoder_expr(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "decode.float"
     Inline(BooleanSchema(..)) -> "decode.bool"
     Reference(name:, ..) -> naming.to_snake_case(name) <> "_decoder()"
+    // Issue #390: this panic guards a contract that the hoist pass
+    // (oaspec/internal/openapi/hoist) is responsible for: every inline
+    // composite (object / allOf / oneOf / anyOf / array of composites)
+    // must be hoisted to components/schemas before codegen runs, so
+    // decoder_expr only ever sees primitives or References. If this
+    // branch fires, the bug is either in hoist or in a new spec shape
+    // that hoist doesn't recognise — fix at the hoist level rather
+    // than here. Converting this dispatch to Result was considered in
+    // #390 but rippled through 9+ caller sites and would have masked
+    // the contract. The panic stays as a fail-fast tripwire.
     Inline(schema) ->
       panic as {
         "oaspec: inline "
         <> schema_kind(schema)
-        <> " schema is not supported in decoder_expr. "
-        <> "Move the schema to components/schemas and use a $ref instead."
+        <> " schema reached decoder_expr after hoist. "
+        <> "This is a hoist contract bug — inline composites must be "
+        <> "moved to components/schemas before codegen. Please open an "
+        <> "issue at https://github.com/nao1215/oaspec/issues with the "
+        <> "spec that triggered this."
       }
   }
 }
@@ -126,12 +139,14 @@ pub fn json_encoder_expr(ref: SchemaRef, value: String) -> String {
     Inline(BooleanSchema(..)) -> "json.bool(" <> value <> ")"
     Reference(name:, ..) ->
       "encode_" <> naming.to_snake_case(name) <> "_json(" <> value <> ")"
+    // Issue #390: same hoist contract as decoder_expr above —
+    // inline composites must be hoisted before reaching this dispatch.
     Inline(schema) ->
       panic as {
         "oaspec: inline "
         <> schema_kind(schema)
-        <> " schema is not supported in json_encoder_expr. "
-        <> "Move the schema to components/schemas and use a $ref instead."
+        <> " schema reached json_encoder_expr after hoist. "
+        <> "This is a hoist contract bug; please file an issue with the spec."
       }
   }
 }
@@ -144,12 +159,14 @@ pub fn json_encoder_fn(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "json.float"
     Inline(BooleanSchema(..)) -> "json.bool"
     Reference(name:, ..) -> "encode_" <> naming.to_snake_case(name) <> "_json"
+    // Issue #390: see decoder_expr's panic note. Inline composites
+    // are a post-hoist invariant violation, not a user-facing error.
     Inline(schema) ->
       panic as {
         "oaspec: inline "
         <> schema_kind(schema)
-        <> " schema is not supported in json_encoder_fn. "
-        <> "Move the schema to components/schemas and use a $ref instead."
+        <> " schema reached json_encoder_fn after hoist. "
+        <> "This is a hoist contract bug; please file an issue with the spec."
       }
   }
 }
@@ -170,12 +187,14 @@ pub fn to_string_fn(ref: SchemaRef, ctx: Context) -> String {
         Error(_) -> "fn(x) { x }"
       }
     }
+    // Issue #390: see decoder_expr's panic note. Inline composites are
+    // a post-hoist invariant violation, not a user-facing error.
     Inline(schema) ->
       panic as {
         "oaspec: inline "
         <> schema_kind(schema)
-        <> " schema is not supported in to_string_fn. "
-        <> "Move the schema to components/schemas and use a $ref instead."
+        <> " schema reached to_string_fn after hoist. "
+        <> "This is a hoist contract bug; please file an issue with the spec."
       }
   }
 }


### PR DESCRIPTION
## Summary

Closes #390.

The Issue suggested replacing the four `panic as { ... }` fallback branches in `schema_dispatch` (`decoder_expr` / `json_encoder_expr` / `json_encoder_fn` / `to_string_fn`) with `Result` returns. After investigation that ripple turned out to be 9+ caller sites in `decoders` / `encoders` / `client_request`, and converting the dispatch to `Result` would have hidden — not surfaced — the actual contract these branches enforce: inline composites must be hoisted to `components/schemas` before codegen runs, and every one of them is.

This PR updates each panic message to:

- point at `oaspec/internal/openapi/hoist` as the post-hoist invariant owner,
- frame the panic as a hoist-contract bug rather than a "spec author error",
- ask users who hit it to file an issue with the offending spec.

The runtime behavior (fail-fast on contract violation) is unchanged.

## Test plan

- [x] \`gleam test\` — 352 passing
- [ ] CI green

Closes #390.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification in the changelog explaining that certain internal error conditions are post-hoist invariant checks (safety tripwires), not unsupported features. Users encountering these errors are encouraged to file issues.

* **Style**
  * Updated error messages to more accurately describe post-hoist invariant violations and added inline comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->