### PR TITLE
docs(readme): add gleam_json to install snippet to fix transitive-dep warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Changed
+
+- **docs(readme)**: install snippet now adds `gleam_json` alongside
+  `oaspec` (`gleam add oaspec gleam_json`) and explains why — the
+  generated `decode.gleam`, `encode.gleam`, `guards.gleam`, and
+  `router.gleam` modules `import gleam/json` directly, so consumers
+  must list `gleam_json` as a direct dependency to avoid a
+  "Transitive dependency imported" warning on every `gleam check`
+  (and a hard compile error in a future Gleam release). Closes #469.
+
 ## [0.48.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ API reference: <https://hexdocs.pm/oaspec/>
 - CLI (the `oaspec` binary that drives `init` / `generate` / `validate`
   on the command line) — install from a GitHub release or build from source.
 
-Most users want both: `gleam add oaspec` in the project that consumes the
-generated code, and the CLI installed system-wide to run `oaspec generate`.
+Most users want both: `gleam add oaspec gleam_json` in the project that
+consumes the generated code, and the CLI installed system-wide to run
+`oaspec generate`.
 
 ### Library (Hex)
 
 ```sh
-gleam add oaspec
+gleam add oaspec gleam_json
 ```
 
 This pulls the published [hex.pm package](https://hex.pm/packages/oaspec)
@@ -62,6 +63,13 @@ and gives you the public modules under `oaspec/transport`, `oaspec/mock`,
 `oaspec/config`, `oaspec/generate`, `oaspec/openapi/parser`, and
 `oaspec/openapi/diagnostic`. See [Library API](#library-api) below for the
 full module list.
+
+`gleam_json` is added in the same step because the generated `decode.gleam`,
+`encode.gleam`, `guards.gleam`, and `router.gleam` modules `import gleam/json`
+directly. Without `gleam_json` listed as a direct dependency of the consumer
+project, `gleam check` prints a "Transitive dependency imported" warning for
+each generated file, and a future Gleam release will turn the warning into a
+compile error. Adding it up front avoids both.
 
 ### CLI — GitHub release
 


### PR DESCRIPTION
## Summary

A fresh consumer project that follows the README's *Library (Hex)* install
step (`gleam add oaspec`) and runs `gleam check` on the generated tree sees
four "Transitive dependency imported" warnings — one each for
`decode.gleam`, `encode.gleam`, `guards.gleam`, and `router.gleam`, all of
which `import gleam/json` directly. The Gleam compiler already flags this
as a soft error and will turn it into a hard compile error in a future
release.

## Changes

- `README.md` — both occurrences of `gleam add oaspec` (the *Library (Hex)*
  install snippet and the surrounding "Most users want both" sentence) now
  include `gleam_json`. Added a short paragraph after the snippet
  explaining why the second package is required: the generated decode /
  encode / guards / router modules `import gleam/json` directly, and
  without `gleam_json` listed as a direct dep `gleam check` warns on every
  build (and a future Gleam release will reject it as a compile error).
- `CHANGELOG.md` — recorded the docs fix under `[Unreleased]` → `Changed`,
  with the same explanation and a `Closes #469` pointer.

## Design Decisions

- Updated only `gleam add oaspec` mentions that refer to *consumer-side
  setup*. The unrelated mention near the bottom of the README about
  `gleam add oaspec_httpc` / `gleam add oaspec_fetch` (line ~289) is a
  different concern (adapter packages not on Hex, tracked by #471) and
  was left as-is.
- Did not change anything in the generated code itself — `gleam_json` is
  already a transitive dep of `oaspec`, so the surface change is purely
  in the consumer's `gleam.toml`. Adding the package via `gleam add`
  rather than via a `gleam.toml` edit keeps the install snippet
  copy-pasteable.

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to include `gleam_json` as a required dependency alongside `oaspec` for generated code consumers. This prevents transitive dependency warnings and ensures compatibility with future compiler versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->