### PR TITLE
refactor(codegen): lift runtime helper blobs into runtime_snippets module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Changed
+
+- **codegen**: lifted the static runtime helper blobs that
+  `internal/codegen/server` (`deep_object_present`,
+  `deep_object_present_any`, `deep_object_additional_properties`,
+  `coerce_dict`, `form_url_decode` / `parse_form_body`,
+  multipart helpers, `form_object_present`, `cookie_lookup`),
+  `internal/codegen/encoders` (`encode_dynamic`), and
+  `internal/codegen/client` (`text_body` / `bytes_body` /
+  `await_response`) splice into generated code into a new
+  `internal/codegen/runtime_snippets` module. Each helper is now a
+  `pub const` string spliced via the new `string_extra.raw`
+  appender; the gating `case requirements.<flag>` shape stays put
+  but the snippet body is no longer interleaved with `se.line` /
+  `se.indent` calls. `server.gleam` shrinks by ~210 lines and the
+  snippets become trivially diff-able. Closes #417.
+
 ## [0.46.0] - 2026-05-04
 
 ### Changed

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -13,6 +13,7 @@ import oaspec/internal/codegen/context.{
 }
 import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/ir_build
+import oaspec/internal/codegen/runtime_snippets
 import oaspec/internal/openapi/schema
 import oaspec/internal/openapi/spec.{type Resolved, Value}
 import oaspec/internal/util/http
