### PR TITLE
feat(content-type): support `*/*` wildcard content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- **codegen(`*/*` content type)**: OpenAPI's `*/*` catch-all media type
+  is now recognised as a supported request and response content type.
+  Specs like Kubernetes' OpenAPI v3 use `*/*` heavily for proxy
+  endpoints and resource-mutation handlers (`replace`, `delete`,
+  `create`) that accept or emit arbitrary bytes; previously each
+  `*/*` declaration produced a hard validation error and the spec was
+  un-generatable. oaspec now treats `*/*` as a synonym for
+  `application/octet-stream` for codegen purposes — the request body
+  is `BitArray`, the response body is `BitArray` — which matches the
+  "any bytes" semantics without committing the SDK to a specific
+  parser. Both client and server modes accept the new shape; the
+  server router exposes the body as raw `BitArray` and the response
+  emitter wraps it in `BytesBody`. Issue #504.
+
 ## [0.52.0] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 361 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 261 test fixtures (including 98 OSS-derived edge-case specs)
+  and 262 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/capability.gleam
+++ b/src/oaspec/internal/capability.gleam
@@ -186,6 +186,12 @@ pub fn registry() -> List(Capability) {
       "Plain text request bodies (raw string passthrough; no JSON encoding)",
     ),
     Capability(
+      "*/*",
+      "request",
+      Supported,
+      "Wildcard request bodies (treated as application/octet-stream — raw BitArray passthrough)",
+    ),
+    Capability(
       "+json/+xml suffix",
       "content-type",
       Supported,
@@ -217,6 +223,12 @@ pub fn registry() -> List(Capability) {
       "response",
       Supported,
       "XML passthrough; no structural decoding yet",
+    ),
+    Capability(
+      "*/*",
+      "response",
+      Supported,
+      "Wildcard responses (treated as application/octet-stream — raw BitArray passthrough)",
     ),
     // Server-mode validation restrictions — features the parser accepts
     // but the server-code generator rejects. Names match the phrasing

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -160,8 +160,13 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
           Value(response) ->
             list.any(dict.to_list(response.content), fn(ce) {
               let #(media_type_name, mt) = ce
-              case media_type_name {
-                "text/plain" -> False
+              // Issue #504: */* and application/octet-stream responses
+              // decode through `bytes_body`, not `dyn_decode`, so they
+              // must not pull the dynamic-decode import in even when
+              // their inline schema is a primitive.
+              case ct_util.from_string(media_type_name) {
+                ct_util.TextPlain -> False
+                ct_util.ApplicationOctetStream | ct_util.Wildcard -> False
                 _ ->
                   case mt.schema {
                     // Issue #493 / CodeRabbit follow-up: array

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -199,7 +199,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
             // `json.to_string`, so a `type: string, format: binary`
             // request body must not pull in `gleam/json`.
             case ct_util.from_string(ct_name) {
-              ct_util.ApplicationOctetStream -> False
+              ct_util.ApplicationOctetStream | ct_util.Wildcard -> False
               _ ->
                 case mt.schema {
                   Some(Inline(schema.StringSchema(..))) -> True
@@ -312,7 +312,10 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
           Value(response) ->
             list.any(dict.to_list(response.content), fn(ce) {
               let #(name, _) = ce
-              ct_util.from_string(name) == ct_util.ApplicationOctetStream
+              case ct_util.from_string(name) {
+                ct_util.ApplicationOctetStream | ct_util.Wildcard -> True
+                _ -> False
+              }
             })
           _ -> False
         }

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -228,7 +228,8 @@ pub fn get_body_type(rb: spec.RequestBody(Resolved), op_id: String) -> String {
     [_, _, ..] -> "String"
     [#(media_type_name, media_type)] ->
       case content_type.from_string(media_type_name) {
-        content_type.ApplicationOctetStream -> "BitArray"
+        content_type.ApplicationOctetStream | content_type.Wildcard ->
+          "BitArray"
         _ ->
           case media_type.schema {
             Some(Reference(name:, ..)) ->

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -77,7 +77,7 @@ pub fn generate_single_content_response(
   headers: Option(HeadersRecord),
 ) -> se.StringBuilder {
   case content_type.from_string(media_type_name) {
-    content_type.ApplicationOctetStream ->
+    content_type.ApplicationOctetStream | content_type.Wildcard ->
       case media_type.schema {
         Some(_) ->
           body_branch(sb, status_code, variant_name, "bytes", headers, fn(sb) {

--- a/src/oaspec/internal/codegen/ir_build.gleam
+++ b/src/oaspec/internal/codegen/ir_build.gleam
@@ -197,7 +197,7 @@ fn request_body_type(
       // response side already does this correctly via
       // `response_inner_type` above; mirror that for the request.
       case content_type.from_string(media_type_name) {
-        content_type.ApplicationOctetStream ->
+        content_type.ApplicationOctetStream | content_type.Wildcard ->
           case media_type.schema {
             Some(_) -> "BitArray"
             None -> "BitArray"
@@ -330,7 +330,8 @@ fn responses_need_types_import(
                 content_type.TextPlain
                 | content_type.ApplicationXml
                 | content_type.TextXml
-                | content_type.ApplicationOctetStream -> False
+                | content_type.ApplicationOctetStream
+                | content_type.Wildcard -> False
                 _ ->
                   case media_type.schema {
                     Some(Reference(..)) -> True
@@ -443,8 +444,9 @@ fn response_inner_type(
           }
         // Issue #304: binary response payloads ride a BitArray variant
         // so handlers can produce real bytes instead of forcing the
-        // payload through `String`.
-        content_type.ApplicationOctetStream ->
+        // payload through `String`. Issue #504: */* shares the same
+        // path; wildcard responses are handed back as raw BitArray.
+        content_type.ApplicationOctetStream | content_type.Wildcard ->
           case media_type.schema {
             Some(_) -> Some("BitArray")
             None -> None

--- a/src/oaspec/internal/codegen/server.gleam
+++ b/src/oaspec/internal/codegen/server.gleam
@@ -1191,11 +1191,13 @@ fn generate_response_conversion(
                             is_default: is_default,
                           )
                       }
-                    content_type.ApplicationOctetStream ->
+                    content_type.ApplicationOctetStream | content_type.Wildcard ->
                       // Issue #304: binary responses thread bytes end-to-end
                       // via `BytesBody(BitArray)` instead of being smuggled
                       // through `String`. The matching response_types
                       // variant carries `BitArray` (see ir_build).
+                      // Issue #504: */* shares the same path — wildcard
+                      // responses are handed to the user as raw BitArray.
                       case media_type.schema {
                         Some(_) ->
                           emit_response_arm(

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -606,9 +606,9 @@ fn validate_request_body(
             path: op_id <> ".requestBody",
             detail: "Content type '"
               <> media_type
-              <> "' is not supported. Supported request content types: application/json (and +json suffix types), text/plain, multipart/form-data, application/x-www-form-urlencoded, application/octet-stream.",
+              <> "' is not supported. Supported request content types: application/json (and +json suffix types), text/plain, multipart/form-data, application/x-www-form-urlencoded, application/octet-stream, */*.",
             hint: Some(
-              "Use application/json (or a +json suffix type like application/problem+json), text/plain, multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream.",
+              "Use application/json (or a +json suffix type like application/problem+json), text/plain, multipart/form-data, application/x-www-form-urlencoded, application/octet-stream, or */*.",
             ),
           ),
         ]
@@ -808,6 +808,10 @@ fn validate_server_request_body_content_types(
           && key != "multipart/form-data"
           && key != "application/octet-stream"
           && key != "text/plain"
+          // Issue #504: */* lands in the same lane as
+          // application/octet-stream — raw bytes through the server's
+          // body parameter — so server codegen accepts it too.
+          && key != "*/*"
           && content_type.is_supported_request(content_type.from_string(key))
         })
       list.map(non_json_but_supported, fn(media_type) {
@@ -973,9 +977,9 @@ fn validate_responses(
             path: path,
             detail: "Response content type '"
               <> media_type_name
-              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/x-ndjson, application/octet-stream, application/xml (and +xml suffix types), text/xml.",
+              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/x-ndjson, application/octet-stream, application/xml (and +xml suffix types), text/xml, */*.",
             hint: Some(
-              "Use application/json (or a +json suffix type), text/plain, application/x-ndjson, application/octet-stream, application/xml (or a +xml suffix type), or text/xml.",
+              "Use application/json (or a +json suffix type), text/plain, application/x-ndjson, application/octet-stream, application/xml (or a +xml suffix type), text/xml, or */*.",
             ),
           ),
         ]

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -821,7 +821,7 @@ fn validate_server_request_body_content_types(
             <> media_type
             <> "' is not supported for server code generation. Server router only supports application/json request bodies with typed decoding.",
           hint: Some(
-            "Use application/json for typed server request bodies, or multipart/form-data, application/x-www-form-urlencoded, or application/octet-stream for non-JSON payloads.",
+            "Use application/json for typed server request bodies, or multipart/form-data, application/x-www-form-urlencoded, application/octet-stream, text/plain, or */* for non-JSON payloads.",
           ),
         )
       })

--- a/src/oaspec/internal/util/content_type.gleam
+++ b/src/oaspec/internal/util/content_type.gleam
@@ -3,6 +3,14 @@ import gleam/string
 import oaspec/internal/capability
 
 /// Supported content types for code generation.
+///
+/// `Wildcard` represents the OpenAPI `*/*` media-type catch-all
+/// (Issue #504). Specs like Kubernetes' OpenAPI v3 use it for
+/// proxy-style endpoints and resource mutation handlers that accept or
+/// emit arbitrary bytes. oaspec treats `*/*` as `application/octet-stream`
+/// for codegen purposes — request body is `BitArray`, response body is
+/// `BitArray` — which matches the "any bytes" semantics without
+/// committing the SDK to a specific parser.
 pub type ContentType {
   ApplicationJson
   TextPlain
@@ -11,6 +19,7 @@ pub type ContentType {
   ApplicationOctetStream
   ApplicationXml
   TextXml
+  Wildcard
   UnsupportedContentType(String)
 }
 
@@ -57,6 +66,10 @@ pub fn from_string(content_type: String) -> ContentType {
     "application/octet-stream" -> ApplicationOctetStream
     "application/xml" -> ApplicationXml
     "text/xml" -> TextXml
+    // OpenAPI `*/*` catch-all (Issue #504). Treated as a synonym for
+    // application/octet-stream by the codegen so the generated code
+    // moves bytes through unchanged.
+    "*/*" -> Wildcard
     other ->
       case string.ends_with(other, "+json") {
         True -> ApplicationJson
@@ -99,6 +112,7 @@ pub fn to_string(content_type: ContentType) -> String {
     ApplicationOctetStream -> "application/octet-stream"
     ApplicationXml -> "application/xml"
     TextXml -> "text/xml"
+    Wildcard -> "*/*"
     UnsupportedContentType(s) -> s
   }
 }
@@ -113,6 +127,7 @@ pub fn is_supported(content_type: ContentType) -> Bool {
     ApplicationOctetStream -> True
     ApplicationXml -> True
     TextXml -> True
+    Wildcard -> True
     _ -> False
   }
 }

--- a/test/fixtures/wildcard_content_type.yaml
+++ b/test/fixtures/wildcard_content_type.yaml
@@ -1,0 +1,41 @@
+openapi: "3.0.3"
+info:
+  title: Wildcard Content Type Test
+  description: |
+    Issue #504. Exercises `*/*` request and response media types as
+    used by Kubernetes' OpenAPI v3 spec for proxy and resource-mutation
+    endpoints. Both shapes should pass validation and generate working
+    Gleam code.
+  version: "1.0.0"
+paths:
+  /upload:
+    post:
+      operationId: uploadOpaqueBytes
+      summary: Accept any payload as raw bytes
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Echo
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+  /proxy:
+    get:
+      operationId: proxyAnyResponse
+      summary: Pass-through proxy returning any media type
+      responses:
+        "200":
+          description: Whatever the upstream returned
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -113,6 +113,9 @@ pub fn content_type_helpers_test() {
     support.capability_registry_covers_content_type_response_helpers_case()
   let _ = support.capability_registry_covers_content_type_request_helpers_case()
   let _ = support.is_supported_request_rejects_unsupported_content_type_case()
+  let _ = support.wildcard_content_type_passes_validation_case()
+  let _ = support.wildcard_content_type_classified_as_supported_case()
+  let _ = support.wildcard_content_type_generates_bitarray_bodies_case()
 }
 
 pub fn location_index_source_loc_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6698,6 +6698,77 @@ paths:
   |> should.be_true()
 }
 
+// --- Issue #504: */* wildcard content type ---
+
+/// `*/*` request bodies and responses parse to BitArray and pass
+/// validation. Kubernetes' OpenAPI v3 spec uses `*/*` heavily for
+/// proxy and resource-mutation endpoints; without this support the
+/// generator can't accept those specs.
+pub fn wildcard_content_type_passes_validation_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/wildcard_content_type.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let spec = hoist.hoist(resolved)
+  let spec = dedup.dedup(spec)
+  let ctx =
+    context.new(
+      spec,
+      config.new(
+        input: "test/fixtures/wildcard_content_type.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Both,
+        validate: False,
+      ),
+    )
+  let errors = validate.validate(ctx)
+  errors |> list.is_empty |> should.be_true()
+}
+
+/// `content_type.from_string("*/*")` round-trips through `Wildcard`
+/// and is reported as supported for both request and response.
+pub fn wildcard_content_type_classified_as_supported_case() {
+  content_type.from_string("*/*")
+  |> should.equal(content_type.Wildcard)
+  content_type.to_string(content_type.Wildcard)
+  |> should.equal("*/*")
+  content_type.is_supported(content_type.Wildcard)
+  |> should.be_true()
+  content_type.is_supported_request(content_type.Wildcard)
+  |> should.be_true()
+  content_type.is_supported_response(content_type.Wildcard)
+  |> should.be_true()
+}
+
+/// End-to-end: generating a client for the wildcard fixture must
+/// produce a `BitArray` request body and a `BitArray` response
+/// variant — the same shape as `application/octet-stream`.
+pub fn wildcard_content_type_generates_bitarray_bodies_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/wildcard_content_type.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/wildcard_content_type.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(request_types_file) =
+    list.find(summary.files, fn(f) { f.path == "request_types.gleam" })
+  let assert Ok(response_types_file) =
+    list.find(summary.files, fn(f) { f.path == "response_types.gleam" })
+  // Request type carries BitArray for the upload op.
+  string.contains(request_types_file.content, "body: BitArray")
+  |> should.be_true()
+  // Response variants carry BitArray for both ops.
+  string.contains(response_types_file.content, "BitArray")
+  |> should.be_true()
+}
+
 // --- form-urlencoded non-object validation tests ---
 
 /// form-urlencoded with non-object schema must be rejected by validation.


### PR DESCRIPTION
## Summary

Recognise `*/*` as a supported request and response content type by
treating it as a synonym for `application/octet-stream` for codegen
purposes — request body becomes `BitArray`, response body becomes
`BitArray`. Without this change, Kubernetes' OpenAPI v3 spec produces
a hard validation error on every proxy and mutation endpoint, making
it un-generatable.

## Changes

- **`src/oaspec/internal/util/content_type.gleam`**: new `Wildcard`
  variant on `ContentType`. `from_string("*/*")` now returns it,
  `to_string(Wildcard)` returns `"*/*"`, and all
  `is_supported*` predicates report it as supported.
- **`src/oaspec/internal/capability.gleam`**: add `*/*` capability
  rows under both `request` and `response` categories so the registry-
  driven `is_supported_request` / `is_supported_response` predicates
  return True.
- **Codegen pattern updates**: every place that branches on
  `ApplicationOctetStream` now also matches `Wildcard`. Touched files:
  `client_ir.gleam`, `client_request.gleam`, `client_response.gleam`,
  `ir_build.gleam`, `server.gleam`. Result: request/response IR types,
  client encoder/decoder, and server response emitter all treat `*/*`
  as raw bytes.
- **`src/oaspec/internal/codegen/validate.gleam`**: extend the server-
  mode request-body whitelist to include `*/*` so server codegen does
  not re-reject the type after the registry approves it. Update the
  user-facing error messages to mention `*/*` in the supported-types
  list.
- **Tests**: new fixture `test/fixtures/wildcard_content_type.yaml`
  (one upload op with `*/*` request and response, one proxy op with
  `*/*` response) plus three test cases in
  `test/oaspec_support.gleam` covering classification, validation,
  and end-to-end generation (request type carries `BitArray`, response
  variants carry `BitArray`).
- **`README.md` / `CHANGELOG.md`**: bump fixture count, add Unreleased
  entry.

## Design Decisions

- **`*/*` as `application/octet-stream` synonym**: the issue's
  recommendation. It's the safest fallback — `*/*` semantically means
  "any bytes" and `BitArray` does not pre-decide a parser. The
  generated server router exposes the body as raw bytes; users can
  post-process if they know the concrete content type.
- **No sibling-preference picker yet**: the issue's optional
  enhancement (when `application/json` and `*/*` appear side-by-side
  in the same `content` map, prefer the typed JSON entry) is out of
  scope here. The current `get_body_type` already falls back to
  `String` when multiple media types are declared, so co-located
  `*/*` does not break the existing path. Specs that declare `*/*`
  alongside other types still work; they just get the multi-content
  `String` fallback. A follow-up can introduce a smarter picker if
  Kubernetes / Stripe surface concrete cases that need it.
- **Server router accepts `*/*` as bytes**: the server-mode whitelist
  in `validate_server_request_body_content_types` is the gate that
  blocks non-JSON / non-form / non-octet-stream types from server
  codegen. Adding `*/*` keeps the policy explicit (rather than relying
  on `is_supported_request` alone, which is registry-driven).

## Limitations

- The generated server's `Content-Type` header (and request matching)
  uses the spec-declared name verbatim, which means `*/*`. A server
  emitting `Content-Type: */*` is technically conformant but not a
  useful real-world value. A spec author who wants the server to
  emit a concrete content type should declare it under a specific
  media-type key (e.g. `application/octet-stream`) instead of
  relying on the wildcard. This is a known follow-up and not blocked
  by this PR.

Closes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full support for the OpenAPI wildcard (`*/*`) media type in code generation, enabling seamless handling of catch-all content types with proper binary data support for requests and responses.

* **Documentation**
  * Updated CHANGELOG documenting wildcard media type support and code generation behavior.
  * Updated test fixture statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->