### PR TITLE
feat(form-urlencoded): encoding.contentType=application/json escape hatch (PR2 of 4)

### DIFF
--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -244,11 +244,39 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       })
     })
 
+  let has_form_urlencoded_json_escape =
+    list.any(operations, fn(op) {
+      let #(_, operation, _, _) = op
+      case operation.request_body {
+        Some(Value(rb)) ->
+          list.any(dict.to_list(rb.content), fn(ce) {
+            let #(ct_name, mt) = ce
+            case ct_util.from_string(ct_name) {
+              ct_util.FormUrlEncoded ->
+                list.any(dict.to_list(mt.encoding), fn(entry) {
+                  let #(_, enc) = entry
+                  case enc.content_type {
+                    Some(value) ->
+                      case ct_util.from_string(value) {
+                        ct_util.ApplicationJson -> True
+                        _ -> False
+                      }
+                    None -> False
+                  }
+                })
+              _ -> False
+            }
+          })
+        _ -> False
+      }
+    })
+
   let needs_json =
     needs_dyn_decode
     // Issue #503: object multipart fields are JSON-encoded into one part,
     // pulling in json.to_string + the per-schema encoder.
     || has_multipart_object_field
+    || has_form_urlencoded_json_escape
     || list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       case operation.request_body {

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -1289,7 +1289,7 @@ fn generate_form_bracket_fields(
 fn form_field_json_encoder_expr(
   ref: schema.SchemaRef,
   value: String,
-  ctx: Context,
+  _ctx: Context,
 ) -> String {
   case ref {
     Inline(schema.StringSchema(..)) -> "json.string(" <> value <> ")"
@@ -1297,26 +1297,19 @@ fn form_field_json_encoder_expr(
     Inline(schema.NumberSchema(..)) -> "json.float(" <> value <> ")"
     Inline(schema.BooleanSchema(..)) -> "json.bool(" <> value <> ")"
     Inline(schema.ArraySchema(items:, ..)) ->
-      "json.array("
-      <> value
-      <> ", "
-      <> form_field_json_encoder_fn(items, ctx)
-      <> ")"
+      "json.array(" <> value <> ", " <> form_field_json_encoder_fn(items) <> ")"
     _ -> schema_dispatch.json_encoder_expr(ref, value)
   }
 }
 
-fn form_field_json_encoder_fn(ref: schema.SchemaRef, ctx: Context) -> String {
-  let _ = ctx
+fn form_field_json_encoder_fn(ref: schema.SchemaRef) -> String {
   case ref {
     Inline(schema.StringSchema(..)) -> "json.string"
     Inline(schema.IntegerSchema(..)) -> "json.int"
     Inline(schema.NumberSchema(..)) -> "json.float"
     Inline(schema.BooleanSchema(..)) -> "json.bool"
     Inline(schema.ArraySchema(items:, ..)) ->
-      "fn(xs) { json.array(xs, "
-      <> form_field_json_encoder_fn(items, ctx)
-      <> ") }"
+      "fn(xs) { json.array(xs, " <> form_field_json_encoder_fn(items) <> ") }"
     _ -> schema_dispatch.json_encoder_fn(ref)
   }
 }

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -1281,6 +1281,64 @@ fn generate_form_bracket_fields(
   }
 }
 
+/// JSON encoder expression for an `encoding.<field>.contentType:
+/// application/json` escape hatch. Falls back to per-property recursion
+/// for inline arrays so a `tags: [string]` field can be lifted to a
+/// single `json.array(...)` call without round-tripping through the
+/// hoist contract.
+fn form_field_json_encoder_expr(
+  ref: schema.SchemaRef,
+  value: String,
+  ctx: Context,
+) -> String {
+  case ref {
+    Inline(schema.StringSchema(..)) -> "json.string(" <> value <> ")"
+    Inline(schema.IntegerSchema(..)) -> "json.int(" <> value <> ")"
+    Inline(schema.NumberSchema(..)) -> "json.float(" <> value <> ")"
+    Inline(schema.BooleanSchema(..)) -> "json.bool(" <> value <> ")"
+    Inline(schema.ArraySchema(items:, ..)) ->
+      "json.array("
+      <> value
+      <> ", "
+      <> form_field_json_encoder_fn(items, ctx)
+      <> ")"
+    _ -> schema_dispatch.json_encoder_expr(ref, value)
+  }
+}
+
+fn form_field_json_encoder_fn(ref: schema.SchemaRef, ctx: Context) -> String {
+  let _ = ctx
+  case ref {
+    Inline(schema.StringSchema(..)) -> "json.string"
+    Inline(schema.IntegerSchema(..)) -> "json.int"
+    Inline(schema.NumberSchema(..)) -> "json.float"
+    Inline(schema.BooleanSchema(..)) -> "json.bool"
+    Inline(schema.ArraySchema(items:, ..)) ->
+      "fn(xs) { json.array(xs, "
+      <> form_field_json_encoder_fn(items, ctx)
+      <> ") }"
+    _ -> schema_dispatch.json_encoder_fn(ref)
+  }
+}
+
+/// Returns true when `encoding[<field>].contentType` resolves to
+/// `application/json` (or `application/json` with parameters such as
+/// `application/json; charset=utf-8`). Per OAS 3.x this triggers the
+/// per-property JSON serialisation escape hatch.
+fn form_encoding_is_json(
+  encoding: Dict(String, spec.Encoding),
+  field_name: String,
+) -> Bool {
+  case dict.get(encoding, field_name) {
+    Ok(spec.Encoding(content_type: Some(ct), ..)) ->
+      case content_type.from_string(ct) {
+        content_type.ApplicationJson -> True
+        _ -> False
+      }
+    _ -> False
+  }
+}
+
 /// Generate application/x-www-form-urlencoded body encoding in the client function.
 pub fn generate_form_urlencoded_body(
   sb: se.StringBuilder,
@@ -1289,23 +1347,28 @@ pub fn generate_form_urlencoded_body(
   ctx: Context,
 ) -> se.StringBuilder {
   let content_entries = ir_build.sorted_entries(rb.content)
-  let #(properties, required_fields) = case content_entries {
+  let #(properties, required_fields, encoding) = case content_entries {
     [#(_, media_type), ..] ->
       case media_type.schema {
         Some(Inline(schema.ObjectSchema(properties:, required:, ..))) -> #(
           ir_build.sorted_entries(properties),
           required,
+          media_type.encoding,
         )
         Some(Reference(..) as schema_ref) ->
           case context.resolve_schema_ref(schema_ref, ctx) {
             Ok(schema.ObjectSchema(properties:, required:, ..)) -> {
-              #(ir_build.sorted_entries(properties), required)
+              #(
+                ir_build.sorted_entries(properties),
+                required,
+                media_type.encoding,
+              )
             }
-            _ -> #([], [])
+            _ -> #([], [], dict.new())
           }
-        _ -> #([], [])
+        _ -> #([], [], dict.new())
       }
-    _ -> #([], [])
+    _ -> #([], [], dict.new())
   }
 
   let sb = sb |> se.indent(1, "let form_parts = []")
@@ -1345,6 +1408,43 @@ pub fn generate_form_urlencoded_body(
         Some(items) -> schema_resolves_to_object(items, ctx)
         None -> False
       }
+      let json_escape_hatch = form_encoding_is_json(encoding, field_name)
+      use <- bool.lazy_guard(json_escape_hatch, fn() {
+        let value_expr = "body." <> gleam_field
+        case is_required {
+          True -> {
+            let inner =
+              form_field_json_encoder_expr(field_schema, value_expr, ctx)
+            sb
+            |> se.indent(
+              1,
+              "let form_parts = [\""
+                <> field_name
+                <> "=\" <> uri.percent_encode(json.to_string("
+                <> inner
+                <> ")), ..form_parts]",
+            )
+          }
+          False -> {
+            let inner = form_field_json_encoder_expr(field_schema, "v", ctx)
+            sb
+            |> se.indent(
+              1,
+              "let form_parts = case body." <> gleam_field <> " {",
+            )
+            |> se.indent(
+              2,
+              "Some(v) -> [\""
+                <> field_name
+                <> "=\" <> uri.percent_encode(json.to_string("
+                <> inner
+                <> ")), ..form_parts]",
+            )
+            |> se.indent(2, "None -> form_parts")
+            |> se.indent(1, "}")
+          }
+        }
+      })
       case is_object, is_array_of_object {
         True, _ ->
           // Nested objects: serialize as field[subkey]=value

--- a/test/fixtures/form_urlencoded_encoding_json.yaml
+++ b/test/fixtures/form_urlencoded_encoding_json.yaml
@@ -1,0 +1,60 @@
+openapi: "3.0.3"
+info:
+  title: Form-urlencoded with encoding.contentType=application/json escape hatch
+  description: |
+    OpenAPI 3.x permits `mediaType.encoding.<field>.contentType` to
+    override the default per-property serialisation inside a
+    `application/x-www-form-urlencoded` body. When the override is
+    `application/json`, the field's value is JSON-encoded into a
+    string and that string is then URL-encoded as a single value.
+
+    Stripe relies on this for fields like `metadata` (an open object
+    of string→string), where indexed-bracket form encoding does not
+    round-trip cleanly across language boundaries. This fixture
+    locks in:
+
+      - `metadata` is a `Reference`-resolved object → emit
+        `metadata=<percent-encoded JSON string>`.
+      - `tags` is an inline array of strings → emit
+        `tags=<percent-encoded JSON array string>`.
+      - `name` has no encoding override → keeps the existing
+        `name=<percent-encoded value>` shape.
+
+    The escape hatch is per-field: only fields whose
+    `encoding[<field>].contentType` resolves to `application/json`
+    take the new path.
+  version: "1.0.0"
+components:
+  schemas:
+    Metadata:
+      type: object
+      additionalProperties:
+        type: string
+paths:
+  /widgets:
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                metadata:
+                  $ref: "#/components/schemas/Metadata"
+                tags:
+                  type: array
+                  items:
+                    type: string
+            encoding:
+              metadata:
+                contentType: application/json
+              tags:
+                contentType: application/json
+      responses:
+        "200":
+          description: ok

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -38,6 +38,7 @@ pub fn codegen_core_regressions_test() {
   let _ = support.form_urlencoded_two_level_nested_object_case()
   let _ = support.form_urlencoded_object_with_primitive_array_case()
   let _ = support.form_urlencoded_object_array_of_object_case()
+  let _ = support.form_urlencoded_encoding_contenttype_json_case()
   let _ = support.head_operation_not_silently_dropped_case()
   let _ = support.options_operation_not_silently_dropped_case()
   let _ = support.optional_request_body_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -16560,3 +16560,51 @@ pub fn form_urlencoded_object_array_of_object_case() {
   string.contains(content, "<> \"[description]\"")
   |> should.be_true()
 }
+
+/// Form-urlencoded body honors per-field
+/// `encoding.<field>.contentType: application/json`. Each tagged
+/// field is JSON-encoded into a single string and that string is
+/// percent-encoded as one form value, while untagged fields keep
+/// their existing form serialisation.
+pub fn form_urlencoded_encoding_contenttype_json_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/form_urlencoded_encoding_json.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/form_urlencoded_encoding_json.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // Reference field is optional (only `name` is required) so it goes
+  // through the `Some(v) -> ... encode_<schema>_json(v) ...` arm and
+  // never re-references `body.metadata` inside the literal payload.
+  string.contains(content, "encode_metadata_json(v)")
+  |> should.be_true()
+  string.contains(content, "json.to_string")
+  |> should.be_true()
+  string.contains(
+    content,
+    "\"metadata=\" <> uri.percent_encode(json.to_string(",
+  )
+  |> should.be_true()
+
+  // Inline array of strings: emitted as `json.array(<value>, json.string)`
+  // and wrapped in the same `json.to_string + percent_encode` envelope.
+  string.contains(content, "json.array(v, json.string)")
+  |> should.be_true()
+  string.contains(content, "\"tags=\" <> uri.percent_encode(json.to_string(")
+  |> should.be_true()
+
+  // Untagged required scalar `name` keeps the existing
+  // `name=<percent-encoded value>` shape — no JSON wrapping.
+  string.contains(content, "\"name=\" <> uri.percent_encode(body.name)")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Second of four PRs that bring oaspec's
`application/x-www-form-urlencoded` support up to a real OpenAPI 3.x
baseline. This PR honors the per-property serialisation override
that real specs (Stripe, GitHub, etc.) rely on:

```yaml
content:
  application/x-www-form-urlencoded:
    schema:
      type: object
      properties:
        metadata: { $ref: "#/components/schemas/Metadata" }
        tags:     { type: array, items: { type: string } }
    encoding:
      metadata: { contentType: application/json }
      tags:     { contentType: application/json }
```

For fields tagged with `contentType: application/json` the client
generator now emits

```gleam
"metadata=" <> uri.percent_encode(json.to_string(encode_metadata_json(v)))
"tags="     <> uri.percent_encode(json.to_string(json.array(v, json.string)))
```

instead of the indexed-bracket form. Untagged fields keep their
existing wire format unchanged.

### Notes

- The escape hatch is per-field. The receiving server must of
  course agree to URL-decode each tagged value as a JSON string,
  which is exactly the contract Stripe documents.
- `needs_json` in the import IR also picks up the new path, so
  `gleam/json` is imported only when an operation actually uses it.
- Inline scalars and inline `array` items are handled directly via
  `json.string` / `json.array(_, encoder)` so the hoist contract is
  not invoked for primitive shapes.

### Test plan

- [x] `gleam check`, `gleam test` (368 tests pass; 1 new TDD case)
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter -- --stats` (0 active errors)
- [x] `bash integration_test/run.sh` (all integration tests still pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-field JSON encoding for application/x-www-form-urlencoded request bodies — fields marked as JSON are encoded as JSON then percent-encoded, ensuring complex objects/arrays are transmitted correctly.

* **Tests**
  * Added fixtures and tests validating per-field JSON encoding, percent-encoding behavior, and mixed-field form submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->