### PR TITLE
fix(config): reject non-YAML --config paths up front with a friendly error (#524)

### DIFF
--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -175,6 +175,25 @@ pub fn load(path: String) -> Result(Config, ConfigError) {
 /// carrying its own `package` / `output_*` / `include` while
 /// sharing the top-level `input:`, `mode:`, and `validate:` values.
 pub fn load_all(path: String) -> Result(List(Config), ConfigError) {
+  // Issue #524: yay's Erlang FFI for `parse_string` returns a raw
+  // `{yaml_error, Message, {Line, Col}}` tuple in some failure
+  // modes, which doesn't structurally match either constructor of
+  // `yay.YamlError`. The downstream `yaml_error_to_string` then
+  // crashes with a `case_clause` runtime error instead of giving
+  // the user a readable diagnostic. Common trigger: passing a
+  // non-YAML file (e.g. `oaspec.toml` instead of `oaspec.yaml`).
+  // Catch the obvious "wrong file extension" case up front and
+  // return a friendly error before yay even sees the file.
+  use _ <- result.try(case non_yaml_extension(path) {
+    Some(ext) ->
+      Error(ParseError(
+        detail: "config files must be YAML; got '."
+        <> ext
+        <> "' extension. Try renaming to '.yaml' (or '.yml').",
+      ))
+    None -> Ok(Nil)
+  })
+
   use content <- result.try(
     simplifile.read(path)
     |> result.map_error(fn(e) {
@@ -678,5 +697,40 @@ fn yaml_error_to_string(error: yay.YamlError) -> String {
   case error {
     yay.UnexpectedParsingError -> "Unexpected parsing error"
     yay.ParsingError(msg:, ..) -> msg
+  }
+}
+
+/// Issue #524: detect a config path whose extension is clearly not
+/// YAML so we can short-circuit with a friendly diagnostic before
+/// the YAML parser hits a shape mismatch and crashes. Returns the
+/// extension (lowercased, without the dot) when the file is plainly
+/// non-YAML; `None` for `.yaml` / `.yml` / no extension (which we
+/// pass through to yay so it can still surface a real parse error
+/// for malformed content).
+fn non_yaml_extension(path: String) -> Option(String) {
+  let lowered = string.lowercase(path)
+  case extension_of(lowered) {
+    Some("yaml") | Some("yml") | None -> None
+    Some(ext) -> Some(ext)
+  }
+}
+
+fn extension_of(path: String) -> Option(String) {
+  // Use the last segment (after the final '/') so `foo/bar.yml`
+  // resolves to `yml` even when an earlier segment contains a dot.
+  let last_segment = case list.last(string.split(path, "/")) {
+    Ok(seg) -> seg
+    // nolint: thrown_away_error -- string.split never returns the empty list, so the Error arm is unreachable
+    Error(_) -> path
+  }
+  case string.split(last_segment, ".") {
+    [_only] -> None
+    [_, ..rest] ->
+      case list.last(rest) {
+        Ok(ext) -> Some(ext)
+        // nolint: thrown_away_error -- empty-rest is impossible after the head match, but covers `last/0` totality
+        Error(_) -> None
+      }
+    [] -> None
   }
 }

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -127,6 +127,8 @@ pub fn content_type_helpers_test() {
   let _ = support.multiple_of_with_range_guard_compiles_case()
   let _ = support.ref_scalar_query_params_decode_with_parse_case()
   let _ = support.oas30_exclusive_bool_emits_strict_guard_case()
+  let _ = support.config_load_rejects_non_yaml_extension_case()
+  let _ = support.config_load_yaml_extensions_bypass_gate_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6875,6 +6875,42 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #524: friendly error on non-YAML config ---
+
+/// Regression guard for #524: passing a non-YAML config path
+/// (here a `.toml`) must surface a friendly `ParseError` instead
+/// of crashing with `case_clause` when yay's Erlang FFI returns
+/// a tuple shape that doesn't match the `YamlError` constructors.
+pub fn config_load_rejects_non_yaml_extension_case() {
+  // The path doesn't need to exist — the extension check happens
+  // before `simplifile.read`.
+  case config.load("/tmp/oaspec-test/oaspec.toml") {
+    Error(config.ParseError(detail:)) -> {
+      string.contains(detail, "config files must be YAML")
+      |> should.be_true()
+      string.contains(detail, "'.toml'")
+      |> should.be_true()
+    }
+    _ -> {
+      panic as "expected ParseError for non-YAML config extension"
+    }
+  }
+}
+
+/// Verify that real YAML extensions (.yaml, .yml) bypass the
+/// extension gate and surface the existing `FileNotFound` for a
+/// missing file (rather than the new friendly extension error).
+pub fn config_load_yaml_extensions_bypass_gate_case() {
+  let assert Error(err) =
+    config.load("/tmp/oaspec-test/definitely-not-a-real-config.yaml")
+  case err {
+    config.FileNotFound(..) -> Nil
+    _ -> {
+      panic as "expected FileNotFound for missing .yaml config"
+    }
+  }
+}
+
 // --- Issue #523: OAS 3.0 boolean exclusiveMinimum/Maximum ---
 
 /// Regression guard for #523: when the spec uses the OAS 3.0


### PR DESCRIPTION
Fixes #524. `oaspec/config.load_all` previously crashed with `case_clause` when yay's FFI returned an error shape that didn't structurally match either `yay.YamlError` constructor (a raw `{yaml_error, ...}` tuple). The most common trigger was passing a non-YAML file (e.g. `oaspec.toml` instead of `oaspec.yaml`).

## Changes

- `src/oaspec/config.gleam`: prepend an extension gate to `load_all`. Non-YAML extensions (`.toml`, `.json`, etc., case-insensitive) get a `ParseError` whose detail names the offending extension and points at `.yaml`/`.yml`. `.yaml`/`.yml` and extensionless paths fall through unchanged.
- `test/oaspec_support.gleam` + `test/oaspec_core_test.gleam`: `config_load_rejects_non_yaml_extension_case` (`.toml` → friendly `ParseError`), `config_load_yaml_extensions_bypass_gate_case` (missing `.yaml` → still `FileNotFound`).

## Notes

- This patches the user-facing symptom. The deeper bug (yay's Erlang FFI returning a shape that doesn't match the Gleam type for some yamerl errors) is upstream in yay itself. Filing that against `nao1215/yay` would be a separate follow-up.
- Genuinely malformed YAML still surfaces the existing `ParseError(detail: "YAML parse error: ...")` because the extension gate only triggers on clearly-non-YAML extensions.

Closes #524