### PR TITLE
docs(adapters): add README files required by gleam publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- **adapters**: README files for `adapters/httpc/` and `adapters/fetch/`.
+  `gleam publish` requires every package to have a README, and the
+  first attempt to push `oaspec_httpc-v0.1.0` failed with `Cannot
+  publish with no README`. Each adapter README describes what the
+  package is, how to install it once published, the quick-start
+  example from the root README's Client transport section, and a
+  pointer to `oaspec/mock` for unit tests. No source-code change.
+
 ## [0.49.0] - 2026-05-04
 
 ### Fixed

--- a/adapters/fetch/README.md
+++ b/adapters/fetch/README.md
@@ -1,0 +1,56 @@
+# oaspec_fetch
+
+JavaScript fetch transport adapter for `oaspec` generated clients,
+backed by `gleam_fetch`.
+
+`oaspec_fetch` bridges the runtime-agnostic `oaspec/transport.AsyncSend`
+contract that `oaspec generate --mode=client` emits to the browser
+fetch API on the JavaScript target. The root `oaspec` package does not
+depend on any specific HTTP library; the transport is composed at the
+call site by plugging this adapter (or your own) into the generated
+client.
+
+For the BEAM target, see the sibling `oaspec_httpc` adapter.
+
+## Install
+
+```sh
+gleam add oaspec_fetch
+```
+
+## Quick start
+
+```gleam
+import api/client
+import oaspec/fetch
+import oaspec/transport
+
+pub fn main() {
+  let send =
+    fetch.send
+    |> transport.with_base_url(client.default_base_url())
+
+  client.list_pets_async(send, limit: Some(10), offset: None)
+  |> transport.run(fn(result) {
+    let _ = result
+    Nil
+  })
+}
+```
+
+The async client variants suffixed `_async` return a `transport.Async`
+value that resolves once the underlying fetch promise settles. The
+adapter exposes helpers to bridge `transport.Async` to native
+JavaScript promises when the host needs to await the result outside
+Gleam.
+
+## Tests in the consumer
+
+For unit tests of code that calls a generated async client, prefer
+`oaspec/mock` over a real network. The adapter's `AsyncSend` shape
+matches `mock.AsyncSend`, so test code substitutes one for the other
+without touching the call sites.
+
+## License
+
+MIT. See the LICENSE file at the root of the oaspec repository.

--- a/adapters/httpc/README.md
+++ b/adapters/httpc/README.md
@@ -1,0 +1,65 @@
+# oaspec_httpc
+
+BEAM HTTP transport adapter for `oaspec` generated clients, backed by
+`gleam_httpc`.
+
+`oaspec_httpc` bridges the runtime-agnostic `oaspec/transport.Send`
+contract that `oaspec generate --mode=client` emits to a real HTTP
+implementation on the BEAM. The root `oaspec` package does not depend
+on any specific HTTP library; the transport is composed at the call
+site by plugging this adapter (or your own) into the generated client.
+
+For the JavaScript target, see the sibling `oaspec_fetch` adapter.
+
+## Install
+
+```sh
+gleam add oaspec_httpc
+```
+
+## Quick start
+
+```gleam
+import api/client
+import oaspec/httpc
+import oaspec/transport
+
+pub fn main() {
+  let send =
+    httpc.send
+    |> transport.with_base_url(client.default_base_url())
+
+  let assert Ok(pets) = client.list_pets(send, limit: Some(10), offset: None)
+}
+```
+
+The bare `httpc.send` is the simplest path. For per-request
+configuration such as timeouts, build a `Send` value with `config()`
+and the `with_*` helpers, then call `build()`:
+
+```gleam
+import oaspec/httpc
+
+let send =
+  httpc.config()
+  |> httpc.with_timeout(5_000)
+  |> httpc.build
+```
+
+## Tests in the consumer
+
+For unit tests of code that calls a generated client, prefer
+`oaspec/mock` over a real network. The adapter's `Send` shape matches
+`mock.Send`, so test code substitutes one for the other without
+touching the call sites:
+
+```gleam
+import oaspec/mock
+
+let send = mock.text(200, "[{\"id\": 1, \"name\": \"Fido\"}]")
+let assert Ok(_) = client.list_pets(send, limit: None, offset: None)
+```
+
+## License
+
+MIT. See the LICENSE file at the root of the oaspec repository.


### PR DESCRIPTION
## Summary

The first attempt to push \`oaspec_httpc-v0.1.0\` to Hex (via the new
release-adapter-httpc workflow added in #475) failed at the publish
step with:

```
error: Cannot publish with no README

You appear to be attempting to publish a package with no README.
All published packages should have one.
```

\`gleam publish\` enforces a README on every package. The in-tree
\`adapters/httpc/\` and \`adapters/fetch/\` directories never had one
because they had only ever been consumed via path deps from a local
checkout. Add a README to each so the next adapter tag push lands on
Hex cleanly.

## Changes

- \`adapters/httpc/README.md\` — new file describing the BEAM HTTP
  adapter: one-paragraph what-it-is, install snippet
  (\`gleam add oaspec_httpc\`), the quick-start example pulled from
  the root README's Client transport section, the configurable
  \`config()\` / \`with_timeout\` / \`build\` path for per-request
  options, and a pointer to \`oaspec/mock\` for unit tests.
- \`adapters/fetch/README.md\` — same shape for the JavaScript fetch
  adapter, using \`fetch.send\` with the async client variants and
  \`transport.run\`.
- \`CHANGELOG.md\` — recorded the addition under \`[Unreleased]\` →
  \`Added\`. No source-code change in either adapter; no version bump.

## Design Decisions

- **No emoji or shields.** Keeping the adapter READMEs deliberately
  plain. The root oaspec README has badges; the adapter READMEs are
  short pointers and the badges add noise per package.
- **Adapter READMEs link concepts to the root README rather than
  duplicating it.** The transport contract, security composition,
  and middleware story all live in the main README's Client transport
  section; duplicating that text here would drift over time.
- **No bump of the adapter version.** \`adapters/httpc/gleam.toml\`
  and \`adapters/fetch/gleam.toml\` stay at \`0.1.0\`; this is a docs
  prerequisite for the first publish, not a content change. The
  \`oaspec_httpc-v0.1.0\` and \`oaspec_fetch-v0.1.0\` tags can be
  re-pushed once this PR merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation for the `fetch` transport adapter, including installation and quick-start examples.
  * Added comprehensive README documentation for the `httpc` transport adapter, including configuration and quick-start examples.
  * Updated CHANGELOG to reflect new adapter documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->