### PR TITLE
feat(transport)!: add Method.Other(String) for WebDAV / vendor verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Breaking
+
+- **`oaspec/transport.Method` gains an `Other(String)` variant.**
+  External callers that exhaustively pattern-match on `Method`
+  (without a catch-all `_ ->`) will fail to compile until they add
+  an arm for `Other(_)`. The new variant is required to express
+  WebDAV (`PROPFIND`, `PROPPATCH`, `MKCOL`, …), CalDAV / CardDAV
+  (`REPORT`, `MKCALENDAR`), and vendor extensions (`PURGE`, `BAN`,
+  `LINK`, `UNLINK`) — the previous closed sum could not represent
+  any of these. The bundled `httpc` and `fetch` adapters route
+  `Other(s) → http.Other(s)` so the wire path is unchanged for
+  callers that use them. New helpers `transport.method_to_wire/1`
+  and `transport.method_from_string/1` (case-insensitive routing
+  for the nine RFC 9110 §9 verbs, `tchar`-validated `Other`
+  passthrough for everything else) keep the construction surface
+  consistent. (#554)
+
 ### Added
 
 - `oaspec/openapi/parser.parse_json_string_with_locations` is now

--- a/adapters/fetch/src/oaspec/fetch.gleam
+++ b/adapters/fetch/src/oaspec/fetch.gleam
@@ -106,6 +106,7 @@ fn convert_method(method: transport.Method) -> http.Method {
     transport.Options -> http.Options
     transport.Trace -> http.Trace
     transport.Connect -> http.Connect
+    transport.Other(s) -> http.Other(s)
   }
 }
 

--- a/adapters/httpc/src/oaspec/httpc.gleam
+++ b/adapters/httpc/src/oaspec/httpc.gleam
@@ -132,6 +132,7 @@ fn convert_method(method: transport.Method) -> http.Method {
     transport.Options -> http.Options
     transport.Trace -> http.Trace
     transport.Connect -> http.Connect
+    transport.Other(s) -> http.Other(s)
   }
 }
 

--- a/src/oaspec/transport.gleam
+++ b/src/oaspec/transport.gleam
@@ -15,6 +15,16 @@ import gleam/string
 // Defined locally to keep the root `oaspec` package free of a
 // `gleam_http` dependency — adapters can convert to `gleam/http.Method`
 // at the runtime boundary.
