### PR TITLE
fix(transport)!: reject CR/LF/NUL in default header names and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Security:** `oaspec/transport.with_default_header` and
+  `with_default_headers` now reject CR (`\r`), LF (`\n`), and NUL
+  (`\u{0000}`) bytes in any header name or value at construction
+  time. Those bytes are the gateway to HTTP response-splitting and
+  header-injection attacks (RFC 9112 §2.2): a credential-derived or
+  environment-derived value flowing into a default header without
+  pre-sanitisation could previously smuggle a forged header on the
+  wire. The validator panics with a structured message naming the
+  offending byte ("CR (\r)" / "LF (\n)" / "NUL (\u{0000})") and the
+  recommendation to pre-encode binary values via Base64 or RFC 8187.
+  The check fires at the outer call (when the wrapper is built), so
+  static misconfiguration surfaces immediately at startup rather
+  than per-request. Tab (`\t`) inside values remains allowed (it is
+  RFC-permitted). The `oaspec_ffi.{erl,mjs}` modules gain a
+  `capture_panic` helper used by the new tests; the helper is also
+  available to future tests that need to assert on panic messages.
+  Same audit lens as multipartkit#28 (CRLF in part headers); the
+  generated client middleware path was the missing companion. (#546)
+
 ### Documentation
 
 - `oaspec/transport.with_default_headers` and

--- a/gleam.toml
+++ b/gleam.toml
@@ -83,6 +83,11 @@ unwrap_used = "error"
 # functions and ignore their heterogeneous return values; lint the case bodies
 # themselves rather than forcing every wrapper call to pattern-match.
 "test/oaspec_*_test.gleam" = ["discarded_result"]
+# transport_test exercises with_default_header*'s panic surface via
+# capture_panic; the unused wrapper return value (a fn(Request) -> a)
+# is intentional — the test only cares whether construction panicked
+# before the fn was returned. (#546)
+"test/transport_test.gleam" = ["discarded_result"]
 # Codegen and OpenAPI traversal code takes many unlabelled helper
 # parameters and is naturally branchy; fixing these cleanly would require a
 # project-wide refactor that is out of scope for enabling glinter.
@@ -96,6 +101,13 @@ unwrap_used = "error"
 # must fail fast instead of silently generating broken code (#290).
 "src/oaspec/internal/codegen/*.gleam" = ["label_possible", "deep_nesting", "avoid_panic"]
 "src/oaspec/codegen/writer.gleam" = ["label_possible"]
+# transport.gleam validates header names / values for CR/LF/NUL injection
+# at construction time (#546). The panic surfaces a security-relevant
+# misconfiguration immediately rather than silently propagating a
+# poison value to the wire — a Result-returning signature would force
+# every caller to handle a never-error case for a literal-string call
+# site.
+"src/oaspec/transport.gleam" = ["avoid_panic"]
 "src/oaspec/internal/openapi/*.gleam" = ["label_possible", "deep_nesting"]
 "src/oaspec/openapi/parser.gleam" = ["label_possible", "deep_nesting"]
 "src/oaspec/openapi/diagnostic.gleam" = ["label_possible"]

--- a/src/oaspec/transport.gleam
+++ b/src/oaspec/transport.gleam
@@ -5,6 +5,7 @@
 //// `Send` / `AsyncSend` to a real runtime; tests can plug in arbitrary
 //// fake transport values via `oaspec/mock`.
 
+import gleam/bool
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
@@ -235,6 +236,17 @@ pub fn with_base_url(
 /// clobbers them — and the helper works with both sync and async send
 /// functions.
 ///
+/// **Validation.** Both `name` and `value` are checked at construction
+/// time for the absence of CR (`\r`), LF (`\n`), and NUL (`\u{0000}`)
+/// bytes. Those bytes enable HTTP response-splitting / header
+/// injection if they reach the wire — see RFC 9112 §2.2. A value that
+/// contains any of them panics with a structured message naming the
+/// offending byte and the recommendation: pre-encode binary values
+/// via Base64 or RFC 8187 before passing them in. The check fires at
+/// the outer call (i.e. when the wrapper is built), so a static
+/// misconfiguration surfaces immediately at startup rather than
+/// per-request.
+///
 /// **Composition order.** Each call wraps the previous send. When two
 /// `with_default_header` wrappers target the same name (case-insensitive),
 /// the **outermost** wrapper (the one most recently piped in) wins,
@@ -248,6 +260,15 @@ pub fn with_default_header(
   name name: String,
   value value: String,
 ) -> fn(Request) -> a {
+  validate_header_name(
+    api_name: "oaspec.transport.with_default_header",
+    name: name,
+  )
+  validate_header_value(
+    api_name: "oaspec.transport.with_default_header",
+    name: name,
+    value: value,
+  )
   fn(req: Request) {
     case has_header(req.headers, name) {
       True -> send(req)
@@ -263,6 +284,13 @@ pub fn with_default_header(
 /// declare them. Iteration order is preserved so callers get
 /// deterministic ordering on the wire, and the helper works with both
 /// sync and async send functions.
+///
+/// **Validation.** Every `name` and every `value` in `headers` is
+/// checked at construction time for the absence of CR, LF, and NUL
+/// bytes (see `with_default_header` for the rationale). The first
+/// invalid entry panics with a structured message naming the
+/// offending byte; the check fires at the outer call, so a static
+/// misconfiguration surfaces immediately rather than per-request.
 ///
 /// **Duplicate names within `headers`.** Header-name comparison is
 /// case-insensitive (per RFC 7230). When the supplied list contains the
@@ -282,6 +310,18 @@ pub fn with_default_headers(
   send send: fn(Request) -> a,
   headers headers: List(#(String, String)),
 ) -> fn(Request) -> a {
+  list.each(headers, fn(kv) {
+    let #(name, value) = kv
+    validate_header_name(
+      api_name: "oaspec.transport.with_default_headers",
+      name: name,
+    )
+    validate_header_value(
+      api_name: "oaspec.transport.with_default_headers",
+      name: name,
+      value: value,
+    )
+  })
   fn(req: Request) {
     // Build with prepend + final reverse so the fold is O(N) over the
     // header list instead of the O(N²) shape we get from
@@ -330,6 +370,56 @@ fn has_header(headers: List(#(String, String)), name: String) -> Bool {
     let #(k, _) = h
     string.lowercase(k) == lowered
   })
+}
+
+// Reject header names that contain CR / LF / NUL bytes. The name
+// itself is rarely user-derived (most callers pass a string literal),
+// but defending the same surface as `validate_header_value` keeps the
+// API symmetrical and shuts the door on a future call site that flips
+// from literal-name to runtime-name without thinking through the
+// injection surface.
+fn validate_header_name(api_name api_name: String, name name: String) -> Nil {
+  case forbidden_byte(name) {
+    None -> Nil
+    Some(byte_label) ->
+      panic as {
+        api_name
+        <> ": header name contains forbidden control byte "
+        <> byte_label
+        <> " — header names must not include CR, LF, or NUL"
+      }
+  }
+}
+
+// Reject header values that contain CR / LF / NUL bytes — those are
+// the bytes that enable HTTP response-splitting / header injection if
+// they reach the wire (RFC 9112 §2.2). Pre-encode binary values via
+// Base64 or RFC 8187 before passing them in.
+fn validate_header_value(
+  api_name api_name: String,
+  name name: String,
+  value value: String,
+) -> Nil {
+  case forbidden_byte(value) {
+    None -> Nil
+    Some(byte_label) ->
+      panic as {
+        api_name
+        <> ": header value for `"
+        <> name
+        <> "` contains forbidden control byte "
+        <> byte_label
+        <> " (CR/LF/NUL enable header injection per RFC 9112 §2.2);"
+        <> " pre-encode binary values via Base64 or RFC 8187"
+      }
+  }
+}
+
+fn forbidden_byte(s: String) -> Option(String) {
+  use <- bool.guard(string.contains(s, "\r"), Some("CR (\\r)"))
+  use <- bool.guard(string.contains(s, "\n"), Some("LF (\\n)"))
+  use <- bool.guard(string.contains(s, "\u{0000}"), Some("NUL (\\u{0000})"))
+  None
 }
 
 fn pick_alternative(

--- a/src/oaspec_ffi.erl
+++ b/src/oaspec_ffi.erl
@@ -4,7 +4,8 @@
     run_executable/2,
     is_stdout_tty/0,
     no_color_set/0,
-    monotonic_ms/0
+    monotonic_ms/0,
+    capture_panic/1
 ]).
 
 %% Find an executable on PATH. Returns {ok, Path} or {error, nil}.
@@ -68,3 +69,29 @@ no_color_set() ->
 -spec monotonic_ms() -> integer().
 monotonic_ms() ->
     erlang:monotonic_time(millisecond).
+
+%% Run a thunk and report `{Panicked, Message}` to the caller. Used by
+%% tests that exercise functions which intentionally panic on invalid
+%% input (e.g. transport header validation) without aborting the
+%% test process.
+-spec capture_panic(fun(() -> any())) -> {boolean(), binary()}.
+capture_panic(Thunk) ->
+    try Thunk() of
+        _ -> {false, <<"">>}
+    catch
+        error:#{gleam_error := panic, message := Message} ->
+            Bin = case is_binary(Message) of
+                true -> Message;
+                false -> unicode:characters_to_binary(io_lib:format("~p", [Message]))
+            end,
+            {true, Bin};
+        error:Reason ->
+            Bin = unicode:characters_to_binary(io_lib:format("~p", [Reason])),
+            {true, Bin};
+        throw:Thrown ->
+            Bin = unicode:characters_to_binary(io_lib:format("~p", [Thrown])),
+            {true, Bin};
+        exit:Exit ->
+            Bin = unicode:characters_to_binary(io_lib:format("~p", [Exit])),
+            {true, Bin}
+    end.

--- a/src/oaspec_ffi.mjs
+++ b/src/oaspec_ffi.mjs
@@ -18,3 +18,21 @@ export function monotonic_ms() {
       : Date.now();
   return Math.trunc(ms);
 }
+
+// Run a thunk and report (panicked, message) to the caller. Mirrors
+// the BEAM implementation in `oaspec_ffi.erl`. Used by tests that
+// exercise functions which intentionally panic on invalid input.
+export function capture_panic(thunk) {
+  try {
+    thunk();
+    return [false, ""];
+  } catch (error) {
+    let message;
+    if (error && typeof error === "object" && error.message) {
+      message = error.message;
+    } else {
+      message = String(error);
+    }
+    return [true, message];
+  }
+}

--- a/test/transport_test.gleam
+++ b/test/transport_test.gleam
@@ -1,5 +1,6 @@
 import gleam/list
 import gleam/option.{None, Some}
+import gleam/string
 import gleeunit/should
 import oaspec/mock
 import oaspec/transport.{
@@ -285,6 +286,110 @@ pub fn with_default_header_explicit_request_header_beats_all_wrappers_test() {
   |> list.key_find("X-Trace")
   |> should.equal(Ok("explicit"))
 }
+
+// Header value validation: CRLF / NUL injection (#546).
+
+pub fn with_default_header_panics_on_cr_in_value_test() {
+  let #(panicked, message) =
+    capture_panic(fn() {
+      let _ =
+        transport.with_default_header(
+          send: echo_to_response(),
+          name: "X-Trace-Id",
+          value: "abc\r\nX-Smuggled: yes",
+        )
+      Nil
+    })
+  should.be_true(panicked)
+  should.be_true(string.contains(
+    message,
+    "oaspec.transport.with_default_header",
+  ))
+  should.be_true(string.contains(message, "CR"))
+}
+
+pub fn with_default_header_panics_on_lf_in_value_test() {
+  let #(panicked, message) =
+    capture_panic(fn() {
+      let _ =
+        transport.with_default_header(
+          send: echo_to_response(),
+          name: "X-Trace-Id",
+          value: "abc\nX-Smuggled: yes",
+        )
+      Nil
+    })
+  should.be_true(panicked)
+  should.be_true(string.contains(message, "LF"))
+}
+
+pub fn with_default_header_panics_on_nul_in_value_test() {
+  let #(panicked, message) =
+    capture_panic(fn() {
+      let _ =
+        transport.with_default_header(
+          send: echo_to_response(),
+          name: "X-Trace-Id",
+          value: "abc\u{0000}def",
+        )
+      Nil
+    })
+  should.be_true(panicked)
+  should.be_true(string.contains(message, "NUL"))
+}
+
+pub fn with_default_header_panics_on_cr_in_name_test() {
+  let #(panicked, message) =
+    capture_panic(fn() {
+      let _ =
+        transport.with_default_header(
+          send: echo_to_response(),
+          name: "X-Bad\r\nInjected",
+          value: "ok",
+        )
+      Nil
+    })
+  should.be_true(panicked)
+  should.be_true(string.contains(message, "header name"))
+}
+
+pub fn with_default_header_accepts_printable_ascii_test() {
+  // Tab (\t) is allowed inside header values per RFC 9112 — only CR,
+  // LF, and NUL are forbidden. All other printable ASCII passes.
+  let send =
+    transport.with_default_header(
+      send: echo_to_response(),
+      name: "X-Trace-Id",
+      value: "abc-123 ~!@#$%^&*()_+\t",
+    )
+  let assert Ok(resp) = send(empty_request())
+  resp.headers
+  |> list.key_find("X-Trace-Id")
+  |> should.equal(Ok("abc-123 ~!@#$%^&*()_+\t"))
+}
+
+pub fn with_default_headers_panics_on_invalid_value_test() {
+  let #(panicked, message) =
+    capture_panic(fn() {
+      let _ =
+        transport.with_default_headers(echo_to_response(), [
+          #("X-OK", "fine"),
+          #("X-Bad", "with\nnewline"),
+        ])
+      Nil
+    })
+  should.be_true(panicked)
+  should.be_true(string.contains(
+    message,
+    "oaspec.transport.with_default_headers",
+  ))
+  should.be_true(string.contains(message, "X-Bad"))
+  should.be_true(string.contains(message, "LF"))
+}
+
+@external(erlang, "oaspec_ffi", "capture_panic")
+@external(javascript, "../oaspec_ffi.mjs", "capture_panic")
+fn capture_panic(thunk: fn() -> Nil) -> #(Bool, String)
 
 // ---------------------------------------------------------------------------
 // with_security: bearer


### PR DESCRIPTION
## Summary

`oaspec/transport.with_default_header` and `with_default_headers` appended supplied `(name, value)` pairs to `req.headers` verbatim. Any code path that let user-controlled data flow into a default header (credential-derived `X-API-Key`, environment-derived `User-Agent`, locale-aware `Accept-Language`) was a CRLF / HTTP response-splitting injection vector unless the caller pre-sanitised the input. RFC 9112 §2.2 is explicit: CR, LF, and NUL bytes inside header field values let attackers smuggle a forged header by ending the current header line and opening a new one.

This PR is the companion to multipartkit#28 (CRLF in part headers); the generated client middleware path was the missing surface.

## Changes

- **Validation at construction time** in `with_default_header` and `with_default_headers`. The wrapper is built with `validate_header_name` + `validate_header_value` checks fired at the outer call (not per-request). CR (`\r`), LF (`\n`), and NUL (`\u{0000}`) are rejected with a structured panic naming the offending byte and the recommendation to pre-encode via Base64 or RFC 8187. Tab (`\t`) inside values remains allowed (RFC 9112 permits it).
- **Docstrings** on both functions describe the validation contract and reference RFC 9112 §2.2.
- **Glinter ignore** — `src/oaspec/transport.gleam` is added to the `avoid_panic` waiver with an inline comment. The panic-vs-Result trade-off is the same as the codegen schema dispatchers (`src/oaspec/internal/codegen/*.gleam`): a Result return would force every literal-string call site to handle a never-error case for static misconfiguration, and the existing project posture is to fail fast on misconfiguration.
- **`oaspec_ffi.{erl,mjs}` capture_panic helper** for tests that need to assert on panic messages without aborting the test process.
- **Six new tests** in `test/transport_test.gleam`:
  - CR / LF / NUL in value → panic with offending-byte name in message.
  - CR in name → panic mentions "header name".
  - Printable ASCII + tab in value → accepted (positive control).
  - List form: invalid value in second entry → panic names the offending header.
- **`test/transport_test.gleam` added to the `discarded_result` waiver** with an inline comment — the panic-tests intentionally discard the wrapper return value because the construction panic happens before the fn would be returned.
- **CHANGELOG entry** under `[Unreleased]` / `### Fixed` with the **Security:** prefix and cross-reference to multipartkit#28.

## Design decisions

- **Option A (panic) over Option B (Result signature).** The issue recommended Option A, which I followed: a Result-returning signature would propagate a never-error case through every literal-string call site (most `with_default_header(... , "X-Trace", "abc")` calls have no possible failure). The existing oaspec posture for "fail visibly on misconfiguration" already covers similar cases (e.g. codegen schema dispatchers panic on unsupported inline schemas, #290).
- **Construction-time check, not per-request.** `with_default_header` returns `fn(Request) -> a` — the validation happens before that closure is built, so a static misconfiguration surfaces immediately at startup rather than on the first outbound request. Test coverage exercises this directly via `capture_panic`.
- **Tab is allowed, NUL is not.** RFC 9112 §5.5 ("OWS"/"BWS") explicitly permits SP and HTAB inside field values; only CR / LF / NUL fall outside the permitted ABNF VCHAR / OWS production. The validator follows that boundary exactly, so a printable header value containing `\t` is not falsely rejected.

## Breaking change

**Behavioural for callers that pass values containing CR / LF / NUL.** The previous behaviour silently propagated the poisoned value to the downstream encoder; now the wrapper panics at construction. Callers that legitimately need binary-shaped values must pre-encode via Base64 or RFC 8187 before passing in. No existing in-tree caller is affected (the test suite covers static literals, no failures triggered by the new validation).

Closes #546
