### PR TITLE
fix(guards): recurse into nested-record properties when collecting guard calls (#520)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 366 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 268 test fixtures (including 98 OSS-derived edge-case specs)
+  and 269 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -60,25 +60,22 @@ fn schema_has_validator_visiting(
   ctx: Context,
   visiting: List(String),
 ) -> Bool {
-  case list.contains(visiting, name) {
-    True -> False
-    False ->
-      case context.spec(ctx).components {
-        Some(components) ->
-          case dict.get(components.schemas, name) {
-            Ok(schema_ref) ->
-              !ir_build.is_internal_schema(schema_ref)
-              && !list.is_empty(
-                collect_guard_calls_visiting(name, schema_ref, ctx, [
-                  name,
-                  ..visiting
-                ]),
-              )
-            // nolint: thrown_away_error -- unknown schema name simply has no validator
-            Error(_) -> False
-          }
-        None -> False
+  use <- bool.guard(when: list.contains(visiting, name), return: False)
+  case context.spec(ctx).components {
+    Some(components) ->
+      case dict.get(components.schemas, name) {
+        Ok(schema_ref) ->
+          !ir_build.is_internal_schema(schema_ref)
+          && !list.is_empty(
+            collect_guard_calls_visiting(name, schema_ref, ctx, [
+              name,
+              ..visiting
+            ]),
+          )
+        // nolint: thrown_away_error -- unknown schema name simply has no validator
+        Error(_) -> False
       }
+    None -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -45,16 +45,40 @@ pub type GuardModule {
 /// Check whether a named component schema has a composite validator.
 /// Used by server/client generators to decide whether to emit guard calls.
 pub fn schema_has_validator(name: String, ctx: Context) -> Bool {
-  case context.spec(ctx).components {
-    Some(components) ->
-      case dict.get(components.schemas, name) {
-        Ok(schema_ref) ->
-          !ir_build.is_internal_schema(schema_ref)
-          && !list.is_empty(collect_guard_calls(name, schema_ref, ctx))
-        // nolint: thrown_away_error -- unknown schema name simply has no validator
-        Error(_) -> False
+  schema_has_validator_visiting(name, ctx, [])
+}
+
+/// Cycle-aware variant. `visiting` is the stack of schema names whose
+/// `schema_has_validator` evaluation is currently in flight. When a
+/// nested-record check would recurse back into one of them (e.g. a
+/// recursive `Comment` schema whose `replies` is `array<Comment>`, or
+/// mutually-recursive `User` ↔ `Link`), we short-circuit the loop by
+/// returning `False` for that arm — the schema can still earn a
+/// validator through other (non-cyclic) constraints.
+fn schema_has_validator_visiting(
+  name: String,
+  ctx: Context,
+  visiting: List(String),
+) -> Bool {
+  case list.contains(visiting, name) {
+    True -> False
+    False ->
+      case context.spec(ctx).components {
+        Some(components) ->
+          case dict.get(components.schemas, name) {
+            Ok(schema_ref) ->
+              !ir_build.is_internal_schema(schema_ref)
+              && !list.is_empty(
+                collect_guard_calls_visiting(name, schema_ref, ctx, [
+                  name,
+                  ..visiting
+                ]),
+              )
+            // nolint: thrown_away_error -- unknown schema name simply has no validator
+            Error(_) -> False
+          }
+        None -> False
       }
-    None -> False
   }
 }
 
@@ -139,12 +163,35 @@ pub fn build_module(ctx: Context) -> GuardModule {
       let #(name, schema_ref) = entry
       let guard_calls = collect_guard_calls(name, schema_ref, ctx)
       list.any(guard_calls, fn(call) {
-        let #(_, _, is_required) = call
+        let #(_, _, is_required, _) = call
         !is_required
       })
     })
   let imports = case needs_option {
     True -> ["gleam/option", ..imports]
+    False -> imports
+  }
+
+  // Issue #520: nested-composite and composite-list emissions use
+  // `list.append`/`list.reverse`/`list.fold` to merge inner failures
+  // into the outer accumulator, so `gleam/list` becomes mandatory
+  // whenever any schema has a Composite or CompositeList call —
+  // independent of the existing `has_list` (which tracks array-length
+  // constraints).
+  let needs_list_for_composites =
+    list.any(schemas, fn(entry) {
+      let #(name, schema_ref) = entry
+      let guard_calls = collect_guard_calls(name, schema_ref, ctx)
+      list.any(guard_calls, fn(call) {
+        let #(_, _, _, kind) = call
+        case kind {
+          Composite | CompositeList -> True
+          Direct -> False
+        }
+      })
+    })
+  let imports = case needs_list_for_composites && !constraint_types.has_list {
+    True -> ["gleam/list", ..imports]
     False -> imports
   }
 
@@ -705,20 +752,61 @@ fn build_composite_guard_function(
       let gleam_type = composite_validator_type(name, schema_ref, ctx)
       let call_lines =
         list.flat_map(guard_calls, fn(call) {
-          let #(guard_fn, accessor, is_required) = call
-          case is_required {
-            True -> [
+          let #(guard_fn, accessor, is_required, kind) = call
+          case kind, is_required {
+            Direct, True -> [
               "  let errors = case " <> guard_fn <> "(" <> accessor <> ") {",
               "    Ok(_) -> errors",
               "    Error(failure) -> [failure, ..errors]",
               "  }",
             ]
-            False -> [
+            Direct, False -> [
               "  let errors = case " <> accessor <> " {",
               "    option.Some(v) -> case " <> guard_fn <> "(v) {",
               "      Ok(_) -> errors",
               "      Error(failure) -> [failure, ..errors]",
               "    }",
+              "    option.None -> errors",
+              "  }",
+            ]
+            // Issue #520: nested-record validators return
+            // `Result(_, List(ValidationFailure))`; merge their failure
+            // list into the outer accumulator.
+            Composite, True -> [
+              "  let errors = case " <> guard_fn <> "(" <> accessor <> ") {",
+              "    Ok(_) -> errors",
+              "    Error(failures) -> list.append(list.reverse(failures), errors)",
+              "  }",
+            ]
+            Composite, False -> [
+              "  let errors = case " <> accessor <> " {",
+              "    option.Some(v) -> case " <> guard_fn <> "(v) {",
+              "      Ok(_) -> errors",
+              "      Error(failures) -> list.append(list.reverse(failures), errors)",
+              "    }",
+              "    option.None -> errors",
+              "  }",
+            ]
+            // Issue #520: lists of validatable records are folded so
+            // every element runs through the inner composite validator.
+            CompositeList, True -> [
+              "  let errors = list.fold("
+                <> accessor
+                <> ", errors, fn(errs, item) {",
+              "    case " <> guard_fn <> "(item) {",
+              "      Ok(_) -> errs",
+              "      Error(failures) -> list.append(list.reverse(failures), errs)",
+              "    }",
+              "  })",
+            ]
+            CompositeList, False -> [
+              "  let errors = case " <> accessor <> " {",
+              "    option.Some(items) -> list.fold(items, errors, fn(errs, item) {",
+              "      case " <> guard_fn <> "(item) {",
+              "        Ok(_) -> errs",
+              "        Error(failures) -> list.append(list.reverse(failures), errs)",
+              "      }",
+              "    })",
               "    option.None -> errors",
               "  }",
             ]
@@ -1333,16 +1421,42 @@ fn composite_validator_type(
   }
 }
 
-/// A guard call with metadata about whether the field is optional.
-/// #(guard_fn_name, accessor_expr, is_optional)
+/// Shape of a generated guard invocation.
+///
+/// - `Direct`: the validator returns `Result(T, ValidationFailure)` —
+///   the historical leaf case (range / pattern / length / unique).
+/// - `Composite`: the validator returns
+///   `Result(T, List(ValidationFailure))` — the per-schema aggregator
+///   for a nested record. Issue #520.
+/// - `CompositeList`: the field is `List(T)` and each item must be
+///   recursively validated against its composite validator. Issue
+///   #520.
+type GuardCallKind {
+  Direct
+  Composite
+  CompositeList
+}
+
+/// A guard call with metadata about whether the field is optional and
+/// what shape its validator returns.
+/// #(guard_fn_name, accessor_expr, is_required, kind)
 type GuardCall =
-  #(String, String, Bool)
+  #(String, String, Bool, GuardCallKind)
 
 /// Collect all guard function calls for a schema's constrained fields.
 fn collect_guard_calls(
   name: String,
   schema_ref: SchemaRef,
   ctx: Context,
+) -> List(GuardCall) {
+  collect_guard_calls_visiting(name, schema_ref, ctx, [])
+}
+
+fn collect_guard_calls_visiting(
+  name: String,
+  schema_ref: SchemaRef,
+  ctx: Context,
+  visiting: List(String),
 ) -> List(GuardCall) {
   let schema = context.resolve_schema_ref(schema_ref, ctx)
   case schema {
@@ -1358,12 +1472,19 @@ fn collect_guard_calls(
         |> list.flat_map(fn(entry) {
           let #(prop_name, prop_ref) = entry
           let is_required = list.contains(required, prop_name)
-          collect_field_guard_calls(name, prop_name, prop_ref, is_required, ctx)
+          collect_field_guard_calls(
+            name,
+            prop_name,
+            prop_ref,
+            is_required,
+            ctx,
+            visiting,
+          )
         })
       let size_calls = case min_properties, max_properties {
         None, None -> []
         _, _ -> [
-          #(guard_function_name(name, "", "properties"), "value", True),
+          #(guard_function_name(name, "", "properties"), "value", True, Direct),
         ]
       }
       list.append(prop_calls, size_calls)
@@ -1374,21 +1495,28 @@ fn collect_guard_calls(
       |> list.flat_map(fn(entry) {
         let #(prop_name, prop_ref) = entry
         let is_required = list.contains(merged.required, prop_name)
-        collect_field_guard_calls(name, prop_name, prop_ref, is_required, ctx)
+        collect_field_guard_calls(
+          name,
+          prop_name,
+          prop_ref,
+          is_required,
+          ctx,
+          visiting,
+        )
       })
     }
     Ok(StringSchema(min_length:, max_length:, pattern:, ..)) -> {
       let calls = case min_length, max_length {
         None, None -> []
         _, _ -> [
-          #(guard_function_name(name, "", "length"), "value", True),
+          #(guard_function_name(name, "", "length"), "value", True, Direct),
         ]
       }
       case pattern {
         None -> calls
         Some(_) ->
           list.append(calls, [
-            #(guard_function_name(name, "", "pattern"), "value", True),
+            #(guard_function_name(name, "", "pattern"), "value", True, Direct),
           ])
       }
     }
@@ -1403,21 +1531,31 @@ fn collect_guard_calls(
       let calls = case minimum, maximum {
         None, None -> []
         _, _ -> [
-          #(guard_function_name(name, "", "range"), "value", True),
+          #(guard_function_name(name, "", "range"), "value", True, Direct),
         ]
       }
       let calls = case exclusive_minimum, exclusive_maximum {
         None, None -> calls
         _, _ ->
           list.append(calls, [
-            #(guard_function_name(name, "", "exclusive_range"), "value", True),
+            #(
+              guard_function_name(name, "", "exclusive_range"),
+              "value",
+              True,
+              Direct,
+            ),
           ])
       }
       case multiple_of {
         None -> calls
         Some(_) ->
           list.append(calls, [
-            #(guard_function_name(name, "", "multiple_of"), "value", True),
+            #(
+              guard_function_name(name, "", "multiple_of"),
+              "value",
+              True,
+              Direct,
+            ),
           ])
       }
     }
@@ -1432,21 +1570,31 @@ fn collect_guard_calls(
       let calls = case minimum, maximum {
         None, None -> []
         _, _ -> [
-          #(guard_function_name(name, "", "range"), "value", True),
+          #(guard_function_name(name, "", "range"), "value", True, Direct),
         ]
       }
       let calls = case exclusive_minimum, exclusive_maximum {
         None, None -> calls
         _, _ ->
           list.append(calls, [
-            #(guard_function_name(name, "", "exclusive_range"), "value", True),
+            #(
+              guard_function_name(name, "", "exclusive_range"),
+              "value",
+              True,
+              Direct,
+            ),
           ])
       }
       case multiple_of {
         None -> calls
         Some(_) ->
           list.append(calls, [
-            #(guard_function_name(name, "", "multiple_of"), "value", True),
+            #(
+              guard_function_name(name, "", "multiple_of"),
+              "value",
+              True,
+              Direct,
+            ),
           ])
       }
     }
@@ -1454,12 +1602,12 @@ fn collect_guard_calls(
       let length_calls = case min_items, max_items {
         None, None -> []
         _, _ -> [
-          #(guard_function_name(name, "", "length"), "value", True),
+          #(guard_function_name(name, "", "length"), "value", True, Direct),
         ]
       }
       let unique_calls = case unique_items {
         True -> [
-          #(guard_function_name(name, "", "unique"), "value", True),
+          #(guard_function_name(name, "", "unique"), "value", True, Direct),
         ]
         False -> []
       }
@@ -1470,12 +1618,17 @@ fn collect_guard_calls(
 }
 
 /// Collect guard calls for a single field.
+///
+/// `visiting` is propagated from `collect_guard_calls_visiting` so the
+/// nested-record (`Composite` / `CompositeList`) branches can break
+/// schema-graph cycles when deciding whether to emit a recursive call.
 fn collect_field_guard_calls(
   schema_name: String,
   prop_name: String,
   prop_ref: SchemaRef,
   is_required: Bool,
   ctx: Context,
+  visiting: List(String),
 ) -> List(GuardCall) {
   let resolved = context.resolve_schema_ref(prop_ref, ctx)
   let accessor = "value." <> naming.to_snake_case(prop_name)
@@ -1488,6 +1641,7 @@ fn collect_field_guard_calls(
             guard_function_name(schema_name, prop_name, "length"),
             accessor,
             is_required,
+            Direct,
           ),
         ]
       }
@@ -1499,6 +1653,7 @@ fn collect_field_guard_calls(
               guard_function_name(schema_name, prop_name, "pattern"),
               accessor,
               is_required,
+              Direct,
             ),
           ])
       }
@@ -1518,6 +1673,7 @@ fn collect_field_guard_calls(
             guard_function_name(schema_name, prop_name, "range"),
             accessor,
             is_required,
+            Direct,
           ),
         ]
       }
@@ -1529,6 +1685,7 @@ fn collect_field_guard_calls(
               guard_function_name(schema_name, prop_name, "exclusive_range"),
               accessor,
               is_required,
+              Direct,
             ),
           ])
       }
@@ -1540,6 +1697,7 @@ fn collect_field_guard_calls(
               guard_function_name(schema_name, prop_name, "multiple_of"),
               accessor,
               is_required,
+              Direct,
             ),
           ])
       }
@@ -1559,6 +1717,7 @@ fn collect_field_guard_calls(
             guard_function_name(schema_name, prop_name, "range"),
             accessor,
             is_required,
+            Direct,
           ),
         ]
       }
