### PR TITLE
docs(transport): document first-occurrence-wins for default headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Documentation
+
+- `oaspec/transport.with_default_headers` and
+  `with_default_header` docstrings now spell out the dedup contracts
+  explicitly. The list form is **first-occurrence-wins** (e.g.
+  `[#("X-Env", "staging"), #("X-Env", "prod")]` keeps `staging` and
+  silently drops `prod`); the wrapper form is
+  **outermost-wrapper-wins** when piping the same name through
+  multiple `with_default_header` calls. Pick one shape per code path
+  to avoid surprises. New tests pin the list-form rule for duplicate
+  names (case-insensitive dedup, order preserved between distinct
+  names). The wrapper-form composition rule is documented but tested
+  separately in #555. (#547)
+
 ## [0.59.0] - 2026-05-07
 
 This release lifts oaspec's `application/x-www-form-urlencoded`,

--- a/src/oaspec/transport.gleam
+++ b/src/oaspec/transport.gleam
@@ -212,9 +212,21 @@ pub fn with_base_url(
   fn(req: Request) { send(Request(..req, base_url: Some(base_url))) }
 }
 
-// Inject a single header when the request does not already declare it.
-// Explicit request headers win — middleware never clobbers them, and the
-// helper works with both sync and async send functions.
+/// Inject a single default header when the request does not already
+/// declare it. Header-name comparison is case-insensitive (per RFC 7230),
+/// so a request that already carries `x-trace-id` blocks a default
+/// `X-Trace-Id`. Explicit request headers always win — middleware never
+/// clobbers them — and the helper works with both sync and async send
+/// functions.
+///
+/// **Composition order.** Each call wraps the previous send. When two
+/// `with_default_header` wrappers target the same name (case-insensitive),
+/// the **outermost** wrapper (the one most recently piped in) wins,
+/// because the request reaches it first and inserts before the inner
+/// check runs. This is the *opposite* of the list form below — see
+/// `with_default_headers` for the in-list rule. Reach for the
+/// `with_default_headers([...])` shape if you want a single source of
+/// truth for the dedup ordering.
 pub fn with_default_header(
   send send: fn(Request) -> a,
   name name: String,
@@ -231,9 +243,25 @@ pub fn with_default_header(
   }
 }
 
