### PR TITLE
feat(release): add tag-driven Hex publishing for oaspec_httpc and oaspec_fetch adapters

### DIFF
--- a/.github/workflows/release-adapter-fetch.yml
+++ b/.github/workflows/release-adapter-fetch.yml
@@ -1,0 +1,57 @@
+name: Release oaspec_fetch adapter
+
+on:
+  push:
+    tags:
+      - "oaspec_fetch-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish oaspec_fetch to Hex
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+
+      - name: Install rebar3
+        run: |
+          wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
+          chmod +x /usr/local/bin/rebar3
+
+      # See the matching comment in release-adapter-httpc.yml for why
+      # the path dep is rewritten just before publishing.
+      - name: Resolve current oaspec version
+        id: oaspec
+        run: |
+          OASPEC_VERSION=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' gleam.toml)
+          echo "version=$OASPEC_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Replace path dep with Hex version constraint
+        working-directory: adapters/fetch
+        run: |
+          sed -i \
+            "s|oaspec = { path = \"../..\" }|oaspec = \">= ${{ steps.oaspec.outputs.version }} and < 1.0.0\"|" \
+            gleam.toml
+          echo "--- adapters/fetch/gleam.toml after rewrite ---"
+          cat gleam.toml
+
+      - name: Download dependencies
+        working-directory: adapters/fetch
+        run: gleam deps download
+
+      - name: Build (warnings as errors)
+        working-directory: adapters/fetch
+        run: gleam build --warnings-as-errors --target javascript
+
+      - name: Publish to Hex
+        working-directory: adapters/fetch
+        run: echo 'I am not using semantic versioning' | gleam publish -y
+        env:
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}

--- a/.github/workflows/release-adapter-httpc.yml
+++ b/.github/workflows/release-adapter-httpc.yml
@@ -1,0 +1,62 @@
+name: Release oaspec_httpc adapter
+
+on:
+  push:
+    tags:
+      - "oaspec_httpc-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish oaspec_httpc to Hex
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+
+      - name: Install rebar3
+        run: |
+          wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
+          chmod +x /usr/local/bin/rebar3
+
+      # The committed adapters/httpc/gleam.toml depends on the parent
+      # oaspec via `path = "../.."` so monorepo development works
+      # without a Hex round-trip. Hex itself rejects path deps on
+      # publish, so swap the parent dep to a Hex version constraint
+      # *just for the publish step*. The constraint floor is taken
+      # from the parent gleam.toml's current version, so the published
+      # adapter pins to whatever oaspec release is current at tag time.
+      - name: Resolve current oaspec version
+        id: oaspec
+        run: |
+          OASPEC_VERSION=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' gleam.toml)
+          echo "version=$OASPEC_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Replace path dep with Hex version constraint
+        working-directory: adapters/httpc
+        run: |
+          sed -i \
+            "s|oaspec = { path = \"../..\" }|oaspec = \">= ${{ steps.oaspec.outputs.version }} and < 1.0.0\"|" \
+            gleam.toml
+          echo "--- adapters/httpc/gleam.toml after rewrite ---"
+          cat gleam.toml
+
+      - name: Download dependencies
+        working-directory: adapters/httpc
+        run: gleam deps download
+
+      - name: Build (warnings as errors)
+        working-directory: adapters/httpc
+        run: gleam build --warnings-as-errors
+
+      - name: Publish to Hex
+        working-directory: adapters/httpc
+        run: echo 'I am not using semantic versioning' | gleam publish -y
+        env:
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ within `Changed` / `Fixed` and stay as-is.
   also does not work (each adapter is in a subdirectory of the
   oaspec repo). Closes #470.
 
