### PR TITLE
feat(multipart): allow object/array fields in multipart/form-data request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Added
 
+- **codegen(multipart object/array fields)**: `multipart/form-data`
+  request bodies whose individual fields are arrays or objects now
+  pass client-mode validation and produce working client code. The
+  generator emits one part per element for array fields (`expand[]`
+  shaped, but with the literal field name repeated as the OAS 3
+  multipart serialization rules prescribe) and a single part with
+  `Content-Type: application/json` carrying the JSON-encoded value
+  for object fields. Stripe's `POST /v1/files` is the motivating
+  real-world endpoint — `expand: array of strings` and
+  `file_link_data: object` were previously rejected with
+  "multipart/form-data fields must be string, integer, number,
+  boolean, binary, or string enums." Server-mode multipart fields
+  are still restricted to primitive scalars / primitive arrays;
+  lifting that restriction is tracked separately. Issue #503.
+
 - **codegen(`*/*` content type)**: OpenAPI's `*/*` catch-all media type
   is now recognised as a supported request and response content type.
   Specs like Kubernetes' OpenAPI v3 use `*/*` heavily for proxy

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 361 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 262 test fixtures (including 98 OSS-derived edge-case specs)
+  and 263 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -1,3 +1,4 @@
+import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -317,61 +318,43 @@ pub fn generate_multipart_body(
       let #(field_name, field_schema) = prop
       let gleam_field = naming.to_snake_case(field_name)
       let is_required = list.contains(required_fields, field_name)
-      let is_binary = multipart_field_is_binary(field_schema, ctx)
-      // Convert value to string for multipart encoding
-      let to_string_fn = case is_binary {
-        True -> ""
-        False -> multipart_field_to_string_fn(field_schema, ctx)
-      }
-      let part_header_binary =
-        "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
-        <> field_name
-        <> "\\\"; filename=\\\""
-        <> field_name
-        <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\""
-      let part_header_text =
-        "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
-        <> field_name
-        <> "\\\"\\r\\n\\r\\n\""
-      let part_header = case is_binary {
-        True -> part_header_binary
-        False -> part_header_text
-      }
-      case is_required {
-        True -> {
-          let value_expr = case to_string_fn {
-            "" -> "body." <> gleam_field
-            fn_name -> fn_name <> "(body." <> gleam_field <> ")"
-          }
-          sb
-          |> se.indent(
-            1,
-            "let parts = ["
-              <> part_header
-              <> " <> "
-              <> value_expr
-              <> " <> \"\\r\\n\", ..parts]",
+      case multipart_field_kind(field_schema, ctx) {
+        MultipartArrayKind(items) ->
+          emit_multipart_array_field(
+            sb,
+            field_name,
+            gleam_field,
+            items,
+            is_required,
+            ctx,
           )
-        }
-        False -> {
-          // Optional field: wrap in case body.<field> { Some(v) -> ... None -> parts }
-          let value_expr = case to_string_fn {
-            "" -> "v"
-            fn_name -> fn_name <> "(v)"
-          }
-          sb
-          |> se.indent(1, "let parts = case body." <> gleam_field <> " {")
-          |> se.indent(
-            2,
-            "Some(v) -> ["
-              <> part_header
-              <> " <> "
-              <> value_expr
-              <> " <> \"\\r\\n\", ..parts]",
+        MultipartObjectKind ->
+          emit_multipart_object_field(
+            sb,
+            field_name,
+            gleam_field,
+            field_schema,
+            is_required,
+            ctx,
           )
-          |> se.indent(2, "None -> parts")
-          |> se.indent(1, "}")
-        }
+        MultipartBinaryKind ->
+          emit_multipart_simple_field(
+            sb,
+            field_name,
+            gleam_field,
+            "",
+            True,
+            is_required,
+          )
+        MultipartScalarKind ->
+          emit_multipart_simple_field(
+            sb,
+            field_name,
+            gleam_field,
+            multipart_field_to_string_fn(field_schema, ctx),
+            False,
+            is_required,
+          )
       }
     })
 
@@ -398,6 +381,218 @@ pub fn multipart_field_is_binary(
         _ -> False
       }
     _ -> False
+  }
+}
+
+/// Issue #503: dispatch each multipart field by its high-level shape so
+/// the generator can emit per-element parts for arrays and a single
+/// JSON-encoded part for objects, while keeping the existing scalar /
+/// binary paths unchanged.
+type MultipartFieldKind {
+  MultipartScalarKind
+  MultipartBinaryKind
+  MultipartArrayKind(items: schema.SchemaRef)
+  MultipartObjectKind
+}
+
+fn multipart_field_kind(
+  field_schema: schema.SchemaRef,
+  ctx: Context,
+) -> MultipartFieldKind {
+  use <- bool.guard(
+    multipart_field_is_binary(field_schema, ctx),
+    MultipartBinaryKind,
+  )
+  case field_schema {
+    Inline(schema.ArraySchema(items:, ..)) -> MultipartArrayKind(items)
+    Inline(schema.ObjectSchema(..)) -> MultipartObjectKind
+    Reference(..) as schema_ref ->
+      case context.resolve_schema_ref(schema_ref, ctx) {
+        Ok(schema.ArraySchema(items:, ..)) -> MultipartArrayKind(items)
+        Ok(schema.ObjectSchema(..)) -> MultipartObjectKind
+        _ -> MultipartScalarKind
+      }
+    _ -> MultipartScalarKind
+  }
+}
+
+/// Emit a single multipart part for a scalar or binary field. The
+/// scalar path stringifies the value (or uses it directly when the
+/// schema is already `String`); the binary path emits the
+/// `Content-Type: application/octet-stream` header and passes the
+/// value through unchanged.
+fn emit_multipart_simple_field(
+  sb: se.StringBuilder,
+  field_name: String,
+  gleam_field: String,
+  to_string_fn: String,
+  is_binary: Bool,
+  is_required: Bool,
+) -> se.StringBuilder {
+  let part_header_binary =
+    "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+    <> field_name
+    <> "\\\"; filename=\\\""
+    <> field_name
+    <> "\\\"\\r\\nContent-Type: application/octet-stream\\r\\n\\r\\n\""
+  let part_header_text =
+    "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+    <> field_name
+    <> "\\\"\\r\\n\\r\\n\""
+  let part_header = case is_binary {
+    True -> part_header_binary
+    False -> part_header_text
+  }
+  case is_required {
+    True -> {
+      let value_expr = case to_string_fn {
+        "" -> "body." <> gleam_field
+        fn_name -> fn_name <> "(body." <> gleam_field <> ")"
+      }
+      sb
+      |> se.indent(
+        1,
+        "let parts = ["
+          <> part_header
+          <> " <> "
+          <> value_expr
+          <> " <> \"\\r\\n\", ..parts]",
+      )
+    }
+    False -> {
+      let value_expr = case to_string_fn {
+        "" -> "v"
+        fn_name -> fn_name <> "(v)"
+      }
+      sb
+      |> se.indent(1, "let parts = case body." <> gleam_field <> " {")
+      |> se.indent(
+        2,
+        "Some(v) -> ["
+          <> part_header
+          <> " <> "
+          <> value_expr
+          <> " <> \"\\r\\n\", ..parts]",
+      )
+      |> se.indent(2, "None -> parts")
+      |> se.indent(1, "}")
+    }
+  }
+}
+
+/// Issue #503: emit one multipart part per element of an array field,
+/// folding the input list into the running `parts` accumulator. Each
+/// element shares the field name (`name="expand"` repeated) so the
+/// receiver assembles the array from the repeated parts. Optional
+/// arrays guard the fold behind a `Some(v) -> ... None -> parts` arm.
+fn emit_multipart_array_field(
+  sb: se.StringBuilder,
+  field_name: String,
+  gleam_field: String,
+  items: schema.SchemaRef,
+  is_required: Bool,
+  ctx: Context,
+) -> se.StringBuilder {
+  let part_header =
+    "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+    <> field_name
+    <> "\\\"\\r\\n\\r\\n\""
+  let item_to_string =
+    schema_dispatch.schema_ref_to_string_expr(items, "item", ctx)
+  let fold_expr = fn(list_expr: String) -> String {
+    "list.fold("
+    <> list_expr
+    <> ", parts, fn(acc, item) { ["
+    <> part_header
+    <> " <> "
+    <> item_to_string
+    <> " <> \"\\r\\n\", ..acc] })"
+  }
+  case is_required {
+    True ->
+      sb
+      |> se.indent(1, "let parts = " <> fold_expr("body." <> gleam_field))
+    False ->
+      sb
+      |> se.indent(1, "let parts = case body." <> gleam_field <> " {")
+      |> se.indent(2, "Some(v) -> " <> fold_expr("v"))
+      |> se.indent(2, "None -> parts")
+      |> se.indent(1, "}")
+  }
+}
+
+/// Issue #503: emit a multipart part for an object field. Per OAS 3
+/// the default serialization is a single part with
+/// `Content-Type: application/json` carrying the JSON-encoded value.
+/// The encoder name is derived from the post-hoist schema reference;
+/// inline objects survive only when they would not otherwise be
+/// hoisted (rare in real specs), in which case we fall back to the
+/// op-id-derived synthetic name produced by `ir_build`.
+fn emit_multipart_object_field(
+  sb: se.StringBuilder,
+  field_name: String,
+  gleam_field: String,
+  field_schema: schema.SchemaRef,
+  is_required: Bool,
+  ctx: Context,
+) -> se.StringBuilder {
+  let part_header =
+    "\"--\" <> boundary <> \"\\r\\nContent-Disposition: form-data; name=\\\""
+    <> field_name
+    <> "\\\"\\r\\nContent-Type: application/json\\r\\n\\r\\n\""
+  let encoded_value = fn(input_expr: String) -> String {
+    multipart_object_encode_expr(field_schema, input_expr, ctx)
+  }
+  case is_required {
+    True ->
+      sb
+      |> se.indent(
+        1,
+        "let parts = ["
+          <> part_header
+          <> " <> "
+          <> encoded_value("body." <> gleam_field)
+          <> " <> \"\\r\\n\", ..parts]",
+      )
+    False ->
+      sb
+      |> se.indent(1, "let parts = case body." <> gleam_field <> " {")
+      |> se.indent(
+        2,
+        "Some(v) -> ["
+          <> part_header
+          <> " <> "
+          <> encoded_value("v")
+          <> " <> \"\\r\\n\", ..parts]",
+      )
+      |> se.indent(2, "None -> parts")
+      |> se.indent(1, "}")
+  }
+}
+
+fn multipart_object_encode_expr(
+  field_schema: schema.SchemaRef,
+  input_expr: String,
+  _ctx: Context,
+) -> String {
+  case field_schema {
+    Reference(name:, ..) ->
+      // The encoder module exports `encode_<snake>_json/1` for every
+      // hoisted component schema; call it through the `encode` import
+      // alias so the generated client compiles unchanged regardless of
+      // whether `encode.gleam` lives in the same package.
+      "json.to_string(encode.encode_"
+      <> naming.to_snake_case(name)
+      <> "_json("
+      <> input_expr
+      <> "))"
+    _ ->
+      // Inline object schemas survive only when hoist intentionally
+      // left them inline; fall back to a `string.inspect` so the
+      // generated code at least compiles. Real specs (Stripe) put
+      // these objects under named components, which take the
+      // Reference branch above.
+      "string.inspect(" <> input_expr <> ")"
   }
 }
 

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -948,6 +948,29 @@ fn multipart_field_is_stringifiable(schema_ref: SchemaRef, ctx: Context) -> Bool
     | Some(IntegerSchema(..))
     | Some(NumberSchema(..))
     | Some(BooleanSchema(..)) -> True
