### PR TITLE
fix(codegen): disambiguate inline-enum type name from same-named component schema (#492)

### DIFF
--- a/src/oaspec/internal/codegen/decoders.gleam
+++ b/src/oaspec/internal/codegen/decoders.gleam
@@ -354,8 +354,7 @@ fn generate_inline_enum_decoders(
         case prop_ref {
           Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
             let enum_name =
-              naming.schema_to_type_name(parent_name)
-              <> naming.schema_to_type_name(prop_name)
+              ir_build.inline_enum_type_name_for(parent_name, prop_name, ctx)
             generate_decoder(sb, enum_name, prop_ref, ctx)
           }
           _ -> sb
@@ -553,7 +552,7 @@ fn generate_object_decoder(
       // as optional even if listed in required
       let is_write_only = schema_utils.schema_ref_is_write_only(prop_ref, ctx)
       let is_required = list.contains(required, prop_name) && !is_write_only
-      let field_decoder = schema_ref_to_decoder(prop_ref, name, prop_name)
+      let field_decoder = schema_ref_to_decoder(prop_ref, name, prop_name, ctx)
       let is_nullable_schema =
         schema_utils.schema_ref_is_nullable(prop_ref, ctx)
 
@@ -642,7 +641,7 @@ fn generate_object_decoder(
   let sb = case additional_properties {
     Typed(ap_ref) -> {
       let inner_decoder =
-        schema_ref_to_decoder(ap_ref, name, "additional_properties")
+        schema_ref_to_decoder(ap_ref, name, "additional_properties", ctx)
       sb
       |> se.indent(
         1,
@@ -1018,7 +1017,7 @@ fn generate_array_decoder(
   nullable: Bool,
   ctx: Context,
 ) -> se.StringBuilder {
-  let inner_decoder = schema_ref_to_decoder(items, name, "")
+  let inner_decoder = schema_ref_to_decoder(items, name, "", ctx)
   let inner_type = codec_helpers.qualified_schema_ref_type(items, ctx)
   let list_type = "List(" <> inner_type <> ")"
   let list_decoder = "decode.list(" <> inner_decoder <> ")"
@@ -1373,24 +1372,28 @@ fn get_discriminator_value(
 }
 
 /// Convert a SchemaRef to a decoder expression string.
-/// parent_name is used to resolve inline enum decoder names.
+/// parent_name is used to resolve inline enum decoder names; `ctx` is
+/// threaded so inline-enum names can be disambiguated against
+/// existing component schema names (Issue #492).
 fn schema_ref_to_decoder(
   ref: SchemaRef,
   parent_name: String,
   prop_name: String,
+  ctx: Context,
 ) -> String {
   case ref {
     Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
       // Inline enum: use the generated enum decoder
       let decoder_name =
-        naming.to_snake_case(
-          naming.schema_to_type_name(parent_name)
-          <> naming.schema_to_type_name(prop_name),
-        )
+        naming.to_snake_case(ir_build.inline_enum_type_name_for(
+          parent_name,
+          prop_name,
+          ctx,
+        ))
       decoder_name <> "_decoder()"
     }
     Inline(ArraySchema(items:, ..)) -> {
-      let inner = schema_ref_to_decoder(items, parent_name, prop_name)
+      let inner = schema_ref_to_decoder(items, parent_name, prop_name, ctx)
       "decode.list(" <> inner <> ")"
     }
     _ -> schema_dispatch.decoder_expr(ref)

--- a/src/oaspec/internal/codegen/encoders.gleam
+++ b/src/oaspec/internal/codegen/encoders.gleam
@@ -225,8 +225,7 @@ fn generate_inline_enum_encoders(
         case prop_ref {
           Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
             let enum_name =
-              naming.schema_to_type_name(parent_name)
-              <> naming.schema_to_type_name(prop_name)
+              ir_build.inline_enum_type_name_for(parent_name, prop_name, ctx)
             generate_encoder(sb, enum_name, prop_ref, ctx)
           }
           _ -> sb
@@ -392,6 +391,7 @@ fn generate_encoder(
                 prop_ref,
                 name,
                 prop_name,
+                ctx,
               )
           }
 
@@ -416,7 +416,12 @@ fn generate_encoder(
                   <> "\", json.nullable(value."
                   <> field_name
                   <> ", "
-                  <> schema_ref_to_json_encoder_fn(prop_ref, name, prop_name)
+                  <> schema_ref_to_json_encoder_fn(
+                  prop_ref,
+                  name,
+                  prop_name,
+                  ctx,
+                )
                   <> "))"
                   <> trailing,
               )
@@ -426,7 +431,7 @@ fn generate_encoder(
               // Re-derive the encoder expression with `x` substituted for
               // `value.<field>` so we encode the unwrapped Some value.
               let some_encoder_expr =
-                schema_ref_to_json_encoder("x", prop_ref, name, prop_name)
+                schema_ref_to_json_encoder("x", prop_ref, name, prop_name, ctx)
               sb
               |> se.indent(2, "case value." <> field_name <> " {")
               |> se.indent(3, "option.None -> []")
@@ -462,7 +467,12 @@ fn generate_encoder(
                   <> "\", json.nullable(value."
                   <> field_name
                   <> ", "
-                  <> schema_ref_to_json_encoder_fn(prop_ref, name, prop_name)
+                  <> schema_ref_to_json_encoder_fn(
+                  prop_ref,
+                  name,
+                  prop_name,
+                  ctx,
+                )
                   <> "))]"
                   <> trailing,
               )
@@ -476,7 +486,12 @@ fn generate_encoder(
       let sb = case additional_properties {
         Typed(ap_ref) -> {
           let inner_encoder_fn =
-            schema_ref_to_json_encoder_fn(ap_ref, name, "additional_properties")
+            schema_ref_to_json_encoder_fn(
+              ap_ref,
+              name,
+              "additional_properties",
+              ctx,
+            )
           // Issue #320: each statement of the lambda body is emitted via
           // a separate `se.indent` call rather than as embedded `\n`
           // inside one string. The previous form was easy to misread
@@ -827,7 +842,7 @@ fn generate_encoder(
       // of the bare `json.array(...)` it had been emitting.
       let inner_type = codec_helpers.qualified_schema_ref_type(items, ctx)
       let list_type = "List(" <> inner_type <> ")"
-      let inner_encoder = schema_ref_to_json_encoder_fn(items, name, "")
+      let inner_encoder = schema_ref_to_json_encoder_fn(items, name, "", ctx)
       let array_expr = "json.array(value, " <> inner_encoder <> ")"
       let #(gleam_type, json_expr) = case metadata.nullable {
         True -> #(
@@ -873,27 +888,31 @@ fn generate_primitive_encoder(
 }
 
 /// Convert a SchemaRef to a json.Json encoder expression.
-/// Returns an expression that produces json.Json (not String).
+/// Returns an expression that produces json.Json (not String). `ctx`
+/// is threaded so inline-enum encoder names can be disambiguated
+/// against existing component schema names (Issue #492).
 fn schema_ref_to_json_encoder(
   value_expr: String,
   ref: SchemaRef,
   parent_name: String,
   prop_name: String,
+  ctx: Context,
 ) -> String {
   case ref {
     Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
       let fn_name =
         "encode_"
-        <> naming.to_snake_case(
-          naming.schema_to_type_name(parent_name)
-          <> naming.schema_to_type_name(prop_name),
-        )
+        <> naming.to_snake_case(ir_build.inline_enum_type_name_for(
+          parent_name,
+          prop_name,
+          ctx,
+        ))
         <> "_json"
       fn_name <> "(" <> value_expr <> ")"
     }
     Inline(ArraySchema(items:, ..)) -> {
       let inner_fn =
-        schema_ref_to_json_encoder_fn(items, parent_name, prop_name)
+        schema_ref_to_json_encoder_fn(items, parent_name, prop_name, ctx)
       "json.array(" <> value_expr <> ", " <> inner_fn <> ")"
     }
     _ -> schema_dispatch.json_encoder_expr(ref, value_expr)
@@ -906,18 +925,21 @@ fn schema_ref_to_json_encoder_fn(
   ref: SchemaRef,
   parent_name: String,
   prop_name: String,
+  ctx: Context,
 ) -> String {
   case ref {
     Inline(StringSchema(enum_values:, ..)) if enum_values != [] -> {
       "encode_"
-      <> naming.to_snake_case(
-        naming.schema_to_type_name(parent_name)
-        <> naming.schema_to_type_name(prop_name),
-      )
+      <> naming.to_snake_case(ir_build.inline_enum_type_name_for(
+        parent_name,
+        prop_name,
+        ctx,
+      ))
       <> "_json"
     }
     Inline(ArraySchema(items:, ..)) -> {
-      let inner = schema_ref_to_json_encoder_fn(items, parent_name, prop_name)
+      let inner =
+        schema_ref_to_json_encoder_fn(items, parent_name, prop_name, ctx)
       "fn(items) { json.array(items, " <> inner <> ") }"
     }
     _ -> schema_dispatch.json_encoder_fn(ref)

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -654,7 +654,7 @@ fn inline_enums_from_properties(
   parent_name: String,
   properties: dict.Dict(String, SchemaRef),
   required: List(String),
-  _ctx: Context,
+  ctx: Context,
 ) -> List(Declaration) {
   let entries = sorted_entries(properties)
   list.filter_map(entries, fn(entry) {
@@ -672,8 +672,7 @@ fn inline_enums_from_properties(
             if enum_values != []
           -> {
             let type_name =
-              naming.schema_to_type_name(parent_name)
-              <> naming.schema_to_type_name(prop_name)
+              inline_enum_type_name_for(parent_name, prop_name, ctx)
             let deduped_variants = dedup.dedup_enum_variants(enum_values)
             let variants =
               list.zip(enum_values, deduped_variants)
@@ -1045,9 +1044,7 @@ fn schema_ref_to_type_with_inline_enum(
     // schemas). Wrap explicitly here so the type, decoder, and
     // encoder agree on `Option(EnumType)`.
     Inline(StringSchema(metadata:, enum_values:, ..)) if enum_values != [] -> {
-      let base =
-        naming.schema_to_type_name(parent_name)
-        <> naming.schema_to_type_name(prop_name)
+      let base = inline_enum_type_name_for(parent_name, prop_name, ctx)
       case metadata.nullable {
         True -> "Option(" <> base <> ")"
         False -> base
@@ -1055,6 +1052,23 @@ fn schema_ref_to_type_with_inline_enum(
     }
     _ -> schema_ref_to_type(ref, ctx)
   }
+}
+
+/// Resolve the disambiguated inline-enum type name for `<parent_name>.<prop_name>`
+/// against the current context's component schema names (Issue #492). Returns
+/// the bare `<Parent><Prop>` PascalCase concat when no collision exists, or a
+/// numerically-suffixed variant (`<Parent><Prop>2`, `<Parent><Prop>3`, …) when
+/// a component schema already maps to the same Gleam type name.
+pub fn inline_enum_type_name_for(
+  parent_name: String,
+  prop_name: String,
+  ctx: Context,
+) -> String {
+  let schema_names = case context.spec(ctx).components {
+    Some(components) -> components.schemas |> dict.keys
+    None -> []
+  }
+  naming.inline_enum_type_name(parent_name, prop_name, schema_names)
 }
 
 fn schema_ref_to_type(ref: SchemaRef, _ctx: Context) -> String {

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -156,6 +156,46 @@ pub fn synthetic_list_suffix(
   "_list"
 }
 
+/// Compute the Gleam type name for an inline string-enum property,
+/// disambiguating against existing component schema names so the
+/// generated `pub type` does not collide with a same-named component
+/// schema. Issue #492 — GitHub's OpenAPI spec declares
+/// `code-scanning-variant-analysis` (with an inline `status` enum) AND
+/// a separate `code-scanning-variant-analysis-status` component. Both
+/// previously mapped to the Gleam type `CodeScanningVariantAnalysisStatus`,
+/// producing a `Duplicate type definition` at `gleam build`.
+///
+/// Disambiguation appends a numeric suffix (`2`, `3`, ...) to the
+/// inline enum's name when a component schema already claims the bare
+/// name. The component schema keeps its natural name; the inline
+/// enum yields, since the user does not own upstream specs and cannot
+/// rename the component.
+pub fn inline_enum_type_name(
+  parent_name: String,
+  prop_name: String,
+  component_schema_names: List(String),
+) -> String {
+  let base = schema_to_type_name(parent_name) <> schema_to_type_name(prop_name)
+  let component_type_names =
+    list.map(component_schema_names, schema_to_type_name)
+  case list.contains(component_type_names, base) {
+    False -> base
+    True -> bump_inline_enum_suffix(base, 2, component_type_names)
+  }
+}
+
+fn bump_inline_enum_suffix(
+  base: String,
+  suffix: Int,
+  taken: List(String),
+) -> String {
+  let candidate = base <> int.to_string(suffix)
+  case list.contains(taken, candidate) {
+    False -> candidate
+    True -> bump_inline_enum_suffix(base, suffix + 1, taken)
+  }
+}
+
 /// Map a leading `+` to `plus_` and a leading `-` to `minus_` so
 /// `+1` / `-1` style property names survive the snake_case pipeline
 /// as `plus_1` / `minus_1` instead of colliding on a bare `1`.

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -96,6 +96,8 @@ pub fn decoder_semantics_test() {
   let _ = support.nullable_oneof_generates_option_type_case()
   let _ = support.top_level_array_response_uses_json_array_case()
   let _ = support.validate_decode_list_collision_auto_disambiguates_case()
+  let _ =
+    support.validate_inline_enum_component_collision_auto_disambiguates_case()
   let _ = support.additional_properties_false_emits_unknown_key_check_case()
   let _ = support.oneof_decoder_rejects_multi_branch_matches_case()
   let _ =

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -14328,6 +14328,115 @@ components:
             $ref: '#/components/schemas/Card'
 "
 
+/// Issue #492: GitHub's OpenAPI spec declares
+/// `code-scanning-variant-analysis-status` as a top-level component
+/// (4 enum values) AND a separate `code-scanning-variant-analysis`
+/// component whose inline `status` property is a 6-value enum. Both
+/// previously mapped to the Gleam type name
+/// `CodeScanningVariantAnalysisStatus`, producing a `Duplicate type
+/// definition` at `gleam build`. The fixture below is a minimised
+/// reproduction.
+const inline_enum_component_collision_spec = "
+openapi: 3.0.3
+info:
+  title: Inline Enum Component Collision
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    code-scanning-variant-analysis-status:
+      type: string
+      enum: [pending, succeeded, failed, canceled]
+    code-scanning-variant-analysis:
+      type: object
+      required: [id, status]
+      properties:
+        id:
+          type: integer
+        status:
+          type: string
+          enum: [pending, in_progress, succeeded, failed, canceled, timed_out]
+"
+
+pub fn validate_inline_enum_component_collision_auto_disambiguates_case() {
+  // Issue #492: the inline enum's generated type name used to collide
+  // with the same-named component schema's type name, breaking the
+  // generated module's `gleam build`. The codegen now appends a
+  // numeric suffix to the inline enum and leaves the component
+  // schema alone.
+  let assert Ok(spec) =
+    parser.parse_string(inline_enum_component_collision_spec)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let errors = validate.validate(ctx)
+  errors |> should.equal([])
+
+  // Generated types.gleam carries the component-schema enum at its
+  // natural name and the disambiguated inline enum at the suffixed
+  // name; neither name appears twice.
+  let type_files = types.generate(ctx)
+  let assert Ok(types_file) =
+    list.find(type_files, fn(f) { f.path == "types.gleam" })
+  let content = types_file.content
+  // Component schema keeps the natural name.
+  string.contains(content, "pub type CodeScanningVariantAnalysisStatus {")
+  |> should.be_true()
+  // Inline enum yields and gets the numeric suffix.
+  string.contains(content, "pub type CodeScanningVariantAnalysisStatus2 {")
+  |> should.be_true()
+  // Single definition of each, not a duplicate.
+  list.length(string.split(
+    content,
+    "pub type CodeScanningVariantAnalysisStatus {",
+  ))
+  |> should.equal(2)
+  list.length(string.split(
+    content,
+    "pub type CodeScanningVariantAnalysisStatus2 {",
+  ))
+  |> should.equal(2)
+
+  // The decoder/encoder for the inline enum point at the suffixed
+  // name (so they line up with the type definition above). The
+  // trailing digit attaches to the preceding word per the naming
+  // pipeline's rule (`Status2` → `status2`, not `status_2`).
+  let decoder_files = decoders.generate(ctx)
+  let assert Ok(decode_file) =
+    list.find(decoder_files, fn(f) { f.path == "decode.gleam" })
+  string.contains(
+    decode_file.content,
+    "code_scanning_variant_analysis_status2_decoder",
+  )
+  |> should.be_true()
+  let encoder_files = encoders.generate(ctx)
+  let assert Ok(encode_file) =
+    list.find(encoder_files, fn(f) { f.path == "encode.gleam" })
+  string.contains(
+    encode_file.content,
+    "encode_code_scanning_variant_analysis_status2",
+  )
+  |> should.be_true()
+}
+
 pub fn validate_decode_list_collision_auto_disambiguates_case() {
   // Issue #493: previously this collision was a hard validation
   // error. The codegen now auto-disambiguates the synthetic list


### PR DESCRIPTION
## Summary

GitHub's OpenAPI spec has a component `code-scanning-variant-analysis-status` (4-value enum) AND a separate `code-scanning-variant-analysis` whose inline `status` property is a 6-value enum. Both previously resolved to the same Gleam type name (`CodeScanningVariantAnalysisStatus`), so the generated `types.gleam` carried two `pub type` definitions and `gleam build` rejected it. The codegen now appends a numeric suffix (`2`, `3`, …) to the inline enum's name when a component schema already claims it, so the user-owned component name wins and the inline enum yields.

Closes #492

## Changes

- `src/oaspec/internal/util/naming.gleam`: new `inline_enum_type_name(parent, prop, component_schema_names)` helper that returns the base PascalCase concat or a numerically-suffixed variant when a component schema already maps to the same Gleam type name.
- `src/oaspec/internal/codegen/ir_build.gleam`: new `inline_enum_type_name_for(parent, prop, ctx)` wrapper that pulls the component name list off `ctx`. Both `inline_enums_from_properties` (the `pub type` declaration site) and `schema_ref_to_type_with_inline_enum` (the type-expression site for record fields) now route through it.
- `src/oaspec/internal/codegen/decoders.gleam`: `schema_ref_to_decoder` and `generate_inline_enum_decoders` use the wrapper. The signature of `schema_ref_to_decoder` gains a `Context` arg and the three callers pass `ctx`.
- `src/oaspec/internal/codegen/encoders.gleam`: `schema_ref_to_json_encoder`, `schema_ref_to_json_encoder_fn`, and `generate_inline_enum_encoders` use the wrapper. Both helper signatures gain a `Context` arg and all six call sites pass `ctx`.
- `test/oaspec_support.gleam`: minimised reproduction spec + `validate_inline_enum_component_collision_auto_disambiguates_case` asserting the component keeps `CodeScanningVariantAnalysisStatus`, the inline enum gets `CodeScanningVariantAnalysisStatus2`, and the matching decoder/encoder fn names line up with the suffixed type.
- `test/oaspec_codegen_test.gleam`: wires the new test case into `decoder_semantics_test`.

## Design Decisions

- **Disambiguate the inline enum, not the component.** The user does not own upstream specs (GitHub, Stripe, Kubernetes) and cannot rename their components, so the inline enum is the one that yields. Same rationale as the Issue #493 fix that shifted the synthetic `_list` decoder to `_list_items`.
- **Numeric suffix (`2`, `3`, …) for consistency with hoist.** `hoist.find_unique_name` already uses numeric suffixes for hoisted-schema collisions; reusing the convention keeps the user-facing naming model uniform. A semantic word (`Kind`, `Enum`) could itself collide with another component (`FooStatusKind`), whereas numeric is provably collision-free in one pass.
- **Single source of truth via `naming.inline_enum_type_name`.** The five (now seven) call sites that used to recompute `to_pascal_case(parent) <> to_pascal_case(prop)` ad hoc all delegate to the helper, so type/decoder/encoder names cannot drift apart.
- **No new validation diagnostic.** The pre-fix scenario passed validation but failed `gleam build`; rather than adding a hard reject (which the user couldn't act on for vendored specs), the codegen silently auto-disambiguates.

## Limitations

- Two **inline** enums in different parents that happen to generate the same `<Parent><Prop>` PascalCase name are still allowed to mint the bare name (only component-vs-inline collisions are handled). Not exercised by the GitHub spec scenario; flagged as a follow-up if a real-world spec hits it.