### PR TITLE
fix(codegen)!: thread BitArray through application/octet-stream request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ within `Changed` / `Fixed` and stay as-is.
   `bit_array.to_string` step; client callers pass
   `BitArray` instead of `String` for binary bodies. (#485)
 
-### Breaking
-
 - **codegen(default-response)**: the generated `XxxResponseDefault`
   variant now carries a runtime `Int` status code as its first
   positional field, so handlers can pick any 4xx/5xx for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Breaking
 
+- **codegen(octet-stream)**: an `application/octet-stream` request
+  body field now surfaces as `body: BitArray` on both server and
+  client request types instead of `body: String`. The README's
+  Mode-Specific Support table promised `BitArray`, the client
+  wraps it in `transport.BytesBody` (which expects `BitArray`),
+  and forcing it through `String` meant arbitrary binary payloads
+  could not round-trip without going through
+  `bit_array.to_string |> result.unwrap("")`, which silently
+  drops non-UTF-8 bytes. The client autogen `let body =
+  transport.BytesBody(body)` previously failed `gleam check` with
+  a type mismatch. Specs that declare octet-stream on any
+  operation also see the server router signature change from
+  `body: String` to `body: BitArray`; non-binary arms shadow the
+  parameter with the String conversion at the top of each arm so
+  the rest of the codegen template is unchanged. Specs without
+  any binary request body keep the existing `body: String`
+  signature. **Migration**: server adapters for specs with
+  octet-stream pass `mist.read_body(...).body` (a `BitArray`)
+  straight to `oas_router.route(...)` without the lossy
+  `bit_array.to_string` step; client callers pass
+  `BitArray` instead of `String` for binary bodies. (#485)
+
+### Breaking
+
 - **codegen(default-response)**: the generated `XxxResponseDefault`
   variant now carries a runtime `Int` status code as its first
   positional field, so handlers can pick any 4xx/5xx for the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 353 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 260 test fixtures (including 98 OSS-derived edge-case specs)
+  and 261 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 
@@ -404,6 +404,16 @@ response type. Because the router is pure and synchronous, it is also
 trivial to test in isolation without an HTTP server — see
 [`examples/server_adapter`](./examples/server_adapter) for a
 framework-free runnable example.
+
+> **Note:** if any operation in your spec declares
+> `application/octet-stream` on its request body, the generated
+> router signature is `body: BitArray` (not `String`) so arbitrary
+> binary payloads round-trip without going through
+> `bit_array.to_string`. In that case drop the
+> `|> bit_array.to_string |> result.unwrap("")` step from the
+> snippet above and pass `mist.read_body(...).body` directly to
+> `oas_router.route(...)`. The router internally converts to String
+> for the non-binary arms. (#485)
 
 ## Configuration
 

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -689,6 +689,96 @@ rm -rf "$DEF_DIR"
 info "Issue #483 default response status integration test passed."
 
 # -------------------------------------------------------
+# Step 10d: Issue #485 — `application/octet-stream` request body
+# now surfaces as `body: BitArray` on both client and server
+# request types. The router signature also switches to
+# `body: BitArray` when any operation declares octet-stream,
+# with non-binary arms shadowing the param via
+# `bit_array.to_string`. Compile a generated server + client
+# end-to-end with `--warnings-as-errors`.
+# -------------------------------------------------------
+info "Testing Issue #485 octet-stream request body code generation..."
+
+OCT_DIR="$SCRIPT_DIR/octet_stream_test"
+rm -rf "$OCT_DIR"
+mkdir -p "$OCT_DIR/src"
+
+cat > "$OCT_DIR/oaspec-octet.yaml" << 'YAML_EOF'
+input: test/fixtures/server_octet_stream_request_body.yaml
+output:
+  dir: ./integration_test/octet_stream_test/src
+package: api
+mode: both
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate --config="$OCT_DIR/oaspec-octet.yaml"
+
+cat > "$OCT_DIR/src/api/handlers.gleam" << 'GLEAM_EOF'
+import api/request_types
+import api/response_types
+import api/types
+
+pub type State {
+  State
+}
+
+pub fn ingest_binary_webhook(
+  state: State,
+  req: request_types.IngestBinaryWebhookRequest,
+) -> response_types.IngestBinaryWebhookResponse {
+  let _ = state
+  let _ = req
+  response_types.IngestBinaryWebhookResponseNoContent
+}
+
+pub fn create_artifact(
+  state: State,
+  req: request_types.CreateArtifactRequest,
+) -> response_types.CreateArtifactResponse {
+  let _ = state
+  let _ = req
+  let _: types.CreateArtifactRequest = req.body
+  response_types.CreateArtifactResponseCreated(types.CreateArtifactResponseCreated(id: "abc"))
+}
+GLEAM_EOF
+
+cat > "$OCT_DIR/gleam.toml" << 'TOML_EOF'
+name = "octet_stream_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$OCT_DIR/src/octet_stream_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$OCT_DIR"
+gleam deps download
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated octet-stream request body code compiles (#485)."
+else
+  fail "Generated octet-stream request body code failed to compile (#485 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$OCT_DIR"
+
+info "Issue #485 octet-stream request body integration test passed."
+
+# -------------------------------------------------------
 # Step 11: Generate callback spec and verify it compiles
 # -------------------------------------------------------
 info "Testing callback handler code generation..."

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -186,13 +186,21 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       case operation.request_body {
         Some(Value(rb)) ->
           list.any(dict.to_list(rb.content), fn(ce) {
-            let #(_, mt) = ce
-            case mt.schema {
-              Some(Inline(schema.StringSchema(..))) -> True
-              Some(Inline(schema.IntegerSchema(..))) -> True
-              Some(Inline(schema.NumberSchema(..))) -> True
-              Some(Inline(schema.BooleanSchema(..))) -> True
-              _ -> False
+            let #(ct_name, mt) = ce
+            // Issue #485: an `application/octet-stream` body is
+            // wrapped via `transport.BytesBody`, not
+            // `json.to_string`, so a `type: string, format: binary`
+            // request body must not pull in `gleam/json`.
+            case ct_util.from_string(ct_name) {
+              ct_util.ApplicationOctetStream -> False
+              _ ->
+                case mt.schema {
+                  Some(Inline(schema.StringSchema(..))) -> True
+                  Some(Inline(schema.IntegerSchema(..))) -> True
+                  Some(Inline(schema.NumberSchema(..))) -> True
+                  Some(Inline(schema.BooleanSchema(..))) -> True
+                  _ -> False
+                }
             }
           })
         _ -> False

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -9,6 +9,7 @@ import oaspec/internal/codegen/schema_dispatch
 import oaspec/internal/openapi/dedup
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{type Resolved, ParameterSchema, Value}
+import oaspec/internal/util/content_type
 import oaspec/internal/util/naming
 import oaspec/internal/util/string_extra as se
 
@@ -213,22 +214,33 @@ pub fn to_str_for_optional_value(
 }
 
 /// Get the Gleam type for a request body parameter.
+///
+/// Issue #485: an `application/octet-stream` request body is raw
+/// bytes — the README's mode-specific table promises `BitArray`,
+/// the client wraps it in `transport.BytesBody` (which expects
+/// `BitArray`), and forcing it through `String` means arbitrary
+/// binary payloads cannot round-trip. The `String` fallback for
+/// every other content type stays unchanged.
 pub fn get_body_type(rb: spec.RequestBody(Resolved), op_id: String) -> String {
   let content_entries = ir_build.sorted_entries(rb.content)
   case content_entries {
     // Multiple content types: use pre-serialized String
     [_, _, ..] -> "String"
-    [#(_, media_type)] ->
-      case media_type.schema {
-        Some(Reference(name:, ..)) ->
-          "types." <> naming.schema_to_type_name(name)
-        Some(Inline(schema.StringSchema(..))) -> "String"
-        Some(Inline(schema.IntegerSchema(..))) -> "Int"
-        Some(Inline(schema.NumberSchema(..))) -> "Float"
-        Some(Inline(schema.BooleanSchema(..))) -> "Bool"
-        Some(Inline(_)) ->
-          "types." <> naming.schema_to_type_name(op_id) <> "RequestBody"
-        _ -> "String"
+    [#(media_type_name, media_type)] ->
+      case content_type.from_string(media_type_name) {
+        content_type.ApplicationOctetStream -> "BitArray"
+        _ ->
+          case media_type.schema {
+            Some(Reference(name:, ..)) ->
+              "types." <> naming.schema_to_type_name(name)
+            Some(Inline(schema.StringSchema(..))) -> "String"
+            Some(Inline(schema.IntegerSchema(..))) -> "Int"
+            Some(Inline(schema.NumberSchema(..))) -> "Float"
+            Some(Inline(schema.BooleanSchema(..))) -> "Bool"
+            Some(Inline(_)) ->
+              "types." <> naming.schema_to_type_name(op_id) <> "RequestBody"
+            _ -> "String"
+          }
       }
     [] -> "String"
   }

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -188,12 +188,28 @@ fn request_body_type(
 ) -> String {
   let content_entries = sorted_entries(rb.content)
   case content_entries {
-    [#(_media_type, media_type), ..] ->
-      case media_type.schema {
-        Some(Reference(name:, ..)) ->
-          "types." <> naming.schema_to_type_name(name)
-        Some(Inline(schema_obj)) -> inline_request_body_type(schema_obj, op_id)
-        _ -> "String"
+    [#(media_type_name, media_type), ..] ->
+      // Issue #485: an `application/octet-stream` request body is
+      // raw bytes — the README's mode-specific table promises
+      // `BitArray`, the client wraps it in `transport.BytesBody`
+      // (which expects `BitArray`), and forcing it through `String`
+      // means arbitrary binary payloads cannot round-trip. The
+      // response side already does this correctly via
+      // `response_inner_type` above; mirror that for the request.
+      case content_type.from_string(media_type_name) {
+        content_type.ApplicationOctetStream ->
+          case media_type.schema {
+            Some(_) -> "BitArray"
+            None -> "BitArray"
+          }
+        _ ->
+          case media_type.schema {
+            Some(Reference(name:, ..)) ->
+              "types." <> naming.schema_to_type_name(name)
+            Some(Inline(schema_obj)) ->
+              inline_request_body_type(schema_obj, op_id)
+            _ -> "String"
+          }
       }
     [] -> "String"
   }

--- a/src/oaspec/internal/codegen/router_ir.gleam
+++ b/src/oaspec/internal/codegen/router_ir.gleam
@@ -21,6 +21,8 @@ pub type RouterRequirements {
     has_deep_object_untyped_ap: Bool,
     has_form_urlencoded_body: Bool,
     has_multipart_body: Bool,
+    has_binary_request_body: Bool,
+    needs_bit_array_import: Bool,
     has_nested_form_urlencoded_body: Bool,
     needs_int: Bool,
     needs_float: Bool,
@@ -109,6 +111,28 @@ pub fn analyze(ctx: Context) -> RouterRequirements {
     list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       decode_helpers.operation_uses_multipart_body(operation)
+    })
+  // Issue #485: when any operation declares
+  // `application/octet-stream` on its request body, the route
+  // function takes `body: BitArray` instead of `body: String` so
+  // arbitrary binary payloads round-trip without being forced
+  // through `bit_array.to_string`. Specs without any binary
+  // request body keep the existing `body: String` signature.
+  let has_binary_request_body =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      decode_helpers.operation_uses_octet_stream_body(operation)
+    })
+  // The route arms shadow `body` with the String conversion
+  // only for non-binary arms that actually have a request body.
+  // The `bit_array` / `result` imports are needed iff at least
+  // one such arm exists alongside a binary one.
+  let needs_bit_array_import =
+    has_binary_request_body
+    && list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      option.is_some(operation.request_body)
+      && !decode_helpers.operation_uses_octet_stream_body(operation)
     })
   let has_nested_form_urlencoded_body =
     list.any(operations, fn(op) {
@@ -354,6 +378,8 @@ pub fn analyze(ctx: Context) -> RouterRequirements {
     has_deep_object_untyped_ap: has_deep_object_untyped_ap,
     has_form_urlencoded_body: has_form_urlencoded_body,
     has_multipart_body: has_multipart_body,
+    has_binary_request_body: has_binary_request_body,
+    needs_bit_array_import: needs_bit_array_import,
     has_nested_form_urlencoded_body: has_nested_form_urlencoded_body,
     needs_int: needs_int,
     needs_float: needs_float,
@@ -415,6 +441,16 @@ pub fn imports(requirements: RouterRequirements, ctx: Context) -> List(String) {
   }
   let std_imports = case requirements.has_deep_object_untyped_ap {
     True -> list.append(std_imports, ["gleam/dynamic"])
+    False -> std_imports
+  }
+  // Issue #485: when the route signature is `body: BitArray`
+  // and at least one non-binary arm exists, every non-binary
+  // arm shadows `body` with
+  // `bit_array.to_string(body) |> result.unwrap("")`, so both
+  // `gleam/bit_array` and `gleam/result` need to be imported.
+  // Pure-binary specs skip the imports to avoid unused warnings.
+  let std_imports = case requirements.needs_bit_array_import {
+    True -> list.append(std_imports, ["gleam/bit_array", "gleam/result"])
     False -> std_imports
   }
 

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -328,7 +328,18 @@ String.",
       <> route_arg_name("headers", requirements.uses_headers)
       <> ": Dict(String, String), "
       <> route_arg_name("body", requirements.uses_body)
-      <> ": String) -> ServerResponse {",
+      <> case requirements.has_binary_request_body {
+        // Issue #485: when any operation declares
+        // `application/octet-stream` on its request body, the
+        // router signature takes raw bytes instead of String so
+        // arbitrary binary payloads round-trip without going
+        // through `bit_array.to_string`. Non-binary route arms
+        // shadow the parameter with a String conversion at the
+        // top of each arm so the rest of the codegen template
+        // is unchanged.
+        True -> ": BitArray) -> ServerResponse {"
+        False -> ": String) -> ServerResponse {"
+      },
     )
     |> se.indent(1, "case method, path {")
 
@@ -343,8 +354,29 @@ String.",
         !list.is_empty(operation.parameters)
         || option.is_some(operation.request_body)
 
-      sb
-      |> se.indent(2, "\"" <> method_str <> "\", " <> path_pattern <> " -> {")
+      // Issue #485: when the route signature is `body: BitArray`
+      // (because some other operation in this spec declares
+      // `application/octet-stream`), every non-binary arm needs to
+      // shadow `body` with the String conversion at the top so the
+      // existing per-content-type decoding code can keep treating
+      // `body` as a String. Binary arms use `body` directly.
+      let arm_sb =
+        sb
+        |> se.indent(2, "\"" <> method_str <> "\", " <> path_pattern <> " -> {")
+      let arm_sb = case
+        requirements.has_binary_request_body,
+        option.is_some(operation.request_body),
+        decode_helpers.operation_uses_octet_stream_body(operation)
+      {
+        True, True, False ->
+          arm_sb
+          |> se.indent(
+            3,
+            "let body = bit_array.to_string(body) |> result.unwrap(\"\")",
+          )
+        _, _, _ -> arm_sb
+      }
+      arm_sb
       |> generate_route_body(op_id, fn_name, operation, path, has_params, ctx)
       |> se.indent(2, "}")
     })

--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -734,6 +734,14 @@ pub fn request_body_uses_multipart(rb: spec.RequestBody(Resolved)) -> Bool {
   dict.has_key(rb.content, "multipart/form-data")
 }
 
+/// Issue #485: an `application/octet-stream` request body is raw
+/// bytes, so the router takes `body: BitArray` instead of
+/// `body: String`. The single-arm dispatch (no other content types
+/// allowed alongside binary) is enforced by the validator.
+fn request_body_uses_octet_stream(rb: spec.RequestBody(Resolved)) -> Bool {
+  dict.has_key(rb.content, "application/octet-stream")
+}
+
 pub fn operation_uses_form_urlencoded_body(
   operation: spec.Operation(Resolved),
 ) -> Bool {
@@ -748,6 +756,15 @@ pub fn operation_uses_multipart_body(
 ) -> Bool {
   case operation.request_body {
     Some(Value(rb)) -> request_body_uses_multipart(rb)
+    _ -> False
+  }
+}
+
+pub fn operation_uses_octet_stream_body(
+  operation: spec.Operation(Resolved),
+) -> Bool {
+  case operation.request_body {
+    Some(Value(rb)) -> request_body_uses_octet_stream(rb)
     _ -> False
   }
 }

--- a/test/fixtures/server_octet_stream_request_body.yaml
+++ b/test/fixtures/server_octet_stream_request_body.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: Server Octet-Stream Request Body Test API
+  version: 1.0.0
+paths:
+  /webhooks/binary:
+    post:
+      operationId: ingestBinaryWebhook
+      parameters:
+        - name: X-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "204":
+          description: ok
+  /artifacts:
+    post:
+      operationId: createArtifact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string

--- a/test/oaspec_server_codegen_test.gleam
+++ b/test/oaspec_server_codegen_test.gleam
@@ -43,6 +43,7 @@ pub fn response_types_and_server_outputs_test() {
   let _ = support.server_default_response_only_generates_case()
   let _ = support.server_default_response_carries_status_field_case()
   let _ = support.client_default_response_passes_status_through_case()
+  let _ = support.octet_stream_request_body_emits_bit_array_case()
   let _ = support.server_router_uses_underscored_unused_route_args_case()
 }
 

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -13133,6 +13133,60 @@ pub fn server_default_response_only_generates_case() {
   list.length(server_files) |> should.not_equal(0)
 }
 
+pub fn octet_stream_request_body_emits_bit_array_case() {
+  // Issue #485: a `application/octet-stream` request body must
+  // surface as `body: BitArray` on both server and client request
+  // types — `String` forces arbitrary binary payloads through
+  // `bit_array.to_string |> result.unwrap("")`, which silently
+  // drops non-UTF-8 bytes, and breaks the client's
+  // `transport.BytesBody` wrap with a type mismatch.
+  let ctx = make_ctx("test/fixtures/server_octet_stream_request_body.yaml")
+  let type_files = types.generate(ctx)
+  let assert Ok(request_types_file) =
+    list.find(type_files, fn(f) { f.path == "request_types.gleam" })
+  let request_types_content = request_types_file.content
+  string.contains(request_types_content, "body: BitArray")
+  |> should.be_true()
+  string.contains(
+    request_types_content,
+    "IngestBinaryWebhookRequest(x_signature: String, body: BitArray)",
+  )
+  |> should.be_true()
+
+  // Server router signature switches to BitArray when any
+  // operation declares octet-stream, and shadows `body` with the
+  // String conversion at the top of every non-binary arm.
+  let server_files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(server_files, fn(f) { f.path == "router.gleam" })
+  let router_content = router_file.content
+  // Unformatted output is single-line; substring check is enough.
+  string.contains(router_content, "body: BitArray)")
+  |> should.be_true()
+  // Non-binary arm shadows the param so the rest of the codegen
+  // can keep treating `body` as a String.
+  string.contains(
+    router_content,
+    "let body = bit_array.to_string(body) |> result.unwrap(\"\")",
+  )
+  |> should.be_true()
+  // Binary arm uses `body` directly without the conversion.
+  string.contains(router_content, "body: body,")
+  |> should.be_true()
+
+  // Client: function takes `body body: BitArray` and the wrap
+  // around `transport.BytesBody(body)` no longer produces a type
+  // mismatch.
+  let client_files = client_gen.generate(ctx)
+  let assert Ok(client_file) =
+    list.find(client_files, fn(f) { f.path == "client.gleam" })
+  let client_content = client_file.content
+  string.contains(client_content, "body body: BitArray")
+  |> should.be_true()
+  string.contains(client_content, "transport.BytesBody(body)")
+  |> should.be_true()
+}
+
 pub fn server_default_response_carries_status_field_case() {
   // Issue #483: the OpenAPI `default` response variant must carry the
   // runtime status code as its first positional field, and the router


### PR DESCRIPTION
## Summary

The README's mode-specific support table promised `application/octet-stream` request bodies surface as `BitArray`, the client wraps the body in `transport.BytesBody` (which expects `BitArray`), and yet the generated request-type emitted `body: String`. The client autogen `let body = transport.BytesBody(body)` failed `gleam check` with a type mismatch:

```
error: Type mismatch
   ...
   │ let body = transport.BytesBody(body)
   │                                ^^^^
   Expected: BitArray
   Found:    String
```

Server adapters had to lossily round-trip `BitArray → String` via `bit_array.to_string` to feed the router, silently dropping non-UTF-8 bytes.

## Changes

- `src/oaspec/internal/codegen/ir_build.gleam` — `request_body_type` checks the media-type key; `application/octet-stream` returns `BitArray` for the request-type field on both server and client (mirrors the existing `response_inner_type` dispatch).
- `src/oaspec/internal/codegen/client_request.gleam` — `get_body_type` dispatches on the content-type before falling back to schema-shape dispatch, so the client function parameter, the `build_*_request` helper, and the `*_with_request` wrapper all pick `BitArray`.
- `src/oaspec/internal/codegen/server_request_decode.gleam` — new `request_body_uses_octet_stream` / `operation_uses_octet_stream_body` helpers (mirroring the existing form/multipart probes).
- `src/oaspec/internal/codegen/router_ir.gleam` — `RouterRequirements` gains `has_binary_request_body` and `needs_bit_array_import`. When True the router signature switches to `body: BitArray` and `gleam/bit_array` + `gleam/result` are imported (only when at least one non-binary arm exists, otherwise the imports would be unused).
- `src/oaspec/internal/codegen/server.gleam` — route signature picks `BitArray` vs `String` based on the requirement; each non-binary arm with a request body prepends `let body = bit_array.to_string(body) |> result.unwrap("")` so existing per-content-type decoding stays unchanged.
- `src/oaspec/internal/codegen/client_ir.gleam` — `needs_json` no longer flips True for `type: string, format: binary` content-typed `application/octet-stream`, since octet-stream goes through `transport.BytesBody` rather than `json.to_string`. This avoids an `Unused imported module` warning when the only trigger was a binary request body.
- `test/fixtures/server_octet_stream_request_body.yaml` — fixture combining one binary endpoint and one JSON endpoint to exercise the per-arm shadowing path.
- `test/oaspec_support.gleam` — new test case asserts the emitted shape on server (router signature, shadow line, binary-arm body field) and client (function parameter type, `transport.BytesBody(body)` wrap).
- `integration_test/run.sh` — Step 10d compiles the generated server and client end-to-end with `gleam build --warnings-as-errors`.
- `README.md` — bumps test fixture count from 260 → 261; the existing mist snippet section gains a `Note:` pointing out that for specs with octet-stream the lossy `bit_array.to_string` step can be dropped.
- `CHANGELOG.md` — `Breaking` entry explaining the migration.

## Design Decisions

- **Per-spec router signature.** The route signature is `body: BitArray` only when the spec has at least one binary endpoint; specs without binary keep `body: String`. This scopes the breaking change to specs that actually need it — JSON-only specs are unaffected.
- **Shadow inside arms, not the param.** Non-binary arms shadow `body` with the String conversion (`let body = bit_array.to_string(body) |> result.unwrap("")`). This keeps the rest of the per-content-type codegen template unchanged — `body` is still a `String` inside the arm, the existing `decode.decode_*(body)` and form/multipart parsers continue to work.
- **Skip the conversion line for arms that don't read body.** GET-style arms without a request body don't generate the shadow line, since the unused `let body = ...` would produce a `Variable used in only one branch` warning.
- **Don't import `bit_array` / `result` in pure-binary specs.** When every arm is binary, no shadow line is emitted, so the imports would be unused. `needs_bit_array_import` requires at least one non-binary arm alongside a binary one.

## Test plan

- [x] `just all` passes (format-check, typecheck, build, unit tests, shellspec, integration including the new Step 10d, escript, smoke)
- [x] Unit tests assert the new shape on server (router signature, shadow line, binary-arm field) and client (function parameter, `transport.BytesBody(body)` wrap)
- [x] Integration step compiles the generated server and client end-to-end with `gleam build --warnings-as-errors`

Closes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for generating code that handles `application/octet-stream` request bodies, properly typed as `BitArray` on both server and client.

* **Breaking Changes**
  * Generated request body type for `application/octet-stream` endpoints changes from `String` to `BitArray`. Server adapters and client callers must be updated accordingly.

* **Tests**
  * Added integration test validating binary request body code generation and compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->