### PR TITLE
docs(transport): document with_default_header outermost-wins composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ within `Changed` / `Fixed` and stay as-is.
   names (case-insensitive dedup, order preserved between distinct
   names). The wrapper-form composition rule is documented but tested
   separately in #555. (#547)
+- The transport module gains a "Header middleware composition" comment
+  block above the `with_default_header*` family that summarises both
+  rules side-by-side, and the wrapper-form composition rule
+  (`with_default_header` outermost wins) is now pinned by three new
+  tests: same name → outermost wrapper wins, same rule under
+  case-insensitive name comparison, and an explicit request header
+  beats every stacked wrapper layer. The two rules are inverse to
+  each other; the docs and tests now make that explicit so users do
+  not mistake one for the other when mixing the two shapes. (#555)
 
 ## [0.59.0] - 2026-05-07
 

--- a/src/oaspec/transport.gleam
+++ b/src/oaspec/transport.gleam
@@ -201,6 +201,22 @@ fn add_credential(creds: Credentials, entry: CredentialEntry) -> Credentials {
 // Send middleware
 // ---------------------------------------------------------------------------
 
+// Header-middleware composition rules at a glance:
+//
+// - `with_default_header` (single name/value, wrapper form) — each call
+//   wraps the previous send. When two wrappers target the same name
+//   (case-insensitive), the **outermost** wrapper (the one most recently
+//   piped in) wins, because the request reaches it first and inserts
+//   before the inner check runs.
+// - `with_default_headers` (list form) — when the supplied list contains
+//   the same name twice, the **first occurrence** is kept and the rest
+//   are silently dropped.
+//
+// The two rules are each correct in isolation but inverse to each other.
+// Pick one shape per code path to avoid surprises. In both forms,
+// headers already on the inbound request always win — middleware never
+// clobbers explicit caller intent.
+
 // Override the request's base URL. Always wins over any `base_url` set
 // by the request builder, so callers can target staging / proxy hosts
 // without regenerating clients. Works with both `transport.Send` and

--- a/test/transport_test.gleam
+++ b/test/transport_test.gleam
@@ -239,6 +239,53 @@ pub fn with_default_headers_first_wins_preserves_order_for_others_test() {
   kept |> should.equal([#("X-A", "a"), #("X-B", "b")])
 }
 
+// Pin the wrapper-form composition rule: when two with_default_header
+// wrappers target the same name, the OUTERMOST wrapper (the one most
+// recently piped in) wins, because the request reaches it first. This
+// is the inverse of the list-form rule above (#555).
+pub fn with_default_header_outermost_wrapper_wins_for_same_name_test() {
+  let send =
+    echo_to_response()
+    |> transport.with_default_header(name: "X-Trace", value: "v1")
+    |> transport.with_default_header(name: "X-Trace", value: "v2")
+  let assert Ok(resp) = send(empty_request())
+  resp.headers
+  |> list.key_find("X-Trace")
+  |> should.equal(Ok("v2"))
+}
+
+pub fn with_default_header_outermost_wins_is_case_insensitive_test() {
+  // Same composition rule, but the inner wrapper uses a lower-case
+  // name. The outer wrapper still wins because the request reaches it
+  // first; the inner wrapper sees the already-set header and skips.
+  let send =
+    echo_to_response()
+    |> transport.with_default_header(name: "x-trace", value: "v1")
+    |> transport.with_default_header(name: "X-Trace", value: "v2")
+  let assert Ok(resp) = send(empty_request())
+  resp.headers
+  |> list.key_find("X-Trace")
+  |> should.equal(Ok("v2"))
+  // Lower-case duplicate must not slip in under a different key.
+  resp.headers
+  |> list.key_find("x-trace")
+  |> should.equal(Error(Nil))
+}
+
+pub fn with_default_header_explicit_request_header_beats_all_wrappers_test() {
+  // An explicit request header beats every wrapper layer regardless
+  // of how many with_default_header calls are stacked above it.
+  let send =
+    echo_to_response()
+    |> transport.with_default_header(name: "X-Trace", value: "wrapper-1")
+    |> transport.with_default_header(name: "X-Trace", value: "wrapper-2")
+  let req = Request(..empty_request(), headers: [#("X-Trace", "explicit")])
+  let assert Ok(resp) = send(req)
+  resp.headers
+  |> list.key_find("X-Trace")
+  |> should.equal(Ok("explicit"))
+}
+
 // ---------------------------------------------------------------------------
 // with_security: bearer
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`with_default_header` wraps a `Send`; each pipe (`|>`) layers a new wrapper. When two wrappers target the same name, the **outermost** wrapper (the one most recently piped) wins, because the request reaches it first and the inner wrapper's `has_header` check skips. The user-facing intuition "later in the pipe = closer to the wire" matches this, but it is the **inverse** of the list-form rule (`with_default_headers`, first-occurrence-wins, documented in #547).

The two rules are each correct in isolation but confuse users who mix the shapes. This PR is the companion to #547: the list-form rule was already pinned there; this PR pins the wrapper-form rule and surfaces the side-by-side comparison.

## Changes

- **New "Header middleware composition" comment block** above the `with_default_header*` family in `src/oaspec/transport.gleam`. Summarises both rules at a glance with their inverse relationship called out, and notes that explicit request headers always win regardless of form.
- **Three new tests** in `test/transport_test.gleam`:
  - `with_default_header_outermost_wrapper_wins_for_same_name_test` — pins the wrapper-form rule from the issue's reproducer (`v1` then `v2` → request gets `v2`).
  - `with_default_header_outermost_wins_is_case_insensitive_test` — same rule when the inner wrapper uses lower-cased name; no duplicate slips in under the lower-cased key.
  - `with_default_header_explicit_request_header_beats_all_wrappers_test` — explicit request headers beat every stacked wrapper layer, regardless of how many `with_default_header` calls sit above them.
- **CHANGELOG entry** under `[Unreleased]` / `### Documentation`, cross-referencing #547.

## Design decisions

- I did not add a separate Markdown / module-level "Header middleware composition" doc page beyond the in-source comment block. The transport module's existing approach is to keep contracts close to the function definitions, and the comment block plus the docstrings (already cross-referencing each other from #547) cover the same surface without splitting the doc across files.
- The new tests assert behaviour, not message strings — there's no panic in this code path, so there's nothing format-sensitive to pin.

## Breaking change

None. Doc + tests only.

Closes #555
