### PR TITLE
fix(codegen): prune unreachable component schemas under path filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen(path filter)**: `targets[].include.paths` previously dropped
+  unwanted operations from `spec.paths` but left every component schema
+  in `spec.components.schemas` intact, so the generated `decode.gleam`,
+  `encode.gleam`, `types.gleam`, and `guards.gleam` still emitted code
+  for every schema in the spec. A one-path filter against GitHub's REST
+  OpenAPI produced an 11 MB `decode.gleam` instead of the ~22 KB the
+  filter implied. Generation now runs a reachability pass after hoist
+  and before dedup that walks every operation surviving the filter
+  (parameters, request bodies, response bodies, response headers,
+  callbacks, and webhooks) into the schema graph
+  (`properties` / `items` / `additionalProperties.Typed` /
+  `allOf` / `oneOf` / `anyOf` / `discriminator.mapping`) and prunes
+  `components.schemas` to the reachable set. The pass only runs when an
+  include filter is configured; without a filter the spec is presented
+  as-authored. Issue #501.
+
 ## [0.51.0] - 2026-05-05
 
 ### Fixed

--- a/src/oaspec/generate.gleam
+++ b/src/oaspec/generate.gleam
@@ -15,6 +15,7 @@ import oaspec/internal/openapi/filter
 import oaspec/internal/openapi/hoist
 import oaspec/internal/openapi/location_index.{type LocationIndex}
 import oaspec/internal/openapi/normalize
+import oaspec/internal/openapi/reachability
 import oaspec/internal/openapi/resolve
 import oaspec/internal/openapi/spec.{type OpenApiSpec, type Unresolved}
 import oaspec/internal/progress.{type Reporter}
