### PR TITLE
fix(codegen): emit bare constructor reference for empty-object decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen(decoders)**: a schema declared as
+  `type: object, properties: {}, additionalProperties: false`
+  surfaces in `types.gleam` as a no-arg variant
+  (`pub type EmptyObject { EmptyObject }`), but the matching
+  decoder emitted `decode.success(types.EmptyObject())` —
+  invalid Gleam, since the constructor is a value not a
+  function. The compile failure surfaced on real-world specs
+  (notably the GitHub OpenAPI subset, where multiple endpoints
+  return Empty Object). The decoder generator now special-cases
+  the empty-`param_names` branch and emits the bare reference
+  `decode.success(types.EmptyObject)`. A regression test in
+  `oaspec_support.empty_object_decoder_omits_constructor_parens_case`
+  locks the behaviour in. Closes #474.
+
 ### Changed
 
 - **docs(readme)**: install snippet now adds `gleam_json` alongside

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -749,16 +749,23 @@ fn generate_object_decoder(
     Forbidden | Unspecified -> param_names
   }
 
-  let sb =
-    sb
-    |> se.indent(
-      1,
+  // Issue #474: schemas with no constructor params (e.g. an empty
+  // object `type: object, properties: {}, additionalProperties: false`)
+  // surface in the type module as a no-arg variant — `pub type
+  // EmptyObject { EmptyObject }`. Calling such a constructor with `()`
+  // is invalid Gleam ("This value is being called as a function but
+  // its type is: types.EmptyObject"). Emit the bare constructor
+  // reference in that case.
+  let constructor_call = case list.is_empty(param_names) {
+    True -> "decode.success(types." <> type_name <> ")"
+    False ->
       "decode.success(types."
-        <> type_name
-        <> "("
-        <> se.join_with(param_names, ", ")
-        <> "))",
-    )
+      <> type_name
+      <> "("
+      <> se.join_with(param_names, ", ")
+      <> "))"
+  }
+  let sb = sb |> se.indent(1, constructor_call)
 
   let sb = sb |> se.line("}") |> se.blank_line()
 

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -4,6 +4,7 @@ pub fn codegen_core_regressions_test() {
   let _ = support.allof_with_primitive_sub_schema_case()
   let _ = support.allof_part_types_not_in_generated_types_case()
   let _ = support.allof_part_types_not_in_generated_decoders_case()
+  let _ = support.empty_object_decoder_omits_constructor_parens_case()
   let _ = support.allof_part_types_not_in_generated_encoders_case()
   let _ = support.generation_is_idempotent_case()
   let _ = support.generated_type_fields_are_alphabetically_ordered_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -14545,3 +14545,53 @@ pub fn diagnostic_render_without_file_path_matches_to_string_case() {
     )
   diagnostic.render(d, None) |> should.equal(diagnostic.to_string(d))
 }
+
+/// Issue #474: a schema declared as `type: object, properties: {},
+/// additionalProperties: false` surfaces in `types.gleam` as a no-arg
+/// variant — `pub type EmptyObject { EmptyObject }`. The decoder
+/// emitted by `decoders.generate` must reference that constructor as
+/// the bare value `types.EmptyObject`, not as a function call
+/// `types.EmptyObject()` (which Gleam rejects with `This value is
+/// being called as a function but its type is: types.EmptyObject`).
+pub fn empty_object_decoder_omits_constructor_parens_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+components:
+  schemas:
+    EmptyObject:
+      type: object
+      properties: {}
+      additionalProperties: false
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let spec = hoist.hoist(spec)
+  let ctx = make_ctx_from_spec(spec)
+  let files = decoders.generate(ctx)
+
+  let assert Ok(decode_file) =
+    list.find(files, fn(f) { string.contains(f.path, "decode") })
+  let content = decode_file.content
+
+  // Bare-constructor reference is required.
+  string.contains(content, "decode.success(types.EmptyObject)")
+  |> should.be_true()
+
+  // Function-call form is the bug — it must not appear.
+  string.contains(content, "decode.success(types.EmptyObject())")
+  |> should.be_false()
+}


### PR DESCRIPTION
## Summary

A schema declared as
`type: object, properties: {}, additionalProperties: false` surfaces in
`types.gleam` as a no-arg variant — `pub type EmptyObject { EmptyObject }`.
The decoder generator was unconditionally appending `()` to the constructor
when emitting the success value:

```gleam
decode.success(types.EmptyObject())
```

This is invalid Gleam. The compiler reports:

```
error: Type mismatch
   ┌─ /…/src/<api>/decode.gleam:576:18
576 │   decode.success(types.EmptyObject())
   │                  ^^^^^^^^^^^^^^^^^

This value is being called as a function but its type is:
    types.EmptyObject
```

The bug bites real-world specs: the GitHub OpenAPI subset uses the empty-
object pattern for several response bodies, so any oaspec consumer pointing
at GitHub (or any API with empty-payload return types) fails to compile
the generated code. Reported by @halostatue in #474.

## Changes

- **`src/oaspec/internal/codegen/decoders.gleam`** — special-case the
  empty-\`param_names\` branch in the success-emission path. When the
  record has no constructor arguments, emit the bare reference
  \`decode.success(types.<TypeName>)\` instead of the function-call form.
  When there are arguments, behaviour is unchanged.
- **`test/oaspec_support.gleam`** — new regression case
  \`empty_object_decoder_omits_constructor_parens_case\`. Builds a minimal
  spec with a `properties: {}, additionalProperties: false` schema, runs
  it through `decoders.generate`, and asserts both that the bare form
  appears and that the function-call form does not.
- **`test/oaspec_codegen_test.gleam`** — register the new case so it runs
  with `gleam test`.
- **`CHANGELOG.md`** — `Fixed` entry under `[Unreleased]` documenting the
  bug, the affected scenario, and the regression test that locks the
  behaviour in.

## Design Decisions

- **Scoped fix to the decoder.** The type emission side already produces
  the correct `pub type EmptyObject { EmptyObject }` shape (no parens),
  so no changes are needed in `ir_render.gleam` for this issue. Only the
  decoder's success-path emission was emitting the wrong form.
- **Bare reference, not `EmptyObject(Nil)`.** The reporter suggested
  changing the type to `pub type EmptyObject { EmptyObject(Nil) }` so
  the function-call form would compile. That would change every encoder
  / type-consumer site to thread a unit value, which is more invasive
  than fixing the one decoder line. The bare reference matches the
  existing type emission and keeps the constructor's API minimal.
- **Test asserts the absence of the buggy form too.** A pure positive
  assertion (\`contains "decode.success(types.EmptyObject)"\`) would
  pass even if some other line happened to emit the buggy form
  elsewhere; the negative check makes the regression explicit.

Closes #474