### PR TITLE
chore(changelog): consolidate two ### Fixed sections in [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- `oaspec/openapi/parser.parse_json_string_with_locations` is now
+  public, mirroring `parse_string_with_locations` (the YAML variant).
+  OTP's `json:decode/3` does not expose token positions, so the
+  returned `LocationIndex` is always `location_index.empty()` — the
+  type signature still matches the YAML path so downstream tooling
+  (LSP-style features, error-hint generators, source-map producers)
+  can dispatch over both formats with one signature, only losing
+  location-aware diagnostics on the JSON branch. New
+  `parse_string_or_json_with_locations` auto-routes by inspecting
+  the first non-whitespace byte (`{` or `[` → JSON, else YAML), so
+  callers do not have to write the dispatch wrapper themselves. (#550)
+
 ### Fixed
 
 - `oaspec/codegen/writer.write_all` no longer writes shared files
@@ -27,23 +41,6 @@ within `Changed` / `Fixed` and stay as-is.
   fix lands in `resolve_paths` and `expected_paths` so `--check`
   does not double-count drift on shared files when paths overlap.
   (#548)
-
-### Added
-
-- `oaspec/openapi/parser.parse_json_string_with_locations` is now
-  public, mirroring `parse_string_with_locations` (the YAML variant).
-  OTP's `json:decode/3` does not expose token positions, so the
-  returned `LocationIndex` is always `location_index.empty()` — the
-  type signature still matches the YAML path so downstream tooling
-  (LSP-style features, error-hint generators, source-map producers)
-  can dispatch over both formats with one signature, only losing
-  location-aware diagnostics on the JSON branch. New
-  `parse_string_or_json_with_locations` auto-routes by inspecting
-  the first non-whitespace byte (`{` or `[` → JSON, else YAML), so
-  callers do not have to write the dispatch wrapper themselves. (#550)
-
-### Fixed
-
 - **Security:** `oaspec/transport.with_default_header` and
   `with_default_headers` now reject CR (`\r`), LF (`\n`), and NUL
   (`\u{0000}`) bytes in any header name or value at construction


### PR DESCRIPTION
## Summary

The `[Unreleased]` block had two `### Fixed` headings — one introduced by PR #560 (#548 writer dedup) and one already present from PR #558 (#546 transport CRLF/NUL validation). Keep a Changelog expects at most one of each section type per release block, and automated changelog parsers may only process the first occurrence.

This PR merges the two bullet lists under a single `### Fixed` heading and reorders the section blocks to the conventional Keep a Changelog order (Added → Fixed).

## Changes

- Single `### Fixed` block under `[Unreleased]`, containing both bullets in chronological order (writer dedup #548 first, then security #546).
- Reordered the sections so `### Added` comes before `### Fixed`.

## Spotted by

[CodeRabbit on PR #560](https://github.com/nao1215/oaspec/pull/560#discussion_r4e71b3a2).