@@ -1570,6 +1729,7 @@ fn collect_field_guard_calls(
               guard_function_name(schema_name, prop_name, "exclusive_range"),
               accessor,
               is_required,
+              Direct,
             ),
           ])
       }
@@ -1581,11 +1741,12 @@ fn collect_field_guard_calls(
               guard_function_name(schema_name, prop_name, "multiple_of"),
               accessor,
               is_required,
+              Direct,
             ),
           ])
       }
     }
-    Ok(ArraySchema(min_items:, max_items:, unique_items:, ..)) -> {
+    Ok(ArraySchema(items:, min_items:, max_items:, unique_items:, ..)) -> {
       let length_calls = case min_items, max_items {
         None, None -> []
         _, _ -> [
@@ -1593,6 +1754,7 @@ fn collect_field_guard_calls(
             guard_function_name(schema_name, prop_name, "length"),
             accessor,
             is_required,
+            Direct,
           ),
         ]
       }
@@ -1602,12 +1764,55 @@ fn collect_field_guard_calls(
             guard_function_name(schema_name, prop_name, "unique"),
             accessor,
             is_required,
+            Direct,
           ),
         ]
         False -> []
       }
-      list.append(length_calls, unique_calls)
+      // Issue #520: when the array's items are a `$ref` to a schema
+      // that has its own composite validator, fold over the list and
+      // run the inner validator on every element. Without this, an
+      // out-of-range element in `Poll.options` (where each option has
+      // a constrained `weight`) silently passes the outer
+      // `validate_poll`.
+      let item_calls = case items {
+        Reference(name: item_name, ..) ->
+          case schema_has_validator_visiting(item_name, ctx, visiting) {
+            True -> [
+              #(
+                "validate_" <> naming.to_snake_case(item_name),
+                accessor,
+                is_required,
+                CompositeList,
+              ),
+            ]
+            False -> []
+          }
+        _ -> []
+      }
+      list.flatten([length_calls, unique_calls, item_calls])
     }
