### PR TITLE
docs(README): clarify server-side security: is parsed but not enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Added
 
+- **docs(README)**: clarify that server-side OpenAPI `security:`
+  declarations are parsed but **not enforced** by the generated
+  router. The previous Mode-Specific Support table listed
+  `Security` as `yes` for the server, which spec authors
+  reasonably read as "the router emits a 401 when the request
+  lacks the declared credentials" — the router does no such
+  check; handlers must verify auth themselves. The table entry
+  now reads `parsed (not enforced)`, the prose support list and
+  the OpenAPI Support coverage paragraph distinguish client vs.
+  server behaviour explicitly, and a new `Server security model`
+  subsection documents the two practical options (enforce in the
+  handler, or wrap `router.route/6` in an outer auth-checking
+  adapter). No source code change in this entry; the underlying
+  router behaviour is unchanged. (#484)
+
 - **docs(README)**: the main README now ships an inline canonical
   `mist` server-adapter snippet (mirroring the existing inline
   Client transport snippet) so server users can reach a runnable

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ gen/my_api_client/
 - Typed response variants, typed response headers, and `$ref` /
   `default` responses
 - Security: `apiKey`, HTTP (bearer/basic/digest), OAuth2, OpenID Connect
-  (bearer token attachment)
+  (bearer token attachment on the client; **parsed but not enforced** on
+  the server — see [Server security model](#server-security-model))
 
 Generation stops with a diagnostic for:
 
@@ -629,7 +630,7 @@ Coverage is strongest in these areas:
 - Parameters: path, query, header, and cookie parameters, including array serialization (`style: form`, `style: pipeDelimited`, `style: spaceDelimited`) and objects via `style: deepObject`
 - Request bodies: `application/json`, `text/plain`, `application/x-www-form-urlencoded`, and `multipart/form-data`
 - Responses: typed status-code variants, `$ref` responses, `default` responses, typed response headers, and text or binary passthrough cases
-- Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code.
+- Security: `apiKey` (header, query, cookie), HTTP auth (bearer, basic, digest), OAuth2, and OpenID Connect. **Client-side**: the generated client attaches credentials per the `security:` declaration on each operation, walking OR-of-AND alternatives and applying the first satisfied one. For OAuth2 and OpenID Connect, the generated client attaches a bearer token to requests; token acquisition, refresh, and flow execution are outside the generated code. **Server-side**: the `security:` declaration on an operation is parsed but **not enforced** by the generated router — the handler is invoked regardless of whether the request carries the declared credentials. Handlers must check `Authorization` / `X-Api-Key` / cookie themselves and return their own 401. See [Server security model](#server-security-model) below.
 - Generation safety: name collision handling, keyword escaping, validation guards, and capability errors with clear failure modes
 
 ### `format: byte` and `format: binary`
@@ -709,7 +710,47 @@ imports, and each operation forwards to `handlers.<op_name>(req)`.
 | `multipart/form-data` | restricted | yes | Server: must be sole content type; only primitive scalar fields or arrays of primitive scalars |
 | `text/plain` request body | yes | yes | Treated as a single `String` field on the request |
 | `application/octet-stream` request body | yes | yes | Treated as raw `BitArray`/binary on the request |
-| Security (apiKey, HTTP, OAuth2, OpenID Connect) | yes | yes | Client attaches credentials via config; OAuth2/OpenID Connect: bearer token only |
+| Security (apiKey, HTTP, OAuth2, OpenID Connect) | parsed (not enforced) | yes | Client attaches credentials via config; OAuth2/OpenID Connect: bearer token only. **Server-side**: see [Server security model](#server-security-model) — the spec's `security:` requirement is parsed but the generated router does not emit a 401 for missing/invalid credentials. Handlers must enforce auth themselves. (#484) |
+
+### Server security model
+
+Spec authors who declare `security:` on an operation expect "this
+endpoint requires auth". The current oaspec server codegen
+**does not enforce** that requirement: it parses the security
+declaration during validation (so a typo in a scheme name or a
+reference to an undefined `securityScheme` is still caught at
+generation time) but emits no auth check in the generated router.
+A request that omits the declared `Authorization` / `X-Api-Key` /
+session cookie reaches the handler unchanged.
+
+This is intentional in this release — picking a single auth
+enforcement model would prescribe more policy than the rest of
+the codegen does — but it is also a sharp edge worth calling out.
+Until the generator gains a verifier hook, server users have two
+options:
+
+1. **Enforce in the handler.** The router already passes the full
+   `headers` and (for cookie-based schemes) the path / query /
+   body pieces it receives, so the handler can read
+   `dict.get(headers, "authorization")` etc. and short-circuit
+   with a 401 response variant before touching domain logic.
+   Generated `XxxResponse` types include any explicit `"401":`
+   variants, and after #483 the `default` response variant carries
+   a runtime `Int` so a single `Default(401, ...)` arm can cover
+   the catch-all 401 case for any operation.
+
+2. **Enforce in an outer adapter layer.** Wrap the generated
+   `router.route/6` in a thin auth-checking function that runs
+   before dispatch — typically the same place where the framework
+   adapter (`mist`, `wisp`, …) lives. This keeps the per-operation
+   handlers focused on domain logic and centralises the auth
+   policy in one place.
+
+Tracking issue: [#484](https://github.com/nao1215/oaspec/issues/484).
+Future work may add an opt-in verifier signature on the generated
+`State` (e.g. `verify_security: fn(scheme, value) -> Result(...)`)
+so the router can emit the 401 itself; that direction is not yet
+committed to.
 
 ## Library API
 


### PR DESCRIPTION
## Summary

Issue #484 reports that the Mode-Specific Support table listed Security as `yes` on both server and client, but the generated server router emits no auth check — `security:` on an operation is silently dropped, and a request without the declared `Authorization` / `X-Api-Key` reaches the handler unchanged.

The user explicitly asks for either option 1 ("document the current contract") or option 2 ("thread security values into the request type"). This PR ships option 1; option 2/3 (actual enforcement, e.g. a verifier hook on `State`) is still tracked under #484 for future work.

## Changes

- `README.md` — three coordinated edits so the documented contract matches the emitted code:
  - Mode-Specific Support table cell for Security: `yes` → `parsed (not enforced)`, with an inline note linking to the new subsection.
  - OpenAPI Support → coverage list: split into client-side ("attaches credentials per `security:`") and server-side ("parsed but not enforced; handlers must verify auth themselves").
  - `Supported input` upfront list: same client/server split, condensed to one line.
  - New `### Server security model` subsection under Mode-Specific Support that explains *why* the gap exists (picking a single enforcement model would prescribe more policy than the rest of the codegen does) and gives users two concrete workarounds: enforce inside the handler (using the `headers` already passed to `router.route/6`, plus the post-#483 `Default(Int, ...)` shape for catch-all 401s), or wrap `router.route/6` in an outer auth-checking adapter at the framework boundary. Closes by pointing at #484 as the tracking issue for future verifier-hook work.
- `CHANGELOG.md` — `Added` entry under `Unreleased` describing the doc clarification, explicitly noting "no source code change in this entry; the underlying router behaviour is unchanged".

## Design Decisions

- **Docs-only, no codegen change.** Issue #484 spells out a spectrum: option 1 (document) → option 2 (thread auth values into the request type) → option 3 (verifier hook on `State`). Option 1 closes the documentation gap without committing the project to a specific enforcement model. Option 2 / 3 are bigger architectural changes that deserve their own design discussion; doing them now would also delay the bug-fix release.
- **Don't close #484.** The actual router behaviour is unchanged, so the bug — the router not emitting 401 — is still open. The PR body's `Refs #484` (rather than `Closes #484`) keeps the issue available as the tracking handle for the future verifier-hook work.
- **Cross-link to #483.** The "Server security model" subsection explicitly mentions that `Default(Int, ...)` (from the just-merged #483) makes the manual handler-side enforcement substantially cleaner — a single `Default(401, ...)` arm now covers the catch-all 401 case for any operation.

## Test plan

- [x] `just all` passes (no source changes; this is here as a sanity check that the doc edits did not accidentally desync `scripts/check_sync.sh` counters)
- [x] Manual: rendered the README and confirmed the new subsection links land on the right anchor

Refs #484