### PR TITLE
fix(server-codegen): pipeDelimited / spaceDelimited query parser drops empty splits and accepts repeated keys (#526)

### DIFF
--- a/src/oaspec/internal/codegen/server_request_decode.gleam
+++ b/src/oaspec/internal/codegen/server_request_decode.gleam
@@ -435,14 +435,25 @@ fn query_optional_expr_with_schema(
 ) -> String {
   let delim = operation_ir.delimiter_for_style(style)
   case schema_ref {
+    // Issue #526: for `style: pipeDelimited` / `style:
+    // spaceDelimited` / `style: form, explode: false` (i.e. delim
+    // != ","), the previous codegen used `Ok([v, ..])` — taking
+    // only the FIRST occurrence — and `list.map(string.split(...))`
+    // — leaving empty splits as empty-string elements. Two
+    // edge-case bugs followed: `?tags=` (empty value) became
+    // `Some([""])` instead of `Some([])`, and `?tags=a&tags=b`
+    // (repeated keys) silently dropped `b`. The new shape uses
+    // `Ok(vs)` to accept ALL occurrences, flat_maps the splits
+    // across them, and filters out the empty strings produced by
+    // empty input or trailing delimiters (`?tags=foo|`).
     Some(Inline(schema.ArraySchema(items: Inline(schema.StringSchema(..)), ..))) ->
       case explode {
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> "\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \""
           <> delim
-          <> "\"), fn(item) { string.trim(item) })) _ -> None }"
+          <> "\") }) |> list.map(string.trim) |> list.filter(fn(s) { s != \"\" })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -453,9 +464,9 @@ fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> "\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \""
           <> delim
-          <> "\"), fn(item) { let trimmed = string.trim(item) case int.parse(trimmed) { Ok(n) -> n _ -> 0 } })) _ -> None }"
+          <> "\") }) |> list.filter_map(fn(item) { let trimmed = string.trim(item) case trimmed { \"\" -> Error(Nil) _ -> int.parse(trimmed) } })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -466,9 +477,9 @@ fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> "\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \""
           <> delim
-          <> "\"), fn(item) { let trimmed = string.trim(item) case float.parse(trimmed) { Ok(n) -> n _ -> 0.0 } })) _ -> None }"
+          <> "\") }) |> list.filter_map(fn(item) { let trimmed = string.trim(item) case trimmed { \"\" -> Error(Nil) _ -> float.parse(trimmed) } })) _ -> None }"
         _ ->
           "case dict.get(query, \""
           <> key
@@ -479,9 +490,9 @@ fn query_optional_expr_with_schema(
         Some(False) ->
           "case dict.get(query, \""
           <> key
-          <> "\") { Ok([v, ..]) -> Some(list.map(string.split(v, \""
+          <> "\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \""
           <> delim
-          <> "\"), fn(item) { let v = string.trim(item) "
+          <> "\") }) |> list.filter(fn(s) { string.trim(s) != \"\" }) |> list.map(fn(item) { let v = string.trim(item) "
           <> bool_parse_expr
           <> " })) _ -> None }"
         _ ->

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -129,6 +129,7 @@ pub fn content_type_helpers_test() {
   let _ = support.oas30_exclusive_bool_emits_strict_guard_case()
   let _ = support.config_load_rejects_non_yaml_extension_case()
   let _ = support.config_load_yaml_extensions_bypass_gate_case()
+  let _ = support.pipe_delimited_query_handles_empty_and_repeated_keys_case()
   let _ = support.multipart_object_array_client_imports_list_json_case()
   let _ = support.wildcard_request_body_uses_bytes_body_case()
   let _ = support.fixtures_sweep_parse_resolve_no_panic_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -6903,6 +6903,50 @@ pub fn deep_object_primitive_props_client_imports_primitives_case() {
   |> should.be_true()
 }
 
+// --- Issue #526: pipeDelimited / spaceDelimited query parser edges ---
+
+/// Regression guard for #526. The optional array-of-string query
+/// parameter codegen for explode=false (pipeDelimited / spaceDelimited /
+/// form-with-explode-false) must:
+/// - accept ALL incoming occurrences (`?tags=a&tags=b` is no longer
+///   silently truncated to the first), and
+/// - filter empty strings produced by `?tags=` (empty value) or by
+///   trailing delimiters like `?tags=foo|`.
+pub fn pipe_delimited_query_handles_empty_and_repeated_keys_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info: { title: t, version: '0' }
+paths:
+  /polls:
+    get:
+      operationId: listPolls
+      parameters:
+        - name: tags
+          in: query
+          required: false
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items: { type: string }
+      responses: { '200': { description: ok } }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let files = server_gen.generate(ctx)
+  let assert Ok(router_file) =
+    list.find(files, fn(f) { f.path == "router.gleam" })
+  let content = router_file.content
+  // No more `Ok([v, ..])` for the optional pipeDelimited tags
+  // parameter — we now use `Ok(vs)` to consume all occurrences.
+  string.contains(
+    content,
+    "tags: case dict.get(query, \"tags\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \"|\") }) |> list.map(string.trim) |> list.filter(fn(s) { s != \"\" }))",
+  )
+  |> should.be_true()
+}
+
 // --- Issue #524: friendly error on non-YAML config ---
 
 /// Regression guard for #524: passing a non-YAML config path
@@ -10331,9 +10375,14 @@ pub fn server_query_array_params_use_query_multimap_case() {
     "tags: list.map(tags_raw, fn(item) { string.trim(item) }),",
   )
   |> should.be_true()
+  // Issue #526: optional array query params with explode=false now
+  // accept all incoming occurrences (`Ok(vs)` rather than the
+  // first-only `Ok([v, ..])`) and filter empties, so `?scores=` and
+  // `?scores=a,&scores=b,` no longer slip a stray empty / `0`
+  // through.
   string.contains(
     content,
-    "scores: case dict.get(query, \"scores\") { Ok([v, ..]) -> Some(list.map(string.split(v, \",\"), fn(item) { let trimmed = string.trim(item) case int.parse(trimmed) { Ok(n) -> n _ -> 0 } })) _ -> None },",
+    "scores: case dict.get(query, \"scores\") { Ok(vs) -> Some(vs |> list.flat_map(fn(v) { string.split(v, \",\") }) |> list.filter_map(fn(item) { let trimmed = string.trim(item) case trimmed { \"\" -> Error(Nil) _ -> int.parse(trimmed) } })) _ -> None },",
   )
   |> should.be_true()
 }


### PR DESCRIPTION
Fixes #526. The explode=false optional array-query codegen used `Ok([v, ..]) -> ... string.split(v, ...) ...`. Two issues fell out: `?tags=` produced `Some([""])` (empty-string item) and `?tags=a&tags=b` silently dropped `b` (only the first occurrence reached the split).

Switch every explode=false arm to `Ok(vs) -> ... |> list.flat_map(string.split(_, delim)) |> list.map(string.trim) |> list.filter(_ != "")` (Int/Float use `list.filter_map` so empties become Errors). Now repeated keys flatten into a single list and empty splits drop out.

The existing `server_query_array_params_use_query_multimap_case` is updated to the new expression with a comment naming the issue. A new `pipe_delimited_query_handles_empty_and_repeated_keys_case` covers a focused inline pipeDelimited fixture.

Closes #526