+### Added
+
+- **release(adapters)**: dedicated tag-driven publishing
+  workflows for `oaspec_httpc` and `oaspec_fetch`. Tag patterns
+  `oaspec_httpc-v*` and `oaspec_fetch-v*` trigger
+  `.github/workflows/release-adapter-httpc.yml` and
+  `.github/workflows/release-adapter-fetch.yml` respectively;
+  each rewrites the adapter's parent `oaspec = { path = "../.." }`
+  dep to a Hex version constraint floored at the current
+  root-`gleam.toml` version (`>= X.Y.Z and < 1.0.0`) before
+  invoking `gleam publish`, so consumers can `gleam add
+  oaspec_httpc` / `gleam add oaspec_fetch` after any successful
+  adapter release. Decoupling the adapter tag pattern from the
+  main `v*` tag means oaspec releases and adapter releases can
+  cut on independent cadences and avoid `gleam publish` rejecting
+  a re-published version. The README's adapter section now
+  describes the new flow and keeps the path-dep workaround for the
+  interim before the first adapter tag is pushed. Closes #471.
+
 ## [0.48.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -286,28 +286,40 @@ HTTP runtime:
   `gleam_fetch`, with helpers to bridge `transport.Async` and native
   JavaScript promises.
 
-> Note: `oaspec_httpc` and `oaspec_fetch` are not yet published on
-> Hex. `gleam add oaspec_httpc` / `gleam add oaspec_fetch` will fail
-> with "package not found" — track #471 for Hex publication. Until
-> they are published, depend on them via a `path` dependency to a
-> local checkout of the oaspec repository in your consumer project's
-> `gleam.toml`:
->
-> ```toml
-> [dependencies]
-> oaspec = "..."
-> oaspec_fetch = { path = "../oaspec/adapters/fetch" }
-> ```
->
-> A pure `git = "..."` dependency is not a workaround here: each
-> adapter lives in a subdirectory of the oaspec repo (`adapters/httpc/`,
-> `adapters/fetch/`), and Gleam's `gleam.toml` parser does not support
-> a `subpath` field on git dependencies as of Gleam 1.16, so the build
-> tool cannot locate the adapter's `gleam.toml` inside the larger
-> repository.
->
-> See [`examples/petstore_client_fetch/gleam.toml`](./examples/petstore_client_fetch/gleam.toml)
-> for the canonical path-dependency layout used in the bundled examples.
+Both adapters are published to Hex from this repository on tag push:
+`oaspec_httpc-v*` for the BEAM adapter and `oaspec_fetch-v*` for the
+JavaScript adapter, separately from the main `oaspec` release tag
+(`v*`). The publishing workflow swaps each adapter's parent dep
+(`oaspec = { path = "../.." }` in-tree, for monorepo development)
+to a Hex version constraint just before publishing, so consumers
+install with the usual `gleam add` flow:
+
+```sh
+gleam add oaspec_httpc   # BEAM
+gleam add oaspec_fetch   # JavaScript
+```
+
+If `gleam add oaspec_httpc` reports `package not found`, no adapter
+release has been cut yet — depend on the adapter via a path
+dependency to a local checkout of the oaspec repository until the
+first tag push:
+
+```toml
+[dependencies]
+oaspec = "..."
+oaspec_fetch = { path = "../oaspec/adapters/fetch" }
+```
+
+A pure `git = "..."` dependency is not a workaround in that interim
+state: each adapter lives in a subdirectory of the oaspec repo
+(`adapters/httpc/`, `adapters/fetch/`), and Gleam's `gleam.toml`
+parser does not support a `subpath` field on git dependencies as of
+Gleam 1.16, so the build tool cannot locate the adapter's
+`gleam.toml` inside the larger repository.
+
+See [`examples/petstore_client_fetch/gleam.toml`](./examples/petstore_client_fetch/gleam.toml)
+for the canonical path-dependency layout used in the bundled
+examples.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Both sibling adapter packages — `adapters/httpc/` (BEAM, backed by
`gleam_httpc`) and `adapters/fetch/` (JavaScript, backed by
`gleam_fetch`) — depend on the parent oaspec via `{ path = \"../..\" }`
so local monorepo development works out of the box. Hex rejects `path`
deps on publish, so publishing the adapters has so far required a
manual `gleam.toml` rewrite followed by `gleam publish`, which was
never wired into CI. As a result, `gleam add oaspec_httpc` /
`gleam add oaspec_fetch` fail with `package not found`, and consumers
have to vendor or path-link the adapter source — see the README's
adapter caveat (currently kept as the documented fallback).