+//
+// `Other(String)` carries verbs outside the RFC 9110 §9 method
+// registry: WebDAV (`PROPFIND`, `PROPPATCH`, `MKCOL`, …), CalDAV /
+// CardDAV (`REPORT`, `MKCALENDAR`), and vendor extensions (`PURGE`,
+// `BAN`, `LINK`, `UNLINK`). Per RFC 9110 §9.1 method tokens are
+// case-sensitive — construct via `method_from_string` rather than
+// the bare `Other(...)` constructor when the source string may be
+// in a non-canonical case; the constructor enforces the `tchar`
+// charset (RFC 9110 §5.6.2) and routes well-known names to the
+// dedicated variants.
 pub type Method {
   Get
   Post
@@ -25,6 +35,120 @@ pub type Method {
   Options
   Trace
   Connect
+  Other(String)
+}
+
+/// Construction error for `method_from_string`.
+pub type MethodError {
+  /// The supplied string is empty or contains a byte outside the
+  /// `tchar` production from RFC 9110 §5.6.2 (control bytes,
+  /// whitespace, separators like `(`, `)`, `<`, `>`, `@`, `,`, `;`,
+  /// `:`, `\`, `"`, `/`, `[`, `]`, `?`, `=`, `{`, `}`).
+  InvalidMethod(detail: String)
+}
+
+/// Convert a `Method` to its on-wire string. Well-known variants
+/// produce their canonical RFC 9110 spelling (`Get` → `"GET"`);
+/// `Other(s)` returns `s` verbatim — pre-normalise via
+/// `method_from_string` if the source is in a non-canonical case.
+pub fn method_to_wire(method: Method) -> String {
+  case method {
+    Get -> "GET"
+    Post -> "POST"
+    Put -> "PUT"
+    Delete -> "DELETE"
+    Patch -> "PATCH"
+    Head -> "HEAD"
+    Options -> "OPTIONS"
+    Trace -> "TRACE"
+    Connect -> "CONNECT"
+    Other(s) -> s
+  }
+}
+
+/// Smart constructor for `Method`. Routes case-insensitively to the
+/// nine RFC 9110 §9 variants for known names; for everything else,
+/// validates the input against the `tchar` charset (RFC 9110 §5.6.2)
+/// and uppercases the result before wrapping in `Other` so the wire
+/// representation is canonical.
+///
+/// Empty input or a byte outside `tchar` (control bytes, whitespace,
+/// or separators like `(`, `)`, `,`, `;`, `:`, `/`, `[`, etc.) returns
+/// `Error(InvalidMethod(detail))`.
+pub fn method_from_string(s: String) -> Result(Method, MethodError) {
+  case string.lowercase(s) {
+    "get" -> Ok(Get)
+    "post" -> Ok(Post)
+    "put" -> Ok(Put)
+    "delete" -> Ok(Delete)
+    "patch" -> Ok(Patch)
+    "head" -> Ok(Head)
+    "options" -> Ok(Options)
+    "trace" -> Ok(Trace)
+    "connect" -> Ok(Connect)
+    "" ->
+      Error(InvalidMethod(detail: "method string is empty (RFC 9110 §5.6.2)"))
+    _ ->
+      case is_valid_token(s) {
+        True -> Ok(Other(string.uppercase(s)))
+        False ->
+          Error(InvalidMethod(
+            detail: "method `"
+            <> s
+            <> "` contains a byte outside the tchar charset (RFC 9110 §5.6.2)",
+          ))
+      }
+  }
+}
+
+fn is_valid_token(s: String) -> Bool {
+  string.to_utf_codepoints(s)
+  |> list.all(is_tchar)
+}
+
+// RFC 9110 §5.6.2: tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+// / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA.
+// Every other byte (control chars, whitespace, separators) is
+// forbidden inside a method token.
+fn is_tchar(cp: UtfCodepoint) -> Bool {
+  let codepoint = string.utf_codepoint_to_int(cp)
+  case codepoint {
+    0x21 -> True
+    // !
+    0x23 -> True
+    // #
+    0x24 -> True
+    // $
+    0x25 -> True
+    // %
+    0x26 -> True
+    // &
+    0x27 -> True
+    // '
+    0x2A -> True
+    // *
+    0x2B -> True
+    // +
+    0x2D -> True
+    // -
+    0x2E -> True
+    // .
+    0x5E -> True
+    // ^
+    0x5F -> True
+    // _
+    0x60 -> True
+    // `
+    0x7C -> True
+    // |
+    0x7E -> True
+    // ~
+    _ ->
+      // 0..9 / A..Z / a..z
+      { codepoint >= 0x30 && codepoint <= 0x39 }
+      || { codepoint >= 0x41 && codepoint <= 0x5A }
+      || { codepoint >= 0x61 && codepoint <= 0x7A }
+  }
 }
 
 pub type Body {

--- a/test/transport_test.gleam
+++ b/test/transport_test.gleam
@@ -85,17 +85,10 @@ fn list_join(items: List(String), sep: String) -> String {
 }
 
 fn method_to_string(method: transport.Method) -> String {
-  case method {
-    transport.Get -> "GET"
-    transport.Post -> "POST"
-    transport.Put -> "PUT"
-    transport.Delete -> "DELETE"
-    transport.Patch -> "PATCH"
-    transport.Head -> "HEAD"
-    transport.Options -> "OPTIONS"
-    transport.Trace -> "TRACE"
-    transport.Connect -> "CONNECT"
-  }
+  // Defer to the public helper so the dual list (test helper +
+  // production helper) cannot drift apart on a future Method
+  // variant addition.
+  transport.method_to_wire(method)
 }
 
 // ---------------------------------------------------------------------------
@@ -285,6 +278,87 @@ pub fn with_default_header_explicit_request_header_beats_all_wrappers_test() {
   resp.headers
   |> list.key_find("X-Trace")
   |> should.equal(Ok("explicit"))
+}
+
+// Method.Other(String) + smart constructor (#554).
+
+pub fn method_to_wire_round_trips_known_verbs_test() {
+  // The nine RFC 9110 §9 verbs canonicalise to their uppercase
+  // RFC spelling.
+  transport.method_to_wire(transport.Get) |> should.equal("GET")
+  transport.method_to_wire(transport.Post) |> should.equal("POST")
+  transport.method_to_wire(transport.Put) |> should.equal("PUT")
+  transport.method_to_wire(transport.Delete) |> should.equal("DELETE")
+  transport.method_to_wire(transport.Patch) |> should.equal("PATCH")
+  transport.method_to_wire(transport.Head) |> should.equal("HEAD")
+  transport.method_to_wire(transport.Options) |> should.equal("OPTIONS")
+  transport.method_to_wire(transport.Trace) |> should.equal("TRACE")
+  transport.method_to_wire(transport.Connect) |> should.equal("CONNECT")
+}
+
+pub fn method_to_wire_passes_through_other_verbatim_test() {
+  // Other(s) returns s as-is. The smart constructor is responsible
+  // for case normalisation; bare Other("propfind") would round-trip
+  // as lowercase, which the tchar charset permits but RFC 9110 §9.1
+  // says is case-sensitive.
+  transport.method_to_wire(transport.Other("PROPFIND"))
+  |> should.equal("PROPFIND")
+  transport.method_to_wire(transport.Other("propfind"))
+  |> should.equal("propfind")
+}
+
+pub fn method_from_string_routes_known_verbs_case_insensitive_test() {
+  let assert Ok(transport.Get) = transport.method_from_string("GET")
+  let assert Ok(transport.Get) = transport.method_from_string("get")
+  let assert Ok(transport.Post) = transport.method_from_string("Post")
+  let assert Ok(transport.Connect) = transport.method_from_string("CONNECT")
+}
+
+pub fn method_from_string_uppercases_other_verbs_test() {
+  let assert Ok(transport.Other("PROPFIND")) =
+    transport.method_from_string("PROPFIND")
+  let assert Ok(transport.Other("PROPFIND")) =
+    transport.method_from_string("propfind")
+  let assert Ok(transport.Other("MKCOL")) =
+    transport.method_from_string("mkcol")
+  let assert Ok(transport.Other("PURGE")) =
+    transport.method_from_string("purge")
+}
+
+pub fn method_from_string_rejects_empty_test() {
+  case transport.method_from_string("") {
+    Error(transport.InvalidMethod(detail)) ->
+      should.be_true(string.contains(detail, "empty"))
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn method_from_string_rejects_separator_bytes_test() {
+  // Slash is in the separators set per RFC 9110 §5.6.2 — rejected.
+  case transport.method_from_string("HELLO/WORLD") {
+    Error(transport.InvalidMethod(detail)) ->
+      should.be_true(string.contains(detail, "tchar"))
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn method_from_string_rejects_whitespace_test() {
+  case transport.method_from_string("HE LLO") {
+    Error(transport.InvalidMethod(_)) -> Nil
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn method_from_string_round_trips_via_to_wire_test() {
+  // from_string → to_wire → from_string must be idempotent for any
+  // valid input. Pin the round-trip on the canonical verbs and a
+  // representative WebDAV verb.
+  list.each(["GET", "propfind", "MKCOL", "purge"], fn(input) {
+    let assert Ok(method) = transport.method_from_string(input)
+    let wire = transport.method_to_wire(method)
+    let assert Ok(method2) = transport.method_from_string(wire)
+    should.equal(method, method2)
+  })
 }
 
 // Header value validation: CRLF / NUL injection (#546).


### PR DESCRIPTION
## Summary

`transport.Method` was a closed sum of the nine RFC 9110 §9 verbs. WebDAV (`PROPFIND`, `PROPPATCH`, `MKCOL`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`), CalDAV / CardDAV (`REPORT`, `MKCALENDAR`), and vendor extensions (`PURGE` for Varnish, `BAN` for some CDNs, `LINK` / `UNLINK`) were unexpressible — internal services with these specs could not use oaspec at all.

This PR adds `Method.Other(String)` and a smart-constructor pair (`method_to_wire`, `method_from_string`) that handles case-insensitive routing for the known verbs and `tchar`-validated passthrough for the rest.

## Changes

- **`transport.Method` gains `Other(String)`.** The closed sum becomes open. The encode/decode pipeline already takes a string at the wire boundary, so the new variant does not change runtime shape.
- **`transport.method_to_wire(method) -> String`.** Returns the canonical RFC 9110 spelling for the nine known verbs (`Get → "GET"`). `Other(s)` returns `s` verbatim — pre-normalise via `method_from_string` if the source is in a non-canonical case.
- **`transport.method_from_string(s) -> Result(Method, MethodError)`.** Case-insensitive routing for the nine known verbs. Other inputs are validated against the `tchar` charset (RFC 9110 §5.6.2) and uppercased before wrapping in `Other` so the wire form is canonical. Empty input or a forbidden byte returns `InvalidMethod(detail)`.
- **`MethodError` enum** with a single `InvalidMethod(detail: String)` variant.
- **`httpc` and `fetch` adapters** route `Other(s) → http.Other(s)`. `gleam_http.Method` already has the same variant, so the wire path is unchanged for callers that use the bundled adapters.
- **Eight new tests** in `test/transport_test.gleam`:
  - `method_to_wire_round_trips_known_verbs`
  - `method_to_wire_passes_through_other_verbatim`
  - `method_from_string_routes_known_verbs_case_insensitive`
  - `method_from_string_uppercases_other_verbs`
  - `method_from_string_rejects_empty`
  - `method_from_string_rejects_separator_bytes` (covers `/` in the input)
  - `method_from_string_rejects_whitespace`
  - `method_from_string_round_trips_via_to_wire` (across `GET`, `propfind`, `MKCOL`, `purge`)
- **The local `method_to_string` test helper** is collapsed onto `transport.method_to_wire` so the dual list cannot drift.
- **CHANGELOG entry** under `[Unreleased]` / `### Breaking`.

## Design decisions

- **Case normalisation in the constructor, not in `to_wire`.** RFC 9110 §9.1 says method tokens are case-sensitive on the wire. Normalising at construction time gives callers a single, predictable wire form (`PROPFIND`, not `propfind`) without hiding the case-sensitive semantics from anyone who builds an `Other` directly. Callers who want a non-canonical case can still build `Other(...)` by hand.
- **Charset validation, not full RFC 9110 token validation.** The validator covers the `tchar` set (alphanumerics + `!#$%&'*+-.^_\`|~`). It does not enforce length limits or known-method-registry checks — those are policy decisions that belong upstream (in the OpenAPI parser or a project-specific allow-list).
- **Codegen integration deferred.** The OpenAPI parser's `spec.HttpMethod` is a separate, narrower ADT that currently rejects unknown methods upstream. Threading `Other` through the spec layer (so a spec declaring `mkcol:` under a path produces `transport.Other("MKCOL")` in the generated client) is a follow-up issue — this PR fixes the runtime ADT first.
- **`gleam_http` already has `Other(String)`.** No adapter logic changes beyond adding the missing arm.

## Breaking change

**Yes.** External callers that exhaustively pattern-match on `transport.Method` (no catch-all `_ ->`) will fail to compile until they add an arm for `Other(_)`. The CHANGELOG marks this under `### Breaking` with a migration note. The bundled in-repo callers (httpc adapter, fetch adapter, internal codegen translator, test helper) are all updated; no other oaspec module pattern-matches on `Method`.

Closes #554