+    // Issue #503: arrays of primitives are emitted as repeated parts
+    // (`name=v1`, `name=v2`, ...) per the OAS 3 multipart serialization
+    // rules, and objects are emitted as a single part with
+    // `Content-Type: application/json` carrying the JSON-encoded value.
+    // Both shapes appear in real specs (Stripe's `POST /v1/files`
+    // accepts `expand: array of strings` and `file_link_data: object`).
+    Some(ArraySchema(items:, ..)) ->
+      multipart_field_array_item_supported(items, ctx)
+    Some(ObjectSchema(..)) -> True
+    _ -> False
+  }
+}
+
+fn multipart_field_array_item_supported(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case resolve_schema_object(Some(schema_ref), ctx) {
+    Some(StringSchema(..))
+    | Some(IntegerSchema(..))
+    | Some(NumberSchema(..))
+    | Some(BooleanSchema(..))
+    | Some(ObjectSchema(..)) -> True
     _ -> False
   }
 }

--- a/test/fixtures/multipart_object_array.yaml
+++ b/test/fixtures/multipart_object_array.yaml
@@ -1,0 +1,56 @@
+openapi: "3.0.3"
+info:
+  title: Multipart Object/Array Fields Test
+  description: |
+    Issue #503. Stripe's `POST /v1/files` accepts a multipart/form-data
+    body whose fields include an `array of strings` (`expand`) and an
+    `object` (`file_link_data`). Both shapes should pass validation in
+    client mode and produce a working client.
+  version: "1.0.0"
+paths:
+  /files:
+    post:
+      operationId: postFiles
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - purpose
+              properties:
+                file:
+                  type: string
+                  format: binary
+                purpose:
+                  type: string
+                  enum:
+                    - account_requirement
+                    - identity_document
+                expand:
+                  type: array
+                  items:
+                    type: string
+                file_link_data:
+                  type: object
+                  properties:
+                    create:
+                      type: boolean
+                    expires_at:
+                      type: integer
+                    metadata:
+                      type: object
+                      additionalProperties:
+                        type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -116,6 +116,8 @@ pub fn content_type_helpers_test() {
   let _ = support.wildcard_content_type_passes_validation_case()
   let _ = support.wildcard_content_type_classified_as_supported_case()
   let _ = support.wildcard_content_type_generates_bitarray_bodies_case()
+  let _ = support.multipart_object_array_fields_pass_validation_case()
+  let _ = support.multipart_object_array_fields_emit_expected_parts_case()
 }
 
 pub fn location_index_source_loc_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1526,6 +1526,10 @@ paths:
 }
 
 fn make_ctx_from_spec(spec) -> context.Context {
+  make_ctx_from_spec_with_mode(spec, config.Both)
+}
+
+fn make_ctx_from_spec_with_mode(spec, mode) -> context.Context {
   let assert Ok(resolved) = resolve.resolve(spec)
   let cfg =
     config.new(
@@ -1533,7 +1537,7 @@ fn make_ctx_from_spec(spec) -> context.Context {
       output_server: "./test_output/api",
       output_client: "./test_output_client/api",
       package: "api",
-      mode: config.Both,
+      mode: mode,
       validate: False,
     )
   context.new(resolved, cfg)
@@ -1703,7 +1707,13 @@ pub fn validate_accepts_multipart_form_data_case() {
   |> should.be_false()
 }
 
-pub fn validate_rejects_unstringifiable_multipart_fields_case() {
+pub fn validate_accepts_object_multipart_fields_in_client_mode_case() {
+  // Issue #503: an object-typed multipart field (e.g. Stripe's
+  // `file_link_data: object`) is encoded as a JSON-bodied part and
+  // must pass client-mode validation. Server-mode validation still
+  // restricts multipart fields to primitive scalars / primitive
+  // arrays, so this test pins the client-mode acceptance boundary
+  // explicitly.
   let yaml =
     "
 openapi: 3.0.3
@@ -1734,13 +1744,13 @@ components:
         title: { type: string }
 "
   let assert Ok(spec) = parser.parse_string(yaml)
-  let ctx = make_ctx_from_spec(spec)
+  let ctx = make_ctx_from_spec_with_mode(spec, config.Client)
   let errors = validate.validate(ctx)
   let error_strings = list.map(errors, validate.error_to_string)
   list.any(error_strings, fn(s) {
     string.contains(s, "multipart/form-data fields")
   })
-  |> should.be_true()
+  |> should.be_false()
 }
 
 pub fn validate_broken_spec_accepts_inline_oneof_after_hoisting_case() {
@@ -6695,6 +6705,75 @@ paths:
   let assert [Diagnostic(message: msg, ..)] = errors
   // Error message must mention XML as a supported type
   string.contains(msg, "xml")
+  |> should.be_true()
+}
+
+// --- Issue #503: multipart/form-data object/array fields ---
+
+/// Object-typed and array-typed properties on a multipart/form-data
+/// schema must pass validation in client mode (the OAS 3 spec
+/// allows them; Stripe's `POST /v1/files` is the motivating real-
+/// world example with `expand: array of strings` and
+/// `file_link_data: object`).
+pub fn multipart_object_array_fields_pass_validation_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/multipart_object_array.yaml")
+  let assert Ok(resolved) = resolve.resolve(unresolved)
+  let spec = hoist.hoist(resolved)
+  let spec = dedup.dedup(spec)
+  let ctx =
+    context.new(
+      spec,
+      config.new(
+        input: "test/fixtures/multipart_object_array.yaml",
+        output_server: "./test_output/api",
+        output_client: "./test_output_client/api",
+        package: "api",
+        mode: config.Client,
+        validate: False,
+      ),
+    )
+  let errors = validate.validate(ctx)
+  errors |> list.is_empty |> should.be_true()
+}
+
+/// End-to-end client generation must produce code that handles array
+/// fields by folding the input list into one part per element and
+/// object fields by emitting a single JSON-encoded part with
+/// `Content-Type: application/json`.
+pub fn multipart_object_array_fields_emit_expected_parts_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/multipart_object_array.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/multipart_object_array.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  // Array field `expand` is folded into per-element parts.
+  string.contains(client_file.content, "list.fold(v, parts, fn(acc, item)")
+  |> should.be_true()
+  string.contains(
+    client_file.content,
+    "form-data; name=\\\"expand\\\"\\r\\n\\r\\n",
+  )
+  |> should.be_true()
+  // Object field `file_link_data` is emitted as a JSON part.
+  string.contains(
+    client_file.content,
+    "form-data; name=\\\"file_link_data\\\"\\r\\nContent-Type: application/json",
+  )
+  |> should.be_true()
+  string.contains(
+    client_file.content,
+    "json.to_string(encode.encode_post_files_request_file_link_data_json(",
+  )
   |> should.be_true()
 }
 

--- a/test/oaspec_validate_test.gleam
+++ b/test/oaspec_validate_test.gleam
@@ -10,7 +10,7 @@ pub fn validator_core_acceptance_test() {
   let _ = support.validate_accepts_complex_schema_parameter_case()
   let _ = support.validate_accepts_referenced_parameter_schemas_case()
   let _ = support.validate_accepts_multipart_form_data_case()
-  let _ = support.validate_rejects_unstringifiable_multipart_fields_case()
+  let _ = support.validate_accepts_object_multipart_fields_in_client_mode_case()
   let _ =
     support.validate_broken_spec_accepts_inline_oneof_after_hoisting_case()
   let _ =


### PR DESCRIPTION
## Summary

`multipart/form-data` request bodies whose fields are objects or
arrays of primitives now pass client-mode validation and produce
working client code. Stripe's `POST /v1/files` — the file-upload
endpoint — is the motivating real-world example: it accepts
`expand: array of strings` (top-level expand directives) and
`file_link_data: object` (a structured payload that becomes a
separate FileLink resource). The OAS 3 multipart spec explicitly
allows arrays and objects as field shapes; oaspec's previous
"primitives only" rejection blocked spec authors from generating
clients for those endpoints.

## Changes

- **`src/oaspec/internal/codegen/validate.gleam`**:
  `multipart_field_is_stringifiable` now also accepts
  `ArraySchema(items: <primitive | object>)` and
  `ObjectSchema(..)`. A new `multipart_field_array_item_supported`
  helper keeps the array-item allow-list explicit.
- **`src/oaspec/internal/codegen/client_request.gleam`**: introduce
  a `MultipartFieldKind` ADT (`Scalar`, `Binary`, `Array(items)`,
  `Object`) and dispatch each field through it. New
  `emit_multipart_array_field` folds the input list into one part per
  element, sharing the field name. New `emit_multipart_object_field`
  emits a single part with `Content-Type: application/json`, calling
  the corresponding `encode.encode_<schema>_json` helper to serialise
  the value. Existing scalar / binary paths are extracted to
  `emit_multipart_simple_field` so all four kinds share the same
  required / optional handling.
- **Tests / fixtures**: new fixture
  `test/fixtures/multipart_object_array.yaml` mirrors Stripe's
  `POST /v1/files` shape (binary + enum + array of strings + nested
  object) and is exercised by two new test cases — one covers
  validation, the other inspects the generated `client.gleam` for
  the bracketed/JSON-shaped multipart parts. The previous
  `validate_rejects_unstringifiable_multipart_fields_case` is
  rewritten as
  `validate_accepts_object_multipart_fields_in_client_mode_case`
  (with the matching mode-specific helper) since the rejection is
  no longer raised in client mode.
- **`README.md` / `CHANGELOG.md`**: bump fixture count, add Unreleased
  entry.

## Design Decisions

- **Default OAS 3 multipart serialization**: array fields emit
  repeated parts with the same name, object fields emit a single
  JSON-encoded part. Both match the OAS 3 default serialization
  rules; spec authors who need different semantics can declare an
  `encoding` directive (no-op for now, follow-up).
- **Object encoder reuse**: object multipart fields call the
  existing `encode_<schema>_json` helper produced by `encoders.gleam`
  rather than introducing a parallel JSON serializer. The encoder is
  always present for object schemas surviving hoist, so the
  generated multipart code links cleanly.
- **Array item type via `schema_dispatch.schema_ref_to_string_expr`**:
  reuse the already-shared item-stringification helper (also used by
  the form-urlencoded path) so primitive item types (string, int,
  bool, …) format consistently with the rest of the client.
- **Server-mode policy unchanged**: the server router retains its
  primitive-only multipart restriction
  (`validate_server_multipart_request_body`). Lifting it requires a
  full server decoder rewrite (router parsing of repeated multipart
  parts, JSON re-decoding of object parts) and is out of scope here.

## Limitations

- **Server mode still rejects** object / array multipart fields. The
  validator emits a clear server-only error pointing the author at
  client mode; lifting this is tracked as a follow-up.
- **Inline object multipart fields** fall back to `string.inspect`
  (instead of the typed encoder). Real specs (Stripe, GitHub) put
  objects under named components, so this only triggers on
  hand-rolled inline-object specs that hoist intentionally leaves
  inline. A follow-up can wire the inline path through
  `op_id`-derived synthetic encoder names if it surfaces in
  practice.

Closes #503