@@ -149,64 +150,18 @@ fn generate_default_base_url(
 /// Emit the text_body helper that extracts a UTF-8 string from a
 /// `transport.Body`, surfacing `InvalidResponse` for non-text bodies.
 fn generate_text_body_helper(sb: se.StringBuilder) -> se.StringBuilder {
-  sb
-  |> se.line(
-    "fn text_body(body: transport.Body) -> Result(String, ClientError) {",
-  )
-  |> se.indent(1, "case body {")
-  |> se.indent(2, "transport.TextBody(text) -> Ok(text)")
-  |> se.indent(
-    2,
-    "transport.BytesBody(_) -> Error(InvalidResponse(detail: \"expected text body, got bytes\"))",
-  )
-  |> se.indent(
-    2,
-    "transport.EmptyBody -> Error(InvalidResponse(detail: \"expected text body, got empty body\"))",
-  )
-  |> se.indent(1, "}")
-  |> se.line("}")
-  |> se.blank_line()
+  se.raw(sb, runtime_snippets.text_body)
 }
 
 /// Emit the bytes_body helper for binary response bodies.
 fn generate_bytes_body_helper(sb: se.StringBuilder) -> se.StringBuilder {
-  sb
-  |> se.line(
-    "fn bytes_body(body: transport.Body) -> Result(BitArray, ClientError) {",
-  )
-  |> se.indent(1, "case body {")
-  |> se.indent(2, "transport.BytesBody(bytes) -> Ok(bytes)")
-  |> se.indent(
-    2,
-    "transport.TextBody(_) -> Error(InvalidResponse(detail: \"expected binary body, got text\"))",
-  )
-  |> se.indent(
-    2,
-    "transport.EmptyBody -> Error(InvalidResponse(detail: \"expected binary body, got empty body\"))",
-  )
-  |> se.indent(1, "}")
-  |> se.line("}")
-  |> se.blank_line()
+  se.raw(sb, runtime_snippets.bytes_body)
 }
 
 /// Emit the async helper that maps an async transport result into the
 /// generated response type.
 fn generate_async_response_helper(sb: se.StringBuilder) -> se.StringBuilder {
-  sb
-  |> se.line("fn await_response(")
-  |> se.indent(
-    1,
-    "response_async: transport.Async(Result(transport.Response, transport.TransportError)),",
-  )
-  |> se.indent(1, "decode: fn(transport.Response) -> Result(a, ClientError),")
-  |> se.line(") -> transport.Async(Result(a, ClientError)) {")
-  |> se.indent(1, "response_async")
-  |> se.indent(1, "|> transport.map(fn(resp_result) {")
-  |> se.indent(2, "resp_result |> result.map_error(TransportError)")
-  |> se.indent(1, "})")
-  |> se.indent(1, "|> transport.map_try(decode)")
-  |> se.line("}")
-  |> se.blank_line()
+  se.raw(sb, runtime_snippets.await_response)
 }
 
 fn emit_simple_query_param(

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -19,6 +19,7 @@ import oaspec/internal/codegen/context.{
   type Context, type GeneratedFile, GeneratedFile,
 }
 import oaspec/internal/codegen/ir_build
+import oaspec/internal/codegen/runtime_snippets
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
 import oaspec/internal/openapi/dedup
@@ -175,44 +176,19 @@ fn generate_encoders(
   // Generate encoders for anonymous inline schemas from operations
   let sb = generate_anonymous_encoders(sb, ctx, operations)
 
-  // Generate encode_dynamic helper if needed for untyped additionalProperties
+  // Generate encode_dynamic helper if needed for untyped additionalProperties.
+  //
+  // The fallback `_ -> json.null()` arm covers unsupported dynamic
+  // classifications (List, Dict, Tuple, etc.). Emitting the type name as a
+  // string would silently corrupt payloads; null at least fails loud when
+  // the receiving end doesn't tolerate it.
   let sb = case needs_dynamic {
     True ->
       sb
       |> se.doc_comment(
         "Encode a Dynamic value to JSON by inspecting its runtime type.",
       )
-      |> se.line("fn encode_dynamic(value: dynamic.Dynamic) -> json.Json {")
-      |> se.indent(1, "case dynamic.classify(value) {")
-      |> se.indent(2, "\"String\" ->")
-      |> se.indent(3, "case decode.run(value, decode.string) {")
-      |> se.indent(4, "Ok(s) -> json.string(s)")
-      |> se.indent(4, "Error(_) -> json.null()")
-      |> se.indent(3, "}")
-      |> se.indent(2, "\"Int\" ->")
-      |> se.indent(3, "case decode.run(value, decode.int) {")
-      |> se.indent(4, "Ok(i) -> json.int(i)")
-      |> se.indent(4, "Error(_) -> json.null()")
-      |> se.indent(3, "}")
-      |> se.indent(2, "\"Float\" ->")
-      |> se.indent(3, "case decode.run(value, decode.float) {")
-      |> se.indent(4, "Ok(f) -> json.float(f)")
-      |> se.indent(4, "Error(_) -> json.null()")
-      |> se.indent(3, "}")
-      |> se.indent(2, "\"Bool\" ->")
-      |> se.indent(3, "case decode.run(value, decode.bool) {")
-      |> se.indent(4, "Ok(b) -> json.bool(b)")
-      |> se.indent(4, "Error(_) -> json.null()")
-      |> se.indent(3, "}")
-      |> se.indent(2, "\"Nil\" -> json.null()")
-      // Fallback: unsupported dynamic classifications (List, Dict, Tuple,
-      // etc.) emit `json.null()` rather than the type name as a string.
-      // Emitting the type name silently corrupts payloads; null at least
-      // fails loud when the receiving end doesn't tolerate it.
-      |> se.indent(2, "_ -> json.null()")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
+      |> se.raw(runtime_snippets.encode_dynamic)
     False -> sb
   }
 

--- a/src/oaspec/internal/codegen/runtime_snippets.gleam
+++ b/src/oaspec/internal/codegen/runtime_snippets.gleam
@@ -1,0 +1,248 @@
+//// Static runtime helper snippets spliced into generated code.
+////
+//// Each constant is emitted byte-for-byte (via `string_extra.raw`) when its
+//// gating flag in `RouterRequirements` / encoder analysis / client analysis
+//// holds. Lifting them out of the original `se.line` / `se.indent` chains in
+//// `server` / `encoders` / `client` keeps the generator functions short and
+//// makes the snippet bodies trivially diff-able.
+////
+//// Each snippet ends with a trailing newline + blank line so the caller
+//// can chain the next emission immediately without an explicit
+//// `se.blank_line()` afterwards.
+
+/// Emitted when at least one optional `deepObject` query parameter exists
+/// and that parameter has no `additionalProperties` entry.
+pub const deep_object_present: String = "fn deep_object_present(query: Dict(String, List(String)), prefix: String, props: List(String)) -> Bool {
+  list.any(props, fn(prop) { dict.has_key(query, prefix <> \"[\" <> prop <> \"]\") })
+}
+
+"
+
+/// Emitted when at least one `deepObject` parameter declares
+/// `additionalProperties` (typed or untyped).
+pub const deep_object_present_any: String = "fn deep_object_present_any(query: Dict(String, List(String)), prefix: String) -> Bool {
+  let prefix_bracket = prefix <> \"[\"
+  dict.fold(query, False, fn(found, k, _v) { found || string.starts_with(k, prefix_bracket) })
+}
+
+fn deep_object_additional_properties(query: Dict(String, List(String)), prefix: String, known_props: List(String)) -> Dict(String, List(String)) {
+  let prefix_bracket = prefix <> \"[\"
+  let prefix_len = string.length(prefix_bracket)
+  dict.fold(query, dict.new(), fn(acc, k, v) {
+    case string.starts_with(k, prefix_bracket) && string.ends_with(k, \"]\") {
+      True -> {
+        let prop = string.slice(k, prefix_len, string.length(k) - prefix_len - 1)
+        case list.contains(known_props, prop) { True -> acc False -> dict.insert(acc, prop, v) }
+      }
+      False -> acc
+    }
+  })
+}
+
+"
+
+/// Type-safe identity coercion used when `deepObject` parameters have
+/// untyped `additionalProperties` (Dynamic value type).
+pub const coerce_dict: String = "@external(erlang, \"gleam_stdlib\", \"identity\")
+fn coerce_dict(value: Dict(String, List(String))) -> Dict(String, dynamic.Dynamic)
+
+"
+
+/// Emitted when any `application/x-www-form-urlencoded` request body exists.
+pub const form_url_decode_and_parse_form_body: String = "fn form_url_decode(value: String) -> String {
+  let value = string.replace(value, \"+\", \" \")
+  case uri.percent_decode(value) { Ok(decoded) -> decoded Error(_) -> value }
+}
+
+fn parse_form_body(body: String) -> Dict(String, List(String)) {
+  let parts = case body { \"\" -> [] _ -> string.split(body, \"&\") }
+  list.fold(parts, dict.new(), fn(acc, part) {
+    case part {
+      \"\" -> acc
+      _ ->
+        case string.split_once(part, on: \"=\") {
+          Ok(#(raw_key, raw_value)) -> {
+            let key = form_url_decode(raw_key)
+            let value = form_url_decode(raw_value)
+            case dict.get(acc, key) {
+              Ok(existing) -> dict.insert(acc, key, list.append(existing, [value]))
+              Error(_) -> dict.insert(acc, key, [value])
+            }
+          }
+          Error(_) -> {
+            let key = form_url_decode(part)
+            case dict.get(acc, key) {
+              Ok(existing) -> dict.insert(acc, key, list.append(existing, [\"\"]))
+              Error(_) -> dict.insert(acc, key, [\"\"])
+            }
+          }
+        }
+    }
+  })
+}
+
+"
+
+/// Emitted when any `multipart/form-data` request body exists.
+pub const multipart_helpers: String = "fn multipart_boundary(headers: Dict(String, String)) -> Result(String, Nil) {
+  case dict.get(headers, \"content-type\") {
+    Ok(content_type) ->
+      list.find_map(string.split(content_type, \";\"), fn(part) {
+        let trimmed = string.trim(part)
+        case string.starts_with(trimmed, \"boundary=\") {
+          True -> Ok(string.replace(trimmed, \"boundary=\", \"\"))
+          False -> Error(Nil)
+        }
+      })
+    Error(_) -> Error(Nil)
+  }
+}
+
+fn multipart_name(raw_headers: String) -> Result(String, Nil) {
+  list.find_map(string.split(raw_headers, \"\\r\\n\"), fn(line) {
+    case string.contains(line, \"name=\") {
+      True ->
+        list.find_map(string.split(line, \";\"), fn(part) {
+          let trimmed = string.trim(part)
+          case string.starts_with(trimmed, \"name=\") {
+            True -> Ok(string.replace(string.replace(trimmed, \"name=\", \"\"), \"\\\"\", \"\"))
+            False -> Error(Nil)
+          }
+        })
+      False -> Error(Nil)
+    }
+  })
+}
+
+fn parse_multipart_body(body: String, headers: Dict(String, String)) -> Dict(String, List(String)) {
+  case multipart_boundary(headers) {
+    Ok(boundary) -> {
+      let delimiter = \"--\" <> boundary
+      let parts = string.split(body, delimiter)
+      list.fold(parts, dict.new(), fn(acc, part) {
+        let normalized_part = part |> string.remove_prefix(\"\\r\\n\") |> string.remove_suffix(\"\\r\\n\")
+        case normalized_part == \"\" || normalized_part == \"--\" {
+          True -> acc
+          False ->
+            case string.split_once(normalized_part, on: \"\\r\\n\\r\\n\") {
+              Ok(#(raw_part_headers, raw_value)) ->
+                case multipart_name(raw_part_headers) {
+                  Ok(name) -> {
+                    let value = raw_value
+                    case dict.get(acc, name) {
+                      Ok(existing) -> dict.insert(acc, name, list.append(existing, [value]))
+                      Error(_) -> dict.insert(acc, name, [value])
+                    }
+                  }
+                  Error(_) -> acc
+                }
+              Error(_) -> acc
+            }
+        }
+      })
+    }
+    Error(_) -> dict.new()
+  }
+}
+
+"
+
+/// Emitted when at least one nested form-urlencoded request body exists
+/// (a body schema with `style: deepObject` properties).
+pub const form_object_present: String = "fn form_object_present(form_body: Dict(String, List(String)), prefix: String, props: List(String)) -> Bool {
+  list.any(props, fn(prop) { dict.has_key(form_body, prefix <> \"[\" <> prop <> \"]\") })
+}
+
+"
+
+/// Cookie-parameter lookup helper. Wrapped in a `doc_comment(\"Extract a
+/// cookie value from the Cookie header.\")` by the caller before being
+/// spliced in.
+pub const cookie_lookup: String = "fn cookie_lookup(headers: Dict(String, String), key: String) -> Result(String, Nil) {
+  case dict.get(headers, \"cookie\") {
+    Ok(raw) ->
+      list.find_map(string.split(raw, \";\"), fn(part) {
+        let trimmed = string.trim(part)
+        case string.split_once(trimmed, on: \"=\") {
+          Ok(#(cookie_key, cookie_value)) ->
+            case string.trim(cookie_key) == key {
+              True -> uri.percent_decode(string.trim(cookie_value))
+              False -> Error(Nil)
+            }
+          Error(_) -> Error(Nil)
+        }
+      })
+    Error(_) -> Error(Nil)
+  }
+}
+
+"
+
+/// Encoder for untyped `additionalProperties: true` schemas — inspects the
+/// runtime type of each Dynamic value.
+pub const encode_dynamic: String = "fn encode_dynamic(value: dynamic.Dynamic) -> json.Json {
+  case dynamic.classify(value) {
+    \"String\" ->
+      case decode.run(value, decode.string) {
+        Ok(s) -> json.string(s)
+        Error(_) -> json.null()
+      }
+    \"Int\" ->
+      case decode.run(value, decode.int) {
+        Ok(i) -> json.int(i)
+        Error(_) -> json.null()
+      }
+    \"Float\" ->
+      case decode.run(value, decode.float) {
+        Ok(f) -> json.float(f)
+        Error(_) -> json.null()
+      }
+    \"Bool\" ->
+      case decode.run(value, decode.bool) {
+        Ok(b) -> json.bool(b)
+        Error(_) -> json.null()
+      }
+    \"Nil\" -> json.null()
+    _ -> json.null()
+  }
+}
+
+"
+
+/// Client-side helper that extracts a UTF-8 string from a `transport.Body`,
+/// surfacing `InvalidResponse` for non-text bodies.
+pub const text_body: String = "fn text_body(body: transport.Body) -> Result(String, ClientError) {
+  case body {
+    transport.TextBody(text) -> Ok(text)
+    transport.BytesBody(_) -> Error(InvalidResponse(detail: \"expected text body, got bytes\"))
+    transport.EmptyBody -> Error(InvalidResponse(detail: \"expected text body, got empty body\"))
+  }
+}
+
+"
+
+/// Client-side helper for binary response bodies.
+pub const bytes_body: String = "fn bytes_body(body: transport.Body) -> Result(BitArray, ClientError) {
+  case body {
+    transport.BytesBody(bytes) -> Ok(bytes)
+    transport.TextBody(_) -> Error(InvalidResponse(detail: \"expected binary body, got text\"))
+    transport.EmptyBody -> Error(InvalidResponse(detail: \"expected binary body, got empty body\"))
+  }
+}
+
+"
+
+/// Client-side helper that maps an async transport result into the
+/// generated response type.
+pub const await_response: String = "fn await_response(
+  response_async: transport.Async(Result(transport.Response, transport.TransportError)),
+  decode: fn(transport.Response) -> Result(a, ClientError),
+) -> transport.Async(Result(a, ClientError)) {
+  response_async
+  |> transport.map(fn(resp_result) {
+    resp_result |> result.map_error(TransportError)
+  })
+  |> transport.map_try(decode)
+}
+
+"

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -10,6 +10,7 @@ import oaspec/internal/codegen/context.{
 }
 import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/router_ir
+import oaspec/internal/codegen/runtime_snippets
 import oaspec/internal/codegen/server_request_decode as decode_helpers
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/schema.{Inline, Reference}
@@ -279,237 +280,36 @@ String.",
 
   // deep_object_present: only when optional deep object params without AP exist
   let sb = case requirements.needs_deep_object_present {
-    True ->
-      sb
-      |> se.line(
-        "fn deep_object_present(query: Dict(String, List(String)), prefix: String, props: List(String)) -> Bool {",
-      )
-      |> se.indent(
-        1,
-        "list.any(props, fn(prop) { dict.has_key(query, prefix <> \"[\" <> prop <> \"]\") })",
-      )
-      |> se.line("}")
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.deep_object_present)
     False -> sb
   }
 
   // deep_object_present_any and deep_object_additional_properties:
   // only when deep object params with additional_properties exist
   let sb = case requirements.has_deep_object_with_ap {
-    True ->
-      sb
-      |> se.line(
-        "fn deep_object_present_any(query: Dict(String, List(String)), prefix: String) -> Bool {",
-      )
-      |> se.indent(1, "let prefix_bracket = prefix <> \"[\"")
-      |> se.indent(
-        1,
-        "dict.fold(query, False, fn(found, k, _v) { found || string.starts_with(k, prefix_bracket) })",
-      )
-      |> se.line("}")
-      |> se.blank_line()
-      |> se.line(
-        "fn deep_object_additional_properties(query: Dict(String, List(String)), prefix: String, known_props: List(String)) -> Dict(String, List(String)) {",
-      )
-      |> se.indent(1, "let prefix_bracket = prefix <> \"[\"")
-      |> se.indent(1, "let prefix_len = string.length(prefix_bracket)")
-      |> se.indent(1, "dict.fold(query, dict.new(), fn(acc, k, v) {")
-      |> se.indent(
-        2,
-        "case string.starts_with(k, prefix_bracket) && string.ends_with(k, \"]\") {",
-      )
-      |> se.indent(3, "True -> {")
-      |> se.indent(
-        4,
-        "let prop = string.slice(k, prefix_len, string.length(k) - prefix_len - 1)",
-      )
-      |> se.indent(
-        4,
-        "case list.contains(known_props, prop) { True -> acc False -> dict.insert(acc, prop, v) }",
-      )
-      |> se.indent(3, "}")
-      |> se.indent(3, "False -> acc")
-      |> se.indent(2, "}")
-      |> se.indent(1, "})")
-      |> se.line("}")
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.deep_object_present_any)
     False -> sb
   }
 
   // coerce_dict: type-safe identity for converting Dict value types at compile time
   // Only needed when deepObject params with Untyped additional_properties exist
   let sb = case requirements.has_deep_object_untyped_ap {
-    True ->
-      sb
-      |> se.line("@external(erlang, \"gleam_stdlib\", \"identity\")")
-      |> se.line(
-        "fn coerce_dict(value: Dict(String, List(String))) -> Dict(String, dynamic.Dynamic)",
-      )
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.coerce_dict)
     False -> sb
   }
 
   let sb = case requirements.has_form_urlencoded_body {
-    True ->
-      sb
-      |> se.line("fn form_url_decode(value: String) -> String {")
-      |> se.indent(1, "let value = string.replace(value, \"+\", \" \")")
-      |> se.indent(
-        1,
-        "case uri.percent_decode(value) { Ok(decoded) -> decoded Error(_) -> value }",
-      )
-      |> se.line("}")
-      |> se.blank_line()
-      |> se.line(
-        "fn parse_form_body(body: String) -> Dict(String, List(String)) {",
-      )
-      |> se.indent(
-        1,
-        "let parts = case body { \"\" -> [] _ -> string.split(body, \"&\") }",
-      )
-      |> se.indent(1, "list.fold(parts, dict.new(), fn(acc, part) {")
-      |> se.indent(2, "case part {")
-      |> se.indent(3, "\"\" -> acc")
-      |> se.indent(3, "_ ->")
-      |> se.indent(4, "case string.split_once(part, on: \"=\") {")
-      |> se.indent(5, "Ok(#(raw_key, raw_value)) -> {")
-      |> se.indent(6, "let key = form_url_decode(raw_key)")
-      |> se.indent(6, "let value = form_url_decode(raw_value)")
-      |> se.indent(6, "case dict.get(acc, key) {")
-      |> se.indent(
-        7,
-        "Ok(existing) -> dict.insert(acc, key, list.append(existing, [value]))",
-      )
-      |> se.indent(7, "Error(_) -> dict.insert(acc, key, [value])")
-      |> se.indent(6, "}")
-      |> se.indent(5, "}")
-      |> se.indent(5, "Error(_) -> {")
-      |> se.indent(6, "let key = form_url_decode(part)")
-      |> se.indent(6, "case dict.get(acc, key) {")
-      |> se.indent(
-        7,
-        "Ok(existing) -> dict.insert(acc, key, list.append(existing, [\"\"]))",
-      )
-      |> se.indent(7, "Error(_) -> dict.insert(acc, key, [\"\"])")
-      |> se.indent(6, "}")
-      |> se.indent(5, "}")
-      |> se.indent(4, "}")
-      |> se.indent(2, "}")
-      |> se.indent(1, "})")
-      |> se.line("}")
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.form_url_decode_and_parse_form_body)
     False -> sb
   }
 
   let sb = case requirements.has_multipart_body {
-    True ->
-      sb
-      |> se.line(
-        "fn multipart_boundary(headers: Dict(String, String)) -> Result(String, Nil) {",
-      )
-      |> se.indent(1, "case dict.get(headers, \"content-type\") {")
-      |> se.indent(2, "Ok(content_type) ->")
-      |> se.indent(
-        3,
-        "list.find_map(string.split(content_type, \";\"), fn(part) {",
-      )
-      |> se.indent(4, "let trimmed = string.trim(part)")
-      |> se.indent(4, "case string.starts_with(trimmed, \"boundary=\") {")
-      |> se.indent(
-        5,
-        "True -> Ok(string.replace(trimmed, \"boundary=\", \"\"))",
-      )
-      |> se.indent(5, "False -> Error(Nil)")
-      |> se.indent(4, "}")
-      |> se.indent(3, "})")
-      |> se.indent(2, "Error(_) -> Error(Nil)")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
-      |> se.line(
-        "fn multipart_name(raw_headers: String) -> Result(String, Nil) {",
-      )
-      |> se.indent(
-        1,
-        "list.find_map(string.split(raw_headers, \"\\r\\n\"), fn(line) {",
-      )
-      |> se.indent(2, "case string.contains(line, \"name=\") {")
-      |> se.indent(3, "True ->")
-      |> se.indent(4, "list.find_map(string.split(line, \";\"), fn(part) {")
-      |> se.indent(5, "let trimmed = string.trim(part)")
-      |> se.indent(5, "case string.starts_with(trimmed, \"name=\") {")
-      |> se.indent(
-        6,
-        "True -> Ok(string.replace(string.replace(trimmed, \"name=\", \"\"), \"\\\"\", \"\"))",
-      )
-      |> se.indent(6, "False -> Error(Nil)")
-      |> se.indent(5, "}")
-      |> se.indent(4, "})")
-      |> se.indent(3, "False -> Error(Nil)")
-      |> se.indent(2, "}")
-      |> se.indent(1, "})")
-      |> se.line("}")
-      |> se.blank_line()
-      |> se.line(
-        "fn parse_multipart_body(body: String, headers: Dict(String, String)) -> Dict(String, List(String)) {",
-      )
-      |> se.indent(1, "case multipart_boundary(headers) {")
-      |> se.indent(2, "Ok(boundary) -> {")
-      |> se.indent(3, "let delimiter = \"--\" <> boundary")
-      |> se.indent(3, "let parts = string.split(body, delimiter)")
-      |> se.indent(3, "list.fold(parts, dict.new(), fn(acc, part) {")
-      |> se.indent(
-        4,
-        "let normalized_part = part |> string.remove_prefix(\"\\r\\n\") |> string.remove_suffix(\"\\r\\n\")",
-      )
-      |> se.indent(
-        4,
-        "case normalized_part == \"\" || normalized_part == \"--\" {",
-      )
-      |> se.indent(5, "True -> acc")
-      |> se.indent(5, "False ->")
-      |> se.indent(
-        6,
-        "case string.split_once(normalized_part, on: \"\\r\\n\\r\\n\") {",
-      )
-      |> se.indent(7, "Ok(#(raw_part_headers, raw_value)) ->")
-      |> se.indent(8, "case multipart_name(raw_part_headers) {")
-      |> se.indent(9, "Ok(name) -> {")
-      |> se.indent(10, "let value = raw_value")
-      |> se.indent(10, "case dict.get(acc, name) {")
-      |> se.indent(
-        11,
-        "Ok(existing) -> dict.insert(acc, name, list.append(existing, [value]))",
-      )
-      |> se.indent(11, "Error(_) -> dict.insert(acc, name, [value])")
-      |> se.indent(10, "}")
-      |> se.indent(9, "}")
-      |> se.indent(9, "Error(_) -> acc")
-      |> se.indent(8, "}")
-      |> se.indent(7, "Error(_) -> acc")
-      |> se.indent(6, "}")
-      |> se.indent(4, "}")
-      |> se.indent(3, "})")
-      |> se.indent(2, "}")
-      |> se.indent(2, "Error(_) -> dict.new()")
-      |> se.indent(1, "}")
-      |> se.line("}")
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.multipart_helpers)
     False -> sb
   }
 
   let sb = case requirements.has_nested_form_urlencoded_body {
-    True ->
-      sb
-      |> se.line(
-        "fn form_object_present(form_body: Dict(String, List(String)), prefix: String, props: List(String)) -> Bool {",
-      )
-      |> se.indent(
-        1,
-        "list.any(props, fn(prop) { dict.has_key(form_body, prefix <> \"[\" <> prop <> \"]\") })",
-      )
-      |> se.line("}")
-      |> se.blank_line()
+    True -> se.raw(sb, runtime_snippets.form_object_present)
     False -> sb
   }
 
@@ -572,26 +372,7 @@ fn route_arg_name(name: String, used: Bool) -> String {
 fn generate_cookie_lookup(sb: se.StringBuilder) -> se.StringBuilder {
   sb
   |> se.doc_comment("Extract a cookie value from the Cookie header.")
-  |> se.line(
-    "fn cookie_lookup(headers: Dict(String, String), key: String) -> Result(String, Nil) {",
-  )
-  |> se.indent(1, "case dict.get(headers, \"cookie\") {")
-  |> se.indent(2, "Ok(raw) ->")
-  |> se.indent(3, "list.find_map(string.split(raw, \";\"), fn(part) {")
-  |> se.indent(4, "let trimmed = string.trim(part)")
-  |> se.indent(4, "case string.split_once(trimmed, on: \"=\") {")
-  |> se.indent(5, "Ok(#(cookie_key, cookie_value)) ->")
-  |> se.indent(6, "case string.trim(cookie_key) == key {")
-  |> se.indent(7, "True -> uri.percent_decode(string.trim(cookie_value))")
-  |> se.indent(7, "False -> Error(Nil)")
-  |> se.indent(6, "}")
-  |> se.indent(5, "Error(_) -> Error(Nil)")
-  |> se.indent(4, "}")
-  |> se.indent(3, "})")
-  |> se.indent(2, "Error(_) -> Error(Nil)")
-  |> se.indent(1, "}")
-  |> se.line("}")
-  |> se.blank_line()
+  |> se.raw(runtime_snippets.cookie_lookup)
 }
 
 /// Generate the body of a single route case branch.

--- a/src/oaspec/internal/util/string_extra.gleam
+++ b/src/oaspec/internal/util/string_extra.gleam
@@ -33,6 +33,13 @@ pub fn blank_line(sb: StringTree) -> StringTree {
   |> string_tree.append("\n")
 }
 
+/// Append a pre-built block of source text verbatim (no implicit newlines).
+/// Used by codegen to splice in static `runtime_snippets` constants without
+/// going through `line` / `indent` chains.
+pub fn raw(sb: StringTree, text: String) -> StringTree {
+  string_tree.append(sb, text)
+}
+
 /// Generate a file header with auto-generation notice.
 pub fn file_header(version: String) -> StringTree {
   new()


### PR DESCRIPTION
## Summary

`server.gleam` / `encoders.gleam` / `client.gleam` used to emit ~330 lines of
runtime helper bodies inline through interleaved `se.line` / `se.indent`
calls. Each helper (deep-object lookups, form/multipart parsers, cookie
lookup, dynamic JSON encoder, body extractors) is a self-contained snippet
of static text, so the interleaving was pure noise.

This PR lifts each helper to a `pub const String` in a new
`internal/codegen/runtime_snippets` module and appends it via a new
`string_extra.raw` helper. The gating `case requirements.<flag>` shape
stays put; only the snippet body moves out.

- `server.gleam` shrinks by ~210 lines.
- Snippets are now trivially diff-able as plain strings.
- The post-format byte output is unchanged; all golden snapshots still match.

Closes #417.

## Test plan

- [x] `gleam test` — 352 passing
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter` — 0 errors / 0 warnings
- [x] `bash scripts/check_sync.sh`
- [x] golden snapshot tests (`golden_petstore_test`, `golden_complex_supported_test`) pass byte-for-byte
