### PR TITLE
fix(server-codegen): decode $ref'd integer/number/boolean optional query params with their scalar parser (#522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 366 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 270 test fixtures (including 98 OSS-derived edge-case specs)
+  and 271 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/codegen/router_ir.gleam
+++ b/src/oaspec/internal/codegen/router_ir.gleam
@@ -150,7 +150,7 @@ pub fn analyze(ctx: Context) -> RouterRequirements {
       list.any(operation.parameters, fn(ref_p) {
         case ref_p {
           Value(p) ->
-            decode_helpers.query_schema_needs_int(spec.parameter_schema(p))
+            decode_helpers.query_schema_needs_int(spec.parameter_schema(p), ctx)
             || decode_helpers.deep_object_param_needs_int(p, ctx)
           _ -> False
         }
@@ -173,7 +173,10 @@ pub fn analyze(ctx: Context) -> RouterRequirements {
       list.any(operation.parameters, fn(ref_p) {
         case ref_p {
           Value(p) ->
-            decode_helpers.query_schema_needs_float(spec.parameter_schema(p))
+            decode_helpers.query_schema_needs_float(
+              spec.parameter_schema(p),
+              ctx,
+            )
             || decode_helpers.deep_object_param_needs_float(p, ctx)
           _ -> False
         }

--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -297,6 +297,31 @@ pub fn query_optional_expr(
   )
 }
 
+/// Issue #522: classify the underlying scalar kind of a SchemaRef,
+/// resolving `$ref` to its target schema. Used by query / header /
+/// cookie parameter codegen so that ref-typed scalars get the same
+/// `int.parse` / `float.parse` / boolean parsing as their inline
+/// equivalents — not the raw-String fallback that pre-fix produced
+/// (resulting in `Expected Option(Int), Found Option(String)` build
+/// errors).
+type ScalarKind {
+  IntegerScalar
+  NumberScalar
+  BooleanScalar
+}
+
+fn schema_ref_scalar_kind(
+  schema_ref: SchemaRef,
+  ctx: Context,
+) -> Option(ScalarKind) {
+  case context.resolve_schema_ref(schema_ref, ctx) {
+    Ok(schema.IntegerSchema(..)) -> Some(IntegerScalar)
+    Ok(schema.NumberSchema(..)) -> Some(NumberScalar)
+    Ok(schema.BooleanSchema(..)) -> Some(BooleanScalar)
+    _ -> None
+  }
+}
+
 /// If `schema_ref` is a `$ref` to a string enum schema, return the
 /// generated Gleam type name and the list of enum values (in spec
 /// order). Used by query parameter codegen to emit a string→variant
@@ -494,9 +519,31 @@ fn query_optional_expr_with_schema(
           <> " _ -> None }"
         }
         None ->
-          "case dict.get(query, \""
-          <> key
-          <> "\") { Ok([v, ..]) -> Some(v) _ -> None }"
+          // Issue #522: when the `$ref` resolves to an integer /
+          // number / boolean schema, mirror the parse handling of
+          // the corresponding `Inline(...)` arms above. Pre-fix this
+          // path emitted `Some(v)` (a String) into a typed
+          // `Option(Int|Float|Bool)` slot, breaking `gleam build`.
+          case schema_ref_scalar_kind(ref, ctx) {
+            Some(IntegerScalar) ->
+              "case dict.get(query, \""
+              <> key
+              <> "\") { Ok([v, ..]) -> { case int.parse(v) { Ok(n) -> Some(n) _ -> None } } _ -> None }"
+            Some(NumberScalar) ->
+              "case dict.get(query, \""
+              <> key
+              <> "\") { Ok([v, ..]) -> { case float.parse(v) { Ok(n) -> Some(n) _ -> None } } _ -> None }"
+            Some(BooleanScalar) ->
+              "case dict.get(query, \""
+              <> key
+              <> "\") { Ok([v, ..]) -> Some("
+              <> bool_parse_expr
+              <> ") _ -> None }"
+            None ->
+              "case dict.get(query, \""
+              <> key
+              <> "\") { Ok([v, ..]) -> Some(v) _ -> None }"
+          }
       }
     None ->
       "case dict.get(query, \""
@@ -704,7 +751,7 @@ pub fn deep_object_param_needs_int(
   ctx: Context,
 ) -> Bool {
   deep_object_param_needs(param, ctx, fn(prop) {
-    query_schema_needs_int(Some(prop.schema_ref))
+    query_schema_needs_int(Some(prop.schema_ref), ctx)
   })
 }
 
@@ -713,7 +760,7 @@ pub fn deep_object_param_needs_float(
   ctx: Context,
 ) -> Bool {
   deep_object_param_needs(param, ctx, fn(prop) {
-    query_schema_needs_float(Some(prop.schema_ref))
+    query_schema_needs_float(Some(prop.schema_ref), ctx)
   })
 }
 
@@ -1238,20 +1285,39 @@ pub fn query_schema_needs_string(schema_ref: Option(SchemaRef)) -> Bool {
   }
 }
 
-pub fn query_schema_needs_int(schema_ref: Option(SchemaRef)) -> Bool {
+pub fn query_schema_needs_int(
+  schema_ref: Option(SchemaRef),
+  ctx: Context,
+) -> Bool {
   case schema_ref {
     Some(Inline(schema.IntegerSchema(..))) -> True
     Some(Inline(schema.ArraySchema(items: Inline(schema.IntegerSchema(..)), ..))) ->
       True
+    // Issue #522: a `$ref` whose target is `type: integer` triggers
+    // `int.parse` emission downstream, so the router needs the
+    // `gleam/int` import. Pre-fix, only inline scalars were detected.
+    Some(Reference(..) as ref) ->
+      case schema_ref_scalar_kind(ref, ctx) {
+        Some(IntegerScalar) -> True
+        _ -> False
+      }
     _ -> False
   }
 }
 
-pub fn query_schema_needs_float(schema_ref: Option(SchemaRef)) -> Bool {
+pub fn query_schema_needs_float(
+  schema_ref: Option(SchemaRef),
+  ctx: Context,
+) -> Bool {
   case schema_ref {
     Some(Inline(schema.NumberSchema(..))) -> True
     Some(Inline(schema.ArraySchema(items: Inline(schema.NumberSchema(..)), ..))) ->
       True
+    Some(Reference(..) as ref) ->
+      case schema_ref_scalar_kind(ref, ctx) {
+        Some(NumberScalar) -> True
+        _ -> False
+      }
     _ -> False
   }
 }

--- a/test/codegen_unit_test.gleam
+++ b/test/codegen_unit_test.gleam
@@ -299,23 +299,29 @@ pub fn server_request_decode_query_schema_needs_string_test() {
 }
 
 pub fn server_request_decode_query_schema_needs_int_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   server_request_decode.query_schema_needs_int(
     Some(schema.Inline(test_helpers.int_schema())),
+    ctx,
   )
   |> should.be_true()
   server_request_decode.query_schema_needs_int(
     Some(schema.Inline(test_helpers.string_schema())),
+    ctx,
   )
   |> should.be_false()
 }
 
 pub fn server_request_decode_query_schema_needs_float_test() {
+  let ctx = test_helpers.make_minimal_ctx()
   server_request_decode.query_schema_needs_float(
     Some(schema.Inline(test_helpers.float_schema())),
+    ctx,
   )
   |> should.be_true()
   server_request_decode.query_schema_needs_float(
     Some(schema.Inline(test_helpers.int_schema())),
+    ctx,
   )
   |> should.be_false()
 }

--- a/test/fixtures/server_ref_scalar_query_params.yaml
+++ b/test/fixtures/server_ref_scalar_query_params.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.3"
+info:
+  title: Server $ref scalar query parameters test
+  description: |
+    Issue #522. Exercises optional query parameters whose schema is
+    a `$ref` to an Integer / Number / Boolean component schema.
+    Pre-fix the server router emitted `Some(v)` (where v is String)
+    into `Option(Int|Float|Bool)` slots, breaking `gleam build`.
+  version: "1.0.0"
+paths:
+  /entries:
+    get:
+      operationId: listEntries
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema: { $ref: "#/components/schemas/EntryType" }
+        - name: ratio_min
+          in: query
+          required: false
+          schema: { $ref: "#/components/schemas/Ratio" }
+        - name: active
+          in: query
+          required: false
+          schema: { $ref: "#/components/schemas/Active" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { count: { type: integer } }
+components:
+  schemas:
+    EntryType:
+      type: integer
+      enum: [1, 2]
+    Ratio:
+      type: number
+      format: double
+    Active:
+      type: boolean

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -125,6 +125,7 @@ pub fn content_type_helpers_test() {
   let _ = support.nested_validate_recurses_into_records_case()
   let _ = support.nested_validate_handles_cycles_case()
   let _ = support.multiple_of_with_range_guard_compiles_case()
+  let _ = support.ref_scalar_query_params_decode_with_parse_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6875,6 +6875,41 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #522: optional `$ref` scalar query params ---
+
+/// Regression guard for #522: an optional query parameter whose
+/// schema is a `$ref` to a non-enum integer / number / boolean
+/// component must be decoded with the scalar parse function (not
+/// dropped through to a raw String). The matching `gleam/int` /
+/// `gleam/float` import must also land in the router's import set.
+pub fn ref_scalar_query_params_decode_with_parse_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/server_ref_scalar_query_params.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/server_ref_scalar_query_params.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Server,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(router_file) =
+    list.find(summary.files, fn(f) { f.path == "router.gleam" })
+  // Integer ref → int.parse(v)
+  string.contains(router_file.content, "case int.parse(v)")
+  |> should.be_true()
+  // Number ref → float.parse(v)
+  string.contains(router_file.content, "case float.parse(v)")
+  |> should.be_true()
+  // Imports follow the parse calls.
+  string.contains(router_file.content, "import gleam/int")
+  |> should.be_true()
+  string.contains(router_file.content, "import gleam/float")
+  |> should.be_true()
+}
+
 // --- Issue #521: multipleOf codegen body + imports ---
 
 /// Regression guard for #521: a NumberSchema with both `minimum`


### PR DESCRIPTION
Fixes #522. The optional query-parameter codegen only recognised inline scalar schemas. When a parameter's schema was a `$ref` to a non-string-enum component (e.g. `EntryType: { type: integer, enum: [1,2] }`), the codegen fell through to `Some(v)` (String) into a typed `Option(Int|Float|Bool)` slot, breaking `gleam build`. The client side handled this correctly already.

## Changes

- `src/oaspec/internal/codegen/server_request_decode.gleam`: add `schema_ref_scalar_kind/2` (private) which resolves `SchemaRef` to IntegerScalar / NumberScalar / BooleanScalar. Use it in `query_optional_expr_with_schema` after the existing `schema_ref_string_enum` branch to emit `int.parse(v)` / `float.parse(v)` / `bool_parse_expr` for ref'd scalars. Extend `query_schema_needs_int` / `query_schema_needs_float` to take `ctx` and resolve refs so the import gate fires for ref'd scalars too.
- `src/oaspec/internal/codegen/router_ir.gleam`, `test/codegen_unit_test.gleam`: update callers for the new `ctx` parameter.
- `test/fixtures/server_ref_scalar_query_params.yaml`: new fixture with `$ref` to integer / number / boolean optional query params.
- `test/oaspec_support.gleam` + `test/oaspec_core_test.gleam`: `ref_scalar_query_params_decode_with_parse_case` asserts `int.parse(v)` / `float.parse(v)` and the matching imports land.

## Notes

- The required-query-parameter, header, and cookie paths use a different "open / close parse case" scaffolding and are out of scope for this PR; if they exhibit the same issue with `$ref` scalars, that's a follow-up. The user-reported repro (round 2 of yesterday's gleam-oss-test session) only exercised the optional path.

Closes #522