### PR TITLE
fix(server-codegen): decode multipart/form-data enum fields into variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Fixed
 
+- **server-codegen(multipart)**: a `multipart/form-data` request body
+  field whose schema is a `$ref` to a string-enum schema is now
+  decoded into the generated sum-type variant rather than copied as
+  raw `String` into the enum-typed slot of the request type. The
+  previous shape (`category: case dict.get(multipart_body,
+  "category") { Ok([v, ..]) -> v _ -> "" }`) failed `gleam check`
+  with a type mismatch (`Expected: types.Category, Found: String`),
+  putting a perfectly normal OpenAPI shape (enum field on a
+  multipart upload) outside the "autogen compiles unmodified"
+  promise. The same fix also covers
+  `application/x-www-form-urlencoded` bodies, which share the
+  underlying `body_required_expr` / `body_optional_expr` codepath.
+  Required enum fields fall back to the first declared variant on
+  miss / unknown (mirroring the type-zero fallback already used for
+  primitive required body fields per #327); optional enum fields
+  fall back to `None` (mirroring the permissive behaviour of #305
+  for `$ref`-typed enum query parameters). (#482)
+
 - **cli(config)**: `validate_no_target_overlap` no longer rejects
   a single-target config with `mode: both` whose `output.server`
   and `output.client` resolve to the same directory. The check
@@ -32,6 +50,13 @@ within `Changed` / `Fixed` and stay as-is.
   existing rejection test for multi-target overlap.
 
 ### Added
+
+- **docs(README)**: the main README now ships an inline canonical
+  `mist` server-adapter snippet (mirroring the existing inline
+  Client transport snippet) so server users can reach a runnable
+  shape without first drilling into `examples/server_adapter`. Stale
+  references to `router.route/5` were corrected to `route/6` (the
+  app_state parameter has been emitted for several releases). (#480)
 
 - **adapters**: README files for `adapters/httpc/` and `adapters/fetch/`.
   `gleam publish` requires every package to have a README, and the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 353 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 257 test fixtures (including 98 OSS-derived edge-case specs)
+  and 259 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -523,6 +523,79 @@ rm -rf "$MULTI_DIR"
 info "Multipart server integration tests passed."
 
 # -------------------------------------------------------
+# Step 10b: Issue #482 — multipart/form-data with `$ref`-typed
+# string-enum field must compile end-to-end. Before the fix the
+# router copied the raw String into the sum-typed slot, breaking
+# `gleam check`.
+# -------------------------------------------------------
+info "Testing Issue #482 multipart enum-field server code generation..."
+
+ENUM_MULTI_DIR="$SCRIPT_DIR/multipart_enum_test"
+rm -rf "$ENUM_MULTI_DIR"
+mkdir -p "$ENUM_MULTI_DIR/src"
+
+cat > "$ENUM_MULTI_DIR/oaspec-multi-enum.yaml" << 'YAML_EOF'
+input: test/fixtures/server_multipart_enum_field.yaml
+output:
+  server: ./integration_test/multipart_enum_test/src/api
+package: api
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$ENUM_MULTI_DIR/oaspec-multi-enum.yaml" \
+  --mode=server
+
+cat > "$ENUM_MULTI_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/request_types
+import api/response_types
+
+pub type State {
+  State
+}
+
+pub fn upload_thing(state: State, req: request_types.UploadThingRequest) -> response_types.UploadThingResponse {
+  let _ = state
+  let _ = req
+  response_types.UploadThingResponseNoContent
+}
+GLEAM_EOF
+
+cat > "$ENUM_MULTI_DIR/gleam.toml" << 'TOML_EOF'
+name = "multipart_enum_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$ENUM_MULTI_DIR/src/multipart_enum_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$ENUM_MULTI_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated multipart enum-field server code compiles (#482)."
+else
+  fail "Generated multipart enum-field server code failed to compile (#482 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$ENUM_MULTI_DIR"
+
+info "Issue #482 multipart enum-field integration test passed."
+
+# -------------------------------------------------------
 # Step 11: Generate callback spec and verify it compiles
 # -------------------------------------------------------
 info "Testing callback handler code generation..."

--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -1271,6 +1271,57 @@ fn multipart_body_optional_expr_with_schema(
   body_optional_expr(key, "multipart_body", False, "_", schema_ref, ctx)
 }
 
+/// Inline string-enum dispatch for a required form/multipart body
+/// field (issue #482). When the dict is missing the key, or the value
+/// is outside the spec's enum set, falls back to the first variant —
+/// mirroring the type-zero fallback used for primitive required body
+/// fields (#327). The handler is responsible for any stricter
+/// validation.
+fn body_required_enum_expr(
+  lookup: String,
+  type_name: String,
+  values: List(String),
+) -> String {
+  let default = case values {
+    [first, ..] -> "types." <> type_name <> naming.to_pascal_case(first)
+    [] -> ""
+  }
+  let arms =
+    values
+    |> list.map(fn(v) {
+      "\"" <> v <> "\" -> types." <> type_name <> naming.to_pascal_case(v)
+    })
+    |> string.join(" ")
+  "case "
+  <> lookup
+  <> " { Ok([v, ..]) -> case v { "
+  <> arms
+  <> " _ -> "
+  <> default
+  <> " } _ -> "
+  <> default
+  <> " }"
+}
+
+/// Inline string-enum dispatch for an optional form/multipart body
+/// field (issue #482). Unknown values map to `None`, matching the
+/// permissive behaviour already used for `$ref`-typed enum query
+/// parameters (#305).
+fn body_optional_enum_expr(
+  lookup: String,
+  miss: String,
+  type_name: String,
+  values: List(String),
+) -> String {
+  "case "
+  <> lookup
+  <> " { Ok([v, ..]) -> "
+  <> enum_match_option_expr("v", type_name, values)
+  <> " "
+  <> miss
+  <> " -> None }"
+}
+
 /// Generate a required body field expression.
 /// `source` is the dict name (e.g., "form_body", "multipart_body").
 /// `trim_items` controls whether array items are trimmed (form_body) or
@@ -1292,6 +1343,29 @@ fn body_required_expr(
 ) -> String {
   let lookup = "dict.get(" <> source <> ", \"" <> key <> "\")"
   let base = "case " <> lookup <> " { Ok([v, ..]) -> v _ -> \"\" }"
+  // Issue #482: a `$ref`-typed string-enum field must dispatch to the
+  // generated sum-type variant. Without this branch the codegen falls
+  // through to `base` (raw String), which fails `gleam check` because
+  // the field's compile-time type is `types.<EnumName>`.
+  case
+    schema_ref
+    |> option.then(fn(ref) { schema_ref_string_enum(ref, ctx) })
+  {
+    Some(#(type_name, values)) ->
+      body_required_enum_expr(lookup, type_name, values)
+    None -> body_required_expr_kind(lookup, base, schema_ref, trim_items, ctx)
+  }
+}
+
+/// Existing per-`BodyFieldKind` dispatch for `body_required_expr`,
+/// extracted so the enum check above can short-circuit cleanly.
+fn body_required_expr_kind(
+  lookup: String,
+  base: String,
+  schema_ref: Option(SchemaRef),
+  trim_items: Bool,
+  ctx: Context,
+) -> String {
   case schema_ref_body_field_kind(schema_ref, ctx) {
     BodyFieldStringArray ->
       case trim_items {
@@ -1348,6 +1422,29 @@ fn body_optional_expr(
   ctx: Context,
 ) -> String {
   let lookup = "dict.get(" <> source <> ", \"" <> key <> "\")"
+  // Issue #482: as in `body_required_expr`, a `$ref`-typed string-enum
+  // field needs string→variant dispatch. Without this branch the field
+  // ends up as `Some(v)` where `v: String` clashes with the
+  // `Option(types.<EnumName>)` slot.
+  case
+    schema_ref
+    |> option.then(fn(ref) { schema_ref_string_enum(ref, ctx) })
+  {
+    Some(#(type_name, values)) ->
+      body_optional_enum_expr(lookup, miss, type_name, values)
+    None -> body_optional_expr_kind(lookup, miss, schema_ref, trim_items, ctx)
+  }
+}
+
+/// Existing per-`BodyFieldKind` dispatch for `body_optional_expr`,
+/// extracted so the enum check above can short-circuit cleanly.
+fn body_optional_expr_kind(
+  lookup: String,
+  miss: String,
+  schema_ref: Option(SchemaRef),
+  trim_items: Bool,
+  ctx: Context,
+) -> String {
   case schema_ref_body_field_kind(schema_ref, ctx) {
     BodyFieldStringArray ->
       case trim_items {

--- a/test/fixtures/server_form_urlencoded_enum_field.yaml
+++ b/test/fixtures/server_form_urlencoded_enum_field.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Server Form Urlencoded Enum Field Test API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - category
+              properties:
+                category:
+                  $ref: "#/components/schemas/Category"
+                tag:
+                  $ref: "#/components/schemas/Category"
+      responses:
+        "204":
+          description: ok
+components:
+  schemas:
+    Category:
+      type: string
+      enum:
+        - logs
+        - screenshots
+        - configs

--- a/test/fixtures/server_multipart_enum_field.yaml
+++ b/test/fixtures/server_multipart_enum_field.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Server Multipart Enum Field Test API
+  version: 1.0.0
+paths:
+  /things:
+    post:
+      operationId: uploadThing
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - category
+              properties:
+                category:
+                  $ref: "#/components/schemas/Category"
+                tag:
+                  $ref: "#/components/schemas/Category"
+      responses:
+        "204":
+          description: ok
+components:
+  schemas:
+    Category:
+      type: string
+      enum:
+        - logs
+        - screenshots
+        - configs

--- a/test/oaspec_server_codegen_test.gleam
+++ b/test/oaspec_server_codegen_test.gleam
@@ -20,6 +20,8 @@ pub fn server_param_and_body_codegen_test() {
   let _ = support.server_multipart_body_is_parsed_case()
   let _ = support.server_form_urlencoded_ref_fields_are_parsed_case()
   let _ = support.server_multipart_ref_fields_are_parsed_case()
+  let _ = support.server_multipart_enum_field_dispatches_to_variant_case()
+  let _ = support.server_form_urlencoded_enum_field_dispatches_to_variant_case()
   let _ = support.server_cookie_param_generates_cookie_lookup_case()
   let _ = support.server_cookie_param_optional_string_case()
   let _ = support.server_cookie_param_integer_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -9780,6 +9780,58 @@ pub fn server_multipart_ref_fields_are_parsed_case() {
   |> should.be_true()
 }
 
+pub fn server_multipart_enum_field_dispatches_to_variant_case() {
+  // Issue #482: `$ref`-typed string-enum field on a multipart body must
+  // dispatch into the generated sum-type variant, not be copied as raw
+  // String. Without this fix `gleam check` rejects the autogen output.
+  let ctx = make_ctx("test/fixtures/server_multipart_enum_field.yaml")
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+  let content = router_file.content
+
+  // Required enum field falls back to first variant on miss / unknown.
+  string.contains(
+    content,
+    "category: case dict.get(multipart_body, \"category\") { Ok([v, ..]) -> case v { \"logs\" -> types.CategoryLogs \"screenshots\" -> types.CategoryScreenshots \"configs\" -> types.CategoryConfigs _ -> types.CategoryLogs } _ -> types.CategoryLogs }",
+  )
+  |> should.be_true()
+  // Optional enum field falls back to None on miss / unknown.
+  string.contains(
+    content,
+    "tag: case dict.get(multipart_body, \"tag\") { Ok([v, ..]) -> case v { \"logs\" -> Some(types.CategoryLogs) \"screenshots\" -> Some(types.CategoryScreenshots) \"configs\" -> Some(types.CategoryConfigs) _ -> None } _ -> None }",
+  )
+  |> should.be_true()
+  // The previous broken shape — copying the raw String — must be gone.
+  string.contains(
+    content,
+    "category: case dict.get(multipart_body, \"category\") { Ok([v, ..]) -> v _ -> \"\" }",
+  )
+  |> should.be_false()
+}
+
+pub fn server_form_urlencoded_enum_field_dispatches_to_variant_case() {
+  // Issue #482: same fix applies to application/x-www-form-urlencoded
+  // bodies, which share the body_required_expr / body_optional_expr
+  // codepath with multipart.
+  let ctx = make_ctx("test/fixtures/server_form_urlencoded_enum_field.yaml")
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+  let content = router_file.content
+
+  string.contains(
+    content,
+    "category: case dict.get(form_body, \"category\") { Ok([v, ..]) -> case v { \"logs\" -> types.CategoryLogs \"screenshots\" -> types.CategoryScreenshots \"configs\" -> types.CategoryConfigs _ -> types.CategoryLogs } _ -> types.CategoryLogs }",
+  )
+  |> should.be_true()
+  string.contains(
+    content,
+    "tag: case dict.get(form_body, \"tag\") { Ok([v, ..]) -> case v { \"logs\" -> Some(types.CategoryLogs) \"screenshots\" -> Some(types.CategoryScreenshots) \"configs\" -> Some(types.CategoryConfigs) _ -> None } _ -> None }",
+  )
+  |> should.be_true()
+}
+
 // --- Server cookie parameter end-to-end tests ---
 
 pub fn server_cookie_param_generates_cookie_lookup_case() {


### PR DESCRIPTION
## Summary

A `\$ref`-typed string-enum field on a `multipart/form-data` (or `application/x-www-form-urlencoded`) request body was copied into the generated request type as a raw `String`, which immediately fails `gleam check` because the slot's compile-time type is the generated sum type:

```
error: Type mismatch
   ...
   │ category: case dict.get(multipart_body, "category") {
   │     Ok([v, ..]) -> v       // v: String, but field expects types.Category
   │     _ -> ""
   │ },
```

The query-parameter codepath already handled this correctly (via `enum_match_option_expr` + `schema_ref_string_enum`, #305). The form/multipart body codepath had not been updated.

## Changes

- `src/oaspec/internal/codegen/server_request_decode.gleam`
  - `body_required_expr` and `body_optional_expr` now consult `schema_ref_string_enum` before the per-`BodyFieldKind` dispatch and emit a string→variant case.
  - New helpers `body_required_enum_expr` and `body_optional_enum_expr` keep the per-key logic out of the dispatcher.
- `test/fixtures/server_multipart_enum_field.yaml`, `test/fixtures/server_form_urlencoded_enum_field.yaml` — new fixtures with required + optional enum fields.
- `test/oaspec_support.gleam` — two new test cases asserting the exact emitted shape (and that the buggy "raw String" shape is gone).
- `test/oaspec_server_codegen_test.gleam` — wires the new test cases into the test runner.
- `integration_test/run.sh` — Step 10b: compiles a generated multipart-enum-field server with `gleam build --warnings-as-errors` so a regression breaks CI end-to-end.
- `README.md` — bumps the test-fixture count from 257 → 259 (`scripts/check_sync.sh` enforces this).
- `CHANGELOG.md` — `Unreleased` entries for #482 and (retroactively) #480.

## Design Decisions

- **Required-field fallback = first declared variant.** The prior `body_required_expr` already returns type-zero defaults for primitive required fields (`""`, `0`, `0.0`, `False`, `[]`) per #327, on the principle that the handler is responsible for application-level validation rather than the router crashing the BEAM. Enums have no canonical "zero" — picking the first declared variant keeps the codegen consistent with that philosophy and avoids introducing a 422-escape route, which would be a deeper architectural change.
- **Optional-field fallback = `None`.** Mirrors the permissive #305 behaviour for `\$ref`-typed enum query parameters.
- **The fix lives in the shared `body_required_expr` / `body_optional_expr` helpers**, so multipart and form-urlencoded both benefit from a single change. This is the codepath the issue author suspected was shared; verified.
- **`types` import gating** (`router_ir.gleam`) is unaffected: it already imports `types` whenever `has_form_urlencoded_body || has_multipart_body` is true, so the new emitted `types.<EnumName><Variant>` references resolve.

## Test plan

- [x] `just all` passes (format-check, typecheck, build, unit (355), shellspec, integration including the new Step 10b, escript, smoke)
- [x] New unit tests assert both the new variant-dispatch shape and the absence of the previous broken raw-String shape
- [x] New integration step compiles a multipart enum-field server with `--warnings-as-errors`

Closes #482