### PR TITLE
fix(cli): allow single-target mode: both with shared output dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **cli(config)**: `validate_no_target_overlap` no longer rejects
+  a single-target config with `mode: both` whose `output.server`
+  and `output.client` resolve to the same directory. The check
+  was added in #387 to catch cross-config (multi-target) collisions
+  where two `targets:` entries clobber each other on disk; for a
+  single config the case is intentionally allowed because the
+  codegen writes shared files (`types`, `decode`, `encode`,
+  `guards`, `request_types`, `response_types`) with identical
+  content for both modes, plus disjoint server-only files
+  (`router`, `handlers`, `handlers_generated`) and one client-only
+  file (`client`). Previously `gleam run -- generate
+  --config=golden/petstore.oaspec.yaml` (and therefore
+  `just update-golden`) failed with `two targets resolve to the
+  same output directory`. `active_output_paths` now dedupes
+  intra-config when `output.server == output.client`, leaving the
+  cross-config rejection path unchanged. Added a positive
+  shellspec test under `single-target shared output` alongside the
+  existing rejection test for multi-target overlap.
+
 ### Added
 
 - **adapters**: README files for `adapters/httpc/` and `adapters/fetch/`.

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -1054,6 +1054,49 @@ EOF
     End
   End
 
+  setup_single_target_shared_output_config() {
+    rm -rf "$PROJECT_ROOT/test_single_shared_output"
+    # A single config with mode: both whose `output.server` and
+    # `output.client` resolve to the same directory is the legitimate
+    # case the golden/petstore.oaspec.yaml fixture has used since the
+    # repo started. The codegen writes shared files (types, decode,
+    # encode, guards, request_types, response_types) with identical
+    # content for both modes, plus server-only files (router,
+    # handlers, handlers_generated) and one client-only file
+    # (client.gleam) with unique names — so a shared output directory
+    # never clobbers anything. The CLI must accept this; the
+    # multi-target overlap check above only catches cross-config
+    # collisions.
+    cat > "$PROJECT_ROOT/test_single_shared_output.yaml" <<EOF
+input: test/fixtures/petstore.yaml
+mode: both
+package: api
+output:
+  server: ./test_single_shared_output/api
+  client: ./test_single_shared_output/api
+EOF
+  }
+
+  cleanup_single_target_shared_output_config() {
+    rm -rf "$PROJECT_ROOT/test_single_shared_output" \
+           "$PROJECT_ROOT/test_single_shared_output.yaml"
+  }
+
+  Describe 'single-target shared output'
+    Before 'setup_single_target_shared_output_config'
+    After 'cleanup_single_target_shared_output_config'
+
+    It 'accepts mode: both with output.server == output.client'
+      When run generate --config=./test_single_shared_output.yaml
+      The status should be success
+      The output should include 'Successfully generated'
+      The output should not include 'two targets resolve to the same output directory'
+      The path "$PROJECT_ROOT/test_single_shared_output/api/types.gleam" should be exist
+      The path "$PROJECT_ROOT/test_single_shared_output/api/router.gleam" should be exist
+      The path "$PROJECT_ROOT/test_single_shared_output/api/client.gleam" should be exist
+    End
+  End
+
   setup_multi_target_with_output_override_config() {
     rm -rf "$PROJECT_ROOT/test_multi_targets_override"
     cat > "$PROJECT_ROOT/test_multi_targets_override.yaml" <<EOF

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -470,7 +470,24 @@ fn active_output_paths(cfg: config.Config) -> List(String) {
   case config.mode(cfg) {
     config.Server -> [config.output_server(cfg)]
     config.Client -> [config.output_client(cfg)]
-    config.Both -> [config.output_server(cfg), config.output_client(cfg)]
+    // For a single config with `mode: both`, `output.server` and
+    // `output.client` may legitimately resolve to the same directory.
+    // The codegen writes shared files (types/decode/encode/guards/
+    // request_types/response_types) with identical content for both
+    // modes, plus server-only files (router/handlers/handlers_generated)
+    // and one client-only file (client.gleam) that have unique names —
+    // so a shared output directory does not clobber anything. Dedupe
+    // intra-config to allow this case while still letting
+    // `validate_no_target_overlap` reject cross-config (multi-target)
+    // collisions, which are the real footgun #387 was tracking.
+    config.Both -> {
+      let server_path = config.output_server(cfg)
+      let client_path = config.output_client(cfg)
+      case server_path == client_path {
+        True -> [server_path]
+        False -> [server_path, client_path]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

\`validate_no_target_overlap\` (added in #387 to catch cross-config /
multi-target collisions) was also rejecting a single-target config
with \`mode: both\` whose \`output.server\` and \`output.client\` resolved
to the same path. That case is intentionally safe — the codegen writes
shared files (\`types\`, \`decode\`, \`encode\`, \`guards\`, \`request_types\`,
\`response_types\`) with identical content for both modes, plus disjoint
server-only files (\`router\`, \`handlers\`, \`handlers_generated\`) and one
client-only file (\`client\`). Files never clobber each other, and the
\`golden/petstore.oaspec.yaml\` / \`golden/complex_supported.oaspec.yaml\`
fixtures committed in-tree have always relied on that shape.

The over-aggressive rejection broke \`just update-golden\`:

\`\`\`
Error: Invalid value for targets: two targets resolve to the same
output directory './golden/petstore/api' — give them distinct package
or output paths so generated files do not clobber each other
\`\`\`

so any maintainer trying to refresh golden snapshots after a codegen
change had to either bypass the validator manually or restructure the
golden fixtures, neither of which the fixtures' shape suggests was
intended.

## Changes

- \`src/oaspec/internal/cli.gleam\` — \`active_output_paths\` now dedupes
  intra-config when \`mode: both\` and \`output.server == output.client\`.
  It returns a single path for the shared-directory case, so
  \`find_duplicate_path\` does not flag it. Cross-config collisions are
  unchanged: a multi-target config with two \`targets:\` entries
  pointing at the same output directory still flat_maps to two
  identical paths across configs and trips the same check.
- \`spec/generate_spec.sh\` — new \`single-target shared output\`
  describe block with a positive test
  (\`accepts mode: both with output.server == output.client\`)
  alongside the existing \`overlap detection\` rejection test. Verifies
  status success, that the rejection message does not appear in
  stdout, and that the expected files exist on disk.
- \`CHANGELOG.md\` — \`Fixed\` entry under \`[Unreleased]\` describing the
  scope, why the case is safe, and the dedupe rule.

## Design Decisions

- **Dedupe inside \`active_output_paths\` rather than gating
  \`validate_no_target_overlap\`**. The flat_map → \`find_duplicate_path\`
  shape was set up for cross-config detection; doing the dedupe at
  the source (\`active_output_paths\`) keeps the validator's algorithm
  unchanged and makes the intent local to the function emitting
  paths for one config.
- **Did not alter \`golden/petstore.oaspec.yaml\` or
  \`golden/complex_supported.oaspec.yaml\`**. The fixtures encode a
  real and intentional usage pattern. Splitting them into distinct
  \`output.server\` and \`output.client\` directories would break the
  golden test layout (which expects \`golden/<spec>/api/*\`) and
  obscure the on-disk reality of \`mode: both\` codegen runs. Fixing
  the validator to match the fixture is the right direction.
- **Positive shellspec test alongside the rejection test**. The
  existing \`overlap detection\` describe documents the bad case;
  pairing it with the good case in a sibling describe makes the
  intended behaviour readable as documentation.

## Verification

- \`just update-golden\` succeeds and produces a no-op diff (golden
  files re-generate to the committed bytes).
- \`just all\` (format check + glinter + warnings-as-errors build +
  unit tests + shellspec + integration tests + escript smoke) all
  pass.
- The existing multi-target overlap rejection at
  \`spec/generate_spec.sh:1049\` still passes — the new dedupe only
  affects intra-config paths.