### PR TITLE
fix(guards): repair multipleOf codegen body and import-needs detection (#521)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 366 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 269 test fixtures (including 98 OSS-derived edge-case specs)
+  and 270 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/codegen/guards.gleam
+++ b/src/oaspec/internal/codegen/guards.gleam
@@ -600,13 +600,22 @@ fn collect_schema_constraint_types_inner(
     | Ok(IntegerSchema(exclusive_maximum: Some(_), ..))
     | Ok(IntegerSchema(multiple_of: Some(_), ..)) ->
       ConstraintTypes(..acc, has_integer: True)
+    // Issue #521: a NumberSchema with both `minimum` and
+    // `multipleOf` declared was hitting the range arm first (because
+    // pattern arms are tried top-down), which left
+    // `has_float_multiple_of` False — the resulting `guards.gleam`
+    // emitted `float.truncate` / `int.to_float` calls without the
+    // matching `gleam/float` / `gleam/int` imports. Putting the
+    // multipleOf arm first ensures both flags fire whenever
+    // `multiple_of` is Some, regardless of which other constraints
+    // happen to be present.
+    Ok(NumberSchema(multiple_of: Some(_), ..)) ->
+      ConstraintTypes(..acc, has_float: True, has_float_multiple_of: True)
     Ok(NumberSchema(minimum: Some(_), ..))
     | Ok(NumberSchema(maximum: Some(_), ..))
     | Ok(NumberSchema(exclusive_minimum: Some(_), ..))
     | Ok(NumberSchema(exclusive_maximum: Some(_), ..)) ->
       ConstraintTypes(..acc, has_float: True)
-    Ok(NumberSchema(multiple_of: Some(_), ..)) ->
-      ConstraintTypes(..acc, has_float: True, has_float_multiple_of: True)
     Ok(ArraySchema(min_items: Some(_), ..))
     | Ok(ArraySchema(max_items: Some(_), ..))
     | Ok(ArraySchema(unique_items: True, ..)) ->
@@ -1272,11 +1281,21 @@ fn build_float_multiple_of_guard_function(
         ],
         param_decl: "value: Float",
         return_type: "Result(Float, ValidationFailure)",
+        // Issue #521: the prior expression
+        //   value -. float.truncate(value /. m |> int.to_float) *. m
+        // was malformed — the `|> int.to_float` was applied to a
+        // Float (the result of `value /. m`) instead of the Int
+        // returned by `float.truncate`, and `float.truncate(_)` was
+        // multiplied by `m` (Float) with `*.` (which expects Float on
+        // both sides), so even with `gleam/float` and `gleam/int`
+        // imported the body did not type-check. The corrected form
+        // is `value -. int.to_float(float.truncate(value /. m)) *. m`,
+        // which computes truncation-toward-zero modulo.
         body: string.join(
           [
-            "  let remainder = value -. float.truncate(value /. "
+            "  let remainder = value -. int.to_float(float.truncate(value /. "
               <> float.to_string(m)
-              <> " |> int.to_float) *. "
+              <> ")) *. "
               <> float.to_string(m),
             "  case remainder == 0.0 || remainder == -0.0 {",
             "    False -> "

--- a/test/fixtures/guard_multiple_of_with_range.yaml
+++ b/test/fixtures/guard_multiple_of_with_range.yaml
@@ -1,0 +1,48 @@
+openapi: "3.0.3"
+info:
+  title: multipleOf With Range Guard Test
+  description: |
+    Issue #521. Ensures the `multipleOf` validator codegen produces a
+    body that compiles, AND that the import-needs analyzer pulls in
+    `gleam/float` + `gleam/int` even when a NumberSchema declares
+    both `minimum` and `multipleOf` (the canonical "amount in cents"
+    pattern: `multipleOf: 0.01, minimum: 0`).
+
+    Pre-fix, the import-needs case-arm order put `minimum: Some(_)`
+    first, which shadowed the `multiple_of: Some(_)` arm and left
+    `has_float_multiple_of` False. The generated `guards.gleam` then
+    emitted `float.truncate(...)` / `int.to_float(...)` without the
+    matching imports. The body itself was also broken:
+    `value -. float.truncate(value /. m |> int.to_float) *. m` piped
+    a Float into `int.to_float` and tried to multiply an Int by `0.01`
+    with `*.`. Both halves are exercised here.
+  version: "1.0.0"
+paths:
+  /entries:
+    post:
+      operationId: appendEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Entry" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Entry" }
+components:
+  schemas:
+    Entry:
+      type: object
+      required: [amount, memo]
+      properties:
+        amount:
+          type: number
+          format: double
+          multipleOf: 0.01
+          minimum: 0
+        memo:
+          type: string
+          minLength: 1

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -124,6 +124,7 @@ pub fn content_type_helpers_test() {
   let _ = support.deep_object_primitive_props_client_imports_primitives_case()
   let _ = support.nested_validate_recurses_into_records_case()
   let _ = support.nested_validate_handles_cycles_case()
+  let _ = support.multiple_of_with_range_guard_compiles_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6875,6 +6875,46 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #521: multipleOf codegen body + imports ---
+
+/// Regression guard for #521: a NumberSchema with both `minimum`
+/// (or any range constraint) AND `multipleOf` must produce
+/// (a) `gleam/float` + `gleam/int` imports in the generated
+///     `guards.gleam`, and
+/// (b) a `validate_*_multiple_of` body that compiles —
+///     `value -. int.to_float(float.truncate(value /. m)) *. m`,
+///     not the broken `... |> int.to_float ...` pipe form.
+pub fn multiple_of_with_range_guard_compiles_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/guard_multiple_of_with_range.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/guard_multiple_of_with_range.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Server,
+      validate: True,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(guards_file) =
+    list.find(summary.files, fn(f) { f.path == "guards.gleam" })
+  string.contains(guards_file.content, "import gleam/float")
+  |> should.be_true()
+  string.contains(guards_file.content, "import gleam/int")
+  |> should.be_true()
+  // The corrected body wraps `float.truncate(...)` in
+  // `int.to_float(...)` then multiplies by the divisor.
+  string.contains(
+    guards_file.content,
+    "int.to_float(float.truncate(value /. 0.01)) *. 0.01",
+  )
+  |> should.be_true()
+  // Negative guard: the broken pipe form must not appear.
+  string.contains(guards_file.content, "|> int.to_float)")
+  |> should.be_false()
+}
+
 // --- Issue #520: validate_<schema> recurses into nested records ---
 
 /// Regression guard for #520: `validate_poll` must recurse into


### PR DESCRIPTION
## Summary

Fixes #521. Two distinct bugs in the `multipleOf` validator codegen path made freshly-generated `guards.gleam` fail `gleam build` for any spec that put `multipleOf` on a `number` schema (the common "amount in cents" pattern: `multipleOf: 0.01, minimum: 0`).

## Changes

- **`src/oaspec/internal/codegen/guards.gleam`**:
  - **`collect_schema_constraint_types_inner`** — reorder the `NumberSchema` arms so the `multiple_of` arm precedes the range arms. Previously the range arm matched first when both were declared, leaving `has_float_multiple_of: False` and the import-set without `gleam/float` / `gleam/int`.
  - **`build_float_multiple_of_guard_function`** — replace the broken expression body
    \`value -. float.truncate(value /. m |> int.to_float) *. m\`
    (which piped a Float into `int.to_float` and multiplied an Int by a Float Float-multiply) with the correct truncation-toward-zero modulo:
    \`value -. int.to_float(float.truncate(value /. m)) *. m\`
- **`test/fixtures/guard_multiple_of_with_range.yaml`** — new fixture combining `multipleOf: 0.01` with `minimum: 0` on a NumberSchema.
- **`test/oaspec_support.gleam`** + **`test/oaspec_core_test.gleam`** — `multiple_of_with_range_guard_compiles_case` asserts the imports are present, the corrected body is emitted, and the broken pipe form is gone.
- **`README.md`** — fixture count 269 → 270.

## Design Decisions

- The arm reorder is the minimal fix; both arms set `has_float: True` so pre-existing range-only specs still produce the same import set.
- Negative assertion (`should.be_false()` on `\"|> int.to_float)\"`) prevents the broken form from regressing if someone touches the codegen template in the future.

Closes #521