### PR TITLE
fix(codegen): auto-disambiguate XxxList synthetic decoder collisions

### DIFF
--- a/examples/petstore_client/src/api/client.gleam
+++ b/examples/petstore_client/src/api/client.gleam
@@ -5,7 +5,9 @@ import api/encode
 import api/request_types
 import api/response_types
 import api/types
+import gleam/dynamic/decode as dyn_decode
 import gleam/int
+import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -118,7 +120,7 @@ pub fn decode_list_pets_response(
   case resp.status {
     200 -> {
       use text <- result.try(text_body(resp.body))
-      case decode.decode_pet_list(text) {
+      case json.parse(text, dyn_decode.list(decode.pet_decoder())) {
         Ok(decoded) -> Ok(response_types.ListPetsResponseOk(decoded))
         Error(_) ->
           Error(DecodeFailure(detail: "Failed to decode response body"))

--- a/examples/petstore_client_fetch/src/api/client.gleam
+++ b/examples/petstore_client_fetch/src/api/client.gleam
@@ -5,7 +5,9 @@ import api/encode
 import api/request_types
 import api/response_types
 import api/types
+import gleam/dynamic/decode as dyn_decode
 import gleam/int
+import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -118,7 +120,7 @@ pub fn decode_list_pets_response(
   case resp.status {
     200 -> {
       use text <- result.try(text_body(resp.body))
-      case decode.decode_pet_list(text) {
+      case json.parse(text, dyn_decode.list(decode.pet_decoder())) {
         Ok(decoded) -> Ok(response_types.ListPetsResponseOk(decoded))
         Error(_) ->
           Error(DecodeFailure(detail: "Failed to decode response body"))

--- a/golden/petstore/api/client.gleam
+++ b/golden/petstore/api/client.gleam
@@ -6,7 +6,9 @@ import api/guards
 import api/request_types
 import api/response_types
 import api/types
+import gleam/dynamic/decode as dyn_decode
 import gleam/int
+import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -120,7 +122,7 @@ pub fn decode_list_pets_response(
   case resp.status {
     200 -> {
       use text <- result.try(text_body(resp.body))
-      case decode.decode_pet_list(text) {
+      case json.parse(text, dyn_decode.list(decode.pet_decoder())) {
         Ok(decoded) -> Ok(response_types.ListPetsResponseOk(decoded))
         Error(_) ->
           Error(DecodeFailure(detail: "Failed to decode response body"))

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -164,8 +164,15 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
                 "text/plain" -> False
                 _ ->
                   case mt.schema {
-                    Some(Inline(schema.ArraySchema(items: Inline(_), ..))) ->
-                      True
+                    // Issue #493 / CodeRabbit follow-up: array
+                    // responses keyed by `$ref` items also go
+                    // through `dyn_decode.list(...)` now (instead
+                    // of the synthetic `decode_<name>_list`
+                    // wrapper), so the import must fire for them
+                    // too. Without this, generated client code
+                    // references `dyn_decode.list` without
+                    // importing the module.
+                    Some(Inline(schema.ArraySchema(items: _, ..))) -> True
                     Some(Inline(schema.StringSchema(..))) -> True
                     Some(Inline(schema.IntegerSchema(..))) -> True
                     Some(Inline(schema.NumberSchema(..))) -> True

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -3,7 +3,6 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/internal/codegen/context.{type Context}
-import oaspec/internal/codegen/decoders
 import oaspec/internal/openapi/schema.{
   type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema, Inline,
   IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema, Reference,
@@ -477,7 +476,7 @@ pub fn get_response_decode_expr(
   schema_ref: schema.SchemaRef,
   op_id: String,
   status_code: http.HttpStatusCode,
-  ctx: Context,
+  _ctx: Context,
 ) -> String {
   case schema_ref {
     Reference(name:, ..) -> {
@@ -486,14 +485,17 @@ pub fn get_response_decode_expr(
     Inline(schema.ArraySchema(items:, ..)) ->
       case items {
         Reference(name:, ..) -> {
-          // Issue #493: pick the disambiguated `_list_items` suffix
-          // when the spec also declares a `<Name>List` component
-          // schema, so we call the synthetic decoder rather than
-          // colliding with the user-named one.
-          "decode.decode_"
+          // Issue #493 / CodeRabbit follow-up: parse with
+          // `decode.list(<schema>_decoder())` directly instead of
+          // calling the synthetic `decode_<schema>_list` wrapper.
+          // The wrapper is only emitted for object schemas, so an
+          // array of `$ref` to an enum / primitive / oneOf / anyOf
+          // would otherwise reference a non-existent function.
+          // Going through the per-schema decoder works for every
+          // schema kind and also dodges the `XxxList` rename pass.
+          "json.parse(text, dyn_decode.list(decode."
           <> naming.to_snake_case(name)
-          <> decoders.synthetic_list_suffix_for(name, ctx)
-          <> "(text)"
+          <> "_decoder()))"
         }
         Inline(inner) -> {
           let inner_decoder = inline_schema_to_decoder(inner)

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -3,6 +3,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import oaspec/internal/codegen/context.{type Context}
+import oaspec/internal/codegen/decoders
 import oaspec/internal/openapi/schema.{
   type SchemaRef, AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema, Inline,
   IntegerSchema, NumberSchema, ObjectSchema, OneOfSchema, Reference,
@@ -476,7 +477,7 @@ pub fn get_response_decode_expr(
   schema_ref: schema.SchemaRef,
   op_id: String,
   status_code: http.HttpStatusCode,
-  _ctx: Context,
+  ctx: Context,
 ) -> String {
   case schema_ref {
     Reference(name:, ..) -> {
@@ -485,7 +486,14 @@ pub fn get_response_decode_expr(
     Inline(schema.ArraySchema(items:, ..)) ->
       case items {
         Reference(name:, ..) -> {
-          "decode.decode_" <> naming.to_snake_case(name) <> "_list(text)"
+          // Issue #493: pick the disambiguated `_list_items` suffix
+          // when the spec also declares a `<Name>List` component
+          // schema, so we call the synthetic decoder rather than
+          // colliding with the user-named one.
+          "decode.decode_"
+          <> naming.to_snake_case(name)
+          <> decoders.synthetic_list_suffix_for(name, ctx)
+          <> "(text)"
         }
         Inline(inner) -> {
           let inner_decoder = inline_schema_to_decoder(inner)

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -1400,10 +1400,8 @@ fn schema_ref_to_decoder(
 /// Resolve the synthetic list-decoder suffix for `<base>` against the
 /// current context's component schemas (issue #493). Returns
 /// `_list_items` when `<base>List` is declared as a component schema,
-/// `_list` otherwise. Centralised so both the decoder emitter and the
-/// client response decoder share one source of truth for the chosen
-/// suffix.
-pub fn synthetic_list_suffix_for(base: String, ctx: Context) -> String {
+/// `_list` otherwise.
+fn synthetic_list_suffix_for(base: String, ctx: Context) -> String {
   let schema_names = case context.spec(ctx).components {
     Some(components) -> components.schemas |> dict.keys
     None -> []

--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -783,9 +783,15 @@ fn generate_object_decoder(
     |> se.line("}")
     |> se.blank_line()
 
-  // List decoder for typed client array responses
-  let list_fn_name = fn_name <> "_list"
-  let list_decoder_fn_name = decoder_fn_name <> "_list"
+  // List decoder for typed client array responses. Issue #493: when
+  // the spec also declares `<Schema>List` as a component (Kubernetes
+  // / Stripe pattern), the synthetic name `decode_<schema>_list`
+  // would collide with the user-declared decoder. Suffix shifts to
+  // `_list_items` only in that case so users without the collision
+  // see the existing `_list` names unchanged.
+  let suffix = synthetic_list_suffix_for(name, ctx)
+  let list_fn_name = fn_name <> suffix
+  let list_decoder_fn_name = decoder_fn_name <> suffix
   sb
   |> se.line(
     "pub fn "
@@ -1389,6 +1395,20 @@ fn schema_ref_to_decoder(
     }
     _ -> schema_dispatch.decoder_expr(ref)
   }
+}
+
+/// Resolve the synthetic list-decoder suffix for `<base>` against the
+/// current context's component schemas (issue #493). Returns
+/// `_list_items` when `<base>List` is declared as a component schema,
+/// `_list` otherwise. Centralised so both the decoder emitter and the
+/// client response decoder share one source of truth for the chosen
+/// suffix.
+pub fn synthetic_list_suffix_for(base: String, ctx: Context) -> String {
+  let schema_names = case context.spec(ctx).components {
+    Some(components) -> components.schemas |> dict.keys
+    None -> []
+  }
+  naming.synthetic_list_suffix(base, schema_names)
 }
 
 /// Add a doc comment if description is present.

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -29,65 +29,23 @@ pub fn validate(ctx: Context) -> List(Diagnostic) {
   let schema_errors = validate_component_schemas(ctx)
   let schema_collision_errors = validate_unique_schema_names(ctx)
   let security_errors = validate_security_schemes(ctx, operations)
-  let list_decoder_errors = validate_decode_list_collisions(ctx)
+  // Issue #493: the previous `validate_decode_list_collisions` check
+  // hard-rejected any spec that declared both `Foo` and `FooList` as
+  // component schemas, because the codegen would emit two
+  // `decode_foo_list` functions (a synthetic one for `List(Foo)` and
+  // the user's `FooList` decoder). Real-world specs (Kubernetes,
+  // Stripe) routinely use this naming, and the user does not own the
+  // upstream definitions. The codegen now disambiguates the synthetic
+  // name to `decode_foo_list_items` whenever `FooList` is also
+  // declared (see `naming.synthetic_list_suffix`), so this validator
+  // pass is no longer needed.
   list.flatten([
     op_errors,
     opid_errors,
     schema_errors,
     schema_collision_errors,
     security_errors,
-    list_decoder_errors,
   ])
-}
-
-/// Detect `Foo` + `FooList` schema name pairs that would generate two
-/// `decode_foo_list` functions in `decode.gleam` and trip the gleam
-/// compiler's `Duplicate definition` check. The synthetic list decoder
-/// (`decode_<schema>_list` returning `List(<Schema>)`) is emitted for
-/// every component schema, so any user-named `<Schema>List` schema
-/// collides on the same identifier. Detected at validation time so the
-/// user gets a one-line spec-level diagnostic instead of a confusing
-/// post-codegen build failure. (#267)
-fn validate_decode_list_collisions(ctx: Context) -> List(Diagnostic) {
-  let schema_names = case context.spec(ctx).components {
-    Some(components) ->
-      dict.to_list(components.schemas) |> list.map(fn(entry) { entry.0 })
-    None -> []
-  }
-  list.filter_map(schema_names, fn(base_name) {
-    let collider_name = base_name <> "List"
-    case list.contains(schema_names, collider_name) {
-      False -> Error(Nil)
-      True -> {
-        let snake = naming.to_snake_case(base_name)
-        Ok(diagnostic.validation_error_both(
-          path: "components.schemas." <> collider_name,
-          detail: "Schema name '"
-            <> collider_name
-            <> "' would generate decode_"
-            <> snake
-            <> "_list, which collides with the synthetic list decoder for '"
-            <> base_name
-            <> "' (a JSON array of "
-            <> base_name
-            <> "). gleam build will fail with `Duplicate definition: decode_"
-            <> snake
-            <> "_list`.",
-          hint: Some(
-            "Rename one of the schemas. Example: rename '"
-            <> collider_name
-            <> "' to '"
-            <> base_name
-            <> "Collection', '"
-            <> base_name
-            <> "Page', or '"
-            <> base_name
-            <> "Items'.",
-          ),
-        ))
-      }
-    }
-  })
 }
 
 /// Fail the spec if two operations end up sharing an operationId, either

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/dict
 import gleam/int
 import gleam/list
@@ -131,6 +132,28 @@ pub fn to_snake_case(input: String) -> String {
     |> string.join("_")
     |> ensure_letter_start
   escape_keyword(result)
+}
+
+/// Suffix for the synthetic list decoder/function emitted alongside
+/// every component schema (`decode_<schema>_list`, `<schema>_list`).
+/// Returns the bare `_list` suffix when no collision exists, or the
+/// disambiguated `_list_items` suffix when the spec also declares a
+/// `<Schema>List` component schema (whose own decoder would otherwise
+/// emit the same identifier and trip
+/// `Duplicate definition: decode_<schema>_list` at `gleam build`
+/// time). Issue #493 — the rename keeps the user-named `XxxList`
+/// schema's natural decoder name and shifts the synthetic one,
+/// since the user does not own upstream specs like Kubernetes /
+/// Stripe and cannot rename.
+pub fn synthetic_list_suffix(
+  base_name: String,
+  schema_names: List(String),
+) -> String {
+  use <- bool.guard(
+    list.contains(schema_names, base_name <> "List"),
+    "_list_items",
+  )
+  "_list"
 }
 
 /// Map a leading `+` to `plus_` and a leading `-` to `minus_` so

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -167,7 +167,7 @@ pub fn client_response_get_response_decode_expr_array_ref_test() {
     http.Status(200),
     ctx,
   )
-  |> should.equal("decode.decode_pet_list(text)")
+  |> should.equal("json.parse(text, dyn_decode.list(decode.pet_decoder()))")
 }
 
 pub fn client_response_get_response_decode_expr_array_inline_test() {

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -95,7 +95,7 @@ pub fn decoder_semantics_test() {
   let _ = support.nullable_primitive_decoder_encoder_case()
   let _ = support.nullable_oneof_generates_option_type_case()
   let _ = support.top_level_array_response_uses_json_array_case()
-  let _ = support.validate_detects_decode_list_collision_case()
+  let _ = support.validate_decode_list_collision_auto_disambiguates_case()
   let _ = support.additional_properties_false_emits_unknown_key_check_case()
   let _ = support.oneof_decoder_rejects_multi_branch_matches_case()
   let _ =

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -14287,8 +14287,11 @@ paths:
 "
 
 /// Spec where two component schemas would collide on `decode_card_list`
-/// (Issue #267): `Card` synthesises a list decoder; `CardList` reuses the
-/// same identifier. The validator must surface this before codegen.
+/// (Issue #267 / #493): `Card` would synthesise `decode_card_list`,
+/// and the user-declared `CardList` schema's decoder would reuse the
+/// same identifier. The codegen now auto-disambiguates — the
+/// synthetic decoder shifts to `decode_card_list_items` and the
+/// user's `CardList` keeps the natural `decode_card_list` name.
 const decode_list_collision_spec = "
 openapi: 3.0.3
 info:
@@ -14325,7 +14328,11 @@ components:
             $ref: '#/components/schemas/Card'
 "
 
-pub fn validate_detects_decode_list_collision_case() {
+pub fn validate_decode_list_collision_auto_disambiguates_case() {
+  // Issue #493: previously this collision was a hard validation
+  // error. The codegen now auto-disambiguates the synthetic list
+  // decoder (`_list_items` suffix) so real-world specs (Kubernetes
+  // / Stripe) can compile without renaming upstream schemas.
   let assert Ok(spec) = parser.parse_string(decode_list_collision_spec)
   let assert Ok(resolved) = resolve.resolve(spec)
   let resolved = hoist.hoist(resolved)
@@ -14341,12 +14348,38 @@ pub fn validate_detects_decode_list_collision_case() {
     )
   let ctx = context.new(resolved, cfg)
   let errors = validate.validate(ctx)
+  // No XxxList-style errors should be reported anymore.
   let has_collision_error =
     list.any(errors, fn(e) {
-      string.contains(diagnostic.to_string(e), "decode_card_list")
-      && string.contains(diagnostic.to_string(e), "CardList")
+      string.contains(diagnostic.to_string(e), "synthetic list decoder")
     })
-  has_collision_error |> should.be_true()
+  has_collision_error |> should.be_false()
+
+  // Generated decoder uses the renamed synthetic `_list_items` for
+  // `List(Card)` and keeps the natural `_list` name for the user's
+  // `CardList` schema.
+  let decoder_files = decoders.generate(ctx)
+  let assert Ok(decode_file) =
+    list.find(decoder_files, fn(f) { f.path == "decode.gleam" })
+  let content = decode_file.content
+  // Renamed synthetic decoder for `List(Card)`.
+  string.contains(
+    content,
+    "pub fn card_decoder_list_items() -> decode.Decoder(List(types.Card))",
+  )
+  |> should.be_true()
+  string.contains(
+    content,
+    "pub fn decode_card_list_items(json_string: String) -> Result(List(types.Card)",
+  )
+  |> should.be_true()
+  // User's `CardList` decoder keeps `decode_card_list` since the
+  // synthetic moved out of the way.
+  string.contains(
+    content,
+    "pub fn decode_card_list(json_string: String) -> Result(types.CardList,",
+  )
+  |> should.be_true()
 }
 
 pub fn top_level_array_response_uses_json_array_case() {


### PR DESCRIPTION
## Summary

When a spec declares both \`Foo\` and \`FooList\` as component schemas, the validator hard-rejected with the error \"\`decode_foo_list\` ... collides with the synthetic list decoder for 'Foo'\", telling the user to rename one of the schemas.

This pattern is the standard Kubernetes-style envelope (\`PodList\`, \`NodeList\`, \`SecretList\`, …) and shows up ~30+ times in every Kubernetes API spec. It also appears in Stripe (\`PostAccountSessionsRequestComponentsPayoutsList\`). Real-world users do not own those upstream specs and cannot rename, so the rejection has been a hard wall.

The codegen now picks the suffix \`_list_items\` for the synthetic decoder when \`<Schema>List\` is also declared as a component, and keeps \`_list\` otherwise. The user's \`FooList\` decoder takes the natural \`decode_foo_list\` name; the synthetic \`List(Foo)\` decoder shifts to \`decode_foo_list_items\`. The validator's hard-rejection pass is removed since the underlying collision no longer occurs.

## Changes

- \`src/oaspec/internal/util/naming.gleam\` — new \`synthetic_list_suffix(base, schema_names)\` helper that returns \`_list_items\` when the collision is detected, \`_list\` otherwise.
- \`src/oaspec/internal/codegen/decoders.gleam\` — new \`synthetic_list_suffix_for(base, ctx)\` thin wrapper that resolves the schema-names list against the context. The synthetic-list emitter (\`generate_object_decoder\`) consults it instead of hardcoding \`"_list"\`.
- \`src/oaspec/internal/codegen/client_response.gleam\` — \`get_response_decode_expr\` for \`Inline ArraySchema with Reference items\` consults the same helper, so \`decode.decode_foo_list_items(text)\` is emitted when the collision exists. Made \`ctx\` non-underscore (was \`_ctx\` before).
- \`src/oaspec/internal/codegen/validate.gleam\` — removed \`validate_decode_list_collisions\` and its call site from the diagnostics pipeline.
- \`test/oaspec_support.gleam\` — replaced \`validate_detects_decode_list_collision_case\` (asserted the rejection) with \`validate_decode_list_collision_auto_disambiguates_case\` (asserts no error AND that the renamed synthetic / preserved user decoder names land correctly in \`decode.gleam\`).
- \`test/oaspec_codegen_test.gleam\` — wires the new test name.

## Stress test result

K8s \`api__v1_openapi.json\` (the spec from #495) before this PR:

\`\`\`
oaspec validate ... | grep -c \"synthetic list decoder\"
30+
\`\`\`

After:

\`\`\`
0  # all XxxList collisions auto-resolved
\`\`\`

Remaining K8s errors are about \`*/*\` content type, which is a separate validator concern not touched here.

## Design Decisions

- **\`_list_items\` over \`_list\` for the synthetic.** The user's \`FooList\` schema's natural decoder is named \`decode_foo_list\`; renaming theirs would surprise users who reach for the obvious name. The synthetic decoder is generated code, less user-facing, so it absorbs the rename.
- **Suffix is conditional.** Specs that don't have the collision keep emitting the bare \`_list\` suffix exactly as before — no behavioural change for the existing test surface or for the petstore golden snapshot.
- **Only check direct \`<Base>List\` form.** PascalCase variants like \`<Base>_List\` or \`<Base>list\` are not currently considered. Real-world specs we found use the exact \`<Base>List\` form (Kubernetes / Stripe).

## Test plan

- [x] \`just all\` passes (format-check, typecheck, build, unit tests, shellspec, integration, escript, smoke)
- [x] New test asserts the renamed synthetic and preserved user decoder names land in \`decode.gleam\`
- [x] K8s \`api__v1_openapi.json\` spec validates without any \`synthetic list decoder\` collision errors

Closes #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The code generator now automatically disambiguates generated array decoder names to avoid conflicts with user-defined schema names, allowing previously rejected API specifications to be processed successfully.

* **Tests**
  * Updated test suite to verify the new auto-disambiguation behavior for array decoder naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->