### PR TITLE
perf(naming): memoize pre-compiled regexes via persistent_term FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ within `Changed` / `Fixed` and stay as-is.
   caller sites in `decoders` / `encoders` / `client_request` and
   would have masked the contract that hoist is responsible for. (#390)
 
+### Performance
+
+- naming: `to_pascal_case` / `to_snake_case` no longer recompile the
+  three internal regexes on every call. The compiled `Regexes`
+  record is cached in the BEAM `persistent_term` table via a tiny
+  `oaspec_naming_ffi:memoize/2` Erlang helper — first caller wins,
+  every subsequent call is an O(1) lookup with no GC pressure. On a
+  10k-schema spec this collapses 30k+ regex compiles to 3. The new
+  file is the only FFI in the project; an `ffi_usage` lint
+  exception is added only for `internal/util/naming.gleam`. (#405)
+
 ## [0.44.0] - 2026-05-04
 
 ### Changed

--- a/gleam.toml
+++ b/gleam.toml
@@ -100,3 +100,8 @@ unwrap_used = "error"
 "src/oaspec/openapi/parser.gleam" = ["label_possible", "deep_nesting"]
 "src/oaspec/openapi/diagnostic.gleam" = ["label_possible"]
 "src/oaspec/internal/util/*.gleam" = ["label_possible", "deep_nesting"]
+# naming.gleam memoizes its three pre-compiled regexes via a tiny
+# `oaspec_naming_ffi:memoize/2` helper backed by `persistent_term`.
+# This is the only FFI in the project; the lint rule stays on
+# everywhere else (Issue #405).
+"src/oaspec/internal/util/naming.gleam" = ["label_possible", "deep_nesting", "ffi_usage"]

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -29,10 +29,7 @@ type RegexCacheKey {
 }
 
 @external(erlang, "oaspec_naming_ffi", "memoize")
-fn memoize_regexes(
-  key: RegexCacheKey,
-  compute: fn() -> Regexes,
-) -> Regexes
+fn memoize_regexes(key: RegexCacheKey, compute: fn() -> Regexes) -> Regexes
 
 fn cached_regexes() -> Regexes {
   memoize_regexes(OaspecNamingRegexes, compile_regexes)

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -5,13 +5,37 @@ import gleam/regexp.{type Regexp}
 import gleam/string
 
 /// Pre-compiled regexes used by naming functions.
-/// Compiled once per public function call instead of on every internal call.
+///
+/// Issue #405: previously these were compiled on every public-call
+/// entry (`to_pascal_case` / `to_snake_case`). On a 10k-schema spec
+/// that's 30k+ regex compiles per `oaspec generate`. The FFI helper
+/// `memoize_regexes` below stashes the first-ever computed value in
+/// `persistent_term` so subsequent calls are O(1) lookups with no GC
+/// pressure.
 type Regexes {
   Regexes(
     word_separator: Regexp,
     camel_case: Regexp,
     underscore_before_caps: Regexp,
   )
+}
+
+/// Cache key for the persistent_term store. Zero-arg constructors map
+/// to atoms in Erlang; we only need the type to be unique to oaspec
+/// so the key cannot collide with anything else stored in
+/// persistent_term by other applications.
+type RegexCacheKey {
+  OaspecNamingRegexes
+}
+
+@external(erlang, "oaspec_naming_ffi", "memoize")
+fn memoize_regexes(
+  key: RegexCacheKey,
+  compute: fn() -> Regexes,
+) -> Regexes
+
+fn cached_regexes() -> Regexes {
+  memoize_regexes(OaspecNamingRegexes, compile_regexes)
 }
 
 fn compile_regexes() -> Regexes {
@@ -57,7 +81,7 @@ fn compile_regexes() -> Regexes {
 /// `Minus1`, `N404`) instead of `1`, `1`, `404` — the latter would
 /// be rejected by the parser at the type-constructor position.
 pub fn to_pascal_case(input: String) -> String {
-  let re = compile_regexes()
+  let re = cached_regexes()
   input
   |> rewrite_leading_signs
   |> split_words(re)
@@ -100,7 +124,7 @@ fn ensure_letter_start_pascal(input: String) -> String {
 /// REST API spec, where `+1` and `-1` both collapsed to `1` (issue
 /// #352).
 pub fn to_snake_case(input: String) -> String {
-  let re = compile_regexes()
+  let re = cached_regexes()
   let result =
     input
     |> rewrite_leading_signs

--- a/src/oaspec_naming_ffi.erl
+++ b/src/oaspec_naming_ffi.erl
@@ -1,0 +1,26 @@
+%% Issue #405: persistent_term-backed memoization for the three
+%% pre-compiled regexes used by `oaspec/internal/util/naming`. Without
+%% this, every `to_pascal_case/1` and `to_snake_case/1` call compiles
+%% the same three regexes from scratch — on a 10k-schema spec that's
+%% 30k+ wasted compiles per generate run.
+%%
+%% `persistent_term` is the right primitive here because the cached
+%% values are written exactly once per BEAM process lifetime (the first
+%% caller wins) and read O(1) by every subsequent caller, with no
+%% GC pressure on a hot path. The compute fun is a Gleam closure
+%% returning the same `gleam/regexp` Regexp record the rest of the
+%% naming module already deals with — `persistent_term` stores it
+%% verbatim, no encoding tricks.
+
+-module(oaspec_naming_ffi).
+-export([memoize/2]).
+
+memoize(Key, Compute) ->
+    case persistent_term:get(Key, undefined) of
+        undefined ->
+            Result = Compute(),
+            persistent_term:put(Key, Result),
+            Result;
+        Cached ->
+            Cached
+    end.


### PR DESCRIPTION
## Summary

Closes #405.

\`to_pascal_case/1\` and \`to_snake_case/1\` previously called \`compile_regexes()\` once per public-call entry. On a 10k-schema spec (e.g. GitHub REST OpenAPI) that's 30k+ wasted regex compiles per \`oaspec generate\` run.

This PR adds a 12-line Erlang FFI module (\`src/oaspec_naming_ffi.erl\`) that wraps \`persistent_term:get/2\` + \`persistent_term:put/2\` around a Gleam-supplied compute closure. \`naming.gleam\` exposes a private \`cached_regexes()\` helper that calls the FFI with a unique \`RegexCacheKey\` atom; the first caller computes and stores the compiled \`Regexes\` record, every subsequent caller is an O(1) \`persistent_term\` lookup with no GC pressure.

\`oaspec_naming_ffi.erl\` is the only FFI in the project. An \`ffi_usage\` lint exception is added in \`gleam.toml\` just for \`internal/util/naming.gleam\` — the project-wide \`ffi_usage = \"error\"\` rule stays on for everything else.

## Test plan

- [x] \`gleam test\` — 352 passing
- [x] \`gleam run -m glinter\` — 0 errors (with the new exception applied to naming.gleam only)
- [ ] CI green

Closes #405.