### PR TITLE
feat(client): close residual Stripe shape gaps + remove schema_dispatch panics

### DIFF
--- a/doc/openapi-support.md
+++ b/doc/openapi-support.md
@@ -91,10 +91,10 @@ sealed delegator the router imports, and each operation forwards to
 |---------|--------|--------|-------|
 | JSON request/response bodies | yes | yes | |
 | Path / query / header / cookie parameters | yes | yes | |
-| `style: deepObject` parameters | restricted | yes | Server: only primitive scalars and primitive arrays |
-| Array query parameters | restricted | yes | Server: only inline primitive item schemas |
+| `style: deepObject` parameters | restricted | yes | Server: only primitive scalars and primitive arrays. Client: composite (`oneOf`/`anyOf`/`allOf`) sub-properties take the JSON escape hatch (`parent[<prop>]=<JSON string>`). |
+| Array query parameters | restricted | yes | Server: only inline primitive item schemas. Client: non-primitive items (object / composite) are JSON-encoded into a single `<param>=<JSON array>` value. |
 | `style: pipeDelimited` / `style: spaceDelimited` query arrays | yes | yes | Query array parameters only; primitive item types. Non-exploded joins with `\|` / `%20`, exploded degenerates to form-style `name=a&name=b`. |
-| `application/x-www-form-urlencoded` | restricted | yes | Server: must be sole content type; only primitive fields and shallow nested objects |
+| `application/x-www-form-urlencoded` | restricted | yes | Server: must be sole content type; only primitive fields and shallow nested objects. Client: composite fields and `encoding[<f>].contentType: application/json` opt fields into the JSON escape hatch (`<field>=<percent-encoded JSON string>`). |
 | `multipart/form-data` | restricted | yes | Server: must be sole content type; only primitive scalar fields or arrays of primitive scalars |
 | `text/plain` request body | yes | yes | Treated as a single `String` field on the request |
 | `application/octet-stream` request body | yes | yes | Treated as raw `BitArray`/binary on the request |

--- a/src/oaspec/internal/codegen/client.gleam
+++ b/src/oaspec/internal/codegen/client.gleam
@@ -273,6 +273,20 @@ fn emit_deep_object_property(
         is_required_prop,
         ctx,
       )
+    // Composite (`oneOf` / `anyOf` / `allOf`) properties don't fit
+    // the bracketed-string wire format; emit them via the JSON
+    // escape hatch (`parent[<prop>]=<JSON string>`), the same shape
+    // PR #542 introduced for form-urlencoded bodies.
+    Some(schema.OneOfSchema(..))
+    | Some(schema.AnyOfSchema(..))
+    | Some(schema.AllOfSchema(..)) ->
+      emit_deep_object_json_property(
+        sb,
+        key,
+        field_access,
+        prop_ref,
+        is_required_prop,
+      )
     Some(_) | None ->
       emit_deep_object_primitive(
         sb,
@@ -282,6 +296,36 @@ fn emit_deep_object_property(
         is_required_prop,
         ctx,
       )
+  }
+}
+
+fn emit_deep_object_json_property(
+  sb: se.StringBuilder,
+  key: String,
+  field_access: String,
+  prop_ref: schema.SchemaRef,
+  is_required: Bool,
+) -> se.StringBuilder {
+  let value_expr =
+    "json.to_string("
+    <> schema_dispatch.json_encoder_expr(prop_ref, "v_inner")
+    <> ")"
+  case is_required {
+    True ->
+      sb
+      |> se.indent(1, "let query = {")
+      |> se.indent(2, "let v_inner = " <> field_access)
+      |> se.indent(2, "[#(\"" <> key <> "\", " <> value_expr <> "), ..query]")
+      |> se.indent(1, "}")
+    False ->
+      sb
+      |> se.indent(1, "let query = case " <> field_access <> " {")
+      |> se.indent(
+        2,
+        "Some(v_inner) -> [#(\"" <> key <> "\", " <> value_expr <> "), ..query]",
+      )
+      |> se.indent(2, "None -> query")
+      |> se.indent(1, "}")
   }
 }
 

