### PR TITLE
fix(codegen): reject non-primitive query/header/form-urlencoded array items in both modes + fixture-sweep tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen(non-primitive query/header array items)**: query and
+  header parameters whose `items` resolved to a non-primitive
+  schema (e.g. `tags: array of object`) used to crash the client
+  generator with `oaspec: inline object schema reached
+  to_string_fn after hoist`. The validator only blocked the shape
+  in server mode, so `mode: client` codegen ran unimpeded into
+  the panic. The validator now rejects non-primitive item
+  schemas in BOTH modes for query and header array params, and
+  the rejection follows hoisted `Reference`s through to their
+  resolved shape rather than treating any `Reference` as safe.
+- **codegen(form-urlencoded nested arrays)**: an
+  `application/x-www-form-urlencoded` request body whose nested
+  object property contained an array (`profile.aliases: array of
+  string`) panicked the client generator the same way —
+  `generate_form_nested_object` routed the array through
+  `multipart_field_to_string_fn`, which has no path for inline
+  composite items. The form-urlencoded body validator now runs
+  in both modes and forbids arrays-within-objects regardless of
+  item type, so the spec is rejected with a clear diagnostic
+  before the generator can crash.
+
+### Tests
+
+- **fixture-sweep parse + resolve smoke test**: a new unit case
+  in `test/oaspec_support.gleam` enumerates every top-level
+  `.yaml` under `test/fixtures/` and runs each through
+  `parser.parse_file` and `resolve.resolve`, asserting the
+  pipeline never panics on the suite's 200+ specs. Intentionally
+  malformed fixtures (`broken*.yaml`, `error_invalid_yaml.yaml`,
+  `oaspec*.yaml` config files) are excluded by name. A regression
+  that breaks the parser entry point or the resolver on real-
+  world specs surfaces immediately, instead of waiting for a
+  hand-listed integration test to happen to cover the failing
+  shape.
+- **petstore client surface invariants**: a second unit case
+  enumerates the public API the petstore client exposes —
+  expected files (`client.gleam`, `decode.gleam`, …), one
+  generated `pub fn` per declared operation, one `pub type` per
+  declared component schema, plus the per-file non-empty +
+  provenance smoke checks. Catches a renaming or accidental drop
+  in the client codegen surface without needing a full
+  integration build.
+
 ## [0.55.0] - 2026-05-05
 
 ### Tests

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -393,6 +393,24 @@ fn validate_server_structured_param(
           ),
         ]
       }