+    // Issue #520: a property whose schema is a `$ref` to a record
+    // type with its own composite validator should propagate that
+    // record's failures into the outer aggregator. Pre-fix,
+    // out-of-range nested fields slipped past `validate_<outer>`
+    // entirely.
+    Ok(ObjectSchema(..)) ->
+      case prop_ref {
+        Reference(name: ref_name, ..) ->
+          case schema_has_validator_visiting(ref_name, ctx, visiting) {
+            True -> [
+              #(
+                "validate_" <> naming.to_snake_case(ref_name),
+                accessor,
+                is_required,
+                Composite,
+              ),
+            ]
+            False -> []
+          }
+        _ -> []
+      }
     _ -> []
   }
 }

--- a/test/fixtures/guard_nested_constraints.yaml
+++ b/test/fixtures/guard_nested_constraints.yaml
@@ -1,0 +1,147 @@
+openapi: "3.0.3"
+info:
+  title: Nested Guard Recursion API
+  description: |
+    Issue #520. Exercises the `validate_<schema>` aggregator's
+    recursion into:
+    - required nested record (Poll.metadata: Metadata)
+    - optional nested record (Poll.banner: Banner)
+    - required list of records (Poll.options: array<PollOption>)
+    - optional list of records (Poll.tags: array<Tag>)
+    - mutually-recursive schemas (User has Link, Link has owner: User)
+    - self-recursive schema (Comment.replies: array<Comment>)
+
+    The inner records carry direct constraints; pre-fix, the outer
+    `validate_poll` / `validate_user` skipped them entirely.
+  version: "1.0.0"
+paths:
+  /polls:
+    post:
+      operationId: createPoll
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Poll" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Poll" }
+  /users/{id}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+  /comments:
+    get:
+      operationId: listComments
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/Comment" }
+components:
+  schemas:
+    PollOption:
+      type: object
+      required: [label, weight]
+      properties:
+        label:
+          type: string
+          minLength: 1
+          maxLength: 40
+        weight:
+          type: number
+          minimum: 0
+          maximum: 1
+
+    Tag:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          pattern: "^[a-z0-9-]+$"
+
+    Banner:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+          minLength: 8
+          maxLength: 256
+
+    Metadata:
+      type: object
+      required: [created_by]
+      properties:
+        created_by:
+          type: string
+          minLength: 1
+          maxLength: 80
+
+    Poll:
+      type: object
+      required: [slug, metadata, options]
+      properties:
+        slug:
+          type: string
+          pattern: "^[a-z0-9-]{3,40}$"
+        metadata:
+          $ref: "#/components/schemas/Metadata"
+        banner:
+          $ref: "#/components/schemas/Banner"
+        options:
+          type: array
+          items: { $ref: "#/components/schemas/PollOption" }
+        tags:
+          type: array
+          items: { $ref: "#/components/schemas/Tag" }
+
+    Link:
+      type: object
+      required: [target, owner]
+      properties:
+        target:
+          type: string
+          minLength: 8
+        owner:
+          $ref: "#/components/schemas/User"
+
+    User:
+      type: object
+      required: [name, recent_links]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+        recent_links:
+          type: array
+          items: { $ref: "#/components/schemas/Link" }
+
+    Comment:
+      type: object
+      required: [body, replies]
+      properties:
+        body:
+          type: string
+          minLength: 1
+        replies:
+          type: array
+          items: { $ref: "#/components/schemas/Comment" }

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -122,6 +122,8 @@ pub fn content_type_helpers_test() {
   let _ = support.deep_object_nested_object_emits_bracketed_query_case()
   let _ = support.deep_object_param_client_imports_some_none_case()
   let _ = support.deep_object_primitive_props_client_imports_primitives_case()
+  let _ = support.nested_validate_recurses_into_records_case()
+  let _ = support.nested_validate_handles_cycles_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6875,6 +6875,77 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #520: validate_<schema> recurses into nested records ---
+
+/// Regression guard for #520: `validate_poll` must recurse into
+/// nested records (`Metadata`, `Banner`), required lists of records
+/// (`options: array<PollOption>`), and optional lists of records
+/// (`tags: array<Tag>`). Pre-fix, only direct leaf-level constraints
+/// (e.g. `slug` pattern) were emitted; constraint violations on inner
+/// fields silently passed through to handlers.
+pub fn nested_validate_recurses_into_records_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/guard_nested_constraints.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/guard_nested_constraints.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Server,
+      validate: True,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(guards_file) =
+    list.find(summary.files, fn(f) { f.path == "guards.gleam" })
+  // Required nested record → Composite call into validate_metadata.
+  string.contains(guards_file.content, "validate_metadata(value.metadata)")
+  |> should.be_true()
+  // Optional nested record → Composite under option.Some(v) wrap.
+  string.contains(guards_file.content, "validate_banner(v)")
+  |> should.be_true()
+  // Required list of records → list.fold over options calling validate_poll_option.
+  string.contains(guards_file.content, "validate_poll_option(item)")
+  |> should.be_true()
+  string.contains(guards_file.content, "list.fold(value.options, errors")
+  |> should.be_true()
+  // Optional list of records → option-wrapped list.fold over tags.
+  string.contains(guards_file.content, "validate_tag(item)")
+  |> should.be_true()
+}
+
+/// Regression guard for #520: cycle detection in `schema_has_validator`
+/// must not blow the stack on (a) self-recursive schemas like
+/// `Comment.replies: array<Comment>` and (b) mutually-recursive
+/// schemas like `User` ↔ `Link`. Pre-fix prototype, this fixture
+/// would non-terminate during codegen.
+pub fn nested_validate_handles_cycles_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/guard_nested_constraints.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/guard_nested_constraints.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Server,
+      validate: True,
+    )
+  // The mere fact that `generate.generate` returns `Ok(_)` (rather
+  // than spinning on `User` ↔ `Link` or on `Comment.replies`) is the
+  // important guarantee here.
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(guards_file) =
+    list.find(summary.files, fn(f) { f.path == "guards.gleam" })
+  // User has its own validator (because `name` has length constraints)
+  // so the cycle break inside `Link.owner` shouldn't suppress it.
+  string.contains(guards_file.content, "pub fn validate_user")
+  |> should.be_true()
+  // Link likewise has direct constraints on `target`.
+  string.contains(guards_file.content, "pub fn validate_link")
+  |> should.be_true()
+}
+
 // --- Issue #503: multipart/form-data object/array fields ---
 
 /// Regression guard: a client whose only multi-shape work is a