This PR adds two dedicated release workflows that automate the
publish, leaving local dev unchanged.

## Changes

- **`.github/workflows/release-adapter-httpc.yml`** — new workflow.
  Triggered by tag `oaspec_httpc-v*`. Reads the current root oaspec
  version from `gleam.toml`, rewrites
  `adapters/httpc/gleam.toml`'s `oaspec = { path = \"../..\" }` to
  `oaspec = \">= X.Y.Z and < 1.0.0\"` (workspace-only — no commit
  created), then runs `gleam build --warnings-as-errors` and
  `gleam publish -y` against the rewritten file. Uses the existing
  `HEXPM_API_KEY` secret.
- **`.github/workflows/release-adapter-fetch.yml`** — same shape for
  the JavaScript adapter, with `--target javascript` on the build
  step.
- **`README.md`** — adapter section now describes the new tag-driven
  flow and keeps the path-dep fallback for the interim window before
  the first adapter tag is pushed. The `subpath = ...` git-dep note
  (added in #470) and the `gleam.toml` parser caveat carry over.
- **`CHANGELOG.md`** — \`### Added\` entry under \`[Unreleased]\`
  describing the new workflows, the version-constraint flooring
  rule, and the rationale for decoupling adapter tags from the main
  \`v*\` release.

## Design Decisions

- **Decoupled tag patterns** (\`oaspec_httpc-v*\` / \`oaspec_fetch-v*\`
  separate from the main \`v*\`) instead of one workflow that
  publishes everything off the same tag. Reasons:
  - Adapter API surface (`oaspec/transport.Send`) changes much less
    often than oaspec's own version cadence — a typical oaspec
    bump (codegen / parser changes) does not need a new adapter
    release. Linking them would force `gleam publish` to reject
    republished adapter versions every other oaspec release.
  - The issue body itself recommends this split (\"tag matches
    `oaspec_httpc-vX.Y.Z` / `oaspec_fetch-vX.Y.Z`, separately from
    the main `oaspec` release\").
- **In-workflow rewrite** of the `path` dep instead of a permanent
  swap to a Hex constraint in the committed \`gleam.toml\`.
  Permanent swap would break local edit-and-test cycles for
  contributors who change `oaspec/transport.gleam` and want to verify
  the adapter against the new behaviour without a Hex round-trip.
- **Version constraint floor** is read from the current root
  \`gleam.toml\` at publish time. So if oaspec is at \`0.49.0\` when
  \`oaspec_httpc-v0.1.0\` is pushed, the published \`oaspec_httpc@0.1.0\`
  pins to \`oaspec >= 0.49.0 and < 1.0.0\`. Future minor oaspec
  bumps satisfy that constraint; a 1.0 bump would require a new
  adapter release, which is the right surfacing point for any
  breaking transport API change.
- **No commit of the rewritten gleam.toml**. The \`sed -i\` runs in
  the workflow's checkout only; no \`git push\` step. Keeps the
  monorepo's path-dep state as the source of truth.

## Limitations

- This PR ships only the workflow scaffolding. The first actual
  publish requires the maintainer to push \`oaspec_httpc-v0.1.0\` and
  \`oaspec_fetch-v0.1.0\` tags after this merges. Until then the
  README's path-dep fallback remains accurate.
- The workflows assume \`HEXPM_API_KEY\` already authorises
  publishing under both \`oaspec_httpc\` and \`oaspec_fetch\` package
  names on the same Hex account. If the secret was scoped per-
  package, the first publish will fail with a 401 and the maintainer
  will need to widen the secret.

Closes #471