-// Inject a list of default headers. Iteration order is preserved so callers
-// get deterministic ordering on the wire, and the helper works with both sync
-// and async send functions.
+/// Inject a list of default headers when the request does not already
+/// declare them. Iteration order is preserved so callers get
+/// deterministic ordering on the wire, and the helper works with both
+/// sync and async send functions.
+///
+/// **Duplicate names within `headers`.** Header-name comparison is
+/// case-insensitive (per RFC 7230). When the supplied list contains the
+/// same name twice (e.g. `[#("X-Env", "staging"), #("X-Env", "prod")]`),
+/// the **first occurrence is kept** and subsequent entries with the
+/// same name are silently dropped. Headers already present on the
+/// inbound request always win over every entry in `headers` regardless
+/// of position.
+///
+/// This is the *opposite* of the wrapper form's composition rule (see
+/// `with_default_header`, where the outermost wrapper wins). The two
+/// rules are each correct in isolation: the list form picks the first
+/// caller-supplied entry; the wrapper form picks the most recently
+/// piped wrapper. Pick one shape per code path and stick to it to
+/// avoid surprises.
 pub fn with_default_headers(
   send send: fn(Request) -> a,
   headers headers: List(#(String, String)),

--- a/test/transport_test.gleam
+++ b/test/transport_test.gleam
@@ -189,6 +189,56 @@ pub fn with_default_headers_skips_existing_test() {
   |> should.equal(Ok("default"))
 }
 
+// Pin the documented "first occurrence wins" rule for duplicate names
+// inside the supplied list. The reverse rule ("last wins") is more common
+// in HTTP intuition, so the surprising-but-deterministic contract is
+// exercised explicitly. (#547)
+pub fn with_default_headers_first_occurrence_wins_for_duplicates_test() {
+  let send =
+    transport.with_default_headers(echo_to_response(), [
+      #("X-Env", "staging"),
+      #("X-Env", "prod"),
+    ])
+  let assert Ok(resp) = send(empty_request())
+  resp.headers
+  |> list.key_find("X-Env")
+  |> should.equal(Ok("staging"))
+}
+
+pub fn with_default_headers_dedup_is_case_insensitive_test() {
+  let send =
+    transport.with_default_headers(echo_to_response(), [
+      #("X-Env", "staging"),
+      #("x-env", "prod"),
+    ])
+  let assert Ok(resp) = send(empty_request())
+  resp.headers
+  |> list.key_find("X-Env")
+  |> should.equal(Ok("staging"))
+  // The lower-case duplicate must not slip in under a different key.
+  resp.headers
+  |> list.key_find("x-env")
+  |> should.equal(Error(Nil))
+}
+
+pub fn with_default_headers_first_wins_preserves_order_for_others_test() {
+  // [#("X-A", "a"), #("X-B", "b"), #("X-A", "c")] — the second X-A is
+  // dropped, but the X-B between them survives in input order.
+  let send =
+    transport.with_default_headers(echo_to_response(), [
+      #("X-A", "a"),
+      #("X-B", "b"),
+      #("X-A", "c"),
+    ])
+  let assert Ok(resp) = send(empty_request())
+  let kept =
+    list.filter(resp.headers, fn(h) {
+      let #(k, _) = h
+      k == "X-A" || k == "X-B"
+    })
+  kept |> should.equal([#("X-A", "a"), #("X-B", "b")])
+}
+
 // ---------------------------------------------------------------------------
 // with_security: bearer
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`oaspec/transport.with_default_headers` folds the supplied list with `has_header(acc, name)` as the dedup key — an inline comment explained that this is the "first-occurrence wins" behaviour, but the **public docstring did not say so**. Callers reasonably guessed one of three other rules (last-occurrence wins, duplicates kept, error on duplicates), and none matched the actual contract. The doc gap is a foot-gun.

This PR documents the rule explicitly on both `with_default_headers` (list form) and `with_default_header` (wrapper form), with a pointer at the inverse rule between them, and pins the list-form contract with three new tests.

## Changes

- **Docstring on `with_default_headers/2`**: explicit "first-occurrence wins" rule with example, case-insensitivity note (per RFC 7230), and pointer at the wrapper-form composition rule.
- **Docstring on `with_default_header/3`**: explicit "outermost wrapper wins" composition rule with rationale ("the request reaches the outermost wrapper first and inserts before the inner check runs"), plus a pointer at the inverse list-form rule.
- **Three new tests** in `test/transport_test.gleam`:
  - `with_default_headers_first_occurrence_wins_for_duplicates_test` — `[#("X-Env", "staging"), #("X-Env", "prod")]` keeps `staging`.
  - `with_default_headers_dedup_is_case_insensitive_test` — `X-Env` and `x-env` collide; the lowercase entry does not slip in under a different key.
  - `with_default_headers_first_wins_preserves_order_for_others_test` — when a duplicate dedup happens, distinct names between still keep input order.
- **CHANGELOG entry** under `[Unreleased]` / `### Documentation`.

## Design decisions

- I did **not** add the optional `with_overriding_headers/2` sibling (last-occurrence wins) the issue mentions. The audit's primary concern is the doc gap, and adding the sibling is a separate API decision that deserves its own issue. The new docstrings call out the alternative ("pick one shape per code path") without prescribing it.
- The wrapper-form composition rule (`with_default_header` outermost wins) is **documented** in this PR but its dedicated property test is reserved for #555 (the companion issue that catalogues the same rule from the wrapper-form angle). This PR's tests focus on the list-form rule per #547's scope.

## Breaking change

None. Doc + tests only — no code path changed.

Closes #547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified header deduplication behavior in middleware: header names are matched case-insensitively, with the first occurrence winning in list form and outermost wrapper winning in composition.

* **Tests**
  * Added tests verifying header deduplication behavior, including case-insensitive matching and order preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->