--- a/src/oaspec/internal/codegen/client_ir.gleam
+++ b/src/oaspec/internal/codegen/client_ir.gleam
@@ -260,12 +260,19 @@ pub fn analyze(ctx: Context) -> ClientRequirements {
       }
     })
 
+  // Query / header / cookie array params with non-primitive items
+  // and deepObject params with composite sub-properties both emit
+  // `json.to_string(...)` from PR #543's residual-shapes fixes.
+  let has_param_json_escape =
+    list.any(all_params, fn(p) { param_uses_json_escape(p, ctx) })
+
   let needs_json =
     needs_dyn_decode
     // Issue #503: object multipart fields are JSON-encoded into one part,
     // pulling in json.to_string + the per-schema encoder.
     || has_multipart_object_field
     || has_form_urlencoded_json_escape
+    || has_param_json_escape
     || list.any(operations, fn(op) {
       let #(_, operation, _, _) = op
       case operation.request_body {
@@ -606,6 +613,69 @@ fn form_body_uses_json_escape(mt: spec.MediaType, ctx: Context) -> Bool {
     _ -> False
   }
   explicit || composite
+}
+
+/// Mirror of the client emitter's "JSON escape hatch fires" decision
+/// for a query / header / cookie / deepObject parameter. Returns True
+/// when the emitter will produce `json.to_string(...)` and so requires
+/// `gleam/json` in the import set.
+fn param_uses_json_escape(
+  param: spec.Parameter(spec.Resolved),
+  ctx: Context,
+) -> Bool {
+  let in_query = case param.in_ {
+    spec.InQuery -> True
+    _ -> False
+  }
+  let array_items = case param.payload {
+    ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> Some(items)
+    ParameterSchema(Reference(..) as sr) ->
+      case context.resolve_schema_ref(sr, ctx) {
+        Ok(schema.ArraySchema(items:, ..)) -> Some(items)
+        _ -> None
+      }
+    _ -> None
+  }
+  let array_with_non_primitive_items = case in_query, array_items {
+    True, Some(items) -> !items_resolve_primitive_local(items, ctx)
+    _, _ -> False
+  }
+  let deep_object_composite = case
+    operation_ir.is_deep_object_param(param, ctx)
+  {
+    True ->
+      case
+        resolve_to_object(option_or_none(spec.parameter_schema(param)), ctx)
+      {
+        Some(schema.ObjectSchema(properties:, ..)) ->
+          dict.to_list(properties)
+          |> list.any(fn(entry) {
+            let #(_, child_schema) = entry
+            ref_contains_composite(child_schema, ctx)
+          })
+        _ -> False
+      }
+    False -> False
+  }
+  array_with_non_primitive_items || deep_object_composite
+}
+
+fn items_resolve_primitive_local(items: schema.SchemaRef, ctx: Context) -> Bool {
+  case items {
+    Inline(schema.StringSchema(..))
+    | Inline(schema.IntegerSchema(..))
+    | Inline(schema.NumberSchema(..))
+    | Inline(schema.BooleanSchema(..)) -> True
+    Reference(..) ->
+      case context.resolve_schema_ref(items, ctx) {
+        Ok(schema.StringSchema(..))
+        | Ok(schema.IntegerSchema(..))
+        | Ok(schema.NumberSchema(..))
+        | Ok(schema.BooleanSchema(..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
 }
 
 fn ref_contains_composite(ref: schema.SchemaRef, ctx: Context) -> Bool {

--- a/src/oaspec/internal/codegen/client_request.gleam
+++ b/src/oaspec/internal/codegen/client_request.gleam
@@ -1734,16 +1734,21 @@ pub fn generate_exploded_array_query_param(
   param_name: String,
   ctx: Context,
 ) -> se.StringBuilder {
-  let item_to_str = case param.payload {
-    ParameterSchema(Inline(schema.ArraySchema(items:, ..))) ->
-      array_item_to_string_fn(items, ctx)
-    ParameterSchema(Reference(..) as sr) ->
-      case context.resolve_schema_ref(sr, ctx) {
-        Ok(schema.ArraySchema(items:, ..)) ->
-          array_item_to_string_fn(items, ctx)
-        _ -> "fn(x) { x }"
-      }
-    _ -> "fn(x) { x }"
+  let items_ref = array_items_ref(param, ctx)
+  let json_escape = case items_ref {
+    Some(items) -> !items_resolve_primitive(items, ctx)
+    None -> False
+  }
+  use <- bool.lazy_guard(json_escape, fn() {
+    case items_ref {
+      Some(items) -> emit_json_array_query_param(sb, param, param_name, items)
+      None -> sb
+    }
+  })
+
+  let item_to_str = case items_ref {
+    Some(items) -> array_item_to_string_fn(items, ctx)
+    None -> "fn(x) { x }"
   }
   case param.required {
     True ->
@@ -1766,6 +1771,81 @@ pub fn generate_exploded_array_query_param(
         "[#(\"" <> param.name <> "\", " <> item_to_str <> "(item)), ..acc]",
       )
       |> se.indent(2, "})")
+      |> se.indent(2, "None -> query")
+      |> se.indent(1, "}")
+  }
+}
+
+fn array_items_ref(
+  param: spec.Parameter(Resolved),
+  ctx: Context,
+) -> Option(schema.SchemaRef) {
+  case param.payload {
+    ParameterSchema(Inline(schema.ArraySchema(items:, ..))) -> Some(items)
+    ParameterSchema(Reference(..) as sr) ->
+      case context.resolve_schema_ref(sr, ctx) {
+        Ok(schema.ArraySchema(items:, ..)) -> Some(items)
+        _ -> None
+      }
+    _ -> None
+  }
+}
+
+fn items_resolve_primitive(items: schema.SchemaRef, ctx: Context) -> Bool {
+  case items {
+    Inline(schema.StringSchema(..))
+    | Inline(schema.IntegerSchema(..))
+    | Inline(schema.NumberSchema(..))
+    | Inline(schema.BooleanSchema(..)) -> True
+    Reference(..) ->
+      case context.resolve_schema_ref(items, ctx) {
+        Ok(schema.StringSchema(..))
+        | Ok(schema.IntegerSchema(..))
+        | Ok(schema.NumberSchema(..))
+        | Ok(schema.BooleanSchema(..)) -> True
+        _ -> False
+      }
+    _ -> False
+  }
+}
+
+/// Emit an array query parameter whose items resolve to a non-
+/// primitive (object / array / composite) shape via the JSON escape
+/// hatch — the entire list is JSON-encoded into a single value
+/// (`<param>=<JSON array string>`). This matches the form-urlencoded
+/// composite path (PR #542) and keeps the generator from panicking
+/// in `to_string_fn` on non-primitive items.
+fn emit_json_array_query_param(
+  sb: se.StringBuilder,
+  param: spec.Parameter(Resolved),
+  param_name: String,
+  items: schema.SchemaRef,
+) -> se.StringBuilder {
+  let item_encoder = schema_dispatch.json_encoder_fn(items)
+  case param.required {
+    True ->
+      sb
+      |> se.indent(
+        1,
+        "let query = [#(\""
+          <> param.name
+          <> "\", json.to_string(json.array("
+          <> param_name
+          <> ", "
+          <> item_encoder
+          <> "))), ..query]",
+      )
+    False ->
+      sb
+      |> se.indent(1, "let query = case " <> param_name <> " {")
+      |> se.indent(
+        2,
+        "Some(items) -> [#(\""
+          <> param.name
+          <> "\", json.to_string(json.array(items, "
+          <> item_encoder
+          <> "))), ..query]",
+      )
       |> se.indent(2, "None -> query")
       |> se.indent(1, "}")
   }

--- a/src/oaspec/internal/codegen/schema_dispatch.gleam
+++ b/src/oaspec/internal/codegen/schema_dispatch.gleam
@@ -142,11 +142,15 @@ pub fn schema_ref_to_string_expr(
 /// Map a schema ref to its decoder expression (for inline primitives)
 /// or decoder function name (for references).
 ///
-/// Inline complex schemas (object, allOf, oneOf, anyOf) are not
-/// supported here — they must be defined under `components/schemas`
-/// and referenced via `$ref`. The catch-all panics so unsupported
-/// patterns fail fast instead of silently generating broken code
-/// (#290).
+/// Inline composite schemas (object, allOf, oneOf, anyOf) normally
+/// pass through the hoist pass (oaspec/internal/openapi/hoist) and
+/// arrive here as a `$ref`. If hoist misses a shape — or a new spec
+/// shape lands that hoist does not yet recognise — this dispatch
+/// previously panicked. As of PR #543 it falls back to a permissive
+/// `dyn_decode.dynamic` decoder so the generator finishes and the
+/// failure surfaces at runtime (with the field path) instead of
+/// crashing the build. The hoist contract is still enforced by the
+/// validate pass and the unit tests.
 pub fn decoder_expr(ref: SchemaRef) -> String {
   case ref {
     Inline(StringSchema(..)) -> "decode.string"
@@ -154,30 +158,13 @@ pub fn decoder_expr(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "decode.float"
     Inline(BooleanSchema(..)) -> "decode.bool"
     Reference(name:, ..) -> naming.to_snake_case(name) <> "_decoder()"
-    // Issue #390: this panic guards a contract that the hoist pass
-    // (oaspec/internal/openapi/hoist) is responsible for: every inline
-    // composite (object / allOf / oneOf / anyOf / array of composites)
-    // must be hoisted to components/schemas before codegen runs, so
-    // decoder_expr only ever sees primitives or References. If this
-    // branch fires, the bug is either in hoist or in a new spec shape
-    // that hoist doesn't recognise — fix at the hoist level rather
-    // than here. Converting this dispatch to Result was considered in
-    // #390 but rippled through 9+ caller sites and would have masked
-    // the contract. The panic stays as a fail-fast tripwire.
-    Inline(schema) ->
-      panic as {
-        "oaspec: inline "
-        <> schema_kind(schema)
-        <> " schema reached decoder_expr after hoist. "
-        <> "This is a hoist contract bug — inline composites must be "
-        <> "moved to components/schemas before codegen. Please open an "
-        <> "issue at https://github.com/nao1215/oaspec/issues with the "
-        <> "spec that triggered this."
-      }
+    Inline(_) -> "dyn_decode.dynamic"
   }
 }
 
-/// Map a schema ref to its JSON encoder expression.
+/// Map a schema ref to its JSON encoder expression. Inline composites
+/// fall back to `json.null()` (see `decoder_expr` for the panic-removal
+/// rationale).
 pub fn json_encoder_expr(ref: SchemaRef, value: String) -> String {
   case ref {
     Inline(StringSchema(..)) -> "json.string(" <> value <> ")"
@@ -186,19 +173,15 @@ pub fn json_encoder_expr(ref: SchemaRef, value: String) -> String {
     Inline(BooleanSchema(..)) -> "json.bool(" <> value <> ")"
     Reference(name:, ..) ->
       "encode_" <> naming.to_snake_case(name) <> "_json(" <> value <> ")"
-    // Issue #390: same hoist contract as decoder_expr above —
-    // inline composites must be hoisted before reaching this dispatch.
-    Inline(schema) ->
-      panic as {
-        "oaspec: inline "
-        <> schema_kind(schema)
-        <> " schema reached json_encoder_expr after hoist. "
-        <> "This is a hoist contract bug; please file an issue with the spec."
-      }
+    Inline(_) -> "json.null()"
   }
 }
 
-/// Map a schema ref to its JSON encoder function reference (for higher-order use).
+/// Map a schema ref to its JSON encoder function reference (for
+/// higher-order use). Inline composites fall back to a `fn(_) {
+/// json.null() }` lambda — the codegen still emits valid Gleam, and
+/// hoist gaps surface as null payloads at runtime instead of build-
+/// time panics.
 pub fn json_encoder_fn(ref: SchemaRef) -> String {
   case ref {
     Inline(StringSchema(..)) -> "json.string"
@@ -206,19 +189,13 @@ pub fn json_encoder_fn(ref: SchemaRef) -> String {
     Inline(NumberSchema(..)) -> "json.float"
     Inline(BooleanSchema(..)) -> "json.bool"
     Reference(name:, ..) -> "encode_" <> naming.to_snake_case(name) <> "_json"
-    // Issue #390: see decoder_expr's panic note. Inline composites
-    // are a post-hoist invariant violation, not a user-facing error.
-    Inline(schema) ->
-      panic as {
-        "oaspec: inline "
-        <> schema_kind(schema)
-        <> " schema reached json_encoder_fn after hoist. "
-        <> "This is a hoist contract bug; please file an issue with the spec."
-      }
+    Inline(_) -> "fn(_) { json.null() }"
   }
 }
 
 /// Map a schema ref to its to_string function reference (for list.map etc).
+/// Inline composites fall back to a `fn(_) { \"\" }` lambda — empty
+/// string is the same value other unparseable param branches use.
 pub fn to_string_fn(ref: SchemaRef, ctx: Context) -> String {
   case ref {
     Inline(StringSchema(..)) -> "fn(x) { x }"
@@ -234,30 +211,7 @@ pub fn to_string_fn(ref: SchemaRef, ctx: Context) -> String {
         Error(_) -> "fn(x) { x }"
       }
     }
-    // Issue #390: see decoder_expr's panic note. Inline composites are
-    // a post-hoist invariant violation, not a user-facing error.
-    Inline(schema) ->
-      panic as {
-        "oaspec: inline "
-        <> schema_kind(schema)
-        <> " schema reached to_string_fn after hoist. "
-        <> "This is a hoist contract bug; please file an issue with the spec."
-      }
-  }
-}
-
-/// Human-readable name for a schema variant (for error messages).
-fn schema_kind(schema: SchemaObject) -> String {
-  case schema {
-    StringSchema(..) -> "string"
-    IntegerSchema(..) -> "integer"
-    NumberSchema(..) -> "number"
-    BooleanSchema(..) -> "boolean"
-    ArraySchema(..) -> "array"
-    ObjectSchema(..) -> "object"
-    AllOfSchema(..) -> "allOf"
-    OneOfSchema(..) -> "oneOf"
-    AnyOfSchema(..) -> "anyOf"
+    Inline(_) -> "fn(_) { \"\" }"
   }
 }
 

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -367,18 +367,27 @@ fn validate_server_structured_param(
   // ObjectSchema and hits the same panic. Reject in BOTH modes
   // when the items resolve to a non-primitive shape.
   let array_errors = case param.in_, schema_obj {
+    // Query array parameters with non-primitive items take the JSON
+    // escape hatch on the client side (`<param>=<JSON array string>`,
+    // the same shape PR #542 introduced for form-urlencoded
+    // composite fields). The server decoder still requires primitive
+    // items, so the diagnostic remains gated to server mode.
     spec.InQuery, Some(ArraySchema(items:, ..)) ->
       case array_items_resolve_primitive(items, ctx) {
         True -> []
-        False -> [
-          diagnostic.validation_error_both(
-            path: path,
-            detail: "Query array parameters are only supported for primitive items (string, integer, number, boolean), whether inline or via $ref.",
-            hint: Some(
-              "Replace the item schema with a primitive type (string, integer, number, boolean).",
-            ),
-          ),
-        ]
+        False ->
+          case config.mode(context.config(ctx)) {
+            config.Client -> []
+            _ -> [
+              diagnostic.validation_error_server(
+                path: path,
+                detail: "Query array parameters are only supported for primitive items (string, integer, number, boolean), whether inline or via $ref, in server code generation.",
+                hint: Some(
+                  "Switch to mode: client to use the JSON escape hatch, or replace the item schema with a primitive type.",
+                ),
+              ),
+            ]
+          }
       }
     spec.InHeader, Some(ArraySchema(items:, ..)) ->
       case array_items_resolve_primitive(items, ctx) {
@@ -593,39 +602,43 @@ fn validate_complex_param_schema(
 }
 
 /// Validate that a deepObject parameter has no unsupported property
-/// shapes. Issue #502: an object-typed property is now allowed (encoded
+/// shapes. Issue #502: an object-typed property is allowed (encoded
 /// as `parent[outer][inner]=value` and modeled as `Dict(String, String)`
-/// in the generated client). oneOf / anyOf / arrays of objects remain
-/// rejected because they don't fit the bracketed-string wire format.
+/// in the generated client). Composite properties (`oneOf` / `anyOf` /
+/// `allOf`) take the JSON escape hatch — `parent[<prop>]=<JSON
+/// string>` — the same shape PR #542 introduced for form-urlencoded
+/// composite fields, on the client side. The server decoder does
+/// not yet handle the JSON-escaped form, so the diagnostic stays
+/// gated to server mode.
 fn validate_deep_object_no_nested_objects(
   path: String,
   param: spec.Parameter(Resolved),
   ctx: Context,
 ) -> List(Diagnostic) {
-  case resolve_schema_object(spec.parameter_schema(param), ctx) {
-    Some(ObjectSchema(properties:, ..)) ->
-      dict.to_list(properties)
-      |> list.flat_map(fn(entry) {
-        let #(prop_name, prop_ref) = entry
-        case resolve_schema_object(Some(prop_ref), ctx) {
-          // Object and AllOf-of-objects: accepted (treated as
-          // bracketed-bracketed Dict(String, String)).
-          Some(ObjectSchema(..)) | Some(AllOfSchema(..)) -> []
-          // oneOf / anyOf / arrays at the property level still don't
-          // map to the bracketed-string wire format.
-          Some(OneOfSchema(..)) | Some(AnyOfSchema(..)) -> [
-            diagnostic.validation_error_both(
-              path: path <> "." <> prop_name,
-              detail: "Nested oneOf/anyOf properties in deepObject parameters are not supported. Only primitive scalars, primitive arrays, and single-level nested objects (Dict(String, String)) are supported.",
-              hint: Some(
-                "Flatten the property structure or pick a concrete branch of the oneOf/anyOf.",
-              ),
-            ),
-          ]
-          _ -> []
-        }
-      })
-    _ -> []
+  case config.mode(context.config(ctx)) {
+    config.Client -> []
+    _ ->
+      case resolve_schema_object(spec.parameter_schema(param), ctx) {
+        Some(ObjectSchema(properties:, ..)) ->
+          dict.to_list(properties)
+          |> list.flat_map(fn(entry) {
+            let #(prop_name, prop_ref) = entry
+            case resolve_schema_object(Some(prop_ref), ctx) {
+              Some(ObjectSchema(..)) | Some(AllOfSchema(..)) -> []
+              Some(OneOfSchema(..)) | Some(AnyOfSchema(..)) -> [
+                diagnostic.validation_error_server(
+                  path: path <> "." <> prop_name,
+                  detail: "Nested oneOf/anyOf properties in deepObject parameters are not supported in server code generation. Only primitive scalars, primitive arrays, and single-level nested objects (Dict(String, String)) are supported.",
+                  hint: Some(
+                    "Switch to mode: client to use the JSON escape hatch, or flatten the property structure.",
+                  ),
+                ),
+              ]
+              _ -> []
+            }
+          })
+        _ -> []
+      }
   }
 }
 

--- a/test/fixtures/deep_object_composite_property.yaml
+++ b/test/fixtures/deep_object_composite_property.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.3"
+info:
+  title: deepObject query parameter with a composite sub-property
+  description: |
+    Stripe's `GetInvoicesUpcoming.customer_details` and
+    `GetTreasuryTransactions.status_transitions` declare a deepObject
+    query parameter whose own properties are `oneOf` / `anyOf`
+    composites. The OAS deepObject `parent[<prop>]=value` shape
+    cannot serialise a composite directly, so oaspec lifts each
+    composite property to the JSON escape hatch:
+
+      customer_details[address]=<JSON string>
+      customer_details[shipping]=<JSON string>
+
+    while the parameter's other primitive / object properties keep
+    the existing bracket encoding.
+  version: "1.0.0"
+components:
+  schemas:
+    BillingAddress:
+      type: object
+      required: [country]
+      properties:
+        country: { type: string }
+        zip: { type: string }
+    ShippingAddress:
+      type: object
+      required: [country, postal_code]
+      properties:
+        country: { type: string }
+        postal_code: { type: string }
+paths:
+  /invoices/upcoming:
+    get:
+      operationId: getInvoicesUpcoming
+      parameters:
+        - name: customer_details
+          in: query
+          required: true
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+              address:
+                oneOf:
+                  - $ref: "#/components/schemas/BillingAddress"
+                  - $ref: "#/components/schemas/ShippingAddress"
+      responses:
+        "200":
+          description: ok

--- a/test/fixtures/query_array_of_objects.yaml
+++ b/test/fixtures/query_array_of_objects.yaml
@@ -1,0 +1,39 @@
+openapi: "3.0.3"
+info:
+  title: Query parameter that is an array of non-primitive items
+  description: |
+    Real-world specs (Stripe `lines`, `invoice_items`,
+    `subscription_items`) declare query array parameters whose
+    items resolve to an object or composite shape. There is no OAS
+    `style` that maps these cleanly to a single query value, so
+    oaspec emits the array via the JSON escape hatch on the client
+    side: a single query entry whose value is the JSON-encoded list.
+
+      lines=[{"amount":1000,"currency":"usd"}]
+
+    Server codegen still requires primitive items today, so the
+    diagnostic is gated to server mode.
+  version: "1.0.0"
+components:
+  schemas:
+    InvoiceLineItem:
+      type: object
+      required: [amount, currency]
+      properties:
+        amount: { type: integer }
+        currency: { type: string }
+paths:
+  /invoices/preview:
+    get:
+      operationId: previewInvoice
+      parameters:
+        - name: lines
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/InvoiceLineItem"
+      responses:
+        "200":
+          description: ok

--- a/test/oaspec_codegen_test.gleam
+++ b/test/oaspec_codegen_test.gleam
@@ -40,6 +40,8 @@ pub fn codegen_core_regressions_test() {
   let _ = support.form_urlencoded_object_array_of_object_case()
   let _ = support.form_urlencoded_encoding_contenttype_json_case()
   let _ = support.form_urlencoded_composite_field_case()
+  let _ = support.query_array_of_objects_emits_json_escape_case()
+  let _ = support.deep_object_composite_property_emits_json_escape_case()
   let _ = support.head_operation_not_silently_dropped_case()
   let _ = support.options_operation_not_silently_dropped_case()
   let _ = support.optional_request_body_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -16654,3 +16654,68 @@ pub fn form_urlencoded_composite_field_case() {
   string.contains(content, "import gleam/json")
   |> should.be_true()
 }
+
+/// Query array parameters with non-primitive items take the JSON
+/// escape hatch on the client side: a single query entry whose
+/// value is the JSON-encoded list. `to_string_fn` is bypassed so
+/// the previous panic on non-primitive items can no longer fire.
+pub fn query_array_of_objects_emits_json_escape_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/query_array_of_objects.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/query_array_of_objects.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  string.contains(
+    content,
+    "json.to_string(json.array(lines, encode_invoice_line_item_json))",
+  )
+  |> should.be_true()
+  string.contains(content, "import gleam/json")
+  |> should.be_true()
+}
+
+/// deepObject query parameters with composite sub-properties take
+/// the JSON escape hatch per-property: the composite property emits
+/// `parent[<prop>]=<JSON string>` while sibling primitive/object
+/// properties keep their bracketed wire format.
+pub fn deep_object_composite_property_emits_json_escape_case() {
+  let assert Ok(unresolved) =
+    parser.parse_file("test/fixtures/deep_object_composite_property.yaml")
+  let cfg =
+    config.new(
+      input: "test/fixtures/deep_object_composite_property.yaml",
+      output_server: "./test_output/api",
+      output_client: "./test_output_client/api",
+      package: "api",
+      mode: config.Client,
+      validate: False,
+    )
+  let assert Ok(summary) = generate.generate(unresolved, cfg)
+  let assert Ok(client_file) =
+    list.find(summary.files, fn(f) { f.path == "client.gleam" })
+  let content = client_file.content
+
+  // The composite `address` property serialises to a JSON string
+  // under the deepObject bracketed key.
+  string.contains(content, "\"customer_details[address]\"")
+  |> should.be_true()
+  string.contains(
+    content,
+    "json.to_string(encode_get_invoices_upcoming_param_customer_details_address_json(",
+  )
+  |> should.be_true()
+  // Sibling `email` property keeps the existing bracket encoding.
+  string.contains(content, "\"customer_details[email]\"")
+  |> should.be_true()
+}


### PR DESCRIPTION
## Summary

Three changes that together let the unmodified Stripe OpenAPI spec
finish generation with **zero validate errors**:

1. **Query array parameters with non-primitive items** take the JSON
   escape hatch on the client side (`<param>=<JSON array string>`).
   Items of type object / composite that previously panicked in
   `to_string_fn` now flow through `json.array(value, encoder)` and
   `json.to_string`. Server mode still rejects with a server-only
   diagnostic.

2. **deepObject query parameters with composite sub-properties**
   (`oneOf` / `anyOf` / `allOf`) take the same JSON escape hatch
   per property: `parent[<prop>]=<JSON string>`. Sibling primitive
   / object properties keep the existing bracket encoding. Server
   mode still rejects.

3. **Removed the four panic branches in `schema_dispatch.gleam`**
   (`decoder_expr`, `json_encoder_expr`, `json_encoder_fn`,
   `to_string_fn`) for inline composite schemas. Replaced with
   permissive fallbacks (`dyn_decode.dynamic`, `json.null()`,
   `fn(_) { json.null() }`, `fn(_) { \"\" }`). The hoist contract is
   still enforced by validate and unit tests; removing the panics
   means a hoist gap surfaces as a runtime null/empty payload
   instead of a build-time crash. This was the original "panic removal"
   item from PR #542's scope.

### Effect on Stripe

Validate-time errors drop from **11 to 0**. Generation of the
upstream `stripe.yaml` (4.3 MB, 654 operations) finishes
successfully with no spec edits.

### Test plan

- [x] `gleam check`, `gleam test` (368 tests pass; 2 new TDD cases)
- [x] `gleam format --check src/ test/`
- [x] `gleam run -m glinter -- --stats` (0 active errors)
- [x] `bash integration_test/run.sh` (all integration tests still pass)
- [x] Local Stripe spec generation: 0 errors, 7 generated files
