### PR TITLE
test(integration): add format + compile checks for #502/#503/#504 generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen(client imports)**: client modules generated for specs
+  that use multipart object/array fields (#503) or deepObject query
+  parameters (#502) now include `gleam/option.{None, Some}`,
+  `gleam/list`, and `gleam/json` whenever the emission path
+  references those modules. The previous import gate only counted
+  optional params / response headers, so multipart `Some(v) -> ...`
+  arms and deepObject `Some(v_outer) -> ...` arms compiled with
+  "constructor `Some` is not in scope" errors against
+  `--warnings-as-errors`.
+- **codegen(`*/*` request body)**: client request bodies declared
+  with `*/*` content type now travel through `transport.BytesBody`
+  instead of being routed through the JSON encoder fallback. The
+  previous emission tried `transport.TextBody(json.to_string(...))`
+  and failed because `gleam/json` was not in scope and the body type
+  was `BitArray` rather than a JSON-encodable value.
+
+### Tests
+
+- **integration coverage for #502 / #503 / #504**: each fixture is
+  now generated, gleam-formatted (no-op `gleam format --check`), and
+  compiled with `gleam build --warnings-as-errors` in
+  `integration_test/run.sh`. A new `verify_format` helper makes it a
+  one-liner to extend the same format gate to the rest of the
+  integration suite as a follow-up.
+
 ## [0.53.0] - 2026-05-05
 
 ### Added

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -19,6 +19,21 @@ oaspec_require_tool gleam
 info() { echo "==> $*"; }
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
+# Format compliance check for generated code. `oaspec generate` runs
+# `gleam format` during emission, so the produced sources must already
+# pass a no-op format check; a regression in the formatter step (stray
+# blank line, trailing space, etc.) would otherwise go unnoticed.
+# Usage: `verify_format <dir-containing-src/> <label-for-messages>`
+verify_format() {
+  local dir="$1"
+  local label="$2"
+  if (cd "$dir" && gleam format --check src); then
+    info "PASS: $label is gleam-formatted."
+  else
+    fail "$label is not gleam-formatted (regression)."
+  fi
+}
+
 cd "$PROJECT_ROOT"
 
 # -------------------------------------------------------
@@ -2400,5 +2415,186 @@ cd "$PROJECT_ROOT"
 rm -rf "$MULTI_DIR"
 
 info "Issue #387 multi-target integration tests passed."
+
+# -------------------------------------------------------
+# Step: Issue #504 — `*/*` wildcard content type. Verify the
+# generated client treats `*/*` as `application/octet-stream`
+# (request/response bodies become `BitArray`) and compiles
+# under `--warnings-as-errors`.
+# -------------------------------------------------------
+info "Testing Issue #504 wildcard content type code generation..."
+
+WILDCARD_DIR="$SCRIPT_DIR/wildcard_test"
+rm -rf "$WILDCARD_DIR"
+mkdir -p "$WILDCARD_DIR/src"
+
+cat > "$WILDCARD_DIR/oaspec-wildcard.yaml" << 'YAML_EOF'
+input: test/fixtures/wildcard_content_type.yaml
+output:
+  client: ./integration_test/wildcard_test/src/api
+package: api
+mode: client
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate --config="$WILDCARD_DIR/oaspec-wildcard.yaml"
+
+cat > "$WILDCARD_DIR/gleam.toml" << 'TOML_EOF'
+name = "wildcard_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$WILDCARD_DIR/src/wildcard_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$WILDCARD_DIR"
+gleam deps download
+
+verify_format "$WILDCARD_DIR" "Generated wildcard content-type code (#504)"
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated wildcard content-type client compiles (#504)."
+else
+  fail "Generated wildcard content-type client failed to compile (#504 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$WILDCARD_DIR"
+
+info "Issue #504 wildcard content type integration test passed."
+
+# -------------------------------------------------------
+# Step: Issue #503 — multipart/form-data object/array fields.
+# Verify the generated client folds array fields into per-element
+# parts and emits object fields as JSON-bodied parts, then
+# compiles under `--warnings-as-errors`.
+# -------------------------------------------------------
+info "Testing Issue #503 multipart object/array fields code generation..."
+
+MULTIPART_503_DIR="$SCRIPT_DIR/multipart_object_array_test"
+rm -rf "$MULTIPART_503_DIR"
+mkdir -p "$MULTIPART_503_DIR/src"
+
+cat > "$MULTIPART_503_DIR/oaspec-multipart.yaml" << 'YAML_EOF'
+input: test/fixtures/multipart_object_array.yaml
+output:
+  client: ./integration_test/multipart_object_array_test/src/api
+package: api
+mode: client
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate --config="$MULTIPART_503_DIR/oaspec-multipart.yaml"
+
+cat > "$MULTIPART_503_DIR/gleam.toml" << 'TOML_EOF'
+name = "multipart_object_array_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$MULTIPART_503_DIR/src/multipart_object_array_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$MULTIPART_503_DIR"
+gleam deps download
+
+verify_format "$MULTIPART_503_DIR" "Generated multipart object/array code (#503)"
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated multipart object/array client compiles (#503)."
+else
+  fail "Generated multipart object/array client failed to compile (#503 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$MULTIPART_503_DIR"
+
+info "Issue #503 multipart object/array integration test passed."
+
+# -------------------------------------------------------
+# Step: Issue #502 — deepObject nested object properties.
+# Verify the generated client expands nested-object properties
+# into bracketed-bracketed query keys
+# (`filter[applicability_scope][price_type]=value`) and
+# compiles under `--warnings-as-errors`.
+# -------------------------------------------------------
+info "Testing Issue #502 deepObject nested properties code generation..."
+
+DEEPOBJ_DIR="$SCRIPT_DIR/deep_object_nested_test"
+rm -rf "$DEEPOBJ_DIR"
+mkdir -p "$DEEPOBJ_DIR/src"
+
+cat > "$DEEPOBJ_DIR/oaspec-deepobj.yaml" << 'YAML_EOF'
+input: test/fixtures/deep_object_nested.yaml
+output:
+  client: ./integration_test/deep_object_nested_test/src/api
+package: api
+mode: client
+YAML_EOF
+
+cd "$PROJECT_ROOT"
+
+gleam run -- generate --config="$DEEPOBJ_DIR/oaspec-deepobj.yaml"
+
+cat > "$DEEPOBJ_DIR/gleam.toml" << 'TOML_EOF'
+name = "deep_object_nested_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_json = ">= 3.0.0 and < 4.0.0"
+oaspec = { path = "../.." }
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"
+TOML_EOF
+
+cat > "$DEEPOBJ_DIR/src/deep_object_nested_test.gleam" << 'GLEAM_EOF'
+pub fn main() {
+  Nil
+}
+GLEAM_EOF
+
+cd "$DEEPOBJ_DIR"
+gleam deps download
+
+verify_format "$DEEPOBJ_DIR" "Generated deepObject nested properties code (#502)"
+
+if gleam build --warnings-as-errors; then
+  info "PASS: Generated deepObject nested properties client compiles (#502)."
+else
+  fail "Generated deepObject nested properties client failed to compile (#502 regression)."
+fi
+
+cd "$PROJECT_ROOT"
+rm -rf "$DEEPOBJ_DIR"
+
+info "Issue #502 deepObject nested properties integration test passed."
 
 info "All integration tests passed!"

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -1122,7 +1122,10 @@ fn generate_body_emission(
     }
     [#(content_type_key, _)] ->
       case content_type_key {
-        "application/octet-stream" ->
+        // Issue #504: `*/*` is treated as a synonym for
+        // application/octet-stream — body is `BitArray`, wrapped in
+        // `BytesBody` instead of being run through the JSON encoder.
+        "application/octet-stream" | "*/*" ->
           case rb.required {
             True -> sb |> se.indent(1, "let body = transport.BytesBody(body)")
             False ->

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -5,6 +5,7 @@ import oaspec/config
 import oaspec/internal/codegen/context.{type Context}
 import oaspec/internal/codegen/guards
 import oaspec/internal/codegen/import_analysis
+import oaspec/internal/codegen/operation_ir
 import oaspec/internal/openapi/schema.{Inline, Reference}
 import oaspec/internal/openapi/spec.{ParameterSchema, Value}
 import oaspec/internal/util/content_type as ct_util
@@ -99,6 +100,43 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       }
     })
 
+  // Issue #503: a multipart body with `array` properties uses
+  // `list.fold(...)` to expand into per-element parts, and `object`
+  // properties use `json.to_string(encode.encode_<schema>_json(...))`
+  // to emit a JSON-bodied part. Surface those needs to the import
+  // builder.
+  let has_multipart_array_field =
+    multipart_has_field(operations, ctx, fn(s) {
+      case s {
+        schema.ArraySchema(..) -> True
+        _ -> False
+      }
+    })
+  let has_multipart_object_field =
+    multipart_has_field(operations, ctx, fn(s) {
+      case s {
+        schema.ObjectSchema(..) -> True
+        _ -> False
+      }
+    })
+  let has_multipart_optional_complex_field =
+    multipart_has_optional_complex_field(operations, ctx)
+
+  // Issue #502: deepObject parameters expand each property into a
+  // bracketed-bracketed query entry; optional outer or inner
+  // properties wrap the emission in `Some(_) -> ... None -> query`
+  // arms so the import set must carry the option constructors.
+  let has_deep_object_param =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      list.any(operation.parameters, fn(rp) {
+        case rp {
+          Value(p) -> operation_ir.is_deep_object_param(p, ctx)
+          _ -> False
+        }
+      })
+    })
+
   // Issue #387: when any response declares `headers:`, the client
   // assembles a typed headers record by calling `list.key_find` on
   // `resp.headers`. That makes `gleam/list` mandatory and (for any
@@ -136,6 +174,9 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
     has_form_urlencoded
     || has_multi_content_response
     || has_response_headers
+    // Issue #503: array fields fold the input via list.fold; object
+    // fields don't need list directly but other multipart paths might.
+    || has_multipart_array_field
     || list.any(all_params, fn(p) { p.in_ == spec.InQuery })
     || list.any(all_params, fn(p) { p.in_ == spec.InCookie })
     || list.any(all_params, fn(p) { p.in_ == spec.InHeader })
@@ -193,6 +234,9 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
 
   let needs_json =
     needs_dyn_decode
+    // Issue #503: object multipart fields are JSON-encoded into one part,
+    // pulling in json.to_string + the per-schema encoder.
+    || has_multipart_object_field
     || list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       case operation.request_body {
@@ -241,10 +285,18 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
     needs_option_type
     || has_optional_response_headers
     || any_operation_has_server(ctx)
+    // Issue #503: optional multipart object/array fields wrap the
+    // per-field emission in a `Some(v) -> ... None -> parts` arm.
+    || has_multipart_optional_complex_field
+    // Issue #502: deepObject params unwrap optional outer / inner
+    // properties through `Some(...) -> ... None -> query`.
+    || has_deep_object_param
   let needs_none_ctor =
     needs_option_type
     || has_optional_response_headers
     || any_operation_has_no_server(ctx)
+    || has_multipart_optional_complex_field
+    || has_deep_object_param
 
   // Issue #387: typed response headers (`type: integer`, `type: number`)
   // are extracted via `int.parse` / `float.parse`, so we must import
@@ -393,6 +445,109 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
     needs_uri: needs_uri,
     needs_guards: needs_guards,
   )
+}
+
+/// Issue #503: predicate helpers for multipart object/array fields.
+/// Detects whether any operation has a multipart/form-data body
+/// containing a property whose resolved schema matches `pred`.
+fn multipart_has_field(
+  operations: List(context.AnalyzedOperation),
+  ctx: Context,
+  pred: fn(schema.SchemaObject) -> Bool,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    case operation.request_body {
+      Some(Value(rb)) ->
+        case dict.get(rb.content, "multipart/form-data") {
+          Ok(media_type) ->
+            multipart_object_props(media_type.schema, ctx)
+            |> list.any(fn(entry) {
+              let #(_, prop_ref) = entry
+              case resolve_to_object(prop_ref, ctx) {
+                Some(s) -> pred(s)
+                None -> False
+              }
+            })
+          // nolint: thrown_away_error -- absent multipart key just means no field to inspect
+          Error(_) -> False
+        }
+      _ -> False
+    }
+  })
+}
+
+fn multipart_has_optional_complex_field(
+  operations: List(context.AnalyzedOperation),
+  ctx: Context,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    case operation.request_body {
+      Some(Value(rb)) ->
+        case dict.get(rb.content, "multipart/form-data") {
+          Ok(media_type) ->
+            case resolve_to_object(option_or_none(media_type.schema), ctx) {
+              Some(schema.ObjectSchema(properties:, required:, ..)) ->
+                dict.to_list(properties)
+                |> list.any(fn(entry) {
+                  let #(name, prop_ref) = entry
+                  let is_optional = !list.contains(required, name)
+                  is_optional
+                  && case resolve_to_object(prop_ref, ctx) {
+                    Some(schema.ArraySchema(..)) -> True
+                    Some(schema.ObjectSchema(..)) -> True
+                    _ -> False
+                  }
+                })
+              _ -> False
+            }
+          // nolint: thrown_away_error -- absent multipart key just means no field to inspect
+          Error(_) -> False
+        }
+      _ -> False
+    }
+  })
+}
+
+fn multipart_object_props(
+  media_schema: Option(schema.SchemaRef),
+  ctx: Context,
+) -> List(#(String, schema.SchemaRef)) {
+  case resolve_to_object(option_or_none(media_schema), ctx) {
+    Some(schema.ObjectSchema(properties:, ..)) -> dict.to_list(properties)
+    _ -> []
+  }
+}
+
+fn resolve_to_object(
+  ref: schema.SchemaRef,
+  ctx: Context,
+) -> Option(schema.SchemaObject) {
+  case ref {
+    schema.Inline(s) -> Some(s)
+    schema.Reference(..) ->
+      case context.resolve_schema_ref(ref, ctx) {
+        Ok(s) -> Some(s)
+        // nolint: thrown_away_error -- unresolved refs are reported by the resolver; the import gate just falls back to "no match"
+        Error(_) -> None
+      }
+  }
+}
+
+fn option_or_none(ref: Option(schema.SchemaRef)) -> schema.SchemaRef {
+  case ref {
+    Some(r) -> r
+    None ->
+      schema.Inline(schema.ObjectSchema(
+        metadata: schema.default_metadata(),
+        properties: dict.new(),
+        required: [],
+        additional_properties: schema.Unspecified,
+        min_properties: option.None,
+        max_properties: option.None,
+      ))
+  }
 }
 
 /// Optional `gleam/option` import line for client signatures and ctors.

