### PR TITLE
fix(parser): accept OAS 3.0 boolean form of exclusiveMinimum / exclusiveMaximum (#523)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stops with a diagnostic instead of emitting partial code.
   types
 - Keep unsupported spec shapes explicit and testable
 - Backed by 366 unit tests, ShellSpec CLI tests, 40 integration compile tests,
-  and 271 test fixtures (including 98 OSS-derived edge-case specs)
+  and 272 test fixtures (including 98 OSS-derived edge-case specs)
 
 API reference: <https://hexdocs.pm/oaspec/>
 

--- a/src/oaspec/internal/openapi/parser_schema.gleam
+++ b/src/oaspec/internal/openapi/parser_schema.gleam
@@ -296,12 +296,37 @@ fn parse_typed_schema(
     }
 
     "integer" -> {
-      let minimum = parser_value.optional_int(node, "minimum")
-      let maximum = parser_value.optional_int(node, "maximum")
-      let exclusive_minimum =
-        parser_value.optional_int(node, "exclusiveMinimum")
-      let exclusive_maximum =
-        parser_value.optional_int(node, "exclusiveMaximum")
+      let raw_minimum = parser_value.optional_int(node, "minimum")
+      let raw_maximum = parser_value.optional_int(node, "maximum")
+      let numeric_excl_min = parser_value.optional_int(node, "exclusiveMinimum")
+      let numeric_excl_max = parser_value.optional_int(node, "exclusiveMaximum")
+      // Issue #523: OAS 3.0 expresses exclusive bounds as a boolean
+      // companion to `minimum` / `maximum` (`exclusiveMinimum: true`
+      // → `minimum` becomes a strict lower bound). OAS 3.1 expresses
+      // them as a numeric value with no separate `minimum`. Accept
+      // both: if the numeric form is present, use it; otherwise look
+      // for the boolean companion and promote `minimum` (or
+      // `maximum`) accordingly.
+      let bool_excl_min = parser_value.optional_bool(node, "exclusiveMinimum")
+      let bool_excl_max = parser_value.optional_bool(node, "exclusiveMaximum")
+      let #(minimum, exclusive_minimum) = case
+        numeric_excl_min,
+        bool_excl_min,
+        raw_minimum
+      {
+        Some(_), _, _ -> #(raw_minimum, numeric_excl_min)
+        None, Some(True), Some(_) -> #(None, raw_minimum)
+        _, _, _ -> #(raw_minimum, None)
+      }
+      let #(maximum, exclusive_maximum) = case
+        numeric_excl_max,
+        bool_excl_max,
+        raw_maximum
+      {
+        Some(_), _, _ -> #(raw_maximum, numeric_excl_max)
+        None, Some(True), Some(_) -> #(None, raw_maximum)
+        _, _, _ -> #(raw_maximum, None)
+      }
       let multiple_of = parser_value.optional_int(node, "multipleOf")
       Ok(IntegerSchema(
         metadata:,
@@ -315,12 +340,34 @@ fn parse_typed_schema(
     }
 
     "number" -> {
-      let minimum = parser_value.optional_float(node, "minimum")
-      let maximum = parser_value.optional_float(node, "maximum")
-      let exclusive_minimum =
+      let raw_minimum = parser_value.optional_float(node, "minimum")
+      let raw_maximum = parser_value.optional_float(node, "maximum")
+      let numeric_excl_min =
         parser_value.optional_float(node, "exclusiveMinimum")
-      let exclusive_maximum =
+      let numeric_excl_max =
         parser_value.optional_float(node, "exclusiveMaximum")
+      // Issue #523: OAS 3.0 boolean form for `exclusiveMinimum` /
+      // `exclusiveMaximum`. See the integer branch above.
+      let bool_excl_min = parser_value.optional_bool(node, "exclusiveMinimum")
+      let bool_excl_max = parser_value.optional_bool(node, "exclusiveMaximum")
+      let #(minimum, exclusive_minimum) = case
+        numeric_excl_min,
+        bool_excl_min,
+        raw_minimum
+      {
+        Some(_), _, _ -> #(raw_minimum, numeric_excl_min)
+        None, Some(True), Some(_) -> #(None, raw_minimum)
+        _, _, _ -> #(raw_minimum, None)
+      }
+      let #(maximum, exclusive_maximum) = case
+        numeric_excl_max,
+        bool_excl_max,
+        raw_maximum
+      {
+        Some(_), _, _ -> #(raw_maximum, numeric_excl_max)
+        None, Some(True), Some(_) -> #(None, raw_maximum)
+        _, _, _ -> #(raw_maximum, None)
+      }
       let multiple_of = parser_value.optional_float(node, "multipleOf")
       Ok(NumberSchema(
         metadata:,

--- a/test/fixtures/guard_oas30_exclusive_bool.yaml
+++ b/test/fixtures/guard_oas30_exclusive_bool.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.3"
+info:
+  title: OAS 3.0 boolean exclusiveMinimum/Maximum test
+  description: |
+    Issue #523. OAS 3.0 expresses exclusive bounds as a *boolean*
+    flag alongside `minimum` / `maximum`:
+      `minimum: 0, exclusiveMinimum: true` → strict `> 0`
+    Pre-fix the parser only handled OAS 3.1's numeric form, so the
+    boolean was silently dropped: the generated `validate_*_range`
+    used `<` / `>` (inclusive) and the boundary value (e.g.
+    `count == 0`) passed validation when the spec required it to
+    fail.
+  version: "1.0.0"
+paths:
+  /visits:
+    post:
+      operationId: recordVisit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/VisitInput" }
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    VisitInput:
+      type: object
+      required: [count, ratio]
+      properties:
+        count:
+          type: integer
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 100
+          exclusiveMaximum: true
+        ratio:
+          type: number
+          format: double
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 1
+          exclusiveMaximum: true

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -126,6 +126,7 @@ pub fn content_type_helpers_test() {
   let _ = support.nested_validate_handles_cycles_case()
   let _ = support.multiple_of_with_range_guard_compiles_case()
   let _ = support.ref_scalar_query_params_decode_with_parse_case()
+  let _ = support.oas30_exclusive_bool_emits_strict_guard_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6875,6 +6875,53 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #523: OAS 3.0 boolean exclusiveMinimum/Maximum ---
+
+/// Regression guard for #523: when the spec uses the OAS 3.0
+/// boolean form `{minimum: N, exclusiveMinimum: true}` the parser
+/// must promote the numeric `minimum` value into the
+/// `exclusive_minimum` slot so the generated guard emits a strict
+/// inequality (`<=` / `>=`) and the failure message says "greater
+/// than" / "less than" (not "at least" / "at most"). Pre-fix the
+/// boolean was silently discarded and boundary values passed
+/// validation.
+pub fn oas30_exclusive_bool_emits_strict_guard_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/guard_oas30_exclusive_bool.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/guard_oas30_exclusive_bool.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Server,
+      validate: True,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(guards_file) =
+    list.find(summary.files, fn(f) { f.path == "guards.gleam" })
+  // Both Integer and Number exclusive-range validators are emitted.
+  string.contains(
+    guards_file.content,
+    "validate_visit_input_count_exclusive_range",
+  )
+  |> should.be_true()
+  string.contains(
+    guards_file.content,
+    "validate_visit_input_ratio_exclusive_range",
+  )
+  |> should.be_true()
+  // Strict-inequality language in the messages.
+  string.contains(guards_file.content, "must be greater than 0")
+  |> should.be_true()
+  string.contains(guards_file.content, "must be less than 100")
+  |> should.be_true()
+  string.contains(guards_file.content, "must be greater than 0.0")
+  |> should.be_true()
+  string.contains(guards_file.content, "must be less than 1.0")
+  |> should.be_true()
+}
+
 // --- Issue #522: optional `$ref` scalar query params ---
 
 /// Regression guard for #522: an optional query parameter whose


### PR DESCRIPTION
Fixes #523. The parser only read `exclusiveMinimum` / `exclusiveMaximum` as numeric values (OAS 3.1). For OAS 3.0 specs that wrote `{minimum: N, exclusiveMinimum: true}` — the canonical OAS 3.0 way to make a bound strict — the boolean was silently dropped, the guard fell through to the inclusive emitter, and boundary values passed validation when the spec required them to fail.

Extend `parse_typed_schema`'s integer / number branches to fall back to the boolean companion when the numeric form is absent. When the boolean is `true` AND the matching `minimum` (or `maximum`) is present, promote the numeric value into `exclusive_minimum` and clear the inclusive bound. The existing exclusive-range guard builder then fires correctly: `<= N` / `>= N` strict comparisons and "must be greater than" / "must be less than" failure messages.

Adds `test/fixtures/guard_oas30_exclusive_bool.yaml` (integer + double both with the boolean form) and `oas30_exclusive_bool_emits_strict_guard_case` asserting the strict-inequality language.

Closes #523