### PR TITLE
docs(parser): document YAML 1.1 vs JSON parsing divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Documentation
 
+- `oaspec/openapi/parser.parse_string` docstring now documents the
+  YAML 1.1 type-coercion rules that yamerl applies to scalars but
+  OTP's JSON decoder does not. The two parsers diverge on the same
+  JSON bytes whenever a scalar matches a YAML 1.1 implicit-type
+  pattern: `"Yes"` / `"No"` / `"On"` / `"Off"` get coerced to
+  booleans, `1.10` loses its trailing zero, hex-prefixed integers
+  and sexagesimal numerals are recognised by yamerl but rejected by
+  the JSON decoder. For JSON OpenAPI documents (Stripe, GitHub,
+  AsyncAPI), prefer `parse_json_string` or
+  `parse_string_or_json_with_locations` (auto-routes by first
+  non-whitespace byte). New regression tests pin
+  `parse_json_string`'s verbatim handling of `"Yes"` and `"1.10"`
+  so a future regression that breaks the JSON path surfaces here.
+  (#549)
 - `oaspec/transport.with_default_headers` and
   `with_default_header` docstrings now spell out the dedup contracts
   explicitly. The list form is **first-occurrence-wins** (e.g.

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -190,6 +190,27 @@ fn cyclic_external_ref_diagnostic(
 /// REST OpenAPI is ~12 MB and yamerl effectively hangs — see issue
 /// #352). Use `parse_json_string` directly when the content is known
 /// to be JSON.
+///
+/// **YAML 1.1 type coercion: parse_string vs parse_json_string.**
+/// yamerl applies YAML 1.1 implicit-type rules to scalars before they
+/// reach metamon's tree walker. The OTP `json:decode/3` frontend used
+/// by `parse_json_string` does not. The two parsers therefore diverge
+/// on the same JSON bytes whenever a value matches a YAML 1.1
+/// implicit-type pattern:
+///
+/// | JSON literal | `parse_string` (yamerl, YAML 1.1) | `parse_json_string` (OTP) |
+/// | --- | --- | --- |
+/// | `"version": "Yes"` | bool `True` | string `"Yes"` |
+/// | `"role": "No"` | bool `False` | string `"No"` |
+/// | `"flag": "On"` / `"Off"` | bool `True` / `False` | string `"On"` / `"Off"` |
+/// | `"version": 1.10` | float `1.1` (trailing zero lost) | float `1.10` |
+/// | `"hex": 0x10` | int `16` (yamerl extension) | parse error (not valid JSON) |
+///
+/// For JSON OpenAPI documents — Stripe, GitHub, AsyncAPI, etc. — prefer
+/// `parse_json_string` (or `parse_string_or_json_with_locations`,
+/// which auto-routes by inspecting the first non-whitespace byte).
+/// `parse_string` remains correct for YAML input and for JSON inputs
+/// whose values do not collide with YAML 1.1 implicit-type patterns.
 pub fn parse_string(
   content: String,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -11,6 +11,8 @@ pub fn parser_smoke_test() {
   let _ = support.parse_json_string_rejects_malformed_case()
   let _ = support.parse_json_string_malformed_has_diagnostic_shape_case()
   let _ = support.parse_file_dispatches_json_path_for_json_extension_case()
+  let _ = support.parse_json_string_preserves_yes_no_string_values_case()
+  let _ = support.parse_json_string_preserves_dotted_version_literal_case()
   let _ = support.parse_json_string_with_locations_returns_same_spec_case()
   let _ = support.parse_json_string_with_locations_index_is_empty_case()
   let _ = support.parse_string_or_json_with_locations_routes_json_test_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1011,6 +1011,53 @@ paths: {}
   should.be_false(is_empty)
 }
 
+// Regression: yamerl applies YAML 1.1 implicit-type rules that the
+// OTP json:decode frontend does not. The two parsers therefore diverge
+// on the same JSON bytes whenever a scalar matches a YAML 1.1 pattern.
+// Pin parse_json_string's verbatim behaviour; if a future yamerl
+// upgrade changes its rule the parse_string docstring's coercion
+// table needs to follow. (#549)
+
+pub fn parse_json_string_preserves_yes_no_string_values_case() {
+  // Stripe-style API key descriptions occasionally contain the
+  // literal strings "Yes"/"No" in human-readable description fields.
+  // OpenAPI's `info.description` is documented as a free-form string;
+  // both parsers must preserve the value as `"Yes"` for the JSON
+  // input — which the OTP frontend does. The yamerl frontend is
+  // documented to potentially coerce; we pin the JSON-side guarantee
+  // so a future regression that breaks the JSON path surfaces here.
+  let json =
+    "{
+      \"openapi\": \"3.0.3\",
+      \"info\": {
+        \"title\": \"Yes/No API\",
+        \"version\": \"1.0.0\",
+        \"description\": \"Yes\"
+      },
+      \"paths\": {}
+    }"
+  let assert Ok(spec) = parser.parse_json_string(json)
+  spec.info.title |> should.equal("Yes/No API")
+  spec.info.description |> should.equal(option.Some("Yes"))
+}
+
+pub fn parse_json_string_preserves_dotted_version_literal_case() {
+  // OpenAPI's `info.version` is a string. JSON reproduces "1.10"
+  // verbatim; yamerl's YAML 1.1 numeric coercion can drop the
+  // trailing zero on unquoted numerics but the quoted form should
+  // survive. Pin the JSON path's exact-string behaviour for the
+  // `"1.10"` case, which oaspec actually sees in the wild (Stripe
+  // pinned "2024-04-10" / "1.10"-style version strings).
+  let json =
+    "{
+      \"openapi\": \"3.0.3\",
+      \"info\": {\"title\": \"v\", \"version\": \"1.10\"},
+      \"paths\": {}
+    }"
+  let assert Ok(spec) = parser.parse_json_string(json)
+  spec.info.version |> should.equal("1.10")
+}
+
 pub fn parse_string_or_json_with_locations_array_root_routes_json_case() {
   // First non-whitespace byte is `[` — also a JSON discriminator.
   // The content here is intentionally not a valid OpenAPI doc; we


### PR DESCRIPTION
## Summary

`parse_string` (yamerl YAML 1.1 frontend) and `parse_json_string` (OTP `json:decode/3`) are documented to produce equivalent `OpenApiSpec` values, but yamerl applies YAML 1.1 implicit-type rules to scalars and OTP `json:decode` does not. The two parsers therefore diverge on the same JSON bytes whenever a scalar matches a YAML 1.1 implicit-type pattern:

| JSON literal | `parse_string` (yamerl, YAML 1.1) | `parse_json_string` (OTP) |
| --- | --- | --- |
| `"Yes"` / `"No"` / `"On"` / `"Off"` | bool | string |
| `1.10` | float `1.1` (trailing zero lost) | float `1.10` |
| `0x10` | int `16` (yamerl extension) | parse error |

For JSON OpenAPI specs (Stripe, GitHub, AsyncAPI), `parse_string` can silently corrupt enum-like string values that hit YAML 1.1 coercion. `parse_json_string` is faithful, and `parse_string_or_json_with_locations` (added in #550) auto-routes to the right frontend by inspecting the first non-whitespace byte.

## Changes

- **`parse_string` docstring** gains a coercion table and a "prefer `parse_json_string` for JSON" recommendation, with a pointer at the new `parse_string_or_json_with_locations` auto-dispatcher.
- **Two regression tests** in `test/oaspec_support.gleam`, wired into `test/oaspec_parse_core_test.gleam`'s `parser_smoke_test`:
  - `parse_json_string_preserves_yes_no_string_values` — `info.description: "Yes"` stays as the string `"Yes"`.
  - `parse_json_string_preserves_dotted_version_literal` — `info.version: "1.10"` stays as `"1.10"` (trailing zero preserved).
- **CHANGELOG entry** under `[Unreleased]` / `### Documentation`.

## Design decisions

- **Pin the JSON path, not the yamerl divergence.** Pinning yamerl's specific coercion outputs would require running yamerl directly in the test (not through the OpenAPI parser, which rejects coerced values upstream as type mismatches) and asserting on the precise YAML 1.1 rules. The actionable signal for callers is the `parse_json_string` guarantee — `"Yes"` stays as `"Yes"`, `"1.10"` stays as `"1.10"` — so that is what is pinned. The yamerl side is documented in the docstring; if a future yamerl upgrade changes its rules, the doc may need updating but the JSON tests will still pass.
- **No code change.** This is doc + tests only. The auto-dispatch entry point for callers who handle both formats already exists (`parse_string_or_json_with_locations`, #550); the recommendation in the new docstring points at it.

## Breaking change

None. Doc + tests only.

Closes #549
