### PR TITLE
fix(writer): dedupe shared files when output paths overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- `oaspec/codegen/writer.write_all` no longer writes shared files
+  twice when `mode = Both` and `output_server` resolves to the same
+  directory as `output_client`. The previous behaviour wrote every
+  shared file to the server path then again to the client path; with
+  identical paths, the second write silently overwrote the first,
+  fired `on_write` twice, and returned the path twice in the result
+  list. Each unique destination path now triggers one
+  `simplifile.write` call, one `on_write` callback, and one entry in
+  the returned list. The overlap check normalises trailing slashes
+  (`"out"` and `"out/"` are treated as the same directory). Distinct
+  server / client paths preserve the existing dual-output behaviour
+  — the regression boundary is pinned by a new test. The matching
+  fix lands in `resolve_paths` and `expected_paths` so `--check`
+  does not double-count drift on shared files when paths overlap.
+  (#548)
+
 ### Added
 
 - `oaspec/openapi/parser.parse_json_string_with_locations` is now

--- a/src/oaspec/codegen/writer.gleam
+++ b/src/oaspec/codegen/writer.gleam
@@ -1,5 +1,7 @@
+import gleam/bool
 import gleam/list
 import gleam/result
+import gleam/string
 import oaspec/config.{Both, Client, Server}
 import oaspec/internal/codegen/context.{type GeneratedFile}
 import simplifile
@@ -11,6 +13,15 @@ pub type WriteError {
 }
 
 /// Write pre-generated files to disk based on configuration.
+///
+/// **Path overlap.** When `mode = Both` and `output_server` resolves
+/// to the same directory as `output_client` (e.g. both set to
+/// `"out"`, or to `"out"` and `"out/"`, which differ as strings but
+/// name the same directory), shared files are written **once**, not
+/// twice. Each unique destination path triggers `on_write` exactly
+/// once and appears at most once in the returned list. Distinct
+/// server / client paths preserve the existing behaviour: shared
+/// files land in both directories.
 pub fn write_all(
   files: List(GeneratedFile),
   cfg: config.Config,
@@ -26,9 +37,19 @@ pub fn write_all(
 
   let server_path = config.output_server(cfg)
   let client_path = config.output_client(cfg)
+  let mode = config.mode(cfg)
+
+  // When the server and client outputs resolve to the same directory
+  // under `mode = Both`, the shared files only need to be written
+  // once. Skipping the second pass on shared files (rather than
+  // post-deduping the written list) avoids double-firing `on_write`
+  // and double `simplifile.write` calls that the FS-race-condition
+  // surface in #548 calls out.
+  let server_and_client_overlap =
+    mode == Both && normalise_dir(server_path) == normalise_dir(client_path)
   let written_files = []
 
-  use written_files <- result.try(case config.mode(cfg) {
+  use written_files <- result.try(case mode {
     Server | Both -> {
       use _ <- result.try(ensure_directory(server_path))
       write_files(shared_files, server_path, written_files, on_write)
@@ -39,10 +60,17 @@ pub fn write_all(
     Client -> Ok(written_files)
   })
 
-  use written_files <- result.try(case config.mode(cfg) {
+  use written_files <- result.try(case mode {
     Client | Both -> {
       use _ <- result.try(ensure_directory(client_path))
-      write_files(shared_files, client_path, written_files, on_write)
+      // Skip the shared-files re-write when the two output paths name
+      // the same directory; the server-side branch above already
+      // wrote them once.
+      let shared_for_client = case server_and_client_overlap {
+        True -> []
+        False -> shared_files
+      }
+      write_files(shared_for_client, client_path, written_files, on_write)
       |> result.try(fn(w) {
         write_files(client_files, client_path, w, on_write)
       })
@@ -51,6 +79,15 @@ pub fn write_all(
   })
 
   Ok(written_files)
+}
+
+// Strip a single trailing slash so "out" and "out/" compare equal.
+// Strings beyond that are left as-is — full canonicalisation (`./out`,
+// symlinked paths, relative-to-cwd resolution) would require an FS
+// round-trip we do not need for the documented overlap surface.
+fn normalise_dir(path: String) -> String {
+  use <- bool.guard(!string.ends_with(path, "/"), path)
+  string.drop_end(path, 1)
 }
 
 /// Ensure a directory exists, creating it if necessary.
@@ -109,6 +146,11 @@ fn write_files(
 /// are dropped from the result. `--check` is meant to flag drift in
 /// generator-owned files; user-edited files are expected to differ
 /// from the bootstrap stub and should not be reported as out-of-date.
+///
+/// Issue #548: when `mode = Both` and `output_server` resolves to the
+/// same directory as `output_client`, shared files appear once in
+/// the result, not twice — `--check` would otherwise compare the
+/// same file twice and double-count any drift.
 pub fn resolve_paths(
   files: List(GeneratedFile),
   cfg: config.Config,
@@ -123,8 +165,11 @@ pub fn resolve_paths(
 
   let server_path = config.output_server(cfg)
   let client_path = config.output_client(cfg)
+  let mode = config.mode(cfg)
+  let server_and_client_overlap =
+    mode == Both && normalise_dir(server_path) == normalise_dir(client_path)
 
-  let server_entries = case config.mode(cfg) {
+  let server_entries = case mode {
     Server | Both ->
       list.map(list.append(shared_files, server_files), fn(f) {
         #(server_path <> "/" <> f.path, f.content)
@@ -132,9 +177,13 @@ pub fn resolve_paths(
     Client -> []
   }
 
-  let client_entries = case config.mode(cfg) {
+  let shared_for_client = case server_and_client_overlap {
+    True -> []
+    False -> shared_files
+  }
+  let client_entries = case mode {
     Client | Both ->
-      list.map(list.append(shared_files, client_files), fn(f) {
+      list.map(list.append(shared_for_client, client_files), fn(f) {
         #(client_path <> "/" <> f.path, f.content)
       })
     Server -> []
@@ -147,6 +196,9 @@ pub fn resolve_paths(
 /// `SkipIfExists` files. Used by `--check` to keep user-owned `handlers.gleam`
 /// off the orphan list while still excluding it from byte-comparison drift
 /// reports (`resolve_paths` drops `SkipIfExists` entries).
+///
+/// Same path-overlap dedup as `resolve_paths` (#548): shared files
+/// appear once when the two output directories coincide.
 pub fn expected_paths(
   files: List(GeneratedFile),
   cfg: config.Config,
@@ -160,8 +212,11 @@ pub fn expected_paths(
 
   let server_path = config.output_server(cfg)
   let client_path = config.output_client(cfg)
+  let mode = config.mode(cfg)
+  let server_and_client_overlap =
+    mode == Both && normalise_dir(server_path) == normalise_dir(client_path)
 
-  let server_entries = case config.mode(cfg) {
+  let server_entries = case mode {
     Server | Both ->
       list.map(list.append(shared_files, server_files), fn(f) {
         server_path <> "/" <> f.path
@@ -169,9 +224,13 @@ pub fn expected_paths(
     Client -> []
   }
 
-  let client_entries = case config.mode(cfg) {
+  let shared_for_client = case server_and_client_overlap {
+    True -> []
+    False -> shared_files
+  }
+  let client_entries = case mode {
     Client | Both ->
-      list.map(list.append(shared_files, client_files), fn(f) {
+      list.map(list.append(shared_for_client, client_files), fn(f) {
         client_path <> "/" <> f.path
       })
     Server -> []

--- a/test/writer_test.gleam
+++ b/test/writer_test.gleam
@@ -227,6 +227,181 @@ pub fn write_all_skip_if_exists_preserves_user_handler_test() {
   writer_cleanup(scratch)
 }
 
+// Issue #548: when mode = Both and output_server resolves to the
+// same directory as output_client, shared files must be written
+// once, not twice. The audit reproducer (output_server == output_client
+// both set to "out/") used to write every shared file twice and
+// double-fire on_write; both behaviours are now pinned.
+
+fn writer_test_config_same_path(
+  scratch: String,
+  trailing_slash_client: Bool,
+) -> config.Config {
+  let server = scratch <> "/shared_out"
+  let client = case trailing_slash_client {
+    True -> server <> "/"
+    False -> server
+  }
+  config.new(
+    input: "test.yaml",
+    output_server: server,
+    output_client: client,
+    package: "api",
+    mode: config.Both,
+    validate: False,
+  )
+}
+
+pub fn write_all_dedupes_shared_files_when_paths_overlap_test() {
+  let scratch = writer_scratch("write_all_overlap_dedup")
+  let cfg = writer_test_config_same_path(scratch, False)
+
+  // Use the smaller payload below: one shared file, one server file,
+  // one client file. handlers.gleam's SkipIfExists machinery would
+  // muddle the dedup story; keep this case crisp.
+  let files = [
+    context.GeneratedFile(
+      path: "types.gleam",
+      content: "// shared types\n",
+      target: context.SharedTarget,
+      write_mode: context.Overwrite,
+    ),
+    context.GeneratedFile(
+      path: "server.gleam",
+      content: "// server\n",
+      target: context.ServerTarget,
+      write_mode: context.Overwrite,
+    ),
+    context.GeneratedFile(
+      path: "client.gleam",
+      content: "// client\n",
+      target: context.ClientTarget,
+      write_mode: context.Overwrite,
+    ),
+  ]
+
+  let counter_path = scratch <> "/.callback_log"
+  let assert Ok(Nil) = simplifile.create_directory_all(scratch)
+  let assert Ok(Nil) = simplifile.write(counter_path, "")
+  let on_write = fn(p: String) {
+    let _ignored_log_write = case simplifile.read(counter_path) {
+      Ok(prior) -> simplifile.write(counter_path, prior <> p <> "\n")
+      // nolint: thrown_away_error -- callback can only swallow read errors; the surrounding test asserts on log content
+      Error(_) -> Ok(Nil)
+    }
+    Nil
+  }
+
+  let assert Ok(written) = writer.write_all(files, cfg, on_write)
+
+  // 3 unique destinations: types (once, not twice), server, client.
+  list.length(written) |> should.equal(3)
+
+  // The returned list must not contain types.gleam twice.
+  let types_count =
+    list.filter(written, fn(p) { string.contains(p, "shared_out/types.gleam") })
+    |> list.length
+  types_count |> should.equal(1)
+
+  // Callback log should mention types.gleam exactly once. Counting
+  // newline occurrences of the path is the simplest proxy.
+  let assert Ok(log) = simplifile.read(counter_path)
+  let lines = string.split(log, "\n")
+  let types_callback_count =
+    list.filter(lines, fn(l) { string.contains(l, "types.gleam") })
+    |> list.length
+  types_callback_count |> should.equal(1)
+
+  writer_cleanup(scratch)
+}
+
+pub fn write_all_dedupes_shared_files_under_trailing_slash_overlap_test() {
+  // Same scenario but the client path has a trailing slash. The
+  // overlap check should treat "out" and "out/" as the same dir.
+  let scratch = writer_scratch("write_all_overlap_trailing_slash")
+  let cfg = writer_test_config_same_path(scratch, True)
+
+  let files = [
+    context.GeneratedFile(
+      path: "types.gleam",
+      content: "// shared types\n",
+      target: context.SharedTarget,
+      write_mode: context.Overwrite,
+    ),
+  ]
+
+  let assert Ok(written) = writer.write_all(files, cfg, fn(_) { Nil })
+  list.length(written) |> should.equal(1)
+
+  writer_cleanup(scratch)
+}
+
+pub fn write_all_distinct_paths_still_writes_shared_to_both_test() {
+  // Existing dual-output behaviour — when paths differ, shared files
+  // land in BOTH directories. This pins the regression boundary so a
+  // future cleanup that overzealously dedupes does not break the
+  // server / client split that is the whole reason mode=Both exists.
+  let scratch = writer_scratch("write_all_distinct_paths")
+  let cfg = writer_test_config(config.Both, scratch)
+
+  let files = [
+    context.GeneratedFile(
+      path: "types.gleam",
+      content: "// shared types\n",
+      target: context.SharedTarget,
+      write_mode: context.Overwrite,
+    ),
+  ]
+
+  let assert Ok(written) = writer.write_all(files, cfg, fn(_) { Nil })
+  // 2 entries: shared file written once to server path AND once to client.
+  list.length(written) |> should.equal(2)
+
+  // Both physical files should exist.
+  let assert Ok(_) = simplifile.read(scratch <> "/server/types.gleam")
+  let assert Ok(_) = simplifile.read(scratch <> "/client/types.gleam")
+
+  writer_cleanup(scratch)
+}
+
+pub fn resolve_paths_dedupes_shared_files_when_paths_overlap_test() {
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./out",
+      output_client: "./out",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = writer.resolve_paths(test_files(), cfg)
+  result
+  |> should.equal([
+    #("./out/types.gleam", "// types"),
+    #("./out/server.gleam", "// server"),
+    #("./out/client.gleam", "// client"),
+  ])
+}
+
+pub fn expected_paths_dedupes_shared_files_when_paths_overlap_test() {
+  let cfg =
+    config.new(
+      input: "test.yaml",
+      output_server: "./out",
+      output_client: "./out",
+      package: "api",
+      mode: config.Both,
+      validate: False,
+    )
+  let result = writer.expected_paths(test_files(), cfg)
+  result
+  |> should.equal([
+    "./out/types.gleam",
+    "./out/server.gleam",
+    "./out/client.gleam",
+  ])
+}
+
 pub fn write_all_on_write_callback_fires_per_written_file_test() {
   // The on_write callback is the hook the CLI uses for "Generated:
   // <path>" output. Every Overwrite file must trigger it exactly once;


### PR DESCRIPTION
## Summary

`writer.write_all` splits files into shared / server / client buckets, then writes shared+server to `output_server` and shared+client to `output_client`. When `mode = Both` and the two output paths resolve to the same directory (e.g. `config.new(output_server: "out", output_client: "out", ...)` — a reasonable shape for monolithic clients-as-server projects, single-package generators, and test fixtures), every shared file was written **twice** to the same path. The second write silently overwrote the first, `on_write` fired twice per shared file, and the returned written-paths list contained the path twice.

## Changes

- **Path-overlap detection in `write_all`.** When `mode == Both && normalise_dir(output_server) == normalise_dir(output_client)`, the client-side branch skips the shared-files re-write — they were already written by the server-side branch. `normalise_dir` strips a trailing slash so `"out"` and `"out/"` compare equal.
- **Same fix in `resolve_paths` and `expected_paths`.** `--check` builds its drift list from `resolve_paths`; without this, the `--check` pipeline would double-count drift on shared files when paths overlap.
- **Five new tests** in `test/writer_test.gleam`:
  - `write_all_dedupes_shared_files_when_paths_overlap_test` — pin the deduplication: 3 unique destinations, callback log shows `types.gleam` exactly once, returned list does not contain it twice.
  - `write_all_dedupes_shared_files_under_trailing_slash_overlap_test` — `"out"` vs `"out/"` are treated as overlap.
  - `write_all_distinct_paths_still_writes_shared_to_both_test` — regression boundary: distinct server / client paths preserve the existing dual-output (shared file lands in both directories).
  - `resolve_paths_dedupes_shared_files_when_paths_overlap_test` — same dedup contract for the `--check` source.
  - `expected_paths_dedupes_shared_files_when_paths_overlap_test` — same for the orphan-detection source.
- **Docstrings** on `write_all`, `resolve_paths`, and `expected_paths` describe the dedup contract.
- **CHANGELOG entry** under `[Unreleased]` / `### Fixed`.

## Design decisions

- **Skip the second write rather than post-dedupe.** Post-deduping the returned list would still trigger the second `simplifile.write` and the second `on_write` call. The audit calls those out explicitly (FS race-condition surface, double-count progress callbacks); skipping the work upfront is the simpler fix that addresses both.
- **Trailing-slash normalisation, not full path canonicalisation.** Resolving `./out` vs `out` or `out` vs `/abs/cwd/out` vs symlinked paths would require an FS round-trip (`simplifile.canonicalise`, which doesn't exist in the current dep). The trailing-slash case is the documented failure surface in the issue and the most common shape; deeper canonicalisation can be a follow-up if a real call site needs it.
- **No new public types or signature changes.** The fix is contained in the implementation. Callers that legitimately depended on the (undocumented) double-callback don't exist in the test suite — the old behaviour was a bug, not a contract.

## Breaking change

Behaviour-only at the FS / progress-callback level (idempotent in spirit):
- One file write per unique destination instead of two.
- One `on_write` call per unique destination instead of two.
- Returned list does not contain duplicates from the same-path overlap.

Non-breaking at the documented contract level. Distinct paths still write shared files to both directories (pinned by a new test).

Closes #548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed duplicate file writes when using dual-output mode with overlapping server and client output directories (e.g., `out` vs `out/`)
* Corrected callback behavior to fire only once per actual write operation, not multiple times for shared files
* Removed duplicate path entries in results when output paths overlap, while preserving correct behavior for distinct directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->