### PR TITLE
fix(client-codegen): import gleam/int|float|bool for deepObject primitive sub-properties (#519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 366 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 267 test fixtures (including 98 OSS-derived edge-case specs)
+  and 268 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -55,10 +55,22 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
         _ -> False
       }
     })
+    || deep_object_param_has_property(operations, ctx, fn(s) {
+      case s {
+        schema.BooleanSchema(..) -> True
+        _ -> False
+      }
+    })
   let needs_float_param =
     list.any(all_params, fn(p) {
       case p.payload {
         ParameterSchema(Inline(schema.NumberSchema(..))) -> True
+        _ -> False
+      }
+    })
+    || deep_object_param_has_property(operations, ctx, fn(s) {
+      case s {
+        schema.NumberSchema(..) -> True
         _ -> False
       }
     })
@@ -357,6 +369,12 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
         _ -> False
       }
     })
+    || deep_object_param_has_property(operations, ctx, fn(s) {
+      case s {
+        schema.IntegerSchema(..) -> True
+        _ -> False
+      }
+    })
 
   let needs_float = needs_float_param || has_float_response_header
 
@@ -532,6 +550,65 @@ fn resolve_to_object(
         // nolint: thrown_away_error -- unresolved refs are reported by the resolver; the import gate just falls back to "no match"
         Error(_) -> None
       }
+  }
+}
+
+/// Issue #519: predicate helper for deepObject query parameter
+/// sub-properties. Detects whether any deepObject query parameter has
+/// a (recursively-nested) property whose resolved schema matches
+/// `pred`. The deepObject codegen path emits `int.to_string` /
+/// `float.to_string` / `bool.to_string` for primitive sub-properties,
+/// so the import gate must mirror that recursion to pull in
+/// `gleam/int` / `gleam/float` / `gleam/bool`.
+fn deep_object_param_has_property(
+  operations: List(context.AnalyzedOperation),
+  ctx: Context,
+  pred: fn(schema.SchemaObject) -> Bool,
+) -> Bool {
+  list.any(operations, fn(op) {
+    let #(_, operation, _, _) = op
+    list.any(operation.parameters, fn(rp) {
+      case rp {
+        Value(p) ->
+          case operation_ir.is_deep_object_param(p, ctx) {
+            False -> False
+            True ->
+              case spec.parameter_schema(p) {
+                Some(ref) ->
+                  case resolve_to_object(ref, ctx) {
+                    Some(obj) -> object_properties_match(obj, ctx, pred)
+                    None -> False
+                  }
+                None -> False
+              }
+          }
+        _ -> False
+      }
+    })
+  })
+}
+
+/// Walk the leaves of an `ObjectSchema`'s property tree, calling
+/// `pred` on each resolved schema. Recurses into nested
+/// `ObjectSchema` properties so the import-needs analysis mirrors
+/// `emit_deep_object_nested_object/_property` in
+/// `oaspec/internal/codegen/client.gleam`.
+fn object_properties_match(
+  obj: schema.SchemaObject,
+  ctx: Context,
+  pred: fn(schema.SchemaObject) -> Bool,
+) -> Bool {
+  case obj {
+    schema.ObjectSchema(properties:, ..) ->
+      list.any(dict.to_list(properties), fn(entry) {
+        let #(_, prop_ref) = entry
+        case resolve_to_object(prop_ref, ctx) {
+          Some(prop_schema) ->
+            pred(prop_schema) || object_properties_match(prop_schema, ctx, pred)
+          None -> False
+        }
+      })
+    _ -> False
   }
 }
 

