### PR TITLE
feat(diagnostics): thread YAML SourceLoc through capability-check errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- **diagnostics**: capability-check errors now carry a YAML
+  `SourceLoc` and the CLI prefixes each rendered diagnostic with
+  `path:line:column:` so editors can jump straight to the offending
+  spec line. Public-API plumbing:
+  `parser.parse_file_with_progress_and_locations` returns the spec
+  *and* a `LocationIndex`, and `generate.generate_with_progress_and_locations`
+  / `validate_only_with_progress_and_locations` thread the index
+  through to capability checks. `diagnostic.capability` gains a
+  required `loc:` parameter (breaking; 0.x) and a new
+  `diagnostic.render(d, file_path)` helper produces the
+  editor-clickable prefix. `location_index.lookup_with_ancestor`
+  walks up dot-separated paths so capability paths that don't
+  exactly match the YAML index still surface the closest known
+  ancestor (e.g. the parent schema's line). Closes #411.
+
+### Changed
+
+- BREAKING: `parser.parse_file_with_progress`,
+  `generate.generate_with_progress`, and
+  `generate.validate_only_with_progress` are removed in favour of the
+  combined `*_with_progress_and_locations` variants. Library callers
+  that relied on the progress-only overloads should migrate to the
+  combined entry point and pass `location_index.empty()` if they
+  don't have a YAML location index. (#411)
+
 ## [0.47.0] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 352 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 353 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 257 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -13,6 +13,7 @@ import oaspec/internal/openapi/capability_check
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/filter
 import oaspec/internal/openapi/hoist
+import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/normalize
 import oaspec/internal/openapi/resolve
 import oaspec/internal/openapi/spec.{type OpenApiSpec, type Unresolved}
@@ -55,6 +56,7 @@ fn prepare_context(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
   reporter: Reporter,
+  index: LocationIndex,
 ) -> Result(PreparedContext, GenerateError) {
   let spec_title = spec.info.title <> " v" <> spec.info.version
 
@@ -93,7 +95,7 @@ fn prepare_context(
   // Check for unsupported features using capability registry
   let #(elapsed, capability_issues) =
     progress.timed(fn() {
-      capability_check.check(spec)
+      capability_check.check(spec, index)
       |> diagnostic.filter_by_mode(config.mode(cfg))
     })
   progress.report(
@@ -127,7 +129,7 @@ fn prepare_context(
   // Check for parsed-but-unused features (capability warnings)
   let #(elapsed, preserved_warnings) =
     progress.timed(fn() {
-      capability_check.check_preserved(ctx)
+      capability_check.check_preserved(ctx, index)
       |> diagnostic.filter_by_mode(config.mode(cfg))
     })
   progress.report(
@@ -162,23 +164,36 @@ fn prepare_context(
 /// Pure generation pipeline: parse → normalize → resolve → capability_check → hoist → dedup → validate → codegen.
 /// Takes an already-parsed spec and config; returns generated files or errors.
 /// Does not perform IO — callers handle writing files and printing output.
+///
+/// Capability-check diagnostics from this entry point carry no source
+/// location information. Callers that already have a YAML
+/// `LocationIndex` (e.g. via `parser.parse_file_with_locations`)
+/// should prefer `generate_with_locations` so capability-check errors
+/// surface line/column for the offending spec node (Issue #411).
 pub fn generate(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
 ) -> Result(GenerationSummary, GenerateError) {
-  generate_with_progress(spec, cfg, progress.noop())
+  generate_with_progress_and_locations(
+    spec,
+    location_index.empty(),
+    cfg,
+    progress.noop(),
+  )
 }
 
-/// Same as `generate`, with a `Reporter` that receives one line per
-/// pipeline stage with elapsed time. Used by the CLI to surface
-/// progress for large specs (issue #352); library callers should
-/// prefer `generate` and pass `progress.noop()` if needed.
-pub fn generate_with_progress(
+/// Combined entry point that accepts both a `LocationIndex` and a
+/// `Reporter`. Issue #411 + #352. The CLI uses this so it can show
+/// per-stage progress AND surface `path:line:column:` in capability
+/// errors at the same time. Library callers that need only one of the
+/// two can pass `location_index.empty()` or `progress.noop()`.
+pub fn generate_with_progress_and_locations(
   spec: OpenApiSpec(Unresolved),
+  index: LocationIndex,
   cfg: Config,
   reporter: Reporter,
 ) -> Result(GenerationSummary, GenerateError) {
-  use prepared <- result.try(prepare_context(spec, cfg, reporter))
+  use prepared <- result.try(prepare_context(spec, cfg, reporter, index))
   let #(elapsed, files) =
     progress.timed(fn() { generate_all_files(prepared.ctx) })
   progress.report(
@@ -198,17 +213,23 @@ pub fn validate_only(
   spec: OpenApiSpec(Unresolved),
   cfg: Config,
 ) -> Result(ValidationSummary, GenerateError) {
-  validate_only_with_progress(spec, cfg, progress.noop())
+  validate_only_with_progress_and_locations(
+    spec,
+    location_index.empty(),
+    cfg,
+    progress.noop(),
+  )
 }
 
-/// Same as `validate_only`, with a `Reporter` that receives one line
-/// per pipeline stage with elapsed time. See `generate_with_progress`.
-pub fn validate_only_with_progress(
+/// Combined `validate_only` entry point that accepts both a
+/// `LocationIndex` and a `Reporter`. Issue #411 + #352.
+pub fn validate_only_with_progress_and_locations(
   spec: OpenApiSpec(Unresolved),
+  index: LocationIndex,
   cfg: Config,
   reporter: Reporter,
 ) -> Result(ValidationSummary, GenerateError) {
-  use prepared <- result.try(prepare_context(spec, cfg, reporter))
+  use prepared <- result.try(prepare_context(spec, cfg, reporter, index))
   Ok(ValidationSummary(
     spec_title: prepared.spec_title,
     warnings: prepared.warnings,

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -331,10 +331,11 @@ fn run_generate(
   let shared_input = config.input(first_cfg)
   io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
-  use spec <- require(
-    parser.parse_file_with_progress(shared_input, reporter),
+  use parsed <- require(
+    parser.parse_file_with_progress_and_locations(shared_input, reporter),
     fn(e) { "Error: " <> parser.parse_error_to_string(e) },
   )
+  let #(spec, locations) = parsed
 
   // Run codegen once per target. `generate_with_progress` re-runs
   // every per-target stage (filter / hoist / dedup / validate /
@@ -355,11 +356,16 @@ fn run_generate(
       False -> Nil
     }
     use summary <- require(
-      generate.generate_with_progress(spec, cfg, reporter),
-      format_generate_error,
+      generate.generate_with_progress_and_locations(
+        spec,
+        locations,
+        cfg,
+        reporter,
+      ),
+      format_generate_error_for(shared_input),
     )
     io.println("Spec loaded: " <> summary.spec_title)
-    print_warnings(summary.warnings)
+    print_warnings_for(shared_input, summary.warnings)
     case fail_on_warnings && summary.warnings != [] {
       True -> {
         io.println_error("")
@@ -785,10 +791,11 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
   let shared_input = config.input(first_cfg)
   io.println("Parsing OpenAPI spec: " <> shared_input)
   let reporter = progress.stdout_with_elapsed()
-  use spec <- require(
-    parser.parse_file_with_progress(shared_input, reporter),
+  use parsed <- require(
+    parser.parse_file_with_progress_and_locations(shared_input, reporter),
     fn(e) { "Error: " <> parser.parse_error_to_string(e) },
   )
+  let #(spec, locations) = parsed
 
   let multi_target = case cfgs {
     [_, _, ..] -> True
@@ -803,11 +810,16 @@ fn run_validate(config_path: String, mode_opt: Option(String)) -> Nil {
       False -> Nil
     }
     use summary <- require(
-      generate.validate_only_with_progress(spec, cfg, reporter),
-      format_generate_error,
+      generate.validate_only_with_progress_and_locations(
+        spec,
+        locations,
+        cfg,
+        reporter,
+      ),
+      format_generate_error_for(shared_input),
     )
     io.println("Spec loaded: " <> summary.spec_title)
-    print_warnings(summary.warnings)
+    print_warnings_for(shared_input, summary.warnings)
   })
   io.println("")
   io.println("Validation passed.")
@@ -911,26 +923,56 @@ fn require(
 }
 
 /// Format a GenerateError into a printable error message.
-fn format_generate_error(err: generate.GenerateError) -> String {
-  let generate.ValidationErrors(errors:) = err
-  "Error: OpenAPI spec contains unsupported features:\n"
-  <> string.join(
-    list.map(errors, fn(validation_error) {
-      "  - " <> diagnostic.to_short_string(validation_error)
-    }),
-    "\n",
-  )
+///
+/// Issue #411: each diagnostic is rendered with an editor-clickable
+/// `path:line:column:` prefix when the spec file path and a `SourceLoc`
+/// are both known. Diagnostics without a `SourceLoc` keep the legacy
+/// short-string format so existing CLI output stays familiar.
+fn format_generate_error_for(
+  file_path: String,
+) -> fn(generate.GenerateError) -> String {
+  fn(err: generate.GenerateError) -> String {
+    let generate.ValidationErrors(errors:) = err
+    let file_opt = case file_path {
+      "" -> None
+      _ -> Some(file_path)
+    }
+    "Error: OpenAPI spec contains unsupported features:\n"
+    <> string.join(
+      list.map(errors, fn(validation_error) {
+        "  - "
+        <> case validation_error.source_loc {
+          diagnostic.SourceLoc(..) ->
+            diagnostic.render(validation_error, file_opt)
+          diagnostic.NoSourceLoc -> diagnostic.to_short_string(validation_error)
+        }
+      }),
+      "\n",
+    )
+  }
 }
 
 /// Print warnings if any exist. Warnings are diagnostics, so they go to stderr
-/// to keep stdout reserved for requested output.
-fn print_warnings(warnings: List(diagnostic.Diagnostic)) -> Nil {
+/// to keep stdout reserved for requested output. Issue #411: see
+/// `format_generate_error_for` for the rendering contract.
+fn print_warnings_for(
+  file_path: String,
+  warnings: List(diagnostic.Diagnostic),
+) -> Nil {
+  let file_opt = case file_path {
+    "" -> None
+    _ -> Some(file_path)
+  }
   case warnings {
     [] -> Nil
     _ -> {
       io.println_error("Warnings:")
       list.each(warnings, fn(w) {
-        io.println_error("  - " <> diagnostic.to_short_string(w))
+        let rendered = case w.source_loc {
+          diagnostic.SourceLoc(..) -> diagnostic.render(w, file_opt)
+          diagnostic.NoSourceLoc -> diagnostic.to_short_string(w)
+        }
+        io.println_error("  - " <> rendered)
       })
     }
   }

--- a/src/oaspec/internal/openapi/capability_check.gleam
+++ b/src/oaspec/internal/openapi/capability_check.gleam
@@ -6,47 +6,67 @@ import gleam/string
 import oaspec/config
 import oaspec/internal/capability
 import oaspec/internal/codegen/context.{type Context}
+import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/schema.{
   type SchemaObject, type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema,
   Inline, ObjectSchema, OneOfSchema, Reference, Typed,
 }
-import oaspec/internal/openapi/spec.{type OpenApiSpec, type Resolved, Value}
+import oaspec/internal/openapi/spec.{
+  type HttpMethod, type OpenApiSpec, type Resolved, Value,
+}
 import oaspec/internal/util/http
 import oaspec/openapi/diagnostic.{
-  type Diagnostic, SeverityError, SeverityWarning, TargetBoth, TargetServer,
+  type Diagnostic, type SourceLoc, SeverityError, SeverityWarning, TargetBoth,
+  TargetServer,
 }
 
 /// Run capability checks on a resolved spec.
 /// Returns errors for unsupported features and warnings for parsed-but-unused features.
-pub fn check(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
-  let schema_errors = check_schemas(spec)
-  let security_errors = check_security_schemes(spec)
+///
+/// The `index` carries YAML line/column information used to attach
+/// `SourceLoc` to each diagnostic (Issue #411). Callers that genuinely
+/// have no source-location data (e.g. tests that synthesise a
+/// `OpenApiSpec` directly) can pass `location_index.empty()`; every
+/// diagnostic will then carry `NoSourceLoc`, matching pre-#411 behaviour.
+pub fn check(
+  spec: OpenApiSpec(Resolved),
+  index: LocationIndex,
+) -> List(Diagnostic) {
+  let schema_errors = check_schemas(spec, index)
+  let security_errors = check_security_schemes(spec, index)
   list.flatten([schema_errors, security_errors])
 }
 
 /// Check all schemas for unsupported keywords stored during lossless parse.
 /// Covers both component schemas and inline schemas in operations.
-fn check_schemas(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
+fn check_schemas(
+  spec: OpenApiSpec(Resolved),
+  index: LocationIndex,
+) -> List(Diagnostic) {
   let component_errors = case spec.components {
     None -> []
     Some(components) ->
       dict.to_list(components.schemas)
       |> list.flat_map(fn(entry) {
         let #(name, schema_ref) = entry
-        check_schema_ref("components.schemas." <> name, schema_ref)
+        check_schema_ref("components.schemas." <> name, schema_ref, index)
       })
   }
-  let inline_errors = check_inline_schemas(spec)
+  let inline_errors = check_inline_schemas(spec, index)
   list.append(component_errors, inline_errors)
 }
 
 /// Check inline schemas within operations (request bodies, responses, parameters).
-fn check_inline_schemas(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
+fn check_inline_schemas(
+  spec: OpenApiSpec(Resolved),
+  index: LocationIndex,
+) -> List(Diagnostic) {
   dict.to_list(spec.paths)
   |> list.flat_map(fn(path_entry) {
     let #(path, ref_or) = path_entry
     case ref_or {
-      Value(path_item) -> check_path_item_schemas("paths." <> path, path_item)
+      Value(path_item) ->
+        check_path_item_schemas("paths." <> path, path_item, index)
       _ -> []
     }
   })
@@ -55,6 +75,7 @@ fn check_inline_schemas(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
 fn check_path_item_schemas(
   base_path: String,
   pi: spec.PathItem(Resolved),
+  index: LocationIndex,
 ) -> List(Diagnostic) {
   let method_ops = [
     #("get", pi.get),
@@ -69,7 +90,7 @@ fn check_path_item_schemas(
   list.flat_map(method_ops, fn(entry) {
     let #(method, maybe_op) = entry
     case maybe_op {
-      Some(op) -> check_operation_schemas(base_path <> "." <> method, op)
+      Some(op) -> check_operation_schemas(base_path <> "." <> method, op, index)
       None -> []
     }
   })
@@ -78,6 +99,7 @@ fn check_path_item_schemas(
 fn check_operation_schemas(
   base_path: String,
   op: spec.Operation(Resolved),
+  index: LocationIndex,
 ) -> List(Diagnostic) {
   // Check request body schemas
   let rb_errors = case op.request_body {
@@ -86,7 +108,12 @@ fn check_operation_schemas(
       |> list.flat_map(fn(entry) {
         let #(ct, mt) = entry
         case mt.schema {
-          Some(sr) -> check_schema_ref(base_path <> ".requestBody." <> ct, sr)
+          Some(sr) ->
+            check_schema_ref(
+              base_path <> ".requestBody.content." <> ct <> ".schema",
+              sr,
+              index,
+            )
           None -> []
         }
       })
@@ -108,9 +135,11 @@ fn check_operation_schemas(
                   base_path
                     <> ".responses."
                     <> http.status_code_to_string(code)
-                    <> "."
-                    <> ct,
+                    <> ".content."
+                    <> ct
+                    <> ".schema",
                   sr,
+                  index,
                 )
               None -> []
             }
@@ -122,22 +151,39 @@ fn check_operation_schemas(
 }
 
 /// Check a SchemaRef recursively for unsupported keywords.
-fn check_schema_ref(path: String, ref: SchemaRef) -> List(Diagnostic) {
+fn check_schema_ref(
+  path: String,
+  ref: SchemaRef,
+  index: LocationIndex,
+) -> List(Diagnostic) {
   case ref {
     Reference(..) -> []
-    Inline(schema_obj) -> check_schema(path, schema_obj)
+    Inline(schema_obj) -> check_schema(path, schema_obj, index)
   }
 }
 
 /// Check a single schema and recurse into children.
-fn check_schema(path: String, schema_obj: SchemaObject) -> List(Diagnostic) {
+fn check_schema(
+  path: String,
+  schema_obj: SchemaObject,
+  index: LocationIndex,
+) -> List(Diagnostic) {
   let metadata = schema.get_metadata(schema_obj)
 
-  // Check unsupported keywords stored by lossless parser
+  // Check unsupported keywords stored by lossless parser. Try the
+  // first offending keyword's exact YAML path (e.g.
+  // `...WithDefs.$defs`) before falling back to the schema-level loc;
+  // pointing at the keyword itself is more useful in editors than
+  // the surrounding schema header.
   let keyword_errors = case metadata.unsupported_keywords {
     [] -> []
     keywords -> {
       let keyword_list = string.join(keywords, "', '")
+      let loc = case keywords {
+        [first, ..] ->
+          location_index.lookup_with_ancestor(index, path <> "." <> first)
+        [] -> location_index.lookup_with_ancestor(index, path)
+      }
       [
         diagnostic.capability(
           severity: SeverityError,
@@ -156,6 +202,7 @@ fn check_schema(path: String, schema_obj: SchemaObject) -> List(Diagnostic) {
           hint: Some(
             "Remove the keyword or restructure the schema using supported constructs.",
           ),
+          loc: loc,
         ),
       ]
     }
@@ -166,20 +213,29 @@ fn check_schema(path: String, schema_obj: SchemaObject) -> List(Diagnostic) {
     ObjectSchema(properties:, additional_properties:, ..) -> {
       let prop_errors =
         dict.to_list(properties)
-        |> list.flat_map(fn(e) { check_schema_ref(path <> "." <> e.0, e.1) })
+        |> list.flat_map(fn(e) {
+          check_schema_ref(path <> ".properties." <> e.0, e.1, index)
+        })
       let ap_errors = case additional_properties {
-        Typed(ap) -> check_schema_ref(path <> ".additionalProperties", ap)
+        Typed(ap) ->
+          check_schema_ref(path <> ".additionalProperties", ap, index)
         _ -> []
       }
       list.append(prop_errors, ap_errors)
     }
-    ArraySchema(items:, ..) -> check_schema_ref(path <> ".items", items)
+    ArraySchema(items:, ..) -> check_schema_ref(path <> ".items", items, index)
     AllOfSchema(schemas:, ..) ->
-      list.flat_map(schemas, fn(s) { check_schema_ref(path <> ".allOf", s) })
+      list.flat_map(schemas, fn(s) {
+        check_schema_ref(path <> ".allOf", s, index)
+      })
     OneOfSchema(schemas:, ..) ->
-      list.flat_map(schemas, fn(s) { check_schema_ref(path <> ".oneOf", s) })
+      list.flat_map(schemas, fn(s) {
+        check_schema_ref(path <> ".oneOf", s, index)
+      })
     AnyOfSchema(schemas:, ..) ->
-      list.flat_map(schemas, fn(s) { check_schema_ref(path <> ".anyOf", s) })
+      list.flat_map(schemas, fn(s) {
+        check_schema_ref(path <> ".anyOf", s, index)
+      })
     _ -> []
   }
 
@@ -187,7 +243,10 @@ fn check_schema(path: String, schema_obj: SchemaObject) -> List(Diagnostic) {
 }
 
 /// Check security schemes for unsupported types (e.g. mutualTLS).
-fn check_security_schemes(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
+fn check_security_schemes(
+  spec: OpenApiSpec(Resolved),
+  index: LocationIndex,
+) -> List(Diagnostic) {
   case spec.components {
     None -> []
     Some(components) ->
@@ -195,28 +254,79 @@ fn check_security_schemes(spec: OpenApiSpec(Resolved)) -> List(Diagnostic) {
       |> list.filter_map(fn(entry) {
         let #(name, ref_or) = entry
         case ref_or {
-          Value(spec.UnsupportedScheme(scheme_type:)) ->
+          Value(spec.UnsupportedScheme(scheme_type:)) -> {
+            let path = "components.securitySchemes." <> name
             Ok(diagnostic.capability(
               severity: SeverityError,
               target: TargetBoth,
-              path: "components.securitySchemes." <> name,
+              path: path,
               detail: "Unsupported security scheme type: '"
                 <> scheme_type
                 <> "'. Supported types: apiKey, http, oauth2, openIdConnect.",
               hint: Some(
                 "Use apiKey, http (bearer), oauth2, or openIdConnect instead.",
               ),
+              loc: location_index.lookup_with_ancestor(index, path),
             ))
+          }
           _ -> Error(Nil)
         }
       })
   }
 }
 
+/// Render a `paths.<url>.<method>` YAML pointer for the AnalyzedOperation
+/// the LocationIndex was built from. The index keys URLs verbatim
+/// (matching yamerl's literal YAML key text) so no `~1` escaping is
+/// needed; method names are folded to lowercase to match the YAML
+/// document.
+fn operation_yaml_prefix(url: String, method: HttpMethod) -> String {
+  "paths." <> url <> "." <> string.lowercase(spec.method_to_string(method))
+}
+
+/// Translate a capability-check `op_id`-rooted path into a YAML pointer
+/// the LocationIndex understands. Unmatched paths (e.g. `webhooks`,
+/// `components.*`) pass through unchanged.
+fn capability_path_to_yaml(
+  path: String,
+  operations: List(context.AnalyzedOperation),
+) -> String {
+  case string.split(path, ".") {
+    [first, ..rest] ->
+      case
+        list.find_map(operations, fn(op) {
+          let #(op_id, _, url, method) = op
+          case op_id == first {
+            True -> Ok(operation_yaml_prefix(url, method))
+            False -> Error(Nil)
+          }
+        })
+      {
+        Ok(prefix) ->
+          case rest {
+            [] -> prefix
+            _ -> prefix <> "." <> string.join(rest, ".")
+          }
+        // nolint: thrown_away_error -- non-op_id paths (e.g. `webhooks`, `components.*`) pass through unchanged; there is no error to propagate here.
+        Error(_) -> path
+      }
+    [] -> path
+  }
+}
+
+/// Resolve a SourceLoc for a capability-check diagnostic path by
+/// translating to a YAML pointer (op_id → paths.<url>.<method>) and
+/// falling back to the closest known ancestor when the exact path
+/// isn't in the index.
+fn lookup_loc(ctx: Context, index: LocationIndex, path: String) -> SourceLoc {
+  let yaml_path = capability_path_to_yaml(path, context.operations(ctx))
+  location_index.lookup_with_ancestor(index, yaml_path)
+}
+
 /// Check for parsed-but-unused AST features, emitting warnings.
 /// This is the single source of truth for "parsed but not generated" diagnostics.
 /// Requires Context because some checks iterate over resolved operations.
-pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
+pub fn check_preserved(ctx: Context, index: LocationIndex) -> List(Diagnostic) {
   let webhook_warnings = case dict.is_empty(context.spec(ctx).webhooks) {
     True -> []
     False -> [
@@ -228,6 +338,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         hint: Some(
           "Webhooks will not appear in generated code. No action needed unless you expected them.",
         ),
+        loc: location_index.lookup_with_ancestor(index, "webhooks"),
       ),
     ]
   }
@@ -247,33 +358,41 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
               list.length(dict.to_list(response.content))
             {
               config.Client, _ -> []
-              _, n if n > 1 -> [
-                diagnostic.capability(
-                  severity: SeverityWarning,
-                  target: TargetServer,
-                  path: base_path <> ".content",
-                  detail: "Multiple response content types are not fully supported for server code generation. Generated server responses lose the content-type header.",
-                  hint: Some(
-                    "Use a single content type per response for full server code generation support.",
+              _, n if n > 1 -> {
+                let path = base_path <> ".content"
+                [
+                  diagnostic.capability(
+                    severity: SeverityWarning,
+                    target: TargetServer,
+                    path: path,
+                    detail: "Multiple response content types are not fully supported for server code generation. Generated server responses lose the content-type header.",
+                    hint: Some(
+                      "Use a single content type per response for full server code generation support.",
+                    ),
+                    loc: lookup_loc(ctx, index, path),
                   ),
-                ),
-              ]
+                ]
+              }
               _, _ -> []
             }
             let header_warnings = []
             let link_warnings = case dict.is_empty(response.links) {
               True -> []
-              False -> [
-                diagnostic.capability(
-                  severity: SeverityWarning,
-                  target: TargetBoth,
-                  path: base_path <> ".links",
-                  detail: "Response links are parsed but not used by code generation.",
-                  hint: Some(
-                    "Response links will not appear in generated code. No action needed.",
+              False -> {
+                let path = base_path <> ".links"
+                [
+                  diagnostic.capability(
+                    severity: SeverityWarning,
+                    target: TargetBoth,
+                    path: path,
+                    detail: "Response links are parsed but not used by code generation.",
+                    hint: Some(
+                      "Response links will not appear in generated code. No action needed.",
+                    ),
+                    loc: lookup_loc(ctx, index, path),
                   ),
-                ),
-              ]
+                ]
+              }
             }
             let content_entries = dict.to_list(response.content)
             let encoding_warnings =
@@ -281,17 +400,22 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
                 let #(media_type_name, media_type) = ce
                 case dict.is_empty(media_type.encoding) {
                   True -> []
-                  False -> [
-                    diagnostic.capability(
-                      severity: SeverityWarning,
-                      target: TargetBoth,
-                      path: base_path <> "." <> media_type_name <> ".encoding",
-                      detail: "MediaType encoding is parsed but not used by code generation.",
-                      hint: Some(
-                        "Encoding settings will not affect generated code. No action needed.",
+                  False -> {
+                    let path =
+                      base_path <> ".content." <> media_type_name <> ".encoding"
+                    [
+                      diagnostic.capability(
+                        severity: SeverityWarning,
+                        target: TargetBoth,
+                        path: path,
+                        detail: "MediaType encoding is parsed but not used by code generation.",
+                        hint: Some(
+                          "Encoding settings will not affect generated code. No action needed.",
+                        ),
+                        loc: lookup_loc(ctx, index, path),
                       ),
-                    ),
-                  ]
+                    ]
+                  }
                 }
               })
             list.flatten([
@@ -316,20 +440,22 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             let #(media_type_name, media_type) = ce
             case dict.is_empty(media_type.encoding) {
               True -> []
-              False -> [
-                diagnostic.capability(
-                  severity: SeverityWarning,
-                  target: TargetBoth,
-                  path: base_path
-                    <> ".content."
-                    <> media_type_name
-                    <> ".encoding",
-                  detail: "Request-body encoding is parsed but not used by code generation.",
-                  hint: Some(
-                    "Encoding settings (contentType, style, explode) will not affect generated code. No action needed.",
+              False -> {
+                let path =
+                  base_path <> ".content." <> media_type_name <> ".encoding"
+                [
+                  diagnostic.capability(
+                    severity: SeverityWarning,
+                    target: TargetBoth,
+                    path: path,
+                    detail: "Request-body encoding is parsed but not used by code generation.",
+                    hint: Some(
+                      "Encoding settings (contentType, style, explode) will not affect generated code. No action needed.",
+                    ),
+                    loc: lookup_loc(ctx, index, path),
                   ),
-                ),
-              ]
+                ]
+              }
             }
           })
         }
@@ -346,6 +472,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         hint: Some(
           "External docs will not appear in generated code. Include documentation in descriptions instead.",
         ),
+        loc: location_index.lookup_with_ancestor(index, "externalDocs"),
       ),
     ]
     None -> []
@@ -359,6 +486,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
         path: "tags",
         detail: "Top-level tags are parsed but not used by code generation.",
         hint: Some("Tags will not appear in generated code. No action needed."),
+        loc: location_index.lookup_with_ancestor(index, "tags"),
       ),
     ]
   }
@@ -384,6 +512,10 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             hint: Some(
               "If a component header should reach a client, reference it from the relevant response.headers entry.",
             ),
+            loc: location_index.lookup_with_ancestor(
+              index,
+              "components.headers",
+            ),
           ),
         ]
       }
@@ -397,6 +529,10 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             detail: "Component examples are parsed but not used by code generation.",
             hint: Some(
               "Component examples will not appear in generated code. Include examples in descriptions instead.",
+            ),
+            loc: location_index.lookup_with_ancestor(
+              index,
+              "components.examples",
             ),
           ),
         ]
@@ -412,6 +548,7 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             hint: Some(
               "Component links will not appear in generated code. No action needed.",
             ),
+            loc: location_index.lookup_with_ancestor(index, "components.links"),
           ),
         ]
       }
@@ -426,6 +563,10 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
             hint: Some(
               "Callback endpoints will not appear in generated code. No action needed unless you expected handler stubs for them.",
             ),
+            loc: location_index.lookup_with_ancestor(
+              index,
+              "components.callbacks",
+            ),
           ),
         ]
       }
@@ -438,16 +579,19 @@ pub fn check_preserved(ctx: Context) -> List(Diagnostic) {
       let #(op_id, operation, _path, _method) = op
       case dict.is_empty(operation.callbacks) {
         True -> Error(Nil)
-        False ->
+        False -> {
+          let path = op_id <> ".callbacks"
           Ok(diagnostic.capability(
             severity: SeverityWarning,
             target: TargetBoth,
-            path: op_id <> ".callbacks",
+            path: path,
             detail: "Operation-level callbacks are parsed and preserved but not used by code generation.",
             hint: Some(
               "The callback endpoints listed here will not appear in generated server/client code. No action needed unless you expected handler stubs.",
             ),
+            loc: lookup_loc(ctx, index, path),
           ))
+        }
       }
     })
   list.flatten([

--- a/src/oaspec/internal/openapi/location_index.gleam
+++ b/src/oaspec/internal/openapi/location_index.gleam
@@ -1,6 +1,7 @@
 import gleam/dict.{type Dict}
 import gleam/list
 import gleam/result
+import gleam/string
 import oaspec/openapi/diagnostic.{type SourceLoc, NoSourceLoc, SourceLoc}
 
 /// An index mapping dotted JSON-pointer paths to source locations.
@@ -51,6 +52,35 @@ pub fn lookup_field(
   dict.get(index.entries, field_path)
   |> result.lazy_or(fn() { dict.get(index.entries, parent) })
   |> result.unwrap(NoSourceLoc)
+}
+
+/// Look up `path` exactly; on miss, drop the trailing dotted segment and
+/// retry, walking up to the closest known ancestor. Returns `NoSourceLoc`
+/// only when the path is empty / no ancestor is in the index.
+///
+/// Used by capability_check to surface the closest available line/column
+/// when the diagnostic path does not exactly match a YAML node (e.g. a
+/// schema property whose YAML location is one segment deeper than the
+/// human-friendly path the diagnostic carries).
+pub fn lookup_with_ancestor(index: LocationIndex, path: String) -> SourceLoc {
+  case dict.get(index.entries, path) {
+    Ok(loc) -> loc
+    // nolint: thrown_away_error -- a dict miss here just signals "try the parent"; the recursion produces the actual NoSourceLoc when no ancestor exists either.
+    Error(_) ->
+      case string.split(path, ".") {
+        [] | [_] -> NoSourceLoc
+        segments -> {
+          let parent_segments = case list.reverse(segments) {
+            [_, ..rest_rev] -> list.reverse(rest_rev)
+            [] -> []
+          }
+          case parent_segments {
+            [] -> NoSourceLoc
+            _ -> lookup_with_ancestor(index, string.join(parent_segments, "."))
+          }
+        }
+      }
+  }
 }
 
 @external(erlang, "yaml_loc_ffi", "build_location_index")

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -138,12 +138,18 @@ pub fn resolve_error(
 // Convenience constructors for capability_check phase
 // ============================================================================
 
+/// Issue #411: capability checks now thread a YAML `SourceLoc` through
+/// every diagnostic. Pass `NoSourceLoc` only when the caller genuinely
+/// has no LocationIndex available (e.g. tests that bypass the parser
+/// path); production code always has one because it goes through
+/// `parser.parse_file_with_locations` / `generate.generate_with_locations`.
 pub fn capability(
   path path: String,
   detail detail: String,
   severity severity: Severity,
   target target: Target,
   hint hint: Option(String),
+  loc loc: SourceLoc,
 ) -> Diagnostic {
   Diagnostic(
     code: "capability",
@@ -151,7 +157,7 @@ pub fn capability(
     severity: severity,
     target: target,
     pointer: path,
-    source_loc: NoSourceLoc,
+    source_loc: loc,
     message: detail,
     hint: hint,
   )
@@ -304,6 +310,28 @@ pub fn to_string(d: Diagnostic) -> String {
   <> d.message
   <> loc_str
   <> hint_str
+}
+
+/// Render a diagnostic with an editor-clickable `path:line:column:`
+/// prefix when the spec file path and a `SourceLoc` are both known.
+/// Falls back to plain `to_string` otherwise.
+///
+/// Issue #411: CI runs that process several specs need a breadcrumb to
+/// which file produced an error; editors recognise the `path:line:col:`
+/// prefix and let users jump straight to the offending YAML line.
+pub fn render(d: Diagnostic, file_path file_path: Option(String)) -> String {
+  case file_path, d.source_loc {
+    Some(path), SourceLoc(line:, column:) ->
+      path
+      <> ":"
+      <> int.to_string(line)
+      <> ":"
+      <> int.to_string(column)
+      <> ": "
+      <> to_string(d)
+    Some(path), NoSourceLoc -> path <> ": " <> to_string(d)
+    None, _ -> to_string(d)
+  }
 }
 
 /// Convert a diagnostic to a short string (for backward-compatible display).

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -40,27 +40,38 @@ import yay
 /// fail fast with a dedicated diagnostic. HTTP/HTTPS URLs are not
 /// followed.
 pub fn parse_file(path: String) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
-  parse_file_with_progress(path, progress.noop())
+  parse_file_internal(path, [], progress.noop())
+  |> result.map(fn(pair) { pair.0 })
 }
 
-/// Same as `parse_file`, with a `Reporter` that receives a line per
-/// stage (read, parse, resolve external refs). Used by the CLI to
-/// give the user feedback on big specs (issue #352).
-pub fn parse_file_with_progress(
+/// Combined `parse_file` entry point that accepts a `Reporter` and
+/// also returns the top-level YAML `LocationIndex`. Issue #411 +
+/// #352. The CLI uses this so capability-check diagnostics surface
+/// `path:line:column:` and progress lines on big specs at the same
+/// time. Library callers that don't need progress should pass
+/// `progress.noop()`; callers that don't need locations can discard
+/// the second tuple element.
+pub fn parse_file_with_progress_and_locations(
   path: String,
   reporter: Reporter,
-) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   parse_file_internal(path, [], reporter)
 }
 
 /// Internal parse entry that threads the `visited` stack through every
 /// external-ref recursion so `A.yaml -> B.yaml -> A.yaml` cycles fail
 /// fast with a dedicated diagnostic instead of spinning forever.
+///
+/// Returns both the parsed spec and the YAML `LocationIndex` built from
+/// the file's content. Recursive external-ref resolution discards
+/// nested files' indices — only the top-level file's index is surfaced
+/// (capability-check needs *one* canonical index, and external refs
+/// land back at their `$ref` site in the main file anyway).
 fn parse_file_internal(
   path: String,
   visited: List(String),
   reporter: Reporter,
-) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   let canonical = canonicalize_ref_path(path)
   use <- bool.guard(
     list.contains(visited, canonical),
@@ -95,8 +106,8 @@ fn parse_file_internal(
   let #(elapsed, parsed) =
     progress.timed(fn() {
       case is_json {
-        True -> parse_json_string(content)
-        False -> parse_string(content)
+        True -> parse_json_string_with_locations(content)
+        False -> parse_string_with_locations(content)
       }
     })
   progress.report(reporter, case is_json {
@@ -109,14 +120,17 @@ fn parse_file_internal(
       <> progress.format_ms(elapsed)
       <> ")"
   })
-  use spec <- result.try(parsed)
+  use #(spec, index) <- result.try(parsed)
   let new_visited = [canonical, ..visited]
   let #(elapsed, resolved) =
     progress.timed(fn() {
       external_loader.resolve_external_component_refs(
         spec,
         external_loader_planner.base_dir_of(path),
-        fn(sub_path) { parse_file_internal(sub_path, new_visited, reporter) },
+        fn(sub_path) {
+          parse_file_internal(sub_path, new_visited, reporter)
+          |> result.map(fn(pair) { pair.0 })
+        },
       )
     })
   progress.report(
@@ -126,6 +140,7 @@ fn parse_file_internal(
       <> ")",
   )
   resolved
+  |> result.map(fn(s) { #(s, index) })
 }
 
 fn format_size(bytes: Int) -> String {
@@ -178,8 +193,19 @@ fn cyclic_external_ref_diagnostic(
 pub fn parse_string(
   content: String,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  parse_string_with_locations(content)
+  |> result.map(fn(pair) { pair.0 })
+}
+
+/// Same as `parse_string` but also returns the YAML `LocationIndex`
+/// built from the input. Caller-side companion to
+/// `parse_file_with_locations` (Issue #411).
+pub fn parse_string_with_locations(
+  content: String,
+) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   use #(root, index) <- result.try(parse_to_node(content))
-  parse_root(root, index)
+  use spec <- result.map(parse_root(root, index))
+  #(spec, index)
 }
 
 /// Parse an OpenAPI spec from a JSON string using OTP's native JSON
@@ -194,8 +220,20 @@ pub fn parse_string(
 pub fn parse_json_string(
   content: String,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  parse_json_string_with_locations(content)
+  |> result.map(fn(pair) { pair.0 })
+}
+
+/// JSON variant of `parse_string_with_locations`. OTP's `json:decode/3`
+/// does not expose token positions so the returned `LocationIndex` is
+/// always empty; capability-check diagnostics from a JSON-only spec
+/// keep `NoSourceLoc`.
+fn parse_json_string_with_locations(
+  content: String,
+) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   use root <- result.try(decode_json_to_node(content))
-  parse_root(root, location_index.empty())
+  use spec <- result.map(parse_root(root, location_index.empty()))
+  #(spec, location_index.empty())
 }
 
 /// Run yamerl on `content` and return the root node plus a

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -117,3 +117,13 @@ pub fn location_index_source_loc_test() {
   let _ = support.location_index_root_path_has_source_loc_case()
   let _ = support.yaml_error_has_source_location_case()
 }
+
+pub fn capability_check_source_loc_test() {
+  let _ =
+    support.location_index_lookup_with_ancestor_falls_back_to_parent_case()
+  let _ =
+    support.location_index_lookup_with_ancestor_no_match_returns_no_source_loc_case()
+  let _ = support.capability_check_attaches_source_loc_to_keyword_error_case()
+  let _ = support.diagnostic_render_includes_file_path_and_loc_case()
+  let _ = support.diagnostic_render_without_file_path_matches_to_string_case()
+}

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -8077,7 +8077,7 @@ webhooks:
   let resolved = hoist.hoist(resolved)
   let resolved = dedup.dedup(resolved)
   let ctx = context.new(resolved, cfg)
-  let issues = capability_check.check_preserved(ctx)
+  let issues = capability_check.check_preserved(ctx, location_index.empty())
   let warnings = diagnostic.warnings_only(issues)
   { warnings != [] }
   |> should.be_true()
@@ -9217,7 +9217,7 @@ paths:
 "
   let assert Ok(spec) = parser.parse_string(yaml)
   let ctx = make_ctx_from_spec(spec)
-  let issues = capability_check.check_preserved(ctx)
+  let issues = capability_check.check_preserved(ctx, location_index.empty())
   let warnings =
     list.filter(issues, fn(issue) {
       issue.severity == diagnostic.SeverityWarning
@@ -11605,7 +11605,7 @@ components:
 pub fn capability_check_warns_on_callbacks_case() {
   let ctx = make_ctx("test/fixtures/oss_swagger_parser_java_callback_ref.yaml")
   let warnings =
-    capability_check.check_preserved(ctx)
+    capability_check.check_preserved(ctx, location_index.empty())
     |> diagnostic.warnings_only
   let messages = list.map(warnings, validate.error_to_string)
   list.any(messages, fn(s) {
@@ -14431,4 +14431,117 @@ components:
     True -> Nil
     False -> should.fail()
   }
+}
+
+// ============================================================================
+// Issue #411: capability-check diagnostics carry source line/column
+// ============================================================================
+
+/// `lookup_with_ancestor` returns the closest known ancestor when the
+/// exact path is absent, walking the dot-separated segments back one
+/// at a time.
+pub fn location_index_lookup_with_ancestor_falls_back_to_parent_case() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+
+  // The exact path doesn't exist, but `info.title` does — so the
+  // ancestor walk should land there rather than at NoSourceLoc.
+  let loc =
+    location_index.lookup_with_ancestor(index, "info.title.unknown_leaf")
+  case loc {
+    SourceLoc(line: _, column: _) -> should.be_true(True)
+    NoSourceLoc -> should.fail()
+  }
+}
+
+/// When *no* ancestor of a path exists in the index, `lookup_with_ancestor`
+/// returns `NoSourceLoc`.
+pub fn location_index_lookup_with_ancestor_no_match_returns_no_source_loc_case() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+"
+  let index = location_index.build(yaml)
+  let loc =
+    location_index.lookup_with_ancestor(index, "totally_unrelated.deep.path")
+  loc |> should.equal(NoSourceLoc)
+}
+
+/// Issue #411: a capability-check error on an unsupported JSON Schema
+/// keyword (`$defs`) must carry a `SourceLoc` pointing into the YAML
+/// document, not `NoSourceLoc`.
+pub fn capability_check_attaches_source_loc_to_keyword_error_case() {
+  let yaml =
+    "openapi: \"3.0.0\"
+info:
+  title: Test
+  version: \"1.0\"
+paths: {}
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        bar:
+          $defs:
+            X:
+              type: string
+"
+  let assert Ok(parsed) = parser.parse_string_with_locations(yaml)
+  let #(spec, index) = parsed
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let issues = capability_check.check(resolved, index)
+  // Must produce at least one capability error
+  let errors = diagnostic.errors_only(issues)
+  errors |> list.length |> should.not_equal(0)
+  // Every emitted capability error should carry a real SourceLoc
+  let loc_present =
+    list.all(errors, fn(d) {
+      case d.source_loc {
+        SourceLoc(..) -> True
+        NoSourceLoc -> False
+      }
+    })
+  loc_present |> should.be_true
+}
+
+/// Issue #411: `diagnostic.render` prepends `path:line:column:` when
+/// both file path and SourceLoc are present.
+pub fn diagnostic_render_includes_file_path_and_loc_case() {
+  let d =
+    diagnostic.capability(
+      severity: diagnostic.SeverityError,
+      target: diagnostic.TargetBoth,
+      path: "components.schemas.Foo",
+      detail: "boom",
+      hint: None,
+      loc: SourceLoc(line: 42, column: 7),
+    )
+  let rendered = diagnostic.render(d, Some("specs/api.yaml"))
+  string.starts_with(rendered, "specs/api.yaml:42:7: ")
+  |> should.be_true
+}
+
+/// Issue #411: `diagnostic.render` falls back to plain `to_string`
+/// when `file_path` is `None`.
+pub fn diagnostic_render_without_file_path_matches_to_string_case() {
+  let d =
+    diagnostic.capability(
+      severity: diagnostic.SeverityError,
+      target: diagnostic.TargetBoth,
+      path: "components.schemas.Foo",
+      detail: "boom",
+      hint: None,
+      loc: SourceLoc(line: 42, column: 7),
+    )
+  diagnostic.render(d, None) |> should.equal(diagnostic.to_string(d))
 }


### PR DESCRIPTION
## Summary

Capability-check diagnostics used to hard-code `source_loc: NoSourceLoc`,
so an error like

```
[CapabilityCheck] Error at components.schemas.Foo: Unsupported JSON Schema keyword '$defs' found.
```

gave the user no way to jump to the offending YAML line. This PR
threads the YAML `LocationIndex` the parser already builds through
to `capability_check`, so every emitted diagnostic carries a real
`SourceLoc`, and renders CLI diagnostics with an editor-clickable
`path:line:column:` prefix.

After:

```
specs/api.yaml:11:9: [CapabilityCheck] Error at components.schemas.WithDefs: Unsupported JSON Schema keyword '$defs' found. ...
```

## Public API changes (breaking, 0.x)

- `diagnostic.capability(...)` gains a required `loc:` parameter.
- `diagnostic.render(d, file_path: Option(String))` renders a
  diagnostic with a `path:line:column:` prefix when both are known;
  falls back to `to_string` otherwise.
- `parser.parse_file_with_progress_and_locations(path, reporter)`
  returns `(spec, index)`. `parse_string_with_locations` does the
  same for in-memory content; `parse_file` / `parse_string` keep
  their old signatures for back-compat. The progress-only overload
  `parse_file_with_progress` is dropped.
- `generate.generate_with_progress_and_locations` and
  `validate_only_with_progress_and_locations` replace the previous
  progress-only overloads. The simple `generate(spec, cfg)` /
  `validate_only(spec, cfg)` entry points still work and pass
  `location_index.empty()` internally.

## Implementation notes

- `location_index.lookup_with_ancestor` walks dot-separated paths
  back one segment at a time, so capability paths that don't
  exactly match the YAML index (e.g.
  `components.schemas.Foo.bar` where the YAML has
  `components.schemas.Foo.properties.bar`) still surface the
  closest known ancestor's line/column.
- `capability_check.capability_path_to_yaml` translates op_id-rooted
  paths to `paths.<url>.<method>` form using the `AnalyzedOperation`
  list; non-op_id paths (`webhooks`, `components.*`) pass through
  unchanged.
- For unsupported-keyword schema errors, the lookup tries the
  exact keyword path first (e.g. `...WithDefs.$defs`) before
  falling back to the schema-level loc, so the diagnostic points
  at the keyword itself rather than the surrounding schema header.

Closes #411.

## Test plan

- [x] `gleam test` — 353 passing (was 352, +1 wrapper test grouping
      the new cases).
- [x] `gleam format --check src/ test/`.
- [x] `gleam run -m glinter` — 0 errors / 0 warnings.
- [x] `bash scripts/check_sync.sh`.
- [x] Manual smoke test: ran `oaspec generate` against
      `test/fixtures/unsupported_defs.yaml`; the CLI now emits
      `path:11:9: [CapabilityCheck] Error ...`, pointing at the
      offending `$defs` value.
- [x] New test cases:
      `location_index_lookup_with_ancestor_falls_back_to_parent_case`,
      `location_index_lookup_with_ancestor_no_match_returns_no_source_loc_case`,
      `capability_check_attaches_source_loc_to_keyword_error_case`,
      `diagnostic_render_includes_file_path_and_loc_case`,
      `diagnostic_render_without_file_path_matches_to_string_case`.