+    // CodeRabbit follow-up: cookie array params take the same
+    // exploded-array codegen path as query/header (see
+    // `client_request.generate_exploded_array_query_param`-style
+    // emission), so a non-primitive item schema would panic in
+    // `to_string_fn` for them too. Reject in both modes.
+    spec.InCookie, Some(ArraySchema(items:, ..)) ->
+      case array_items_resolve_primitive(items, ctx) {
+        True -> []
+        False -> [
+          diagnostic.validation_error_both(
+            path: path,
+            detail: "Cookie array parameters are only supported for primitive items (string, integer, number, boolean), whether inline or via $ref.",
+            hint: Some(
+              "Replace the item schema with a primitive type (string, integer, number, boolean).",
+            ),
+          ),
+        ]
+      }
     _, _ -> []
   }
   // The deepObject server-only constraint (primitive scalars /

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -358,45 +358,76 @@ fn validate_server_structured_param(
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case config.mode(context.config(ctx)) {
-    config.Client -> []
-    _ -> {
-      let schema_obj = resolve_schema_object(spec.parameter_schema(param), ctx)
-      let array_errors = case param.in_, schema_obj {
-        spec.InQuery, Some(ArraySchema(items: Inline(StringSchema(..)), ..))
-        | spec.InQuery, Some(ArraySchema(items: Inline(IntegerSchema(..)), ..))
-        | spec.InQuery, Some(ArraySchema(items: Inline(NumberSchema(..)), ..))
-        | spec.InQuery, Some(ArraySchema(items: Inline(BooleanSchema(..)), ..))
-        -> []
-        spec.InQuery, Some(ArraySchema(..)) -> [
-          diagnostic.validation_error_server(
+  let schema_obj = resolve_schema_object(spec.parameter_schema(param), ctx)
+  // Bug fix: array parameters with non-primitive items panic in
+  // both client and server codegen with "inline composite schema
+  // reached to_string_fn after hoist" because `to_string_fn` has no
+  // path for composite item types — even after hoist promotes the
+  // item to a `$ref`, `to_string_fn` recurses into the resolved
+  // ObjectSchema and hits the same panic. Reject in BOTH modes
+  // when the items resolve to a non-primitive shape.
+  let array_errors = case param.in_, schema_obj {
+    spec.InQuery, Some(ArraySchema(items:, ..)) ->
+      case array_items_resolve_primitive(items, ctx) {
+        True -> []
+        False -> [
+          diagnostic.validation_error_both(
             path: path,
-            detail: "Query array parameters are only supported for inline primitive items in server code generation.",
+            detail: "Query array parameters are only supported for primitive items (string, integer, number, boolean), whether inline or via $ref.",
             hint: Some(
-              "Use inline primitive items (string, integer, number, boolean) for array query parameters.",
+              "Replace the item schema with a primitive type (string, integer, number, boolean).",
             ),
           ),
         ]
-        spec.InHeader, Some(ArraySchema(items: Inline(StringSchema(..)), ..))
-        | spec.InHeader, Some(ArraySchema(items: Inline(IntegerSchema(..)), ..))
-        | spec.InHeader, Some(ArraySchema(items: Inline(NumberSchema(..)), ..))
-        | spec.InHeader, Some(ArraySchema(items: Inline(BooleanSchema(..)), ..))
-        -> []
-        spec.InHeader, Some(ArraySchema(..)) -> [
-          diagnostic.validation_error_server(
-            path: path,
-            detail: "Header array parameters are only supported for inline primitive items in server code generation.",
-            hint: Some(
-              "Use inline primitive items (string, integer, number, boolean) for array header parameters.",
-            ),
-          ),
-        ]
-        _, _ -> []
       }
-      let deep_object_errors =
-        validate_server_deep_object_param(path, param, ctx)
-      list.flatten([array_errors, deep_object_errors])
-    }
+    spec.InHeader, Some(ArraySchema(items:, ..)) ->
+      case array_items_resolve_primitive(items, ctx) {
+        True -> []
+        False -> [
+          diagnostic.validation_error_both(
+            path: path,
+            detail: "Header array parameters are only supported for primitive items (string, integer, number, boolean), whether inline or via $ref.",
+            hint: Some(
+              "Replace the item schema with a primitive type (string, integer, number, boolean).",
+            ),
+          ),
+        ]
+      }
+    _, _ -> []
+  }
+  // The deepObject server-only constraint (primitive scalars /
+  // primitive arrays only) stays gated to server mode — the client
+  // emitter handles nested objects post-#502.
+  let deep_object_errors = case config.mode(context.config(ctx)) {
+    config.Client -> []
+    _ -> validate_server_deep_object_param(path, param, ctx)
+  }
+  list.flatten([array_errors, deep_object_errors])
+}
+
+/// True iff `items` resolves to a primitive scalar shape (string,
+/// integer, number, boolean), whether the schema is inline or
+/// referenced through `$ref`. Hoist may have promoted an inline
+/// primitive into a component during preprocessing, so a
+/// `Reference` here is not automatically safe — we have to look at
+/// what the ref points at.
+fn array_items_resolve_primitive(items: SchemaRef, ctx: Context) -> Bool {
+  case items {
+    Inline(StringSchema(..))
+    | Inline(IntegerSchema(..))
+    | Inline(NumberSchema(..))
+    | Inline(BooleanSchema(..)) -> True
+    Reference(..) ->
+      case context.resolve_schema_ref(items, ctx) {
+        Ok(StringSchema(..))
+        | Ok(IntegerSchema(..))
+        | Ok(NumberSchema(..))
+        | Ok(BooleanSchema(..)) -> True
+        Ok(_) -> False
+        // nolint: thrown_away_error -- unresolved refs surface elsewhere; here we only need the primitive/non-primitive distinction
+        Error(_) -> False
+      }
+    _ -> False
   }
 }
 
@@ -755,12 +786,19 @@ fn validate_server_form_urlencoded_request_body(
   content_keys: List(String),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case config.mode(context.config(ctx)) {
+  // Bug fix: nested arrays inside a form-urlencoded body's nested
+  // objects panic the client codegen too — `generate_form_nested_object`
+  // routes them through `multipart_field_to_string_fn`, which calls
+  // `to_string_fn` on an Inline ArraySchema and hits the
+  // "inline schema reached to_string_fn after hoist" panic. Reject
+  // those shapes in BOTH modes; the server-mode-only multi-content
+  // restriction stays gated to server.
+  let server_mode_errors = case config.mode(context.config(ctx)) {
     config.Client -> []
     _ ->
       case dict.get(content, "application/x-www-form-urlencoded") {
-        Ok(media_type) -> {
-          let content_type_errors = case list.length(content_keys) > 1 {
+        Ok(_) ->
+          case list.length(content_keys) > 1 {
             True -> [
               diagnostic.validation_error_server(
                 path: op_id <> ".requestBody",
@@ -772,35 +810,70 @@ fn validate_server_form_urlencoded_request_body(
             ]
             False -> []
           }
-          let field_errors = case
-            resolve_schema_object(media_type.schema, ctx)
-          {
-            Some(ObjectSchema(properties:, ..)) ->
-              dict.to_list(properties)
-              |> list.flat_map(fn(entry) {
-                let #(field_name, field_schema) = entry
-                case
-                  form_urlencoded_server_field_supported(field_schema, ctx, 0)
-                {
-                  True -> []
-                  False -> [
-                    diagnostic.validation_error_server(
-                      path: op_id <> ".requestBody.form." <> field_name,
-                      detail: "application/x-www-form-urlencoded server request bodies only support primitive scalars, primitive arrays, and nested objects with primitive leaves (max 5 levels).",
-                      hint: Some(
-                        "Simplify to primitive scalars, primitive arrays, or shallow nested objects.",
-                      ),
-                    ),
-                  ]
-                }
-              })
-            _ -> []
-          }
-          list.append(content_type_errors, field_errors)
-        }
         // nolint: thrown_away_error -- absence of the content type means there is nothing to validate here
         Error(_) -> []
       }
+  }
+
+  let field_errors = case
+    dict.get(content, "application/x-www-form-urlencoded")
+  {
+    Ok(media_type) ->
+      case resolve_schema_object(media_type.schema, ctx) {
+        Some(ObjectSchema(properties:, ..)) ->
+          dict.to_list(properties)
+          |> list.flat_map(fn(entry) {
+            let #(field_name, field_schema) = entry
+            case form_urlencoded_field_codegen_safe(field_schema, ctx, 0) {
+              True -> []
+              False -> [
+                diagnostic.validation_error_both(
+                  path: op_id <> ".requestBody.form." <> field_name,
+                  detail: "application/x-www-form-urlencoded request bodies only support primitive scalars, primitive arrays at the top level, and nested objects with primitive leaves (max 5 levels). Nested arrays-within-objects, oneOf, anyOf, and allOf properties are not supported in either client or server codegen.",
+                  hint: Some(
+                    "Simplify to primitive scalars, primitive arrays at the top level, or shallow nested objects with primitive leaves.",
+                  ),
+                ),
+              ]
+            }
+          })
+        _ -> []
+      }
+    // nolint: thrown_away_error -- absence of the content type means there is nothing to validate here
+    Error(_) -> []
+  }
+  list.append(server_mode_errors, field_errors)
+}
+
+/// Tighter form-urlencoded shape predicate that prevents the
+/// generator from recursing into a path it can't render. Mirrors
+/// `form_urlencoded_server_field_supported` but rejects nested
+/// arrays (an array nested inside an object property), which the
+/// client emitter otherwise sends through `to_string_fn` and
+/// crashes.
+fn form_urlencoded_field_codegen_safe(
+  schema_ref: SchemaRef,
+  ctx: Context,
+  depth: Int,
+) -> Bool {
+  case resolve_schema_object(Some(schema_ref), ctx) {
+    Some(StringSchema(..))
+    | Some(IntegerSchema(..))
+    | Some(NumberSchema(..))
+    | Some(BooleanSchema(..)) -> True
+    Some(ArraySchema(items:, ..)) if depth == 0 ->
+      form_urlencoded_server_array_item_supported(items, ctx)
+    // Arrays nested inside object properties are not handled by
+    // the generator (post-hoist they survive as Inline ArraySchema
+    // and `multipart_field_to_string_fn` panics on them).
+    Some(ArraySchema(..)) -> False
+    Some(ObjectSchema(properties:, ..)) if depth < 5 ->
+      dict.to_list(properties)
+      |> list.all(fn(entry) {
+        let #(_, child_schema) = entry
+        form_urlencoded_field_codegen_safe(child_schema, ctx, depth + 1)
+      })
+    _ -> False
   }
 }
 
@@ -890,28 +963,6 @@ fn validate_server_multipart_request_body(
         // nolint: thrown_away_error -- absence of the content type means there is nothing to validate here
         Error(_) -> []
       }
-  }
-}
-
-fn form_urlencoded_server_field_supported(
-  schema_ref: SchemaRef,
-  ctx: Context,
-  depth: Int,
-) -> Bool {
-  case resolve_schema_object(Some(schema_ref), ctx) {
-    Some(StringSchema(..))
-    | Some(IntegerSchema(..))
-    | Some(NumberSchema(..))
-    | Some(BooleanSchema(..)) -> True
-    Some(ArraySchema(items:, ..)) ->
-      form_urlencoded_server_array_item_supported(items, ctx)
-    Some(ObjectSchema(properties:, ..)) if depth < 5 ->
-      dict.to_list(properties)
-      |> list.all(fn(entry) {
-        let #(_, child_schema) = entry
-        form_urlencoded_server_field_supported(child_schema, ctx, depth + 1)
-      })
-    _ -> False
   }
 }
 

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -123,6 +123,8 @@ pub fn content_type_helpers_test() {
   let _ = support.deep_object_param_client_imports_some_none_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
+  let _ = support.fixtures_sweep_parse_resolve_no_panic_case()
+  let _ = support.petstore_client_generated_surface_invariants_case()
 }
 
 pub fn location_index_source_loc_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1,6 +1,7 @@
 import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
+import gleam/result
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -5493,7 +5494,7 @@ fn server_request_shape_boundary_fixtures() -> List(#(String, String, String)) {
     #(
       "server: complex form-urlencoded fields",
       "test/fixtures/server_form_urlencoded_complex_fields.yaml",
-      "application/x-www-form-urlencoded server request bodies only support",
+      "application/x-www-form-urlencoded request bodies only support",
     ),
     #(
       "server: mixed multipart request",
@@ -5542,11 +5543,20 @@ pub fn server_request_shape_boundary_fixtures_case() {
   list.each(server_request_shape_boundary_fixtures(), fn(entry) {
     let #(capability_name, fixture_path, expected_message) = entry
     let ctx = make_ctx(fixture_path)
+    // Some boundaries are server-only (e.g. multipart object/array
+    // server fields), some are now both-mode (e.g. non-primitive
+    // query/header array items, since the client emitter panics on
+    // them too post-fix). Either target is acceptable here — what
+    // matters is that an error fires in server mode with the
+    // expected message.
     let server_errors =
       validate.validate(ctx)
       |> list.filter(fn(e) {
-        e.target == diagnostic.TargetServer
-        && string.contains(e.message, expected_message)
+        case e.target {
+          diagnostic.TargetServer | diagnostic.TargetBoth ->
+            string.contains(e.message, expected_message)
+          _ -> False
+        }
       })
 
     case server_errors != [] {
@@ -6822,6 +6832,146 @@ pub fn multipart_object_array_client_imports_list_json_case() {
   |> should.be_true()
   string.contains(client_file.content, "import gleam/option.{")
   |> should.be_true()
+}
+
+// --- Comprehensive fixture sweep (parse + resolve panic-free) ---
+
+/// Walk every fixture under `test/fixtures/` (top-level `.yaml` files
+/// only) and run them through `parser.parse_file` and
+/// `resolve.resolve`. Some fixtures intentionally trigger parse or
+/// resolve errors (e.g. `broken_openapi.yaml`); the gate here is
+/// that *neither stage panics*. A sanity floor on the success
+/// counts catches a regression that would otherwise turn silently
+/// bad parses into "0 fixtures parsed" without anyone noticing —
+/// pre-existing tests do not enumerate the directory, so a renamed
+/// module function would only surface in the few hand-listed
+/// fixtures the rest of the suite touches.
+pub fn fixtures_sweep_parse_resolve_no_panic_case() {
+  let assert Ok(entries) = simplifile.read_directory("test/fixtures")
+  let paths =
+    entries
+    |> list.filter(fn(name) { string.ends_with(name, ".yaml") })
+    // Some fixtures are intentionally malformed at the YAML level
+    // (`broken-*.yaml`, `broken_*.yaml`, oaspec-config-shaped files
+    // that aren't valid OpenAPI) — yamerl raises an Erlang exception
+    // for those rather than returning a typed error, so we keep them
+    // out of the structural sweep. They are still exercised by
+    // their dedicated unit tests.
+    |> list.filter(fixtures_sweep_includes_path)
+    |> list.map(fn(name) { "test/fixtures/" <> name })
+
+  let #(total, parsed_ok, resolved_ok) =
+    list.fold(paths, #(0, 0, 0), fn(acc, path) {
+      let #(t, p, r) = acc
+      case parser.parse_file(path) {
+        Ok(spec) ->
+          case resolve.resolve(spec) {
+            Ok(_resolved) -> #(t + 1, p + 1, r + 1)
+            // nolint: thrown_away_error -- some fixtures intentionally trigger resolve errors; the gate here is just panic-free traversal
+            Error(_) -> #(t + 1, p + 1, r)
+          }
+        // nolint: thrown_away_error -- broken fixtures are deliberately included
+        Error(_) -> #(t + 1, p, r)
+      }
+    })
+
+  // The fixtures directory has well over 200 valid YAML files; if a
+  // refactor accidentally short-circuits the loop or breaks the
+  // parser entry point we want the floor to fail loudly. The
+  // counts are intentionally conservative so adding a few new
+  // broken fixtures doesn't trip the gate.
+  should.be_true(total >= 200)
+  should.be_true(parsed_ok >= 200)
+  should.be_true(resolved_ok >= 180)
+}
+
+/// Structural invariants for `petstore.yaml` client output. The
+/// fixture is small enough to enumerate every operation exactly, so
+/// any drift in the codegen surface (a missing function, a renamed
+/// variant, a stray empty file) trips one of the explicit asserts.
+/// `string.contains` is a coarse gate, but it pins the public API
+/// shape that downstream users actually call.
+pub fn petstore_client_generated_surface_invariants_case() {
+  let assert Ok(unresolved) = parser.parse_file("test/fixtures/petstore.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/petstore.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+
+  // Every file expected from a client-mode generation must appear.
+  let expected_files = [
+    "types.gleam",
+    "request_types.gleam",
+    "response_types.gleam",
+    "decode.gleam",
+    "encode.gleam",
+    "guards.gleam",
+    "client.gleam",
+  ]
+  list.each(expected_files, fn(name) {
+    list.find(summary.files, fn(f) { f.path == name })
+    |> result.is_ok
+    |> should.be_true
+  })
+
+  // Every emitted file is non-empty and carries the codegen
+  // provenance header. Mirrors the integration-suite gate so a
+  // unit-level run picks up the same regressions.
+  list.each(summary.files, fn(f) {
+    should.be_true(string.length(f.content) > 0)
+    string.contains(f.content, "// Code generated by oaspec")
+    |> should.be_true
+  })
+
+  // Every operation defined in petstore.yaml maps to a generated
+  // client function. Hand-listing them here means a renaming or
+  // accidental drop is caught immediately.
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let expected_ops = ["list_pets", "create_pet", "get_pet", "delete_pet"]
+  list.each(expected_ops, fn(op) {
+    string.contains(client_file.content, "pub fn " <> op <> "(")
+    |> should.be_true
+  })
+
+  // Every component schema declared in petstore.yaml maps to a
+  // generated `pub type` in `types.gleam`.
+  let assert Ok(types_file) =
+    list.find(summary.files, fn(f) { f.path == "types.gleam" })
+  let expected_types = ["Pet", "CreatePetRequest", "PetStatus", "Error"]
+  list.each(expected_types, fn(t) {
+    string.contains(types_file.content, "pub type " <> t)
+    |> should.be_true
+  })
+}
+
+/// Files under `test/fixtures/` that are intentionally not valid
+/// OpenAPI documents (so calling `parser.parse_file` on them is
+/// expected to raise an Erlang-level exception, not return a typed
+/// error). They are excluded from the structural sweep but still
+/// covered by their dedicated unit tests.
+fn fixtures_sweep_includes_path(name: String) -> Bool {
+  // `broken-*.yaml` / `broken_*.yaml` are invalid OpenAPI on
+  // purpose. `oaspec*.yaml` and `oaspec-*.yaml` are *config* files
+  // (not specs) — they live in the same directory by historical
+  // accident and would parse as garbage if fed through the spec
+  // parser. Anything that happens to share that prefix and is a real
+  // spec keeps the sweep exposure via direct fixture tests.
+  !string.starts_with(name, "broken-")
+  && !string.starts_with(name, "broken_")
+  && !string.starts_with(name, "oaspec-")
+  && !string.starts_with(name, "oaspec_")
+  // `error_invalid_yaml.yaml` is intentionally invalid YAML so the
+  // CLI's "we surface a SourceLoc on YAML parse errors" path can be
+  // exercised — it raises a yamerl-level exception rather than
+  // returning a typed error, so it's incompatible with this sweep.
+  && name != "error_invalid_yaml.yaml"
 }
 
 /// Regression guard: a `*/*` request body must travel through
@@ -9402,12 +9552,23 @@ paths:
 pub fn validate_rejects_array_params_for_server_codegen_case() {
   let ctx = make_ctx("test/fixtures/server_query_array_object_items.yaml")
   let errors = validate.validate(ctx)
-  let server_errors =
+  // Bug fix: query array params with non-primitive items now error
+  // in BOTH modes because the client codegen also panics on them;
+  // the diagnostic target switched from `TargetServer` to
+  // `TargetBoth`. Accept either so this test pins the rejection
+  // shape regardless of how the gate is widened.
+  let array_errors =
     list.filter(errors, fn(e) {
-      e.target == diagnostic.TargetServer
-      && string.contains(e.message, "Query array parameters are only supported")
+      case e.target {
+        diagnostic.TargetServer | diagnostic.TargetBoth ->
+          string.contains(
+            e.message,
+            "Query array parameters are only supported",
+          )
+        _ -> False
+      }
     })
-  list.length(server_errors)
+  list.length(array_errors)
   |> should.equal(1)
 }
 

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6967,6 +6967,11 @@ fn fixtures_sweep_includes_path(name: String) -> Bool {
   && !string.starts_with(name, "broken_")
   && !string.starts_with(name, "oaspec-")
   && !string.starts_with(name, "oaspec_")
+  // The bare `oaspec.yaml` config file lives next to the spec
+  // fixtures by historical accident; it's an oaspec.yaml config,
+  // not an OpenAPI document, and would parse as garbage. Exclude
+  // explicitly so the prefix filter above doesn't miss it.
+  && name != "oaspec.yaml"
   // `error_invalid_yaml.yaml` is intentionally invalid YAML so the
   // CLI's "we surface a SourceLoc on YAML parse errors" path can be
   // exercised — it raises a yamerl-level exception rather than


### PR DESCRIPTION
## Summary

While building a fixture-sweep regression test (run `parser.parse_file`
+ `resolve.resolve` over every YAML in `test/fixtures/`), I added a
companion sweep that called `generate.generate` end-to-end. Three
fixtures crashed the generator with `oaspec: inline composite schema
reached to_string_fn after hoist. This is a hoist contract bug; please
file an issue with the spec.` — the panic was reachable from real-world
codegen paths because the validator only rejected the offending shapes
in server mode. This PR closes those panic paths and adds the sweep
gate so future regressions surface immediately.

## Bugs found and fixed

### 1. Query / header array params with non-primitive items (client + server)

Fixtures: `server_query_array_object_items.yaml`,
`server_header_array_object_items.yaml`.

`tags: array of object` survived `validate_server_structured_param`
because the gate was wrapped in `case mode { Client -> [] _ -> ... }`.
The client `generate_exploded_array_query_param` then routed the
ObjectSchema items through `to_string_fn`, which has no path for
composite schemas and panics.

Fix: lift the array-item check out of the mode gate so `validation_error_both`
fires regardless of mode, and follow `Reference` items through to
their resolved shape (post-hoist, an inline ObjectSchema is rewritten
into `Reference(_, "<HoistedName>")`, so `Reference(..) -> True`
unconditionally was equally unsafe). New helper
`array_items_resolve_primitive` makes the predicate explicit.

### 2. Form-urlencoded body with nested arrays inside object properties (client + server)

Fixture: `server_form_urlencoded_nested_body.yaml`
(`profile.aliases: array of string`).

The form-urlencoded validator was server-only and tolerated arrays at
any depth via `form_urlencoded_server_field_supported`. The client
emitter `generate_form_nested_object` then handed the inline
ArraySchema to `multipart_field_to_string_fn` and hit the same panic.

Fix: split the gate into a `server_mode_errors` block (the
multi-content "must be the sole request body" rule, still server-only)
and an always-on `field_errors` block backed by a stricter
`form_urlencoded_field_codegen_safe` predicate that rejects arrays
nested inside object properties. The legacy lenient
`form_urlencoded_server_field_supported` is now unused and removed.

### 3. Validator-test target widening

Two existing tests asserted these shapes were rejected with
`TargetServer`. The new validator emits `TargetBoth`. Tests now accept
either target, so the rejection-shape pin survives the gate widening
without churn on the next refactor.

## Tests added

- **`fixtures_sweep_parse_resolve_no_panic_case`** — enumerates every
  top-level `.yaml` under `test/fixtures/` (excluding intentionally-
  broken / config-shaped files: `broken*.yaml`, `oaspec*.yaml`,
  `error_invalid_yaml.yaml`) and runs each through `parser.parse_file`
  + `resolve.resolve`. The gate is panic-freedom; the sanity floor
  (`total >= 200`, `parsed_ok >= 200`, `resolved_ok >= 180`) catches
  a regression that would otherwise turn "0 fixtures parsed" into a
  silent green build.
- **`petstore_client_generated_surface_invariants_case`** — runs the
  full client-mode pipeline against `petstore.yaml` and asserts:
  every expected file is emitted (7 of them), each is non-empty and
  carries the codegen provenance header, every operation maps to a
  `pub fn` in `client.gleam`, and every component schema maps to a
  `pub type` in `types.gleam`. Catches a renaming / accidental drop in
  the public API surface without needing a full integration build.

## Verification

A standalone sweep over all 250+ valid fixtures × 3 modes (client,
server, both) found **0 remaining panics**. `just all` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array parameter validation to prevent generator panics when handling complex schemas.
  * Enhanced form-data validation to prevent crashes with nested object structures.

* **Tests**
  * Added regression tests for parser and resolver stability across fixture suite.
  * Added integration tests to verify generated client output integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->