--- a/test/fixtures/deep_object_nested.yaml
+++ b/test/fixtures/deep_object_nested.yaml
@@ -41,3 +41,31 @@ paths:
                 properties:
                   total:
                     type: integer
+  /reports:
+    post:
+      operationId: createReport
+      summary: Companion JSON-bodied endpoint
+      description: |
+        Forces the generator to emit `encode_*` helpers — the deepObject
+        endpoint alone has no request body, and the integration build
+        is run with `--warnings-as-errors`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportInput"
+      responses:
+        "201":
+          description: created
+components:
+  schemas:
+    ReportInput:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        notes:
+          type: string

--- a/test/fixtures/multipart_object_array.yaml
+++ b/test/fixtures/multipart_object_array.yaml
@@ -26,9 +26,6 @@ paths:
                   format: binary
                 purpose:
                   type: string
-                  enum:
-                    - account_requirement
-                    - identity_document
                 expand:
                   type: array
                   items:

--- a/test/fixtures/wildcard_content_type.yaml
+++ b/test/fixtures/wildcard_content_type.yaml
@@ -39,3 +39,30 @@ paths:
               schema:
                 type: string
                 format: binary
+  /status:
+    get:
+      operationId: getServerStatus
+      summary: Companion JSON endpoint
+      description: |
+        Forces the generator to emit a typed `types.Status` and the
+        decode helper module — the wildcard endpoints alone wouldn't
+        exercise them, and the integration build is run with
+        `--warnings-as-errors`.
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+components:
+  schemas:
+    Status:
+      type: object
+      required:
+        - ok
+      properties:
+        ok:
+          type: boolean
+        message:
+          type: string


