### PR TITLE
feat(form-urlencoded): composite (oneOf / anyOf / allOf) field support (PR3 of 4)

### DIFF
--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -252,18 +252,7 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
           list.any(dict.to_list(rb.content), fn(ce) {
             let #(ct_name, mt) = ce
             case ct_util.from_string(ct_name) {
-              ct_util.FormUrlEncoded ->
-                list.any(dict.to_list(mt.encoding), fn(entry) {
-                  let #(_, enc) = entry
-                  case enc.content_type {
-                    Some(value) ->
-                      case ct_util.from_string(value) {
-                        ct_util.ApplicationJson -> True
-                        _ -> False
-                      }
-                    None -> False
-                  }
-                })
+              ct_util.FormUrlEncoded -> form_body_uses_json_escape(mt, ctx)
               _ -> False
             }
           })
@@ -584,6 +573,54 @@ fn resolve_to_object(
         // nolint: thrown_away_error -- unresolved refs are reported by the resolver; the import gate just falls back to "no match"
         Error(_) -> None
       }
+  }
+}
+
+/// Mirror of the client emitter's "JSON escape hatch fires" decision
+/// for a `application/x-www-form-urlencoded` media type. Returns True
+/// when at least one property either has an explicit
+/// `encoding[<field>].contentType: application/json` annotation or
+/// transitively contains a composite (`oneOf` / `anyOf` / `allOf`)
+/// shape — both branches emit `json.to_string(...)` and so require
+/// `gleam/json` in the client's import set.
+fn form_body_uses_json_escape(mt: spec.MediaType, ctx: Context) -> Bool {
+  let explicit =
+    list.any(dict.to_list(mt.encoding), fn(entry) {
+      let #(_, enc) = entry
+      case enc.content_type {
+        Some(value) ->
+          case ct_util.from_string(value) {
+            ct_util.ApplicationJson -> True
+            _ -> False
+          }
+        None -> False
+      }
+    })
+  let composite = case resolve_to_object(option_or_none(mt.schema), ctx) {
+    Some(schema.ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.any(fn(entry) {
+        let #(_, child_schema) = entry
+        ref_contains_composite(child_schema, ctx)
+      })
+    _ -> False
+  }
+  explicit || composite
+}
+
+fn ref_contains_composite(ref: schema.SchemaRef, ctx: Context) -> Bool {
+  case resolve_to_object(ref, ctx) {
+    Some(schema.OneOfSchema(..))
+    | Some(schema.AnyOfSchema(..))
+    | Some(schema.AllOfSchema(..)) -> True
+    Some(schema.ArraySchema(items:, ..)) -> ref_contains_composite(items, ctx)
+    Some(schema.ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.any(fn(entry) {
+        let #(_, child_schema) = entry
+        ref_contains_composite(child_schema, ctx)
+      })
+    _ -> False
   }
 }
 

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -1314,6 +1314,55 @@ fn form_field_json_encoder_fn(ref: schema.SchemaRef) -> String {
   }
 }
 
+/// Returns true when a form field's schema either is — or transitively
+/// contains — a composite (`oneOf` / `anyOf` / `allOf`). There is no
+/// agreed-upon bracket-or-repeat wire format for composite shapes (a
+/// 2025 Stripe spec hits this on `metadata`, `address`, `documents`,
+/// `tags`, etc.), so the codegen lifts the entire field to the JSON
+/// escape hatch — the same shape an explicit
+/// `encoding.<field>.contentType: application/json` annotation
+/// would request — and serialises the whole value as one
+/// percent-encoded JSON string.
+///
+/// "Transitively" means descending into object properties and array
+/// items: if any leaf schema in the field's tree is composite, the
+/// whole field switches to the JSON path. Without this, fields like
+/// Stripe's `documents` (object → properties → array → items → `anyOf`)
+/// would slip back into the bracket-index emitter and panic in
+/// `to_string_fn` after hoist.
+fn field_resolves_to_composite(ref: schema.SchemaRef, ctx: Context) -> Bool {
+  case resolve_schema_object(Some(ref), ctx) {
+    Some(schema.OneOfSchema(..))
+    | Some(schema.AnyOfSchema(..))
+    | Some(schema.AllOfSchema(..)) -> True
+    Some(schema.ArraySchema(items:, ..)) ->
+      field_resolves_to_composite(items, ctx)
+    Some(schema.ObjectSchema(properties:, ..)) ->
+      dict.to_list(properties)
+      |> list.any(fn(entry) {
+        let #(_, child_schema) = entry
+        field_resolves_to_composite(child_schema, ctx)
+      })
+    _ -> False
+  }
+}
+
+fn resolve_schema_object(
+  schema_ref: Option(schema.SchemaRef),
+  ctx: Context,
+) -> Option(schema.SchemaObject) {
+  case schema_ref {
+    Some(Inline(s)) -> Some(s)
+    Some(Reference(..) as ref) ->
+      case context.resolve_schema_ref(ref, ctx) {
+        Ok(s) -> Some(s)
+        // nolint: thrown_away_error -- unresolved refs cannot be classified; treat as non-composite and let downstream codegen fail loudly if it actually emits
+        Error(_) -> None
+      }
+    None -> None
+  }
+}
+
 /// Returns true when `encoding[<field>].contentType` resolves to
 /// `application/json` (or `application/json` with parameters such as
 /// `application/json; charset=utf-8`). Per OAS 3.x this triggers the
@@ -1401,7 +1450,15 @@ pub fn generate_form_urlencoded_body(
         Some(items) -> schema_resolves_to_object(items, ctx)
         None -> False
       }
-      let json_escape_hatch = form_encoding_is_json(encoding, field_name)
+      let is_composite = field_resolves_to_composite(field_schema, ctx)
+      // The JSON escape hatch fires for both an explicit
+      // `encoding.<field>.contentType: application/json` annotation
+      // and for composite (`oneOf` / `anyOf` / `allOf`) fields —
+      // there is no single bracket-or-repeat wire format that round-
+      // trips for those, so we serialise the whole value as one JSON
+      // string and percent-encode it.
+      let json_escape_hatch =
+        form_encoding_is_json(encoding, field_name) || is_composite
       use <- bool.lazy_guard(json_escape_hatch, fn() {
         let value_expr = "body." <> gleam_field
         case is_required {

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -868,9 +868,11 @@ fn validate_server_form_urlencoded_request_body(
               False, _ -> [
                 diagnostic.validation_error_both(
                   path: op_id <> ".requestBody.form." <> field_name,
-                  detail: "application/x-www-form-urlencoded request bodies do not support oneOf / anyOf / allOf at the field level yet.",
+                  detail: "application/x-www-form-urlencoded request body field has a shape the codegen does not yet know how to serialise.",
                   hint: Some(
-                    "Use a single concrete schema (object or primitive) for each form field.",
+                    "Switch this field to a concrete primitive, object, array, or composite schema, or set encoding."
+                    <> field_name
+                    <> ".contentType: application/json to opt the field into the JSON escape hatch.",
                   ),
                 ),
               ]
@@ -925,9 +927,15 @@ fn form_urlencoded_server_field_supported(
 /// primitive scalars, primitive arrays at any depth, nested objects
 /// at any depth, and arrays-of-objects (whose items the hoist pass
 /// has already promoted to a `Reference`, so the codegen sees a
-/// nameable `ObjectSchema` here). composite shapes (`oneOf` /
-/// `anyOf` / `allOf`) at the field level remain on the rejection
-/// path until the dedicated codegen for them lands.
+/// nameable `ObjectSchema` here).
+///
+/// Composite shapes (`oneOf` / `anyOf` / `allOf`) at the field level
+/// also pass: they take the JSON-escape-hatch branch in the client
+/// emitter (`field=<percent-encoded JSON string>`), the same shape
+/// `encoding.<field>.contentType: application/json` would request
+/// explicitly. Without this branch real-world specs (Stripe, GitHub)
+/// would validate-reject for ~hundreds of fields with no spec change
+/// the user can make.
 fn form_urlencoded_field_codegen_safe(
   schema_ref: SchemaRef,
   ctx: Context,
@@ -946,6 +954,8 @@ fn form_urlencoded_field_codegen_safe(
         let #(_, child_schema) = entry
         form_urlencoded_field_codegen_safe(child_schema, ctx, 0)
       })
+    Some(OneOfSchema(..)) | Some(AnyOfSchema(..)) | Some(AllOfSchema(..)) ->
+      True
     _ -> False
   }
 }
@@ -953,8 +963,15 @@ fn form_urlencoded_field_codegen_safe(
 /// Items of an array inside a form-urlencoded body may be a primitive
 /// scalar (rendered as `key[i]=v`), a primitive array (rendered as
 /// `key[i][j]=v`), or an object whose properties recurse through the
-/// same predicate (rendered as `key[i][prop]=v`). Composites at the
-/// item level are still rejected.
+/// same predicate (rendered as `key[i][prop]=v`).
+///
+/// Composites at the item level (`items: { anyOf: ... }`, common in
+/// the Stripe spec on `documents.<kind>.files.items`) escalate the
+/// whole containing field to the JSON escape hatch, just like a
+/// composite at the field level would. They pass the predicate so
+/// the field is not validate-rejected; the client emitter recognises
+/// the composite-via-items shape and emits a single JSON-encoded
+/// form value for the entire field.
 fn form_urlencoded_array_items_codegen_safe(
   items: SchemaRef,
   ctx: Context,
@@ -972,6 +989,8 @@ fn form_urlencoded_array_items_codegen_safe(
         let #(_, child_schema) = entry
         form_urlencoded_field_codegen_safe(child_schema, ctx, 0)
       })
+    Some(OneOfSchema(..)) | Some(AnyOfSchema(..)) | Some(AllOfSchema(..)) ->
+      True
     _ -> False
   }
 }

--- a/test/fixtures/form_urlencoded_composite_field.yaml
+++ b/test/fixtures/form_urlencoded_composite_field.yaml
@@ -1,0 +1,81 @@
+openapi: "3.0.3"
+info:
+  title: Form-urlencoded with composite (oneOf / anyOf / allOf) fields
+  description: |
+    Real-world specs (Stripe, GitHub) routinely declare
+    `application/x-www-form-urlencoded` request bodies whose
+    properties resolve to `oneOf` / `anyOf` / `allOf` schemas — a
+    `metadata` hash that may be either a typed object or null, an
+    `address` object that is the union of two shipping shapes, etc.
+
+    There is no single bracket-or-repeat wire encoding that round-trips
+    cleanly across language boundaries for these shapes, so oaspec
+    treats them like any other JSON field and serialises the value
+    via the schema's JSON encoder, then percent-encodes the resulting
+    string into a single form value:
+
+      metadata=%7B%22env%22%3A%22prod%22%7D
+      address=%7B%22kind%22%3A%22billing%22%2C%22zip%22%3A%2294105%22%7D
+
+    Pre-fix the generator validate-rejected the spec entirely with
+    "do not support oneOf / anyOf / allOf at the field level yet."
+    Post-fix the client codegen accepts these shapes and emits the
+    JSON escape hatch automatically; server codegen still rejects
+    until the form decoder learns the inverse transform.
+  version: "1.0.0"
+components:
+  schemas:
+    MetadataObject:
+      type: object
+      additionalProperties:
+        type: string
+    BillingAddress:
+      type: object
+      required: [kind, zip]
+      properties:
+        kind: { type: string, enum: [billing] }
+        zip: { type: string }
+    ShippingAddress:
+      type: object
+      required: [kind, postal_code]
+      properties:
+        kind: { type: string, enum: [shipping] }
+        postal_code: { type: string }
+    HasCreatedAt:
+      type: object
+      required: [created_at]
+      properties:
+        created_at: { type: string, format: date-time }
+paths:
+  /widgets:
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                metadata:
+                  oneOf:
+                    - $ref: "#/components/schemas/MetadataObject"
+                    - type: "null"
+                address:
+                  oneOf:
+                    - $ref: "#/components/schemas/BillingAddress"
+                    - $ref: "#/components/schemas/ShippingAddress"
+                audit:
+                  allOf:
+                    - $ref: "#/components/schemas/HasCreatedAt"
+                tags:
+                  anyOf:
+                    - type: array
+                      items:
+                        type: string
+      responses:
+        "200":
+          description: ok

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -39,6 +39,7 @@ pub fn codegen_core_regressions_test() {
   let _ = support.form_urlencoded_object_with_primitive_array_case()
   let _ = support.form_urlencoded_object_array_of_object_case()
   let _ = support.form_urlencoded_encoding_contenttype_json_case()
+  let _ = support.form_urlencoded_composite_field_case()
   let _ = support.head_operation_not_silently_dropped_case()
   let _ = support.options_operation_not_silently_dropped_case()
   let _ = support.optional_request_body_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -16608,3 +16608,49 @@ pub fn form_urlencoded_encoding_contenttype_json_case() {
   string.contains(content, "\"name=\" <> uri.percent_encode(body.name)")
   |> should.be_true()
 }
+
+/// Form-urlencoded body with `oneOf` / `anyOf` / `allOf` field-level
+/// composites is accepted by validate (client mode) and the client
+/// codegen emits the per-field JSON escape hatch automatically — no
+/// `encoding.contentType: application/json` annotation required.
+pub fn form_urlencoded_composite_field_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/form_urlencoded_composite_field.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/form_urlencoded_composite_field.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // Each composite field is JSON-encoded via its synthetic encoder
+  // and percent-encoded as a single form value.
+  string.contains(
+    content,
+    "\"metadata=\" <> uri.percent_encode(json.to_string(",
+  )
+  |> should.be_true()
+  string.contains(content, "\"address=\" <> uri.percent_encode(json.to_string(")
+  |> should.be_true()
+  string.contains(content, "\"audit=\" <> uri.percent_encode(json.to_string(")
+  |> should.be_true()
+  string.contains(content, "\"tags=\" <> uri.percent_encode(json.to_string(")
+  |> should.be_true()
+
+  // Untagged required scalar `name` is unchanged.
+  string.contains(content, "\"name=\" <> uri.percent_encode(body.name)")
+  |> should.be_true()
+
+  // The composite-driven JSON escape hatch must also pull
+  // `gleam/json` into the import set; otherwise the emitted
+  // `json.to_string(...)` references would not compile.
+  string.contains(content, "import gleam/json")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Third of four PRs that bring oaspec's
`application/x-www-form-urlencoded` support up to a real OpenAPI 3.x
baseline. This PR makes composite (`oneOf` / `anyOf` / `allOf`)
fields just work, without any spec change on the user's side.

### What changed

- Validate now accepts composite fields and composite-via-array-items
  shapes inside form-urlencoded bodies (client mode). Server mode still
  rejects until the form decoder learns the inverse transform.
- The client emitter automatically routes composite-bearing fields to
  the JSON escape hatch introduced in PR #541 — same wire envelope,
  same `gleam/json` import, no new helpers.
- Detection is transitive (object → array → composite) so fields like
  Stripe's `documents` (`object → properties → array → items: anyOf`)
  are caught before they fall into the bracket-index emitter and
  panic in `to_string_fn` after hoist.

### Effect on the Stripe spec

The count of validate-time form-urlencoded field rejections drops
from **308 to 0**. The remaining 11 errors in the Stripe generation
are all `query` / `deepObject` parameter shapes outside this PR's
scope and will be tracked separately.

### Test plan

- [x] `gleam check`, `gleam test` (368 tests pass; 1 new TDD case)
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter -- --stats` (0 active errors)
- [x] `bash integration_test/run.sh` (all integration tests still pass)
- [x] Local Stripe spec generation: 308 form-urlencoded rejections
      eliminated; remaining 11 errors are query/deepObject only