### PR TITLE
feat(form-urlencoded): support nested arrays in object properties (#PR1 of 4)

### DIFF
--- a/doc/openapi-support.md
+++ b/doc/openapi-support.md
@@ -124,7 +124,7 @@ This section stays in sync with `src/oaspec/internal/capability.gleam`.
 - `const` is only supported on string schemas. Non-string `const` values and multi-type schemas with type-specific constraints are rejected explicitly.
 - Parsed but not used by codegen: callbacks, webhooks, externalDocs, tags, examples, links, encoding
 - `xml` annotations are ignored by the parser
-- Remaining server-mode request-shape boundaries: `server: complex path parameters`, `server: non-primitive query array items`, `server: non-primitive header array items`, `server: complex deepObject properties`, `server: mixed form-urlencoded request`, `server: complex form-urlencoded fields`, `server: mixed multipart request`, `server: complex multipart fields`, `server: unsupported request content type`
+- Remaining server-mode request-shape boundaries: `server: complex path parameters`, `server: non-primitive query array items`, `server: non-primitive header array items`, `server: complex deepObject properties`, `server: mixed form-urlencoded request`, `server: mixed multipart request`, `server: complex multipart fields`, `server: unsupported request content type`
 - Detailed server-mode decisions and fixture coverage live in [server-mode-boundaries.md](./server-mode-boundaries.md)
 - Normalized to supported equivalents: `const` string values become single-value enums, `type: [T, null]` becomes nullable, and `type: [T1, T2]` becomes `oneOf`
 <!-- END GENERATED:BOUNDARIES -->

--- a/doc/server-mode-boundaries.md
+++ b/doc/server-mode-boundaries.md
@@ -44,14 +44,6 @@ fixture-backed test covers the behavior.
   Fixtures: `test/fixtures/server_form_urlencoded_body.yaml`,
   `test/fixtures/server_form_urlencoded_mixed_content.yaml`
 
-- [x] `server: complex form-urlencoded fields`
-  Decision: long-term non-goal after primitive fields, primitive arrays, and
-  nested primitive-leaf objects were added.
-  Reason: arrays or objects whose leaves are themselves complex still fall
-  outside the current parser and router contract.
-  Fixtures: `test/fixtures/server_form_urlencoded_nested_body.yaml`,
-  `test/fixtures/server_form_urlencoded_complex_fields.yaml`
-
 - [x] `server: mixed multipart request`
   Decision: long-term non-goal.
   Reason: the generated server path for multipart parsing assumes the multipart

--- a/src/oaspec/internal/capability.gleam
+++ b/src/oaspec/internal/capability.gleam
@@ -265,12 +265,6 @@ pub fn registry() -> List(Capability) {
       "application/x-www-form-urlencoded must be the sole request content type",
     ),
     Capability(
-      "server: complex form-urlencoded fields",
-      "server-validation",
-      Unsupported,
-      "Form fields must be primitive scalars, primitive arrays, or shallow nested objects (max 5 levels)",
-    ),
-    Capability(
       "server: mixed multipart request",
       "server-validation",
       Unsupported,

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -617,7 +617,381 @@ fn form_array_item_to_string(
   case field_schema {
     Inline(schema.ArraySchema(items:, ..)) ->
       schema_dispatch.schema_ref_to_string_expr(items, "item", ctx)
-    _ -> "string.inspect(item)"
+    _ -> "item"
+  }
+}
+
+/// True when `schema_ref` resolves to an `ObjectSchema` post-`$ref`
+/// resolution. Used to dispatch nested-form encoding into the
+/// recursive bracket-key path.
+fn schema_resolves_to_object(schema_ref: schema.SchemaRef, ctx: Context) -> Bool {
+  case schema_ref {
+    Inline(schema.ObjectSchema(..)) -> True
+    Reference(..) ->
+      case context.resolve_schema_ref(schema_ref, ctx) {
+        Ok(schema.ObjectSchema(..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
+}
+
+/// True when `schema_ref` resolves to an `ArraySchema`.
+fn schema_resolves_to_array(schema_ref: schema.SchemaRef, ctx: Context) -> Bool {
+  case schema_ref {
+    Inline(schema.ArraySchema(..)) -> True
+    Reference(..) ->
+      case context.resolve_schema_ref(schema_ref, ctx) {
+        Ok(schema.ArraySchema(..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
+}
+
+/// Resolve `schema_ref` to its ArraySchema items (post-`$ref`).
+/// Caller is expected to have already gated on `schema_resolves_to_array`.
+fn array_items_of(
+  schema_ref: schema.SchemaRef,
+  ctx: Context,
+) -> Option(schema.SchemaRef) {
+  case schema_ref {
+    Inline(schema.ArraySchema(items:, ..)) -> Some(items)
+    Reference(..) ->
+      case context.resolve_schema_ref(schema_ref, ctx) {
+        Ok(schema.ArraySchema(items:, ..)) -> Some(items)
+        _ -> None
+      }
+    _ -> None
+  }
+}
+
+/// Emit serialisation for an array sub-field whose runtime type is
+/// `List(<inner>)`. The wire format depends on what `<inner>` is:
+///
+///   - **primitive items**: OAS `form` style with `explode: true`,
+///     i.e. the same key is repeated per element
+///     (`<prefix>=v1&<prefix>=v2`). This is what the OAS spec defines
+///     as the default and what oaspec's existing server decoder
+///     already parses, so generated clients and servers round-trip
+///     cleanly.
+///   - **object items**: numerical bracket index per element
+///     (`<prefix>[0][<prop>]=v`). OAS leaves this case undefined; we
+///     pick the form Stripe / qs (`indices` mode) / jQuery / Rails
+///     all decode interoperably — the only encoding agreed on across
+///     mainstream form-body parsers.
+///   - **nested array items**: bracket-index recursion
+///     (`<prefix>[0][0]=v`).
+fn generate_form_indexed_array(
+  sb: se.StringBuilder,
+  key_prefix_quoted: String,
+  accessor: String,
+  items_schema: schema.SchemaRef,
+  is_required: Bool,
+  indent_base: Int,
+  parts_var: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  case is_required {
+    True ->
+      emit_array_fold(
+        sb,
+        key_prefix_quoted,
+        accessor,
+        items_schema,
+        indent_base,
+        parts_var,
+        ctx,
+      )
+    False ->
+      sb
+      |> se.indent(
+        indent_base,
+        "let " <> parts_var <> " = case " <> accessor <> " {",
+      )
+      |> se.indent(indent_base + 1, "Some(items) -> {")
+      |> emit_array_fold(
+        key_prefix_quoted,
+        "items",
+        items_schema,
+        indent_base + 2,
+        parts_var,
+        ctx,
+      )
+      |> se.indent(indent_base + 1, "}")
+      |> se.indent(indent_base + 1, "None -> " <> parts_var)
+      |> se.indent(indent_base, "}")
+  }
+}
+
+fn emit_array_fold(
+  sb: se.StringBuilder,
+  key_prefix_quoted: String,
+  list_expr: String,
+  items_schema: schema.SchemaRef,
+  indent_base: Int,
+  parts_var: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  case
+    schema_resolves_to_object(items_schema, ctx),
+    schema_resolves_to_array(items_schema, ctx)
+  {
+    True, _ -> {
+      // Object items: indexed bracket — `<prefix>[<i>][<prop>]=<v>`.
+      let element_key_expr =
+        key_prefix_quoted <> " <> \"[\" <> int.to_string(idx) <> \"]\""
+      sb
+      |> se.indent(
+        indent_base,
+        "let "
+          <> parts_var
+          <> " = list.index_fold("
+          <> list_expr
+          <> ", "
+          <> parts_var
+          <> ", fn(acc, item, idx) {",
+      )
+      |> emit_form_object_recurse(
+        element_key_expr,
+        "item",
+        items_schema,
+        True,
+        indent_base + 1,
+        "acc",
+        ctx,
+      )
+      |> se.indent(indent_base + 1, "acc")
+      |> se.indent(indent_base, "})")
+    }
+    _, True -> {
+      // Nested array items (rare, but representable):
+      // `<prefix>[<i>][<j>]=v`.
+      let element_key_expr =
+        key_prefix_quoted <> " <> \"[\" <> int.to_string(idx) <> \"]\""
+      case array_items_of(items_schema, ctx) {
+        Some(inner_items) ->
+          sb
+          |> se.indent(
+            indent_base,
+            "let "
+              <> parts_var
+              <> " = list.index_fold("
+              <> list_expr
+              <> ", "
+              <> parts_var
+              <> ", fn(acc, item, idx) {",
+          )
+          |> emit_array_fold(
+            element_key_expr,
+            "item",
+            inner_items,
+            indent_base + 1,
+            "acc",
+            ctx,
+          )
+          |> se.indent(indent_base + 1, "acc")
+          |> se.indent(indent_base, "})")
+        None -> sb
+      }
+    }
+    False, False -> {
+      // Primitive items: OAS form/explode default — repeat the same
+      // key per element. Round-trips cleanly with the existing
+      // generated server decoder.
+      let item_value_expr = case
+        schema_dispatch.to_string_fn(items_schema, ctx)
+      {
+        "fn(x) { x }" -> "item"
+        fn_name -> fn_name <> "(item)"
+      }
+      sb
+      |> se.indent(
+        indent_base,
+        "let "
+          <> parts_var
+          <> " = list.fold("
+          <> list_expr
+          <> ", "
+          <> parts_var
+          <> ", fn(acc, item) {",
+      )
+      |> se.indent(
+        indent_base + 1,
+        "["
+          <> key_prefix_quoted
+          <> " <> \"=\" <> uri.percent_encode("
+          <> item_value_expr
+          <> "), ..acc]",
+      )
+      |> se.indent(indent_base, "})")
+    }
+  }
+}
+
+/// Recurse into the properties of an object whose runtime accessor is
+/// `accessor`. Each sub-property is emitted with key
+/// `<key_prefix>[<sub>]=...`. Used both for top-level object fields
+/// and for object items inside arrays. Mutates `acc` (or whatever the
+/// caller's `parts_var` is) — the caller is responsible for emitting
+/// the final `acc` line if needed.
+fn emit_form_object_recurse(
+  sb: se.StringBuilder,
+  key_prefix_quoted: String,
+  accessor: String,
+  schema_ref: schema.SchemaRef,
+  _is_required: Bool,
+  indent_base: Int,
+  parts_var: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  let resolved = context.resolve_schema_ref(schema_ref, ctx)
+  case resolved {
+    Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
+      let props = ir_build.sorted_entries(properties)
+      list.fold(props, sb, fn(sb, entry) {
+        let #(prop_name, prop_ref) = entry
+        let prop_field = naming.to_snake_case(prop_name)
+        let prop_accessor = accessor <> "." <> prop_field
+        let prop_required = list.contains(required, prop_name)
+        let sub_key_quoted =
+          key_prefix_quoted <> " <> \"[" <> prop_name <> "]\""
+        emit_form_field(
+          sb,
+          sub_key_quoted,
+          prop_accessor,
+          prop_ref,
+          prop_required,
+          indent_base,
+          parts_var,
+          ctx,
+        )
+      })
+    }
+    _ -> sb
+  }
+}
+
+/// Single dispatch point for "emit one field whose runtime accessor
+/// is `accessor` under a key built from `key_prefix_quoted`". Routes
+/// objects through `emit_form_object_recurse`, arrays through
+/// `generate_form_indexed_array`, and primitive scalars to a direct
+/// emit. Used inside `emit_form_object_recurse` so deeply nested
+/// shapes terminate cleanly at primitives.
+fn emit_form_field(
+  sb: se.StringBuilder,
+  key_prefix_quoted: String,
+  accessor: String,
+  schema_ref: schema.SchemaRef,
+  is_required: Bool,
+  indent_base: Int,
+  parts_var: String,
+  ctx: Context,
+) -> se.StringBuilder {
+  case
+    schema_resolves_to_object(schema_ref, ctx),
+    schema_resolves_to_array(schema_ref, ctx)
+  {
+    True, _ -> {
+      case is_required {
+        True ->
+          emit_form_object_recurse(
+            sb,
+            key_prefix_quoted,
+            accessor,
+            schema_ref,
+            True,
+            indent_base,
+            parts_var,
+            ctx,
+          )
+        False -> {
+          sb
+          |> se.indent(
+            indent_base,
+            "let " <> parts_var <> " = case " <> accessor <> " {",
+          )
+          |> se.indent(indent_base + 1, "Some(obj) -> {")
+          |> se.indent(indent_base + 2, "let acc2 = " <> parts_var)
+          |> emit_form_object_recurse(
+            key_prefix_quoted,
+            "obj",
+            schema_ref,
+            True,
+            indent_base + 2,
+            "acc2",
+            ctx,
+          )
+          |> se.indent(indent_base + 2, "acc2")
+          |> se.indent(indent_base + 1, "}")
+          |> se.indent(indent_base + 1, "None -> " <> parts_var)
+          |> se.indent(indent_base, "}")
+        }
+      }
+    }
+    _, True -> {
+      case array_items_of(schema_ref, ctx) {
+        Some(items) ->
+          generate_form_indexed_array(
+            sb,
+            key_prefix_quoted,
+            accessor,
+            items,
+            is_required,
+            indent_base,
+            parts_var,
+            ctx,
+          )
+        None -> sb
+      }
+    }
+    False, False -> {
+      let to_str = multipart_field_to_string_fn(schema_ref, ctx)
+      case is_required {
+        True -> {
+          let value_expr = case to_str {
+            "" -> accessor
+            fn_name -> fn_name <> "(" <> accessor <> ")"
+          }
+          sb
+          |> se.indent(
+            indent_base,
+            "let "
+              <> parts_var
+              <> " = ["
+              <> key_prefix_quoted
+              <> " <> \"=\" <> uri.percent_encode("
+              <> value_expr
+              <> "), .."
+              <> parts_var
+              <> "]",
+          )
+        }
+        False -> {
+          let some_value_expr = case to_str {
+            "" -> "v"
+            fn_name -> fn_name <> "(v)"
+          }
+          sb
+          |> se.indent(
+            indent_base,
+            "let " <> parts_var <> " = case " <> accessor <> " {",
+          )
+          |> se.indent(
+            indent_base + 1,
+            "Some(v) -> ["
+              <> key_prefix_quoted
+              <> " <> \"=\" <> uri.percent_encode("
+              <> some_value_expr
+              <> "), .."
+              <> parts_var
+              <> "]",
+          )
+          |> se.indent(indent_base + 1, "None -> " <> parts_var)
+          |> se.indent(indent_base, "}")
+        }
+      }
+    }
   }
 }
 
@@ -676,8 +1050,17 @@ fn generate_form_nested_object(
           }
         _ -> False
       }
-      case is_sub_object {
-        True ->
+      let is_sub_array = case sub_ref {
+        Inline(schema.ArraySchema(..)) -> True
+        Reference(..) as sr ->
+          case context.resolve_schema_ref(sr, ctx) {
+            Ok(schema.ArraySchema(..)) -> True
+            _ -> False
+          }
+        _ -> False
+      }
+      case is_sub_object, is_sub_array {
+        True, _ ->
           // Recurse: generate meta[author][name]=value encoding
           generate_form_bracket_fields(
             sb,
@@ -689,7 +1072,27 @@ fn generate_form_nested_object(
             parts_var,
             ctx,
           )
-        False -> {
+        _, True -> {
+          // Object property whose value is an array — emit indexed
+          // bracket form (`<parent>[<sub>][<i>]=<v>` for primitive
+          // items, `<parent>[<sub>][<i>][<prop>]=<v>` for object
+          // items).
+          case array_items_of(sub_ref, ctx) {
+            Some(items_schema) ->
+              generate_form_indexed_array(
+                sb,
+                "\"" <> field_name <> "[" <> sub_name <> "]\"",
+                sub_accessor,
+                items_schema,
+                sub_required,
+                indent_base,
+                parts_var,
+                ctx,
+              )
+            None -> sb
+          }
+        }
+        False, False -> {
           let to_str = multipart_field_to_string_fn(sub_ref, ctx)
           case sub_required {
             True -> {
@@ -784,8 +1187,17 @@ fn generate_form_bracket_fields(
             }
           _ -> False
         }
-        case is_obj {
-          True ->
+        let is_arr = case prop_ref {
+          Inline(schema.ArraySchema(..)) -> True
+          Reference(..) as sr ->
+            case context.resolve_schema_ref(sr, ctx) {
+              Ok(schema.ArraySchema(..)) -> True
+              _ -> False
+            }
+          _ -> False
+        }
+        case is_obj, is_arr {
+          True, _ ->
             generate_form_bracket_fields(
               sb,
               key_prefix <> "[" <> prop_name <> "]",
@@ -796,7 +1208,22 @@ fn generate_form_bracket_fields(
               parts_var,
               ctx,
             )
-          False -> {
+          _, True ->
+            case array_items_of(prop_ref, ctx) {
+              Some(items_schema) ->
+                generate_form_indexed_array(
+                  sb,
+                  "\"" <> key_prefix <> "[" <> prop_name <> "]\"",
+                  prop_accessor,
+                  items_schema,
+                  prop_required,
+                  indent_base,
+                  parts_var,
+                  ctx,
+                )
+              None -> sb
+            }
+          False, False -> {
             let to_str = multipart_field_to_string_fn(prop_ref, ctx)
             case prop_required {
               True -> {
@@ -905,8 +1332,21 @@ pub fn generate_form_urlencoded_body(
           }
         _ -> False
       }
-      case is_object {
-        True ->
+      // Top-level array of objects (Stripe `marketing_features` shape)
+      // — wire format is `<field>[<i>][<prop>]=<v>`. Distinct from
+      // top-level array of primitives below, which keeps the OAS
+      // `form,explode` repeat shape (`<field>=<v>&<field>=<v>`) for
+      // backwards compatibility.
+      let array_items = case is_array {
+        True -> array_items_of(field_schema, ctx)
+        False -> None
+      }
+      let is_array_of_object = case array_items {
+        Some(items) -> schema_resolves_to_object(items, ctx)
+        None -> False
+      }
+      case is_object, is_array_of_object {
+        True, _ ->
           // Nested objects: serialize as field[subkey]=value
           generate_form_nested_object(
             sb,
@@ -916,10 +1356,28 @@ pub fn generate_form_urlencoded_body(
             is_required,
             ctx,
           )
-        False ->
+        _, True ->
+          case array_items {
+            Some(items_schema) ->
+              generate_form_indexed_array(
+                sb,
+                "\"" <> field_name <> "\"",
+                "body." <> gleam_field,
+                items_schema,
+                is_required,
+                1,
+                "form_parts",
+                ctx,
+              )
+            None -> sb
+          }
+        False, False ->
           case is_array {
             True ->
-              // Arrays: repeat the key for each element (tags=a&tags=b)
+              // Arrays of primitives: repeat the key for each element (tags=a&tags=b).
+              // This is the OAS form,explode default and stays
+              // unchanged for backwards compatibility — only nested
+              // arrays adopt the indexed-bracket form.
               case is_required {
                 True ->
                   sb

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -842,14 +842,35 @@ fn validate_server_form_urlencoded_request_body(
           dict.to_list(properties)
           |> list.flat_map(fn(entry) {
             let #(field_name, field_schema) = entry
-            case form_urlencoded_field_codegen_safe(field_schema, ctx, 0) {
-              True -> []
-              False -> [
+            // Client codegen accepts every shape this predicate
+            // green-lights — primitives, primitive arrays at any
+            // depth, nested objects at any depth, arrays of objects.
+            // The server decoder is more constrained: it still
+            // requires shallow primitive-leaf shapes. Until the
+            // server-side helpers catch up, surface a server-only
+            // diagnostic for the shapes the client now handles but
+            // the server doesn't.
+            let client_safe =
+              form_urlencoded_field_codegen_safe(field_schema, ctx, 0)
+            let server_safe =
+              form_urlencoded_server_field_supported(field_schema, ctx, 0)
+            case client_safe, server_safe {
+              True, True -> []
+              True, False -> [
+                diagnostic.validation_error_server(
+                  path: op_id <> ".requestBody.form." <> field_name,
+                  detail: "application/x-www-form-urlencoded server request bodies only support primitive scalars, primitive arrays at the top level, and nested objects with primitive leaves (max 5 levels). Nested arrays-within-objects, oneOf, anyOf, and allOf properties are not yet supported on the server side.",
+                  hint: Some(
+                    "Switch to mode: client for now, or simplify to primitive scalars, primitive arrays at the top level, or shallow nested objects with primitive leaves.",
+                  ),
+                ),
+              ]
+              False, _ -> [
                 diagnostic.validation_error_both(
                   path: op_id <> ".requestBody.form." <> field_name,
-                  detail: "application/x-www-form-urlencoded request bodies only support primitive scalars, primitive arrays at the top level, and nested objects with primitive leaves (max 5 levels). Nested arrays-within-objects, oneOf, anyOf, and allOf properties are not supported in either client or server codegen.",
+                  detail: "application/x-www-form-urlencoded request bodies do not support oneOf / anyOf / allOf at the field level yet.",
                   hint: Some(
-                    "Simplify to primitive scalars, primitive arrays at the top level, or shallow nested objects with primitive leaves.",
+                    "Use a single concrete schema (object or primitive) for each form field.",
                   ),
                 ),
               ]
@@ -863,13 +884,14 @@ fn validate_server_form_urlencoded_request_body(
   list.append(server_mode_errors, field_errors)
 }
 
-/// Tighter form-urlencoded shape predicate that prevents the
-/// generator from recursing into a path it can't render. Mirrors
-/// `form_urlencoded_server_field_supported` but rejects nested
-/// arrays (an array nested inside an object property), which the
-/// client emitter otherwise sends through `to_string_fn` and
-/// crashes.
-fn form_urlencoded_field_codegen_safe(
+/// Predicate matching the server-side decode contract today:
+/// primitive scalars, primitive arrays at any depth (the server
+/// reads them as repeated keys via `dict.get(form_body, key)
+/// |> Ok(vs)`), and nested objects up to 5 levels with primitive or
+/// primitive-array leaves. Object arrays (`features[0][prop]=v`) and
+/// nested arrays-of-arrays still need the indexed-key decoder
+/// upgrade.
+fn form_urlencoded_server_field_supported(
   schema_ref: SchemaRef,
   ctx: Context,
   depth: Int,
@@ -879,17 +901,76 @@ fn form_urlencoded_field_codegen_safe(
     | Some(IntegerSchema(..))
     | Some(NumberSchema(..))
     | Some(BooleanSchema(..)) -> True
-    Some(ArraySchema(items:, ..)) if depth == 0 ->
-      form_urlencoded_server_array_item_supported(items, ctx)
-    // Arrays nested inside object properties are not handled by
-    // the generator (post-hoist they survive as Inline ArraySchema
-    // and `multipart_field_to_string_fn` panics on them).
-    Some(ArraySchema(..)) -> False
+    Some(ArraySchema(items:, ..)) ->
+      case resolve_schema_object(Some(items), ctx) {
+        Some(StringSchema(..))
+        | Some(IntegerSchema(..))
+        | Some(NumberSchema(..))
+        | Some(BooleanSchema(..)) -> True
+        _ -> False
+      }
     Some(ObjectSchema(properties:, ..)) if depth < 5 ->
       dict.to_list(properties)
       |> list.all(fn(entry) {
         let #(_, child_schema) = entry
-        form_urlencoded_field_codegen_safe(child_schema, ctx, depth + 1)
+        form_urlencoded_server_field_supported(child_schema, ctx, depth + 1)
+      })
+    _ -> False
+  }
+}
+
+/// Form-urlencoded shape predicate. Accepts every shape the codegen
+/// can render via the bracket-index wire format
+/// (`field[a][b][0][c]=v`, Stripe / qs `indices` compatible):
+/// primitive scalars, primitive arrays at any depth, nested objects
+/// at any depth, and arrays-of-objects (whose items the hoist pass
+/// has already promoted to a `Reference`, so the codegen sees a
+/// nameable `ObjectSchema` here). composite shapes (`oneOf` /
+/// `anyOf` / `allOf`) at the field level remain on the rejection
+/// path until the dedicated codegen for them lands.
+fn form_urlencoded_field_codegen_safe(
+  schema_ref: SchemaRef,
+  ctx: Context,
+  _depth: Int,
+) -> Bool {
+  case resolve_schema_object(Some(schema_ref), ctx) {
+    Some(StringSchema(..))
+    | Some(IntegerSchema(..))
+    | Some(NumberSchema(..))
+    | Some(BooleanSchema(..)) -> True
+    Some(ArraySchema(items:, ..)) ->
+      form_urlencoded_array_items_codegen_safe(items, ctx)
+    Some(ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.all(fn(entry) {
+        let #(_, child_schema) = entry
+        form_urlencoded_field_codegen_safe(child_schema, ctx, 0)
+      })
+    _ -> False
+  }
+}
+
+/// Items of an array inside a form-urlencoded body may be a primitive
+/// scalar (rendered as `key[i]=v`), a primitive array (rendered as
+/// `key[i][j]=v`), or an object whose properties recurse through the
+/// same predicate (rendered as `key[i][prop]=v`). Composites at the
+/// item level are still rejected.
+fn form_urlencoded_array_items_codegen_safe(
+  items: SchemaRef,
+  ctx: Context,
+) -> Bool {
+  case resolve_schema_object(Some(items), ctx) {
+    Some(StringSchema(..))
+    | Some(IntegerSchema(..))
+    | Some(NumberSchema(..))
+    | Some(BooleanSchema(..)) -> True
+    Some(ArraySchema(items: inner_items, ..)) ->
+      form_urlencoded_array_items_codegen_safe(inner_items, ctx)
+    Some(ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.all(fn(entry) {
+        let #(_, child_schema) = entry
+        form_urlencoded_field_codegen_safe(child_schema, ctx, 0)
       })
     _ -> False
   }
@@ -981,19 +1062,6 @@ fn validate_server_multipart_request_body(
         // nolint: thrown_away_error -- absence of the content type means there is nothing to validate here
         Error(_) -> []
       }
-  }
-}
-
-fn form_urlencoded_server_array_item_supported(
-  schema_ref: SchemaRef,
-  ctx: Context,
-) -> Bool {
-  case resolve_schema_object(Some(schema_ref), ctx) {
-    Some(StringSchema(..))
-    | Some(IntegerSchema(..))
-    | Some(NumberSchema(..))
-    | Some(BooleanSchema(..)) -> True
-    _ -> False
   }
 }
 

--- a/test/fixtures/form_urlencoded_object_array_of_object.yaml
+++ b/test/fixtures/form_urlencoded_object_array_of_object.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.3"
+info:
+  title: Form-urlencoded with array-of-object field
+  description: |
+    A form-urlencoded body where one of the top-level fields is an
+    array whose items are themselves objects (Stripe's
+    `marketing_features` shape). Each array element's properties
+    must serialise via numerical bracket indices —
+    `marketing_features[0][name]=foo&marketing_features[0][description]=bar` —
+    matching Stripe / qs `indices` mode and jQuery `$.param` defaults.
+
+    Pre-fix the validator rejected the spec entirely because the
+    array-inside-object branch fell off the supported predicate.
+    Post-fix the hoist pass lifts the inline item schema to a
+    dedicated component, the validator accepts the resulting
+    `Reference` items, and the codegen emits the bracket-index shape.
+  version: "1.0.0"
+paths:
+  /products:
+    post:
+      operationId: createProduct
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                marketing_features:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                      description:
+                        type: string
+      responses:
+        "200":
+          description: ok

--- a/test/fixtures/form_urlencoded_object_primitive_array.yaml
+++ b/test/fixtures/form_urlencoded_object_primitive_array.yaml
@@ -1,0 +1,43 @@
+openapi: "3.0.3"
+info:
+  title: Form-urlencoded with primitive array inside object
+  description: |
+    A form-urlencoded body where one of the top-level fields is a
+    nested object whose own property is an array of primitives. Pre-fix
+    this shape was rejected at validate time because the validator's
+    `depth > 0` guard treated any nested array as unsupported, and the
+    client emitter would otherwise crash inside `to_string_fn`.
+
+    Wire format must use Stripe / qs `indices` compatible bracket
+    indices for the array elements (`profile[scores][0]=10`), not the
+    OAS `form,explode` repeat shape (which has no `prefix` semantics
+    once the array is nested inside an object).
+  version: "1.0.0"
+paths:
+  /widgets:
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                profile:
+                  type: object
+                  properties:
+                    scores:
+                      type: array
+                      items:
+                        type: integer
+                    tags:
+                      type: array
+                      items:
+                        type: string
+      responses:
+        "200":
+          description: ok

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -36,6 +36,8 @@ pub fn codegen_core_regressions_test() {
   let _ = support.deep_object_array_leaf_case()
   let _ = support.form_urlencoded_nested_object_case()
   let _ = support.form_urlencoded_two_level_nested_object_case()
+  let _ = support.form_urlencoded_object_with_primitive_array_case()
+  let _ = support.form_urlencoded_object_array_of_object_case()
   let _ = support.head_operation_not_silently_dropped_case()
   let _ = support.options_operation_not_silently_dropped_case()
   let _ = support.optional_request_body_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -5531,11 +5531,6 @@ fn server_request_shape_boundary_fixtures() -> List(#(String, String, String)) {
       "application/x-www-form-urlencoded request bodies are only supported as the sole request content type",
     ),
     #(
-      "server: complex form-urlencoded fields",
-      "test/fixtures/server_form_urlencoded_complex_fields.yaml",
-      "application/x-www-form-urlencoded request bodies only support",
-    ),
-    #(
       "server: mixed multipart request",
       "test/fixtures/server_multipart_mixed_content.yaml",
       "multipart/form-data request bodies are only supported as the sole request content type",
@@ -16488,3 +16483,80 @@ fn pdict_put_list(key: String, value: List(String)) -> List(String)
 
 @external(erlang, "oaspec_test_helpers_ffi", "pdict_get")
 fn pdict_get_list(key: String) -> Result(List(String), Nil)
+
+/// Form-urlencoded body validates and code-generates when one of its
+/// top-level fields is a nested object whose own property is an
+/// array of primitives. The wire format for nested primitive arrays
+/// is the OAS `form, explode: true` default — repeat the same
+/// bracket-key per element (`profile[scores]=10&profile[scores]=20`)
+/// so the generated client and the generated server decoder
+/// round-trip cleanly.
+pub fn form_urlencoded_object_with_primitive_array_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file(
+      "test/fixtures/form_urlencoded_object_primitive_array.yaml",
+    )
+  let cfg =
+    config.new(
+      input: "test/fixtures/form_urlencoded_object_primitive_array.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // Repeated-key wire format for the nested primitive array.
+  string.contains(content, "\"profile[scores]\"")
+  |> should.be_true()
+  // Integer items go through `int.to_string` before percent-encoding.
+  string.contains(content, "uri.percent_encode(int.to_string(item))")
+  |> should.be_true()
+  // The static key must NOT have a numerical index appended.
+  string.contains(content, "\"profile[scores]\" <> \"[\" <> int.to_string(")
+  |> should.be_false()
+}
+
+/// Form-urlencoded body validates and code-generates when one of its
+/// top-level fields is an array whose items are themselves objects
+/// (Stripe `marketing_features`). Each item's properties serialise
+/// via numerical bracket indices —
+/// `marketing_features[0][name]=foo` — matching Stripe / qs `indices`
+/// and jQuery `$.param`.
+pub fn form_urlencoded_object_array_of_object_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file(
+      "test/fixtures/form_urlencoded_object_array_of_object.yaml",
+    )
+  let cfg =
+    config.new(
+      input: "test/fixtures/form_urlencoded_object_array_of_object.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // Required string property of an array element reaches the wire
+  // as `marketing_features[<i>][name]=...`. The runtime index goes
+  // through `int.to_string(idx)`; the static prefix and each
+  // bracket-key segment land in the source as separate literals.
+  string.contains(content, "\"marketing_features\"")
+  |> should.be_true()
+  string.contains(content, "<> int.to_string(idx)")
+  |> should.be_true()
+  string.contains(content, "<> \"[name]\"")
+  |> should.be_true()
+  // Optional description follows the same indexed prefix.
+  string.contains(content, "<> \"[description]\"")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

First of four PRs that bring oaspec's `application/x-www-form-urlencoded`
support up to a real "OpenAPI 3.x compatible" baseline. With this PR
the client codegen accepts arrays nested inside form-body objects,
which is the single biggest missing piece for Stripe-shaped specs and
other real-world OpenAPI documents.

### What changed

- **Primitive array nested in object** (`profile.tags: [string]`) →
  repeated-key wire format (`profile[tags]=a&profile[tags]=b`) per
  OAS `form, explode: true` default. Round-trips cleanly with the
  existing server decoder.
- **Array of objects** (`marketing_features: [{name, description}]`)
  → numerical bracket index
  (`marketing_features[0][name]=foo&marketing_features[0][description]=bar`).
  OAS leaves this case undefined; the chosen format is the only
  encoding Stripe / qs (`indices`) / jQuery / Rails / PHP all decode
  interoperably.
- **Nesting beyond 5 levels** — the artificial depth cap is removed.
- Validation diagnostics split between client (relaxed) and server
  (still strict pending a follow-up decoder upgrade in PR3).

Composite shapes (`oneOf` / `anyOf` / `allOf`) at the field level
remain rejected with a clearer message and are addressed in PR3.

### Test plan

- [x] `gleam check`, `gleam test` (368 tests pass; 2 new fixtures + 2 new TDD cases)
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter -- --stats` (0 errors)
- [x] `bash integration_test/run.sh` (all integration tests still pass)
- [x] Local Stripe spec generation: every `nested array of objects`
      shape that previously aborted now generates cleanly. Remaining
      rejections are limited to the `oneOf/anyOf/allOf` composite
      cases that PR3 will address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced form-urlencoded request encoding to properly handle nested arrays and objects, including arrays of objects and primitive arrays within objects with indexed bracket notation support.
  * Expanded server-side validation for form-urlencoded request bodies with improved depth-limited recursion.

* **Tests**
  * Added new test fixtures and cases for complex form-urlencoded request structures.

* **Documentation**
  * Updated boundary documentation to reflect changes in form-urlencoded request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->