### PR TITLE
fix(codegen)!: thread runtime status through default response variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Breaking
+
+- **codegen(default-response)**: the generated `XxxResponseDefault`
+  variant now carries a runtime `Int` status code as its first
+  positional field, so handlers can pick any 4xx/5xx for the
+  catch-all branch instead of being pinned to 500. Concretely:
+
+      // before
+      DeleteArtifactResponseDefault(types.Error)
+      // after
+      DeleteArtifactResponseDefault(Int, types.Error)
+
+  Variants without a body collapse to `Default(Int)`; variants with
+  declared response headers append the headers record as the last
+  positional field exactly as the other response variants do. The
+  router's `ServerResponse.status` is now sourced from the bound
+  `status` rather than the previous hardcoded `500`, and the client
+  decoder captures the actual response `Int` and threads it back
+  through the variant. **Migration**: every handler that constructs
+  a `Default` variant must be updated to supply the status code
+  (`401`, `404`, …) as the first argument; every caller pattern-
+  matching the variant must add the `status` binding. (#483)
+
 ### Fixed
 
 - **server-codegen(multipart)**: a `multipart/form-data` request body

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 353 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 259 test fixtures (including 98 OSS-derived edge-case specs)
+  and 260 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -596,6 +596,99 @@ rm -rf "$ENUM_MULTI_DIR"
 info "Issue #482 multipart enum-field integration test passed."
 
 # -------------------------------------------------------
+# Step 10c: Issue #483 — the OpenAPI `default` response variant
+# now carries a runtime status code as its first positional field,
+# so handlers can return any 4xx/5xx through the catch-all branch
+# instead of being pinned to 500. Compile a generated server +
+# handler that exercises this end-to-end.
+# -------------------------------------------------------
+info "Testing Issue #483 default response status code generation..."
+
+DEF_DIR="$SCRIPT_DIR/default_status_test"
+rm -rf "$DEF_DIR"
+mkdir -p "$DEF_DIR/src"
+
+cat > "$DEF_DIR/oaspec-default-status.yaml" << 'YAML_EOF'
+input: test/fixtures/server_default_response_status.yaml
+output:
+  server: ./integration_test/default_status_test/src/api
+package: api
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate \
+  --config="$DEF_DIR/oaspec-default-status.yaml" \
+  --mode=server
+
+cat > "$DEF_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/request_types
+import api/response_types
+import api/types
+
+pub type State {
+  State
+}
+
+pub fn delete_artifact(
+  state: State,
+  req: request_types.DeleteArtifactRequest,
+) -> response_types.DeleteArtifactResponse {
+  let _ = state
+  // Issue #483: return 401 (not 500) through the default branch.
+  case req.id {
+    "" ->
+      response_types.DeleteArtifactResponseDefault(
+        401,
+        types.Error(code: "unauthorized", message: "missing id"),
+      )
+    _ -> response_types.DeleteArtifactResponseNoContent
+  }
+}
+
+pub fn list_things(
+  state: State,
+) -> response_types.ListThingsResponse {
+  let _ = state
+  // Empty default body: variant collapses to `Default(Int)`.
+  response_types.ListThingsResponseDefault(503)
+}
+GLEAM_EOF
+
+cat > "$DEF_DIR/gleam.toml" << 'TOML_EOF'
+name = "default_status_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$DEF_DIR/src/default_status_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$DEF_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated default-response-status server compiles (#483)."
+else
+  fail "Generated default-response-status server failed to compile (#483 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$DEF_DIR"
+
+info "Issue #483 default response status integration test passed."
+
+# -------------------------------------------------------
 # Step 11: Generate callback spec and verify it compiles
 # -------------------------------------------------------
 info "Testing callback handler code generation..."

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -14,6 +14,36 @@ import oaspec/internal/util/http
 import oaspec/internal/util/naming
 import oaspec/internal/util/string_extra as se
 
+/// Issue #483: the `default` response branch must capture the actual
+/// runtime status code so the decoded `XxxResponseDefault(...)`
+/// variant can carry it through to the caller. For all non-default
+/// branches the case pattern is the matched status int (or guard
+/// expression for `2xx` ranges); the default branch binds `status`
+/// instead of using `_` so the variant constructor can pass it on.
+fn status_branch_pattern(status_code: http.HttpStatusCode) -> String {
+  case status_code {
+    http.DefaultStatus -> "status"
+    _ -> http.status_code_to_int_pattern(status_code)
+  }
+}
+
+/// Issue #483: prepend the runtime status binding to a variant
+/// constructor's argument list when the status code is `default`. For
+/// every other status the variant arity is unchanged.
+fn prepend_default_status(
+  arg: String,
+  status_code: http.HttpStatusCode,
+) -> String {
+  case status_code {
+    http.DefaultStatus ->
+      case arg {
+        "" -> "status"
+        _ -> "status, " <> arg
+      }
+    _ -> arg
+  }
+}
+
 /// Issue #387: assembled response-headers record. Tracks both the
 /// pre-statements (let bindings or `use` chains that extract each
 /// header field from `resp.headers`) and the final constructor
@@ -72,10 +102,7 @@ pub fn generate_single_content_response(
             get_response_decode_expr(schema_ref, op_id, status_code, ctx)
           let sb =
             sb
-            |> se.indent(
-              2,
-              http.status_code_to_int_pattern(status_code) <> " -> {",
-            )
+            |> se.indent(2, status_branch_pattern(status_code) <> " -> {")
             |> se.indent(3, "use text <- result.try(text_body(resp.body))")
             |> emit_pre_statements(headers)
           sb
@@ -85,7 +112,10 @@ pub fn generate_single_content_response(
             "Ok(decoded) -> Ok("
               <> variant_name
               <> "("
-              <> append_headers_arg("decoded", headers)
+              <> prepend_default_status(
+              append_headers_arg("decoded", headers),
+              status_code,
+            )
               <> "))",
           )
           |> se.indent(
@@ -114,7 +144,7 @@ fn body_branch(
   extract_body: fn(se.StringBuilder) -> se.StringBuilder,
 ) -> se.StringBuilder {
   sb
-  |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
+  |> se.indent(2, status_branch_pattern(status_code) <> " -> {")
   |> extract_body
   |> emit_pre_statements(headers)
   |> se.indent(
@@ -122,7 +152,10 @@ fn body_branch(
     "Ok("
       <> variant_name
       <> "("
-      <> append_headers_arg(body_arg, headers)
+      <> prepend_default_status(
+      append_headers_arg(body_arg, headers),
+      status_code,
+    )
       <> "))",
   )
   |> se.indent(2, "}")
@@ -142,28 +175,39 @@ fn empty_body_branch(
   case headers {
     Some(HeadersRecord(pre_statements: [_, ..], record_expr: expr)) ->
       sb
-      |> se.indent(2, http.status_code_to_int_pattern(status_code) <> " -> {")
+      |> se.indent(2, status_branch_pattern(status_code) <> " -> {")
       |> emit_pre_statements(headers)
-      |> se.indent(3, "Ok(" <> variant_name <> "(" <> expr <> "))")
+      |> se.indent(
+        3,
+        "Ok("
+          <> variant_name
+          <> "("
+          <> prepend_default_status(expr, status_code)
+          <> "))",
+      )
       |> se.indent(2, "}")
     Some(HeadersRecord(record_expr: expr, ..)) ->
       sb
       |> se.indent(
         2,
-        http.status_code_to_int_pattern(status_code)
+        status_branch_pattern(status_code)
           <> " -> Ok("
           <> variant_name
           <> "("
-          <> expr
+          <> prepend_default_status(expr, status_code)
           <> "))",
       )
     None ->
       sb
       |> se.indent(
         2,
-        http.status_code_to_int_pattern(status_code)
+        status_branch_pattern(status_code)
           <> " -> Ok("
           <> variant_name
+          <> case status_code {
+          http.DefaultStatus -> "(status)"
+          _ -> ""
+        }
           <> ")",
       )
   }

--- a/src/oaspec/internal/codegen/ir.gleam
+++ b/src/oaspec/internal/codegen/ir.gleam
@@ -106,6 +106,22 @@ pub type Variant {
   /// Response variant carrying only a typed headers record (no body):
   /// `FooBar(FooBarHeaders)` (issue #306).
   VariantWithHeaders(name: String, headers_type: String)
+  /// Response variant for the OpenAPI `default` catch-all. Always
+  /// carries an Int status code as the first positional field, so
+  /// handlers can pick any 4xx/5xx for the catch-all branch instead
+  /// of the router pinning every response to 500. The body and
+  /// headers types are optional, mirroring the four shapes of the
+  /// other variant kinds (issue #483):
+  ///
+  /// * neither            → `FooDefault(Int)`
+  /// * body only          → `FooDefault(Int, Body)`
+  /// * headers only       → `FooDefault(Int, FooDefaultHeaders)`
+  /// * body + headers     → `FooDefault(Int, Body, FooDefaultHeaders)`
+  VariantDefault(
+    name: String,
+    inner_type: Option(String),
+    headers_type: Option(String),
+  )
 }
 
 /// A typed record for response headers.

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -12,8 +12,8 @@ import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/codegen/import_analysis
 import oaspec/internal/codegen/ir.{
   type Declaration, type Field, type Module, type Variant, EnumType, Field,
-  RecordType, TypeAlias, UnionType, VariantEmpty, VariantWithHeaders,
-  VariantWithType, VariantWithTypeAndHeaders,
+  RecordType, TypeAlias, UnionType, VariantDefault, VariantEmpty,
+  VariantWithHeaders, VariantWithType, VariantWithTypeAndHeaders,
 }
 import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/codegen/schema_utils
@@ -375,65 +375,71 @@ fn response_variant(
     [] -> None
     _ -> Some(variant_name <> "Headers")
   }
-  case content_entries {
-    [] -> empty_variant_with_optional_headers(variant_name, headers_type_opt)
-    [_, _, ..] ->
-      typed_variant_with_optional_headers(
-        variant_name,
-        "String",
-        headers_type_opt,
+  let inner_type_opt = response_inner_type(content_entries, status_code, op_id)
+  // Issue #483: the OpenAPI `default` response is the catch-all for
+  // status codes not declared explicitly. Until now its variant
+  // looked like every other variant (`FooDefault(Body)`) and the
+  // router pinned it to status 500, so a handler could not surface
+  // 401/403/404/...  through the default branch. The `VariantDefault`
+  // shape adds a leading `Int` field that the router and client
+  // decoder both pass through.
+  case status_code {
+    http.DefaultStatus ->
+      VariantDefault(
+        name: variant_name,
+        inner_type: inner_type_opt,
+        headers_type: headers_type_opt,
       )
+    _ ->
+      case inner_type_opt {
+        Some(inner_type) ->
+          typed_variant_with_optional_headers(
+            variant_name,
+            inner_type,
+            headers_type_opt,
+          )
+        None ->
+          empty_variant_with_optional_headers(variant_name, headers_type_opt)
+      }
+  }
+}
+
+/// Resolve a response's `content` entries to the body type that the
+/// generated variant carries, or `None` for empty responses. Extracted
+/// from `response_variant` so the DefaultStatus dispatch (#483) can
+/// reuse the same per-content-type logic.
+fn response_inner_type(
+  content_entries: List(#(String, spec.MediaType)),
+  status_code: http.HttpStatusCode,
+  op_id: String,
+) -> option.Option(String) {
+  case content_entries {
+    [] -> None
+    [_, _, ..] -> Some("String")
     [#(media_type_name, media_type)] ->
       case content_type.from_string(media_type_name) {
         content_type.TextPlain
         | content_type.ApplicationXml
         | content_type.TextXml ->
           case media_type.schema {
-            Some(_) ->
-              typed_variant_with_optional_headers(
-                variant_name,
-                "String",
-                headers_type_opt,
-              )
-            None ->
-              empty_variant_with_optional_headers(
-                variant_name,
-                headers_type_opt,
-              )
+            Some(_) -> Some("String")
+            None -> None
           }
         // Issue #304: binary response payloads ride a BitArray variant
         // so handlers can produce real bytes instead of forcing the
         // payload through `String`.
         content_type.ApplicationOctetStream ->
           case media_type.schema {
-            Some(_) ->
-              typed_variant_with_optional_headers(
-                variant_name,
-                "BitArray",
-                headers_type_opt,
-              )
-            None ->
-              empty_variant_with_optional_headers(
-                variant_name,
-                headers_type_opt,
-              )
+            Some(_) -> Some("BitArray")
+            None -> None
           }
         _ ->
           case media_type.schema {
             Some(ref) -> {
               let suffix = "Response" <> http.status_code_suffix(status_code)
-              let inner_type = schema_ref_to_type_qualified(ref, op_id, suffix)
-              typed_variant_with_optional_headers(
-                variant_name,
-                inner_type,
-                headers_type_opt,
-              )
+              Some(schema_ref_to_type_qualified(ref, op_id, suffix))
             }
-            None ->
-              empty_variant_with_optional_headers(
-                variant_name,
-                headers_type_opt,
-              )
+            None -> None
           }
       }
   }

--- a/src/oaspec/internal/codegen/ir_render.gleam
+++ b/src/oaspec/internal/codegen/ir_render.gleam
@@ -6,7 +6,7 @@ import gleam/string
 import oaspec/internal/codegen/context
 import oaspec/internal/codegen/ir.{
   type Declaration, type Module, type TypeDef, EnumType, RecordType, TypeAlias,
-  UnionType, VariantEmpty, VariantWithHeaders, VariantWithType,
+  UnionType, VariantDefault, VariantEmpty, VariantWithHeaders, VariantWithType,
   VariantWithTypeAndHeaders,
 }
 import oaspec/internal/util/string_extra as se
@@ -77,6 +77,16 @@ fn render_type_def(sb: se.StringBuilder, type_def: TypeDef) -> se.StringBuilder 
               )
             VariantWithHeaders(name: vname, headers_type:) ->
               sb |> se.indent(1, vname <> "(" <> headers_type <> ")")
+            VariantDefault(name: vname, inner_type:, headers_type:) -> {
+              let parts = case inner_type, headers_type {
+                None, None -> ["Int"]
+                Some(t), None -> ["Int", t]
+                None, Some(h) -> ["Int", h]
+                Some(t), Some(h) -> ["Int", t, h]
+              }
+              sb
+              |> se.indent(1, vname <> "(" <> string.join(parts, ", ") <> ")")
+            }
           }
         })
       sb

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -1068,6 +1068,16 @@ fn generate_response_conversion(
               let variant_name =
                 response_type_name <> http.status_code_suffix(status_code)
               let status_int = http.status_code_to_int(status_code)
+              // Issue #483: the OpenAPI `default` response is the only
+              // status whose generated variant carries a runtime status
+              // code (`Foo(Int [, body] [, headers])`). The router
+              // pattern grows a `status` binding and uses it as the
+              // outgoing `ServerResponse.status` instead of the
+              // hardcoded representative-int (which was always 500).
+              let is_default = case status_code {
+                http.DefaultStatus -> True
+                _ -> False
+              }
               let content_entries = dict.to_list(response.content)
               let header_specs = sorted_header_specs(response.headers)
               let has_headers = !list.is_empty(header_specs)
@@ -1084,6 +1094,7 @@ fn generate_response_conversion(
                     body_expr: "EmptyBody",
                     content_type_header: None,
                     header_specs: header_specs,
+                    is_default: is_default,
                   )
                 [#(media_type_name, media_type)] ->
                   case content_type.from_string(media_type_name) {
@@ -1103,6 +1114,7 @@ fn generate_response_conversion(
                               <> "(data)))",
                             content_type_header: Some(media_type_name),
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                         }
                         None ->
@@ -1115,6 +1127,7 @@ fn generate_response_conversion(
                             body_expr: "EmptyBody",
                             content_type_header: None,
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                       }
                     content_type.TextPlain
@@ -1131,6 +1144,7 @@ fn generate_response_conversion(
                             body_expr: "TextBody(data)",
                             content_type_header: Some(media_type_name),
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                         None ->
                           emit_response_arm(
@@ -1142,6 +1156,7 @@ fn generate_response_conversion(
                             body_expr: "EmptyBody",
                             content_type_header: None,
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                       }
                     content_type.ApplicationOctetStream ->
@@ -1160,6 +1175,7 @@ fn generate_response_conversion(
                             body_expr: "BytesBody(data)",
                             content_type_header: Some(media_type_name),
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                         None ->
                           emit_response_arm(
@@ -1171,6 +1187,7 @@ fn generate_response_conversion(
                             body_expr: "EmptyBody",
                             content_type_header: None,
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                       }
                     _ ->
@@ -1189,6 +1206,7 @@ fn generate_response_conversion(
                               <> "(data)))",
                             content_type_header: Some(media_type_name),
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                         }
                         None ->
@@ -1201,6 +1219,7 @@ fn generate_response_conversion(
                             body_expr: "EmptyBody",
                             content_type_header: None,
                             header_specs: header_specs,
+                            is_default: is_default,
                           )
                       }
                   }
@@ -1216,6 +1235,7 @@ fn generate_response_conversion(
                     body_expr: "TextBody(data)",
                     content_type_header: Some(first_media_type),
                     header_specs: header_specs,
+                    is_default: is_default,
                   )
               }
             }
@@ -1284,6 +1304,12 @@ fn response_header_field_type(
 /// True the variant pattern grows an `hdrs` binding and the headers
 /// list is materialised via `list.flatten` so spec-declared response
 /// headers are appended to the implicit `content-type` tuple.
+///
+/// Issue #483: when `is_default` is True the variant pattern grows a
+/// leading `status` binding and the outgoing `ServerResponse.status`
+/// uses that bound value instead of the precomputed `status_int`. The
+/// `Foo(Int [, body] [, headers])` shape comes from `VariantDefault`
+/// in the IR.
 fn emit_response_arm(
   sb: se.StringBuilder,
   variant_name: String,
@@ -1293,12 +1319,21 @@ fn emit_response_arm(
   body_expr body_expr: String,
   content_type_header content_type_header: option.Option(String),
   header_specs header_specs: List(HeaderSpec),
+  is_default is_default: Bool,
 ) -> se.StringBuilder {
-  let pattern_args = case has_data, has_headers {
-    True, True -> "(data, hdrs)"
-    True, False -> "(data)"
-    False, True -> "(hdrs)"
-    False, False -> ""
+  let pattern_args = case is_default, has_data, has_headers {
+    False, True, True -> "(data, hdrs)"
+    False, True, False -> "(data)"
+    False, False, True -> "(hdrs)"
+    False, False, False -> ""
+    True, True, True -> "(status, data, hdrs)"
+    True, True, False -> "(status, data)"
+    True, False, True -> "(status, hdrs)"
+    True, False, False -> "(status)"
+  }
+  let status_expr = case is_default {
+    True -> "status"
+    False -> status_int
   }
   let headers_expr = headers_slot_expr(content_type_header, header_specs)
   sb
@@ -1308,7 +1343,7 @@ fn emit_response_arm(
       <> variant_name
       <> pattern_args
       <> " -> ServerResponse(status: "
-      <> status_int
+      <> status_expr
       <> ", body: "
       <> body_expr
       <> ", headers: "

--- a/test/fixtures/server_default_response_status.yaml
+++ b/test/fixtures/server_default_response_status.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Server Default Response Status Test API
+  version: 1.0.0
+paths:
+  /artifacts/{id}:
+    delete:
+      operationId: deleteArtifact
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+        default:
+          description: any error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: ok
+        default:
+          description: any error
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string

--- a/test/oaspec_server_codegen_test.gleam
+++ b/test/oaspec_server_codegen_test.gleam
@@ -41,6 +41,8 @@ pub fn response_types_and_server_outputs_test() {
   let _ = support.server_empty_response_body_generates_case()
   let _ = support.client_default_response_only_generates_case()
   let _ = support.server_default_response_only_generates_case()
+  let _ = support.server_default_response_carries_status_field_case()
+  let _ = support.client_default_response_passes_status_through_case()
   let _ = support.server_router_uses_underscored_unused_route_args_case()
 }
 

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -13133,6 +13133,79 @@ pub fn server_default_response_only_generates_case() {
   list.length(server_files) |> should.not_equal(0)
 }
 
+pub fn server_default_response_carries_status_field_case() {
+  // Issue #483: the OpenAPI `default` response variant must carry the
+  // runtime status code as its first positional field, and the router
+  // must pass that bound `status` straight through to the outgoing
+  // ServerResponse instead of pinning every `default` branch to 500.
+  let ctx = make_ctx("test/fixtures/server_default_response_status.yaml")
+  let type_files = types.generate(ctx)
+  let assert Ok(response_types_file) =
+    list.find(type_files, fn(f) { f.path == "response_types.gleam" })
+  let response_types_content = response_types_file.content
+  let files = server_gen.generate(ctx)
+
+  // With body: variant signature is `Foo(Int, types.Error)`.
+  string.contains(
+    response_types_content,
+    "DeleteArtifactResponseDefault(Int, types.Error)",
+  )
+  |> should.be_true()
+  // Empty default: signature collapses to `Foo(Int)`.
+  string.contains(response_types_content, "ListThingsResponseDefault(Int)")
+  |> should.be_true()
+
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+  let router_content = router_file.content
+
+  // Router pattern binds `status` and forwards it as the outgoing
+  // status — no more hardcoded 500.
+  string.contains(
+    router_content,
+    "DeleteArtifactResponseDefault(status, data) -> ServerResponse(status: status,",
+  )
+  |> should.be_true()
+  string.contains(
+    router_content,
+    "ListThingsResponseDefault(status) -> ServerResponse(status: status,",
+  )
+  |> should.be_true()
+  // The previous shape — `status: 500` for the default branch — must
+  // be gone for these operations.
+  string.contains(
+    router_content,
+    "DeleteArtifactResponseDefault(data) -> ServerResponse(status: 500,",
+  )
+  |> should.be_false()
+}
+
+pub fn client_default_response_passes_status_through_case() {
+  // Issue #483: the client decoder must capture the actual runtime
+  // status int and pass it as the first arg to the generated
+  // `XxxResponseDefault(...)` variant, instead of dropping it on the
+  // floor.
+  let ctx = make_ctx("test/fixtures/server_default_response_status.yaml")
+  let files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // Default branch binds `status` (instead of `_`) and threads it.
+  string.contains(content, "status -> {")
+  |> should.be_true()
+  string.contains(
+    content,
+    "Ok(response_types.DeleteArtifactResponseDefault(status, decoded))",
+  )
+  |> should.be_true()
+  string.contains(
+    content,
+    "Ok(response_types.ListThingsResponseDefault(status))",
+  )
+  |> should.be_true()
+}
+
 // ===========================================================================
 // Validation for edge-case fixtures
 // ===========================================================================


### PR DESCRIPTION
## Summary

The OpenAPI `default` response is the catch-all for any status code not declared explicitly. The generator emitted a `Default` variant with no status field and the router pinned every default branch to 500, so a handler that wanted to surface 401/404/... through the default branch could not. Symmetrically, the client decoder discarded the actual response status when matching the `_` arm.

This PR adds a runtime `Int` status field to the generated `XxxResponseDefault(...)` variant and threads it through both router and client decoder. **It is a breaking change** for any handler that constructs the Default variant (or caller that pattern-matches it).

## Changes

- `src/oaspec/internal/codegen/ir.gleam` — new IR variant `VariantDefault(name, inner_type: Option(String), headers_type: Option(String))`. Renders as `Foo(Int [, body] [, headers])`.
- `src/oaspec/internal/codegen/ir_render.gleam` — render the new variant.
- `src/oaspec/internal/codegen/ir_build.gleam` — `response_variant` now dispatches on `DefaultStatus`, building `VariantDefault` with the same per-content-type body resolution as the existing variants. Extracts `response_inner_type` for reuse.
- `src/oaspec/internal/codegen/server.gleam` — `emit_response_arm` gains an `is_default: Bool` parameter. When True the case pattern grows a leading `status` binding (`Default(status, data)` etc.) and the outgoing `ServerResponse.status` uses that bound `status` instead of the precomputed `status_int` (always 500).
- `src/oaspec/internal/codegen/client_response.gleam` — new helpers `status_branch_pattern` and `prepend_default_status`. The default branch binds `status -> { ... }` (instead of `_`) and the variant constructor receives `status` as its first arg.
- `test/fixtures/server_default_response_status.yaml` — fixture covering both shapes (with body + empty default).
- `test/oaspec_support.gleam` — two new test cases:
  - `server_default_response_carries_status_field_case` asserts the new `Foo(Int, ...)` shape and that the previous `status: 500` literal is gone.
  - `client_default_response_passes_status_through_case` asserts the client binds `status` and threads it.
- `integration_test/run.sh` — Step 10c compiles a generated server whose handler returns 401/503 through the default branch with `gleam build --warnings-as-errors`.
- `README.md` — bumps the test-fixture count from 259 → 260.
- `CHANGELOG.md` — `Breaking` block under `Unreleased` describing the migration.

## Design Decisions

- **Single new IR kind, not four.** `VariantDefault` carries `Option(inner_type)` and `Option(headers_type)` so it covers all four shapes (no body / body / headers / body+headers) without quadrupling the IR's variant constructors.
- **Positional, not labeled.** All other response variants in the IR are positional (`VariantWithType(..., inner_type)` renders as `Foo(Bar)`). The Default variant matches that style — `Foo(Int)`, `Foo(Int, Body)`, etc. The Int is always first so a reader who pattern-matches the variant gets a uniform "status comes first" rule.
- **Required-field fallback unchanged.** This PR only changes the `default` codepath; concrete-status branches (200/204/...) keep their existing shape and the router's literal `status: 200` etc.
- **No compat shim.** The variant arity changes. A shim variant (`DefaultWithStatus`) was considered and rejected: it would double the API surface for every operation that uses `default`, and the user has to migrate handlers anyway because the spec semantics demand it.

## Test plan

- [x] `just all` passes (format-check, typecheck, build, unit tests, shellspec, integration including the new Step 10c, escript, smoke)
- [x] Unit tests assert the new emitted shape on both server (router pattern + ServerResponse status) and client (decoder pattern + variant constructor)
- [x] Integration test compiles a server whose handler returns `Default(401, ...)` and `Default(503)` through `--warnings-as-errors`

Closes #483