--- a/test/fixtures/deep_object_primitive_props.yaml
+++ b/test/fixtures/deep_object_primitive_props.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.3"
+info:
+  title: deepObject Primitive Property Imports Test
+  description: |
+    Issue #519. The deepObject codegen emits `int.to_string` /
+    `float.to_string` / `bool.to_string` for primitive sub-properties
+    of a deepObject query parameter, but the import-needs analysis in
+    `client_ir.gleam` did not traverse into deepObject properties, so
+    `<package>_client/client.gleam` was missing the corresponding
+    `gleam/int` / `gleam/float` / `gleam/bool` imports and failed to
+    compile.
+
+    This fixture exercises all three primitive sub-property types
+    plus a nested ObjectSchema property to lock the recursive
+    traversal in.
+  version: "1.0.0"
+paths:
+  /things:
+    get:
+      operationId: listThings
+      parameters:
+        - name: filter
+          in: query
+          style: deepObject
+          explode: true
+          required: false
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+              ratio:
+                type: number
+                format: double
+              active:
+                type: boolean
+              nested:
+                type: object
+                properties:
+                  inner_count:
+                    type: integer
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: string

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -121,6 +121,7 @@ pub fn content_type_helpers_test() {
   let _ = support.deep_object_nested_object_passes_client_validation_case()
   let _ = support.deep_object_nested_object_emits_bracketed_query_case()
   let _ = support.deep_object_param_client_imports_some_none_case()
+  let _ = support.deep_object_primitive_props_client_imports_primitives_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6836,6 +6836,45 @@ pub fn deep_object_param_client_imports_some_none_case() {
   |> should.be_true()
 }
 
+// --- Issue #519: deepObject primitive sub-property imports ---
+
+/// Regression guard for #519: a client whose deepObject query
+/// parameter has integer / number / boolean sub-properties (top-level
+/// or nested) must import `gleam/int` / `gleam/float` / `gleam/bool`
+/// because the codegen emits `int.to_string` / `float.to_string` /
+/// `bool.to_string` at those sites. Pre-fix, the import gate didn't
+/// traverse deepObject ObjectSchema properties and the generated
+/// `<package>_client/client.gleam` failed to compile with
+/// `Unknown module: int`.
+pub fn deep_object_primitive_props_client_imports_primitives_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/deep_object_primitive_props.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/deep_object_primitive_props.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  // The deepObject sub-properties trigger int/float/bool to_string
+  // emissions, which in turn require the matching primitive modules.
+  string.contains(client_file.content, "import gleam/int")
+  |> should.be_true()
+  string.contains(client_file.content, "import gleam/float")
+  |> should.be_true()
+  string.contains(client_file.content, "import gleam/bool")
+  |> should.be_true()
+  // Nested-ObjectSchema property inner_count: integer is reached via
+  // the recursive walker.
+  string.contains(client_file.content, "filter[nested][inner_count]")
+  |> should.be_true()
+}
+
 // --- Issue #503: multipart/form-data object/array fields ---
 
 /// Regression guard: a client whose only multi-shape work is a


### PR DESCRIPTION
## Summary

Fixes #519. The client-side `<package>_client/client.gleam` codegen emits `int.to_string` / `float.to_string` / `bool.to_string` for primitive sub-properties of a `style: deepObject` query parameter, but the import-set analysis in `client_ir.gleam` only inspected top-level parameter schemas — it never traversed deepObject `ObjectSchema` properties. As a result, any spec with a deepObject query whose sub-properties were `integer` / `number` / `boolean` (the canonical paginated-cursor pattern, `?page[size]=10&page[after]=...`) produced code that failed `gleam build` with `Unknown module: int|float|bool`.

## Changes

- `src/oaspec/internal/codegen/client_ir.gleam`
  - Add `deep_object_param_has_property/3` walking every deepObject query parameter's resolved schema.
  - Add `object_properties_match/3` that recurses through nested `ObjectSchema` properties (mirroring `emit_deep_object_nested_object` in `client.gleam`).
  - Wire both into `needs_int`, `needs_float_param`, and `needs_bool` so the matching `gleam/int` / `gleam/float` / `gleam/bool` import is emitted whenever the deepObject codegen needs it.
- `test/fixtures/deep_object_primitive_props.yaml` — new fixture exercising all three primitive sub-property types + a nested object property.
- `test/oaspec_support.gleam` — new regression case `deep_object_primitive_props_client_imports_primitives_case` asserting the three imports plus the nested-property emission `filter[nested][inner_count]`.
- `test/oaspec_core_test.gleam` — wire the new case into the test.

## Design Decisions

- The new helpers reuse the existing `resolve_to_object` shape used by `multipart_has_field`, keeping the import-gate analysis style consistent across multipart and deepObject paths.
- Recursive traversal of nested `ObjectSchema` properties matches the codegen's own recursion in `emit_deep_object_nested_object`, ensuring the import gate stays in lockstep with what's actually emitted.
- A predicate-based helper avoids duplicating the traversal three times for int / float / bool.

Closes #519