### PR TITLE
fix(naming): encode dotted schema names as `Dot` word boundary (#494)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 353 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 358 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 261 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ stops with a diagnostic instead of emitting partial code.
 - Produce readable Gleam types, encoders, decoders, request types, and response
   types
 - Keep unsupported spec shapes explicit and testable
-- Backed by 358 unit tests, ShellSpec CLI tests, 40 integration compile tests,
+- Backed by 361 unit tests, ShellSpec CLI tests, 40 integration compile tests,
   and 261 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -78,9 +78,16 @@ fn compile_regexes() -> Regexes {
 /// `-1`, or `404` produce valid Gleam variant names (`Plus1`,
 /// `Minus1`, `N404`) instead of `1`, `1`, `404` — the latter would
 /// be rejected by the parser at the type-constructor position.
+///
+/// Issue #494: `.` is rewritten to a `Dot` word boundary so that
+/// real-world specs (Stripe) which declare `payment_intent.processing`
+/// alongside `payment_intent_processing` produce distinct Gleam type
+/// names (`PaymentIntentDotProcessing` vs `PaymentIntentProcessing`)
+/// instead of colliding on `PaymentIntentProcessing`.
 pub fn to_pascal_case(input: String) -> String {
   let re = cached_regexes()
   input
+  |> rewrite_dot_segments
   |> rewrite_leading_signs
   |> split_words(re)
   |> list.map(capitalize)
@@ -125,6 +132,7 @@ pub fn to_snake_case(input: String) -> String {
   let re = cached_regexes()
   let result =
     input
+    |> rewrite_dot_segments
     |> rewrite_leading_signs
     |> insert_underscores_before_caps(re)
     |> split_words(re)
@@ -194,6 +202,18 @@ fn bump_inline_enum_suffix(
     False -> candidate
     True -> bump_inline_enum_suffix(base, suffix + 1, taken)
   }
+}
+
+/// Replace `.` with `_dot_` so the dot survives the snake/Pascal
+/// pipelines as a `Dot` word boundary instead of being treated as
+/// the same separator class as `_` and `-`. Issue #494 — Stripe's
+/// spec declares `payment_intent.processing` alongside
+/// `payment_intent_processing`, and treating `.` as plain whitespace
+/// (the prior behavior) collapsed both onto the same Gleam type
+/// name. Encoding the dot keeps the two distinguishable while still
+/// producing readable identifiers (`PaymentIntentDotProcessing`).
+fn rewrite_dot_segments(input: String) -> String {
+  string.replace(input, ".", "_dot_")
 }
 
 /// Map a leading `+` to `plus_` and a leading `-` to `minus_` so

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -212,8 +212,16 @@ fn bump_inline_enum_suffix(
 /// (the prior behavior) collapsed both onto the same Gleam type
 /// name. Encoding the dot keeps the two distinguishable while still
 /// producing readable identifiers (`PaymentIntentDotProcessing`).
+///
+/// A literal `_dot_` already in the input is first escaped to
+/// `_dot_literal_` so spec authors who happen to use `_dot_` in a
+/// schema name still produce a name distinct from a sibling that
+/// uses `.` at the same position (`a_dot_b` → `ADotLiteralB`,
+/// `a.b` → `ADotB`).
 fn rewrite_dot_segments(input: String) -> String {
-  string.replace(input, ".", "_dot_")
+  input
+  |> string.replace("_dot_", "_dot_literal_")
+  |> string.replace(".", "_dot_")
 }
 
 /// Map a leading `+` to `plus_` and a leading `-` to `minus_` so

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -172,6 +172,38 @@ pub fn naming_to_snake_case_dot_becomes_dot_word_boundary_test() {
   |> should.equal("payment_intent_processing")
 }
 
+// Edge cases for the `.` → `_dot_` encoding (CodeRabbit on PR #499).
+// Behavior chosen for predictability; documenting it locks in the
+// shape so future refactors can't silently drift.
+
+pub fn naming_dot_encoding_consecutive_dots_test() {
+  // `foo..bar` becomes two consecutive `_dot_` segments. The
+  // word_separator regex collapses runs of `_`/`.`/etc. so the
+  // PascalCase output reads as `FooDotDotBar`.
+  naming.to_pascal_case("foo..bar") |> should.equal("FooDotDotBar")
+  naming.to_snake_case("foo..bar") |> should.equal("foo_dot_dot_bar")
+}
+
+pub fn naming_dot_encoding_leading_and_trailing_dot_test() {
+  // A leading `.` produces a leading `Dot` word; a trailing `.`
+  // produces a trailing `Dot` word. Both still PascalCase and
+  // snake_case to valid Gleam identifiers.
+  naming.to_pascal_case(".foo") |> should.equal("DotFoo")
+  naming.to_snake_case(".foo") |> should.equal("dot_foo")
+  naming.to_pascal_case("foo.") |> should.equal("FooDot")
+  naming.to_snake_case("foo.") |> should.equal("foo_dot")
+}
+
+pub fn naming_dot_encoding_literal_underscore_dot_underscore_test() {
+  // A literal `_dot_` already in the input is escaped to
+  // `_dot_literal_` so a spec that authored `a_dot_b` and a sibling
+  // `a.b` produce distinct Gleam type names.
+  naming.to_pascal_case("a_dot_b") |> should.equal("ADotLiteralB")
+  naming.to_pascal_case("a.b") |> should.equal("ADotB")
+  naming.to_snake_case("a_dot_b") |> should.equal("a_dot_literal_b")
+  naming.to_snake_case("a.b") |> should.equal("a_dot_b")
+}
+
 // Issue #492: inline-enum disambiguation against component schema names.
 
 pub fn naming_inline_enum_type_name_no_collision_returns_base_test() {

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -147,3 +147,44 @@ pub fn naming_schema_to_type_name_keyword_becomes_pascal_test() {
     |> should.equal(expected)
   })
 }
+
+// Issue #494: a `.` in the schema name is encoded as a `Dot` word
+// boundary so the dot survives the snake/Pascal pipelines. Stripe's
+// `payment_intent.processing` and `payment_intent_processing` would
+// otherwise both map to `PaymentIntentProcessing` and trigger the
+// `validate_unique_schema_names` hard error.
+
+pub fn naming_to_pascal_case_dot_becomes_dot_word_boundary_test() {
+  naming.to_pascal_case("payment_intent.processing")
+  |> should.equal("PaymentIntentDotProcessing")
+  naming.to_pascal_case("payment_intent_processing")
+  |> should.equal("PaymentIntentProcessing")
+  naming.to_pascal_case("billing.alert.triggered")
+  |> should.equal("BillingDotAlertDotTriggered")
+  naming.to_pascal_case("billing.alert_triggered")
+  |> should.equal("BillingDotAlertTriggered")
+}
+
+pub fn naming_to_snake_case_dot_becomes_dot_word_boundary_test() {
+  naming.to_snake_case("payment_intent.processing")
+  |> should.equal("payment_intent_dot_processing")
+  naming.to_snake_case("payment_intent_processing")
+  |> should.equal("payment_intent_processing")
+}
+
+// Issue #492: inline-enum disambiguation against component schema names.
+
+pub fn naming_inline_enum_type_name_no_collision_returns_base_test() {
+  naming.inline_enum_type_name("foo", "status", ["bar", "baz"])
+  |> should.equal("FooStatus")
+}
+
+pub fn naming_inline_enum_type_name_collision_appends_numeric_suffix_test() {
+  naming.inline_enum_type_name("foo", "status", ["foo_status"])
+  |> should.equal("FooStatus2")
+}
+
+pub fn naming_inline_enum_type_name_chained_collision_bumps_suffix_test() {
+  naming.inline_enum_type_name("foo", "status", ["foo_status", "foo_status_2"])
+  |> should.equal("FooStatus3")
+}

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -98,6 +98,7 @@ pub fn decoder_semantics_test() {
   let _ = support.validate_decode_list_collision_auto_disambiguates_case()
   let _ =
     support.validate_inline_enum_component_collision_auto_disambiguates_case()
+  let _ = support.validate_stripe_dotted_schema_no_longer_collides_case()
   let _ = support.additional_properties_false_emits_unknown_key_check_case()
   let _ = support.oneof_decoder_rejects_multi_branch_matches_case()
   let _ =

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -13089,8 +13089,11 @@ pub fn to_snake_case_with_hyphen_case() {
 }
 
 pub fn to_snake_case_with_dots_case() {
+  // Issue #494: a `.` is encoded as a `_dot_` word boundary so dotted
+  // schema names (Stripe's `payment_intent.processing`) survive the
+  // pipeline distinguishable from their `_`-separated siblings.
   naming.to_snake_case("app.name")
-  |> should.equal("app_name")
+  |> should.equal("app_dot_name")
 }
 
 // ===========================================================================
@@ -14327,6 +14330,91 @@ components:
           items:
             $ref: '#/components/schemas/Card'
 "
+
+/// Issue #494: Stripe's OpenAPI spec declares pairs of component
+/// schemas that differ only by `.` vs `_` — e.g.
+/// `payment_intent.processing` and `payment_intent_processing`.
+/// Before the fix, both PascalCased to `PaymentIntentProcessing` and
+/// the validator hard-rejected the spec. The naming pipeline now
+/// encodes `.` as a `Dot` word boundary so the two stay
+/// distinguishable (`PaymentIntentDotProcessing` vs
+/// `PaymentIntentProcessing`).
+const stripe_dotted_schema_collision_spec = "
+openapi: 3.0.3
+info:
+  title: Stripe Dotted Schema Collision
+  version: 1.0.0
+servers:
+  - url: https://example.com
+paths:
+  /events:
+    get:
+      operationId: listEvents
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/payment_intent.processing'
+components:
+  schemas:
+    payment_intent.processing:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+          enum: [dotted]
+    payment_intent_processing:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+          enum: [underscored]
+"
+
+pub fn validate_stripe_dotted_schema_no_longer_collides_case() {
+  // Issue #494: the spec must validate without the pre-fix
+  // `Schema names ... all map to Gleam type ... — rename one to avoid
+  // the collision` hard error, and the generated `types.gleam` must
+  // carry both schemas as distinct Gleam types.
+  let assert Ok(spec) = parser.parse_string(stripe_dotted_schema_collision_spec)
+  let assert Ok(resolved) = resolve.resolve(spec)
+  let resolved = hoist.hoist(resolved)
+  let resolved = dedup.dedup(resolved)
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let ctx = context.new(resolved, cfg)
+  let errors = validate.validate(ctx)
+  // The hard rejection must no longer fire on this collision shape.
+  let has_collision_error =
+    list.any(errors, fn(e) {
+      string.contains(diagnostic.to_string(e), "all map to Gleam type")
+    })
+  has_collision_error |> should.be_false()
+
+  // Both schemas survive into types.gleam under distinct names.
+  let type_files = types.generate(ctx)
+  let assert Ok(types_file) =
+    list.find(type_files, fn(f) { f.path == "types.gleam" })
+  string.contains(types_file.content, "pub type PaymentIntentDotProcessing {")
+  |> should.be_true()
+  string.contains(types_file.content, "pub type PaymentIntentProcessing {")
+  |> should.be_true()
+}
 
 /// Issue #492: GitHub's OpenAPI spec declares
 /// `code-scanning-variant-analysis-status` as a top-level component


### PR DESCRIPTION
## Summary

Stripe's OpenAPI spec declares pairs of component schemas that differ only by `.` vs `_` — e.g. `payment_intent.processing` and `payment_intent_processing`. The naming pipeline previously treated both characters as the same separator class, so both schemas PascalCased to `PaymentIntentProcessing` and the validator hard-rejected the spec with `Schema names ... all map to Gleam type ... — rename one to avoid the collision`. The user does not own the Stripe spec, so the rename advice was a hard wall.

The naming pipeline now rewrites `.` as `_dot_` in the preprocessing step, so the dot survives as a `Dot` word boundary in both PascalCase (`PaymentIntentDotProcessing`) and snake_case (`payment_intent_dot_processing`) output. Stripe-style dotted-vs-underscored pairs stay distinguishable, and `oaspec validate` no longer rejects the spec.

Closes #494

## Changes

- `src/oaspec/internal/util/naming.gleam`: new `rewrite_dot_segments` helper invoked at the front of both `to_pascal_case` and `to_snake_case` so the dot encoding flows through every downstream identifier (type names, field names, decoder/encoder fn names).
- `test/naming_test.gleam`: unit tests for the `Dot` encoding on PascalCase and snake_case, plus dedicated tests for the `inline_enum_type_name` helper added in #492.
- `test/oaspec_support.gleam`: minimised reproduction spec (`stripe_dotted_schema_collision_spec`) with the `payment_intent.processing` / `payment_intent_processing` pair and a codegen test asserting both schemas reach `types.gleam` under distinct Gleam names; updated the existing `to_snake_case_with_dots_case` to expect the new encoding.
- `test/oaspec_codegen_test.gleam`: wires the new test case into `decoder_semantics_test`.
- `README.md`: bumps the unit-test count from 353 to 358 to keep `scripts/check_sync.sh` happy.

## Design Decisions

- **Encode `.` instead of suffixing collision losers.** Issue body suggested hash suffixes, semantic suffixes, or numeric suffixes. Encoding the dot as a word boundary preserves the spec's punctuation distinction in the generated names, which is more readable than `PaymentIntentProcessing_5fd7` and more deterministic than numbering (no order dependency on whichever schema appears first). It also handles the related `billing.alert.triggered` vs `billing.alert_triggered` case naturally without any group-aware logic.
- **Apply at the naming-pipeline preprocessing layer**, not at the validator or as a spec rename pass. A naming-layer change is a one-line edit that flows through every callsite (type emit, decoder/encoder fn names, route IR, server dispatch). A spec-rename pass would require walking every `$ref` in the document and was out of proportion to the bug.
- **Keep `validate_unique_schema_names`.** With `.` distinguishable, Stripe's collisions no longer fire it. The check still guards genuine collisions (e.g. case-only differences) so removing it would lose a useful diagnostic. No behavior change is needed there.

## Limitations

- A spec that declares both `Foo.Bar` AND `Foo_dot_Bar` literally would still collide. The `_dot_` encoding chooses readability over collision-proofness for that adversarial case, since real-world schemas don't write `_dot_` literally.
- `.`-containing schema names previously emitted as `FooBar` now emit as `FooDotBar`. No `.` schema names exist in the project's golden fixtures (verified by `grep`), so this is a behavior change visible only to specs that authored dotted names — and for those specs it was the difference between "validator rejects the spec" and "spec compiles."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed naming collision where identifiers containing dots (e.g., `payment_intent.processing`) were incorrectly treated as equivalent to those without dots, causing type definition conflicts.

* **Tests**
  * Added comprehensive test coverage for dot-character handling in identifier transformations.
  * Added regression test to prevent future naming collision issues.

* **Documentation**
  * Updated README to reflect expanded test suite (358 unit tests).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->