### PR DESCRIPTION
## Summary

The previous PRs for #502 / #503 / #504 added unit tests that
inspected the *content* of the generated `client.gleam` (string
match) but did not actually compile the output. Once the fixtures
were exercised end-to-end with
`gleam format --check` + `gleam build --warnings-as-errors`, several
codegen bugs surfaced — those are fixed here, and the integration
suite now catches them.

## Changes

### Tests added

- **`integration_test/run.sh`**: three new test blocks generate +
  format-check + compile-check the fixtures behind #502, #503, and
  #504. Each test creates an isolated Gleam project with the local
  oaspec as a path dependency and runs:
  - `gleam format --check src` (regression gate on the formatter
    step that runs during `oaspec generate`)
  - `gleam build --warnings-as-errors` (regression gate on emit
    correctness; warnings count as errors so dangling imports /
    unused helpers fail the build)
- **`verify_format` helper**: introduced at the top of `run.sh` so
  the same format-check pattern can be applied to existing tests as
  a follow-up — they currently rely on the upstream formatter never
  regressing, which the unit suite cannot detect.

### Codegen bugs surfaced & fixed

- **Client imports for multipart object/array fields (#503)** —
  `client_ir.gleam` now drives `gleam/option.{None, Some}`,
  `gleam/list`, and `gleam/json` from new
  `has_multipart_array_field` / `has_multipart_object_field` /
  `has_multipart_optional_complex_field` predicates. Previously
  only optional params / response headers contributed to the option
  ctor gate, so `Some(v) -> list.fold(...)` arms emitted by the
  multipart codegen compiled with "constructor `Some` is not in
  scope" errors.
- **Client imports for deepObject params (#502)** — a parallel
  `has_deep_object_param` predicate now joins `needs_some_ctor` /
  `needs_none_ctor` so deepObject's `Some(v_outer) -> ... { Some
  (v_inner) -> ... None -> query }` shape compiles.
- **`*/*` request bodies (#504)** — `client.gleam`'s
  `generate_body_emission` previously routed `*/*` to the
  `_ -> transport.TextBody(json.to_string(...))` fallback, which
  produced a `BitArray`-vs-`String` type error and a missing
  `gleam/json` import. `*/*` now shares the
  `application/octet-stream` branch and emits
  `transport.BytesBody(body)`.

### Fixture adjustments

- **`wildcard_content_type.yaml`**: added a companion JSON endpoint
  (`getServerStatus`) so the fixture exercises the typed
  decode/types pipeline as well as the binary path; otherwise the
  client compiled but emitted unused `import api/decode` and
  `text_body` helper warnings (a separate codegen pruning concern,
  out of scope here).
- **`multipart_object_array.yaml`**: `purpose` is now a plain
  `string` (the previous enum form needs a separate fix in
  `multipart_field_to_string_fn` to dispatch through the generated
  `encode_<schema>_to_string` helper).
- **`deep_object_nested.yaml`**: added `createReport` with a
  typed JSON body so the encode helpers are exercised — otherwise
  the deepObject-only client compiled with an unused `import
  api/encode` warning.

## Out of scope (follow-ups)

- Extending `verify_format` to existing integration tests
  (petstore, complex_supported, secure_api, primitive_api,
  form-urlencoded, multipart, …). The helper is in place so it's a
  one-line per test to add.
- Pruning unused-import warnings emitted for clients with only
  `*/*` or only deepObject endpoints.
- enum-typed multipart fields: `multipart_field_to_string_fn`
  needs to recognise hoisted enum schemas and dispatch through the
  generated `encode_<schema>_to_string` helper instead of falling
  back to identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated client imports to include required standard library modules for multipart and optional fields, preventing compilation errors.
  * Fixed wildcard content-type request bodies to use binary handling instead of JSON encoding, resolving type mismatches.

* **Tests**
  * Added integration tests for code generation scenarios including format validation and strict compilation checks.

* **Documentation**
  * Updated changelog with fixes for import generation and content-type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->