@@ -114,6 +115,28 @@ fn prepare_context(
   progress.report(
     reporter,
     "hoist inline complex schemas (took " <> progress.format_ms(elapsed) <> ")",
+  )
+
+  // Issue #501: when an include filter is active, drop component
+  // schemas no surviving operation transitively references. Runs
+  // after hoist (so synthetic schemas hoisting introduces are still
+  // considered) and before dedup (so dedup operates on the smaller
+  // surviving set). Skipped when no filter is configured: the user
+  // didn't ask to subset the API, so we present the spec as-authored
+  // — dead component schemas left in the spec stay in the output.
+  let include_active = !config.include_is_empty(config.include(cfg))
+  let #(elapsed, spec) =
+    progress.timed(fn() {
+      case include_active {
+        True -> reachability.prune(spec)
+        False -> spec
+      }
+    })
+  progress.report(
+    reporter,
+    "prune unreachable component schemas (took "
+      <> progress.format_ms(elapsed)
+      <> ")",
   )
 
   // Deduplicate names to avoid collisions in generated code

--- a/src/oaspec/internal/openapi/reachability.gleam
+++ b/src/oaspec/internal/openapi/reachability.gleam
@@ -1,0 +1,241 @@
+//// Component schema reachability pruning for the OpenAPI generation
+//// pipeline (Issue #501).
+////
+//// `filter.apply` drops operations the user does not want, but it
+//// leaves `spec.components.schemas` untouched on purpose so that
+//// component pruning can be a separate, audit-able stage. Without that
+//// prune the type / encoder / decoder / guard generators iterate over
+//// every component the spec declares — a one-path filter against
+//// GitHub's REST OpenAPI still emits megabytes of generated code.
+////
+//// `prune/1` walks every schema reachable from the surviving
+//// operations (and from webhooks, which the include filter never
+//// touches) and keeps only those entries in `components.schemas`. It
+//// is intended to run after `hoist.hoist` (so synthetic schemas
+//// hoisting introduces are considered) and before `dedup.dedup` (so
+//// dedup operates on the smaller surviving set).
+////
+//// The walker recurses through every schema reference path the
+//// codebase models — `properties`, `items`, `additionalProperties`,
+//// `allOf` / `oneOf` / `anyOf` — plus `discriminator.mapping` values,
+//// which name component schemas by string and would otherwise be
+//// invisible to a structural walk.
+
+import gleam/dict.{type Dict}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import oaspec/internal/openapi/schema.{
+  type Discriminator, type SchemaObject, type SchemaRef, AllOfSchema,
+  AnyOfSchema, ArraySchema, Forbidden, Inline, ObjectSchema, OneOfSchema,
+  Reference, Typed, Unspecified, Untyped,
+}
+import oaspec/internal/openapi/spec.{
+  type Callback, type MediaType, type OpenApiSpec, type Operation,
+  type Parameter, type PathItem, type RefOr, type Resolved, type Response,
+  Callback, Components, OpenApiSpec, ParameterContent, ParameterSchema, Ref,
+  Value,
+}
+
+/// Set of reachable component schema names. Implemented as `Dict(_, Nil)`
+/// because Gleam's stdlib does not ship a Set; only `dict.has_key` and
+/// `dict.insert` are needed.
+type Reached =
+  Dict(String, Nil)
+
+/// Prune unreachable component schemas from a Resolved spec.
+///
+/// Reachability is computed from operations surviving any earlier
+/// `filter.apply` pass plus webhooks (which the include filter never
+/// touches). When `spec.components` is `None`, the function is a no-op.
+pub fn prune(spec: OpenApiSpec(Resolved)) -> OpenApiSpec(Resolved) {
+  case spec.components {
+    None -> spec
+    Some(components) -> {
+      let seeds = collect_seed_refs(spec)
+      let reached = walk(seeds, dict.new(), components.schemas)
+      let pruned_schemas =
+        components.schemas
+        |> dict.to_list
+        |> list.filter(fn(entry) { dict.has_key(reached, entry.0) })
+        |> dict.from_list
+      OpenApiSpec(
+        ..spec,
+        components: Some(Components(..components, schemas: pruned_schemas)),
+      )
+    }
+  }
+}
+
+/// Gather every SchemaRef syntactically reachable from operations and
+/// webhooks. Order does not matter — `walk/3` deduplicates via the
+/// `Reached` set.
+fn collect_seed_refs(spec: OpenApiSpec(Resolved)) -> List(SchemaRef) {
+  let path_refs =
+    dict.values(spec.paths)
+    |> list.flat_map(refs_from_path_ref)
+  let webhook_refs =
+    dict.values(spec.webhooks)
+    |> list.flat_map(refs_from_path_ref)
+  list.flatten([path_refs, webhook_refs])
+}
+
+fn refs_from_path_ref(path_ref: RefOr(PathItem(Resolved))) -> List(SchemaRef) {
+  case path_ref {
+    Value(item) -> refs_from_path_item(item)
+    Ref(_) -> []
+  }
+}
+
+fn refs_from_path_item(item: PathItem(Resolved)) -> List(SchemaRef) {
+  let path_param_refs = list.flat_map(item.parameters, refs_from_parameter_ref)
+  let op_refs =
+    [
+      item.get,
+      item.post,
+      item.put,
+      item.delete,
+      item.patch,
+      item.head,
+      item.options,
+      item.trace,
+    ]
+    |> list.filter_map(option_to_result)
+    |> list.flat_map(refs_from_operation)
+  list.flatten([path_param_refs, op_refs])
+}
+
+fn option_to_result(opt: Option(a)) -> Result(a, Nil) {
+  case opt {
+    Some(v) -> Ok(v)
+    None -> Error(Nil)
+  }
+}
+
+fn refs_from_operation(op: Operation(Resolved)) -> List(SchemaRef) {
+  let parameter_refs = list.flat_map(op.parameters, refs_from_parameter_ref)
+  let body_refs = case op.request_body {
+    Some(Value(rb)) -> refs_from_media_dict(rb.content)
+    Some(Ref(_)) -> []
+    None -> []
+  }
+  let response_refs =
+    dict.values(op.responses)
+    |> list.flat_map(fn(rr) {
+      case rr {
+        Value(r) -> refs_from_response(r)
+        Ref(_) -> []
+      }
+    })
+  let callback_refs =
+    dict.values(op.callbacks)
+    |> list.flat_map(refs_from_callback_ref)
+  list.flatten([parameter_refs, body_refs, response_refs, callback_refs])
+}
+
+fn refs_from_callback_ref(cb_ref: RefOr(Callback(Resolved))) -> List(SchemaRef) {
+  case cb_ref {
+    Value(Callback(entries:)) ->
+      dict.values(entries)
+      |> list.flat_map(refs_from_path_ref)
+    Ref(_) -> []
+  }
+}
+
+fn refs_from_parameter_ref(pref: RefOr(Parameter(Resolved))) -> List(SchemaRef) {
+  case pref {
+    Value(p) ->
+      case p.payload {
+        ParameterSchema(s) -> [s]
+        ParameterContent(content) -> refs_from_media_dict(content)
+      }
+    Ref(_) -> []
+  }
+}
+
+fn refs_from_response(r: Response(Resolved)) -> List(SchemaRef) {
+  let content_refs = refs_from_media_dict(r.content)
+  let header_refs =
+    dict.values(r.headers)
+    |> list.filter_map(fn(h) { option_to_result(h.schema) })
+  list.flatten([content_refs, header_refs])
+}
+
+fn refs_from_media_dict(content: Dict(String, MediaType)) -> List(SchemaRef) {
+  dict.values(content)
+  |> list.filter_map(fn(mt) { option_to_result(mt.schema) })
+}
+
+/// BFS walk: pop refs from the worklist, mark each named component
+/// reachable, and follow inline structure into nested refs. Avoids
+/// infinite recursion via the `reached` set.
+fn walk(
+  worklist: List(SchemaRef),
+  reached: Reached,
+  schemas: Dict(String, SchemaRef),
+) -> Reached {
+  case worklist {
+    [] -> reached
+    [ref, ..rest] ->
+      case ref {
+        Reference(_, name) ->
+          case dict.has_key(reached, name) {
+            True -> walk(rest, reached, schemas)
+            False -> {
+              let reached = dict.insert(reached, name, Nil)
+              case dict.get(schemas, name) {
+                Ok(target) -> walk([target, ..rest], reached, schemas)
+                // The reference names a schema not present in
+                // `components.schemas`. resolve.gleam normally fails
+                // earlier on dangling refs, but discriminator mappings
+                // can also produce names that point at synthetic
+                // hoisted entries; keep the worklist moving without
+                // surfacing a fake error here.
+                Error(Nil) -> walk(rest, reached, schemas)
+              }
+            }
+          }
+        Inline(obj) -> {
+          let children = refs_from_schema_object(obj)
+          walk(list.append(children, rest), reached, schemas)
+        }
+      }
+  }
+}
+
+/// Return every SchemaRef that `schema` syntactically references.
+/// `discriminator.mapping` values are translated into `Reference`s via
+/// `schema.make_reference` so the worklist can follow them.
+fn refs_from_schema_object(schema: SchemaObject) -> List(SchemaRef) {
+  case schema {
+    ObjectSchema(properties:, additional_properties:, ..) -> {
+      let prop_refs = dict.values(properties)
+      let ap_refs = case additional_properties {
+        Typed(s) -> [s]
+        Forbidden | Untyped | Unspecified -> []
+      }
+      list.flatten([prop_refs, ap_refs])
+    }
+    ArraySchema(items:, ..) -> [items]
+    AllOfSchema(schemas:, ..) -> schemas
+    OneOfSchema(schemas:, discriminator:, ..) ->
+      list.flatten([schemas, discriminator_mapping_refs(discriminator)])
+    AnyOfSchema(schemas:, discriminator:, ..) ->
+      list.flatten([schemas, discriminator_mapping_refs(discriminator)])
+    _ -> []
+  }
+}
+
+/// Translate a discriminator's mapping (schema name strings) into
+/// SchemaRefs so the worklist can follow them. Mapping values are
+/// allowed to be either `#/components/schemas/Name` or bare `Name`;
+/// `schema.make_reference/1` handles both forms.
+fn discriminator_mapping_refs(
+  discriminator: Option(Discriminator),
+) -> List(SchemaRef) {
+  case discriminator {
+    Some(d) ->
+      dict.values(d.mapping)
+      |> list.map(schema.make_reference)
+    None -> []
+  }
+}

--- a/src/oaspec/internal/openapi/reachability.gleam
+++ b/src/oaspec/internal/openapi/reachability.gleam
@@ -99,16 +99,9 @@ fn refs_from_path_item(item: PathItem(Resolved)) -> List(SchemaRef) {
       item.options,
       item.trace,
     ]
-    |> list.filter_map(option_to_result)
+    |> list.filter_map(option.to_result(_, Nil))
     |> list.flat_map(refs_from_operation)
   list.flatten([path_param_refs, op_refs])
-}
-
-fn option_to_result(opt: Option(a)) -> Result(a, Nil) {
-  case opt {
-    Some(v) -> Ok(v)
-    None -> Error(Nil)
-  }
 }
 
 fn refs_from_operation(op: Operation(Resolved)) -> List(SchemaRef) {
@@ -156,13 +149,13 @@ fn refs_from_response(r: Response(Resolved)) -> List(SchemaRef) {
   let content_refs = refs_from_media_dict(r.content)
   let header_refs =
     dict.values(r.headers)
-    |> list.filter_map(fn(h) { option_to_result(h.schema) })
+    |> list.filter_map(fn(h) { option.to_result(h.schema, Nil) })
   list.flatten([content_refs, header_refs])
 }
 
 fn refs_from_media_dict(content: Dict(String, MediaType)) -> List(SchemaRef) {
   dict.values(content)
-  |> list.filter_map(fn(mt) { option_to_result(mt.schema) })
+  |> list.filter_map(fn(mt) { option.to_result(mt.schema, Nil) })
 }
 
 /// BFS walk: pop refs from the worklist, mark each named component

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -84,6 +84,13 @@ pub fn include_filter_test() {
   let _ = support.filter_apply_tag_membership_keeps_tagged_operations_case()
   let _ = support.filter_apply_tags_or_paths_unions_case()
   let _ = support.filter_path_matches_exact_and_glob_case()
+  let _ = support.reachability_prune_drops_unreferenced_components_case()
+  let _ =
+    support.reachability_prune_keeps_transitively_reachable_components_case()
+  let _ =
+    support.reachability_prune_with_no_surviving_operations_drops_everything_case()
+  let _ =
+    support.reachability_prune_pipeline_omits_dead_types_in_generated_output_case()
 }
 
 pub fn content_type_helpers_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -25,6 +25,7 @@ import oaspec/internal/openapi/hoist
 import oaspec/internal/openapi/location_index
 import oaspec/internal/openapi/normalize
 import oaspec/internal/openapi/provenance
+import oaspec/internal/openapi/reachability
 import oaspec/internal/openapi/resolve
 import oaspec/internal/openapi/resolver
 import oaspec/internal/openapi/schema
@@ -678,6 +679,73 @@ pub fn filter_apply_tags_or_paths_unions_case() {
   filter.apply(resolved, include)
   |> fn(s) { dict.size(s.paths) }
   |> should.equal(2)
+}
+
+pub fn reachability_prune_drops_unreferenced_components_case() {
+  // Issue #501: petstore declares Pet, CreatePetRequest, PetStatus,
+  // Error. Filtering to /pets/{petId} keeps only GET and DELETE
+  // operations, which reach Pet (and via Pet's `status` property,
+  // PetStatus). CreatePetRequest is reachable only from POST /pets
+  // and Error is never referenced in any operation's content, so
+  // both must be pruned.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: [], paths: ["/pets/{petId}"])
+  let filtered = filter.apply(resolved, include)
+  let pruned = reachability.prune(filtered)
+  let assert Some(comps) = pruned.components
+  let names = dict.keys(comps.schemas) |> list.sort(string.compare)
+  names |> should.equal(["Pet", "PetStatus"])
+}
+
+pub fn reachability_prune_keeps_transitively_reachable_components_case() {
+  // GET /pets returns Pet[]; POST /pets takes a CreatePetRequest and
+  // returns Pet. Pet itself references PetStatus via its `status`
+  // property. So a /pets-only filter must keep CreatePetRequest, Pet,
+  // PetStatus and drop only Error.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: [], paths: ["/pets"])
+  let filtered = filter.apply(resolved, include)
+  let pruned = reachability.prune(filtered)
+  let assert Some(comps) = pruned.components
+  let names = dict.keys(comps.schemas) |> list.sort(string.compare)
+  names |> should.equal(["CreatePetRequest", "Pet", "PetStatus"])
+}
+
+pub fn reachability_prune_with_no_surviving_operations_drops_everything_case() {
+  // When every operation is filtered out, no operation can seed the
+  // walk, so every component schema is unreachable.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let include = config.Include(tags: [], paths: ["/no-such-path"])
+  let filtered = filter.apply(resolved, include)
+  let pruned = reachability.prune(filtered)
+  let assert Some(comps) = pruned.components
+  dict.size(comps.schemas) |> should.equal(0)
+}
+
+pub fn reachability_prune_pipeline_omits_dead_types_in_generated_output_case() {
+  // End-to-end: with an include filter active, the generation
+  // pipeline must emit a `types.gleam` that contains only types
+  // reachable from the surviving operations. petstore's Error and
+  // CreatePetRequest schemas are unreachable from /pets/{petId} and
+  // must not appear in the output.
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let cfg =
+    make_default_cfg()
+    |> config.with_include(config.Include(tags: [], paths: ["/pets/{petId}"]))
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(types_file) =
+    list.find(summary.files, fn(f) { f.path == "types.gleam" })
+  string.contains(types_file.content, "pub type Pet ")
+  |> should.be_true
+  string.contains(types_file.content, "pub type PetStatus")
+  |> should.be_true
+  string.contains(types_file.content, "pub type Error")
+  |> should.be_false
+  string.contains(types_file.content, "pub type CreatePetRequest")
+  |> should.be_false
 }
 
 pub fn filter_path_matches_exact_and_glob_case() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -687,12 +687,17 @@ pub fn reachability_prune_drops_unreferenced_components_case() {
   // operations, which reach Pet (and via Pet's `status` property,
   // PetStatus). CreatePetRequest is reachable only from POST /pets
   // and Error is never referenced in any operation's content, so
-  // both must be pruned.
+  // both must be pruned. The filter→hoist→prune sequence mirrors the
+  // production pipeline so any regression around hoisted inline
+  // schemas surfaces here too.
   let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
   let assert Ok(resolved) = resolve.resolve(unresolved)
   let include = config.Include(tags: [], paths: ["/pets/{petId}"])
-  let filtered = filter.apply(resolved, include)
-  let pruned = reachability.prune(filtered)
+  let pruned =
+    resolved
+    |> filter.apply(include)
+    |> hoist.hoist
+    |> reachability.prune
   let assert Some(comps) = pruned.components
   let names = dict.keys(comps.schemas) |> list.sort(string.compare)
   names |> should.equal(["Pet", "PetStatus"])
@@ -702,12 +707,16 @@ pub fn reachability_prune_keeps_transitively_reachable_components_case() {
   // GET /pets returns Pet[]; POST /pets takes a CreatePetRequest and
   // returns Pet. Pet itself references PetStatus via its `status`
   // property. So a /pets-only filter must keep CreatePetRequest, Pet,
-  // PetStatus and drop only Error.
+  // PetStatus and drop only Error. Pipeline order matches production
+  // (filter → hoist → prune).
   let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
   let assert Ok(resolved) = resolve.resolve(unresolved)
   let include = config.Include(tags: [], paths: ["/pets"])
-  let filtered = filter.apply(resolved, include)
-  let pruned = reachability.prune(filtered)
+  let pruned =
+    resolved
+    |> filter.apply(include)
+    |> hoist.hoist
+    |> reachability.prune
   let assert Some(comps) = pruned.components
   let names = dict.keys(comps.schemas) |> list.sort(string.compare)
   names |> should.equal(["CreatePetRequest", "Pet", "PetStatus"])
@@ -719,8 +728,11 @@ pub fn reachability_prune_with_no_surviving_operations_drops_everything_case() {
   let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
   let assert Ok(resolved) = resolve.resolve(unresolved)
   let include = config.Include(tags: [], paths: ["/no-such-path"])
-  let filtered = filter.apply(resolved, include)
-  let pruned = reachability.prune(filtered)
+  let pruned =
+    resolved
+    |> filter.apply(include)
+    |> hoist.hoist
+    |> reachability.prune
   let assert Some(comps) = pruned.components
   dict.size(comps.schemas) |> should.equal(0)
 }


### PR DESCRIPTION
## Summary

When `targets[].include.paths` was used to subset the API, oaspec dropped
unwanted operations from `spec.paths` but left every component schema
in `spec.components.schemas` intact. The type / encoder / decoder /
guard generators iterate over the whole component dict, so a one-path
filter against GitHub's REST OpenAPI still produced an 11 MB
`decode.gleam` instead of the ~22 KB the filter implied.

This PR adds a reachability pruning pass that walks every operation
surviving the filter into the schema graph and keeps only the
transitively reachable component schemas.

## Changes

- **New** `src/oaspec/internal/openapi/reachability.gleam`: BFS walk from
  surviving operations (path-level parameters, operation parameters,
  request bodies, response bodies, response headers, callbacks) and
  webhooks, through every reference path the codebase models
  (`properties`, `items`, `additionalProperties.Typed`, `allOf` /
  `oneOf` / `anyOf`, plus `discriminator.mapping` schema names). Cycles
  are broken via a visited set keyed on schema name.
- `src/oaspec/generate.gleam`: invoke `reachability.prune` between
  `hoist.hoist` and `dedup.dedup` whenever an include filter is
  configured. When no filter is active the pass is skipped and the
  spec is presented as-authored.
- Four new test cases in `test/oaspec_support.gleam` (wired through
  `include_filter_test`): the prune drops unreferenced components, keeps
  transitively reachable ones, drops everything when no operation
  survives, and the `generate.generate` end-to-end output omits dead
  types from the rendered `types.gleam`.
- `CHANGELOG.md`: Unreleased entry.

## Design Decisions

- **Run after hoist, before dedup.** Hoist may add synthetic component
  schemas while walking the filtered operations, so the prune has to
  see those additions. Dedup operates on schema names, so running it on
  the smaller post-prune set is both faster and avoids renaming names
  that are about to be removed anyway.
- **Skip when no filter is active.** A user without an `include` block
  has not asked to subset the API; pruning anyway would silently delete
  component schemas the spec author chose to publish (e.g. `Error`
  schemas reserved for future use). The pipeline therefore short-circuits
  when `config.include_is_empty(config.include(cfg))` returns true.
- **Walk discriminator.mapping values.** Mapping entries reference
  component schemas by name only, so a purely structural walk would
  miss them. Names are converted via `schema.make_reference/1` and fed
  back into the worklist.
- **Component-level `parameters` / `request_bodies` / `responses` /
  `headers` are not direct seeds.** At the Resolved stage these are
  already inlined into operations wherever they are used, so any schema
  they reference is reachable through the operation seeds.

Closes #501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation with include path filters incorrectly emitting decoder, encoder, type, and guard code for unused schemas. The generation pipeline now intelligently identifies and excludes unused schema definitions when path filtering is enabled.

* **Tests**
  * Added comprehensive test coverage for schema pruning behavior with include filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->