### PR TITLE
docs(readme): drop broken subpath git-dep alternative for adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ within `Changed` / `Fixed` and stay as-is.
   must list `gleam_json` as a direct dependency to avoid a
   "Transitive dependency imported" warning on every `gleam check`
   (and a hard compile error in a future Gleam release). Closes #469.
+- **docs(readme)**: dropped the broken `git = "...", subpath = "..."`
+  alternative from the `oaspec_httpc` / `oaspec_fetch` adapter
+  install note. Gleam's `gleam.toml` parser does not accept a
+  `subpath` field on git dependencies as of Gleam 1.16, so the
+  recommended snippet failed with `data did not match any variant
+  of untagged enum Requirement` before any build started. The
+  surviving `path = "../oaspec/adapters/fetch"` form is the only
+  working approach until the adapters are published to Hex (tracked
+  in #471), and the note now explains why a pure git dependency
+  also does not work (each adapter is in a subdirectory of the
+  oaspec repo). Closes #470.
 
 ## [0.48.0] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -288,17 +288,23 @@ HTTP runtime:
 
 > Note: `oaspec_httpc` and `oaspec_fetch` are not yet published on
 > Hex. `gleam add oaspec_httpc` / `gleam add oaspec_fetch` will fail
-> with "package not found". Until they are published, depend on them
-> from a local checkout via a path or git dependency in your
-> consumer project's `gleam.toml`:
+> with "package not found" — track #471 for Hex publication. Until
+> they are published, depend on them via a `path` dependency to a
+> local checkout of the oaspec repository in your consumer project's
+> `gleam.toml`:
 >
 > ```toml
 > [dependencies]
 > oaspec = "..."
 > oaspec_fetch = { path = "../oaspec/adapters/fetch" }
-> # or
-> # oaspec_fetch = { git = "https://github.com/nao1215/oaspec.git", subpath = "adapters/fetch" }
 > ```
+>
+> A pure `git = "..."` dependency is not a workaround here: each
+> adapter lives in a subdirectory of the oaspec repo (`adapters/httpc/`,
+> `adapters/fetch/`), and Gleam's `gleam.toml` parser does not support
+> a `subpath` field on git dependencies as of Gleam 1.16, so the build
+> tool cannot locate the adapter's `gleam.toml` inside the larger
+> repository.
 >
 > See [`examples/petstore_client_fetch/gleam.toml`](./examples/petstore_client_fetch/gleam.toml)
 > for the canonical path-dependency layout used in the bundled examples.


### PR DESCRIPTION
## Summary

The *Client transport* note for the unpublished `oaspec_httpc` and
`oaspec_fetch` adapter packages listed two install alternatives in the
README:

```toml
oaspec_fetch = { path = "../oaspec/adapters/fetch" }
# or
# oaspec_fetch = { git = "https://github.com/nao1215/oaspec.git", subpath = "adapters/fetch" }
```

The second form does not parse. Gleam 1.16's `gleam.toml` grammar has
no `subpath` field on git dependencies, and copying the snippet fails
with `data did not match any variant of untagged enum Requirement`
before any build runs.

## Changes

- `README.md` — removed the commented-out `git = "...", subpath = "..."`
  alternative from the adapter install note. Kept the working `path =
  "../oaspec/adapters/fetch"` form. Added a short paragraph explaining
  why a plain `git = "..."` dep is also not a workaround: each adapter
  lives in a subdirectory of the oaspec repo, so without `subpath` the
  build tool cannot locate the adapter's `gleam.toml`. Linked to #471
  as the tracking issue for the Hex publication that would make this
  whole detour unnecessary.
- `CHANGELOG.md` — recorded the fix under `[Unreleased]` → `Changed`.

## Design Decisions

- Removed rather than rephrased. A future Gleam version that adds
  `subpath` support could re-introduce a working snippet, but until
  then leaving the broken form (even commented out) signals to the
  reader that it was at some point a viable approach. The simplest fix
  is to delete it.
- Kept the wording neutral about whether `subpath` will ever ship in
  Gleam — only stated that it is not supported as of Gleam 1.16. If
  upstream adds it later, the README can grow back the alternative
  without revisiting the rationale.

Closes #470