### PR DESCRIPTION
## Summary

Fixes #520. The generated `validate_<schema>` aggregator only walked fields with constraints **directly on the leaf type** (`pattern`/`minLength`/`maximum`/etc.). A field whose schema was a `\$ref` to another record — even when that referenced record had its own constraints — was silently skipped. Same for `array<\$ref>`. So a `Poll` whose `options: List(PollOption)` contained an item with out-of-range `weight` passed `validate_poll` even though `validate_poll_option_weight_range` correctly flagged the value when called directly.

## Changes

- `src/oaspec/internal/codegen/guards.gleam`
  - Promote `GuardCall` from a 3-tuple to a 4-tuple carrying a new `GuardCallKind` variant (`Direct` / `Composite` / `CompositeList`).
  - Extend `collect_field_guard_calls` to emit `Composite` for `\$ref` to a validatable record and `CompositeList` for `array<\$ref>` whose item is validatable.
  - Composite emission: `let errors = case validate_X(value.f) { Ok(_) -> errors; Error(failures) -> list.append(list.reverse(failures), errors) }`. Optional outer wraps the `case value.f { option.Some(v) -> ... }` shape.
  - CompositeList emission: `let errors = list.fold(value.f, errors, fn(errs, item) { case validate_X(item) { ... } })`.
  - Cycle-aware `schema_has_validator`: public function delegates to `schema_has_validator_visiting` threading a stack of in-flight schema names through `collect_guard_calls_visiting` / `collect_field_guard_calls`. Back-edges (e.g. `Comment.replies: array<Comment>`, `User` ↔ `Link`) short-circuit to `False` so codegen terminates while leaving each schema's other validator-eligible fields intact.
  - Auto-import `gleam/list` whenever any schema has a `Composite` or `CompositeList` call (the emitted body uses `list.append` / `list.reverse` / `list.fold`).
- `test/fixtures/guard_nested_constraints.yaml` — new fixture exercising required/optional nested records, required/optional list-of-records, mutually-recursive `User` ↔ `Link`, and self-recursive `Comment`.
- `test/oaspec_support.gleam` + `test/oaspec_core_test.gleam` — two support cases (\`nested_validate_recurses_into_records_case\`, \`nested_validate_handles_cycles_case\`) assert the emitted body shapes and that codegen terminates on cycles.
- `README.md` — fixture count bumped from 268 → 269.

## Design Decisions

- `Composite` calls reverse the inner failures before prepending to keep accumulator order consistent with the pre-existing `[failure, ..errors]` convention used by `Direct` calls.
- Cycle break returns `False` (rather than `True` conservatively) so that purely-cyclic schemas without any leaf constraints (e.g. `Comment` with only string fields and a `replies` list) correctly produce no validator at all. Schemas in a cycle that DO have direct leaf constraints still earn validators; the cycle break only suppresses the redundant cross-call within the loop.
- The new `needs_list_for_composites` gate is independent of the existing `has_list` (which tracks array-length constraint emissions), so the import is added precisely when needed and never duplicated.

Closes #520