### PR TITLE
docs(README): inline mist server adapter snippet and fix route arity

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ pub fn handle(
     |> list.fold(dict.new(), fn(acc, kv) {
       dict.upsert(acc, kv.0, fn(prev) {
         case prev {
-          Some(values) -> [kv.1, ..values]
+          Some(values) -> list.append(values, [kv.1])
           None -> [kv.1]
         }
       })

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Working examples live under [`examples/`](./examples):
 
 - [`examples/petstore_client`](./examples/petstore_client) — generated client / decoder roundtrip demo against a stub transport (no network). The example's README shows the one-liner swap to `oaspec_httpc` for real BEAM HTTP. Run it from the repo root with `just example-petstore`.
 - [`examples/petstore_client_fetch`](./examples/petstore_client_fetch) — JavaScript-target client usage through the first-party fetch adapter. Run it from the repo root with `just example-petstore-fetch`.
-- [`examples/server_adapter`](./examples/server_adapter) — wires the generated `router.route/5` to a framework-free adapter. Run it from the repo root with `just example-server-adapter`.
+- [`examples/server_adapter`](./examples/server_adapter) — wires the generated `router.route/6` to a framework-free adapter. Run it from the repo root with `just example-server-adapter`.
 
 ### Client transport
 
@@ -320,6 +320,89 @@ Gleam 1.16, so the build tool cannot locate the adapter's
 See [`examples/petstore_client_fetch/gleam.toml`](./examples/petstore_client_fetch/gleam.toml)
 for the canonical path-dependency layout used in the bundled
 examples.
+
+### Server transport
+
+Generated server code is the dual of the client side: the codegen
+emits a single pure router function, and adapters bridge it to a real
+HTTP framework. `api/router.route/6` takes the primitive pieces of a
+request — `state`, `method`, `path`, `query`, `headers`, `body` — and
+returns a `ServerResponse` whose `body` is a sum
+(`TextBody(String)`, `BytesBody(BitArray)`, `EmptyBody`), so binary
+endpoints carry real bytes through without a String round-trip.
+
+A canonical [`mist`](https://hexdocs.pm/mist/) adapter looks like
+this:
+
+```gleam
+import api/handlers
+import api/router as oas_router
+import gleam/bit_array
+import gleam/bytes_tree
+import gleam/dict
+import gleam/http
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/result
+import gleam/string
+import gleam/uri
+import mist
+
+pub fn handle(
+  req: Request(mist.Connection),
+  state: handlers.State,
+) -> Response(mist.ResponseData) {
+  let method = req.method |> http.method_to_string |> string.uppercase
+  let path =
+    req.path
+    |> string.split(on: "/")
+    |> list.filter(fn(segment) { segment != "" })
+  let query =
+    req.query
+    |> option.unwrap("")
+    |> uri.parse_query
+    |> result.unwrap([])
+    |> list.fold(dict.new(), fn(acc, kv) {
+      dict.upsert(acc, kv.0, fn(prev) {
+        case prev {
+          Some(values) -> [kv.1, ..values]
+          None -> [kv.1]
+        }
+      })
+    })
+  let headers = req.headers |> dict.from_list
+  let body =
+    mist.read_body(req, 16_000_000)
+    |> result.map(fn(read) { read.body })
+    |> result.unwrap(<<>>)
+    |> bit_array.to_string
+    |> result.unwrap("")
+
+  let resp = oas_router.route(state, method, path, query, headers, body)
+
+  let mist_body = case resp.body {
+    oas_router.TextBody(text) -> mist.Bytes(bytes_tree.from_string(text))
+    oas_router.BytesBody(bytes) ->
+      mist.Bytes(bytes_tree.from_bit_array(bytes))
+    oas_router.EmptyBody -> mist.Bytes(bytes_tree.new())
+  }
+  resp.headers
+  |> list.fold(response.new(resp.status), fn(r, header) {
+    response.set_header(r, header.0, header.1)
+  })
+  |> response.set_body(mist_body)
+}
+```
+
+The same shape works for [`wisp`](https://hexdocs.pm/wisp/): decompose
+its request into the six primitives, call `oas_router.route(...)`,
+render the returned `ServerResponse` back into the framework's
+response type. Because the router is pure and synchronous, it is also
+trivial to test in isolation without an HTTP server — see
+[`examples/server_adapter`](./examples/server_adapter) for a
+framework-free runnable example.
 
 ## Configuration
 

--- a/examples/petstore_client/README.md
+++ b/examples/petstore_client/README.md
@@ -128,7 +128,7 @@ need its own directory in the meantime.
   Petstore client flow on the JavaScript target using the first-party
   fetch adapter.
 - [`examples/server_adapter`](../server_adapter/) — a framework-free runnable
-  example that bridges the generated `router.route/5` to a canned
+  example that bridges the generated `router.route/6` to a canned
   request/response pair. Run it with `just example-server-adapter`.
 
 A `security_client` example is still to come; see Issue #26.

--- a/examples/server_adapter/README.md
+++ b/examples/server_adapter/README.md
@@ -1,7 +1,7 @@
 # server_adapter — minimal HTTP adapter for the generated router
 
 A Gleam project that shows how to bridge the oaspec-generated
-`router.route/5` function to any real HTTP stack (wisp, mist, …).
+`router.route/6` function to any real HTTP stack (wisp, mist, …).
 
 ## What it shows
 
@@ -16,8 +16,8 @@ A Gleam project that shows how to bridge the oaspec-generated
 The shape of the router is deliberately framework-free. Any wisp / mist
 adapter is the same three-step pattern:
 
-1. Decompose the framework's request into the five primitives.
-2. `let response = router.route(method, path, query, headers, body)`.
+1. Decompose the framework's request into the six primitives.
+2. `let response = router.route(state, method, path, query, headers, body)`.
 3. Render `response.status` / `response.body` / `response.headers` back
    into the framework's response type.
 

--- a/examples/server_adapter/README.md
+++ b/examples/server_adapter/README.md
@@ -16,7 +16,9 @@ A Gleam project that shows how to bridge the oaspec-generated
 The shape of the router is deliberately framework-free. Any wisp / mist
 adapter is the same three-step pattern:
 
-1. Decompose the framework's request into the six primitives.
+1. Decompose the framework's request into five primitives
+   (`method`, `path`, `query`, `headers`, `body`) and supply the
+   application `state` (your DB pool, config, etc.).
 2. `let response = router.route(state, method, path, query, headers, body)`.
 3. Render `response.status` / `response.body` / `response.headers` back
    into the framework's response type.

--- a/examples/server_adapter/src/server_adapter_example.gleam
+++ b/examples/server_adapter/src/server_adapter_example.gleam
@@ -1,4 +1,4 @@
-//// Runnable example: wiring the oaspec-generated `router.route/5` into a
+//// Runnable example: wiring the oaspec-generated `router.route/6` into a
 //// minimal adapter.
 ////
 //// The generated router is HTTP-framework-agnostic: it takes the primitive


### PR DESCRIPTION
## Summary

- Adds a "Server transport" subsection to the main README mirroring the existing "Client transport" section, with a canonical [`mist`](https://hexdocs.pm/mist/) adapter snippet so server users can reach a runnable shape without first drilling into `examples/server_adapter`.
- Updates stale `router.route/5` references to `router.route/6` (the actually emitted signature includes `app_state` as the first parameter).

## Changes

- `README.md` — new `### Server transport` subsection placed right after `### Client transport` and before `## Configuration`. Inline ~50-line mist adapter showing the full request → `oas_router.route(...)` → `mist.ResponseData` mapping (method/path/query/headers/body decomposition + `ResponseBody` sum dispatch). Notes that the same shape works for `wisp`.
- `README.md` — fixes `route/5` → `route/6` in the runnable-examples bullet.
- `examples/server_adapter/README.md` — fixes `route/5` → `route/6`, and corrects the prose snippet `router.route(method, path, query, headers, body)` → `router.route(state, method, path, query, headers, body)`.
- `examples/petstore_client/README.md` — fixes `route/5` → `route/6` in the cross-reference.
- `examples/server_adapter/src/server_adapter_example.gleam` — fixes `route/5` → `route/6` in the module doc comment.

## Design Decisions

- Chose `mist` over `wisp` for the canonical snippet (per the issue) since `mist` shares the BEAM target with `oaspec_httpc` and is the most common direct-server choice. Added a one-line note that `wisp` follows the same shape.
- Wrote out the full query-parsing fold (`uri.parse_query` + `dict.upsert`) instead of leaving it as `// parse req.query into Dict(...)` so the snippet is copy-paste-runnable, not just illustrative.
- Used unqualified `Some`/`None` constructors and module-qualified `option.unwrap` to match the prevailing style in the generated codegen output (e.g. `examples/server_adapter/src/api/router.gleam`).
- Left historical `route/5` references in `CHANGELOG.md` untouched — those are accurate point-in-time records.

## Test plan

- [x] `just all` passes (format-check, typecheck, build, unit, shellspec, integration, escript, smoke).
- [ ] Reviewer eyeballs the snippet for `mist` API correctness against the latest `mist` release.

Closes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server adapter documentation and examples to reflect current API conventions.
  * Enhanced documentation with detailed server transport section including request/response handling patterns and complete adapter example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->