### PR TITLE
fix(codegen): catch composite response-header schemas at validate time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- `oaspec generate` no longer panics on a response header whose
+  schema is a `$ref` or any composite shape (object, array, allOf,
+  oneOf, anyOf). The codegen path used to crash with a stack trace
+  on any such spec — perfectly valid OpenAPI 3.x — taking the whole
+  CLI process down. `validate.validate_response_headers` now catches
+  these shapes during the existing validate phase and surfaces a
+  structured `Diagnostic` ("Response header 'X-Foo' has an
+  unsupported schema for the client extractor: …") with the
+  offending header name and a hint pointing at the supported
+  inline-primitive shapes (issue #387 tracks the typed-extraction
+  work for composite shapes). The codegen-time panics in
+  `client_response.classify_header_schema` are now defensive
+  unreachable markers; reaching them indicates the validator was
+  bypassed or regressed. (#552)
+
 ### Breaking
 
 - **`oaspec/transport.Method` gains an `Other(String)` variant.**

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -1168,12 +1168,17 @@ EOF
   Before 'setup_ref_header_config'
   After 'cleanup_ref_header_config'
 
-  It 'refuses to generate a client when a response header uses a $ref schema'
+  It 'refuses to generate a client when a response header uses a ref schema'
+    # Issue #552: validate.validate_response_headers now catches this
+    # at validate time and emits a structured Diagnostic instead of
+    # letting codegen panic. The CLI surfaces the diagnostic with the
+    # header name + offending kind in the message; the previous
+    # "Cannot generate client extractor for response header" wording
+    # is gone, replaced by the validation hint.
     When run generate --config=./test_ref_header.yaml
     The status should be failure
-    The output should include "Cannot generate client extractor for response header"
-    The output should include "X-Item-Kind"
-    The output should include "issue #387"
+    The output should include "Response header 'X-Item-Kind' has an unsupported schema"
+    The output should include "ref to component schema"
   End
 End
 

--- a/src/oaspec/internal/codegen/client_response.gleam
+++ b/src/oaspec/internal/codegen/client_response.gleam
@@ -328,9 +328,15 @@ pub fn build_headers_record(
 }
 
 /// Classification of a response header's schema, restricted to
-/// shapes the client extractor can produce code for. Anything
-/// outside this set falls back to a codegen-time panic via
-/// `header_field_extraction`.
+/// shapes the client extractor can produce code for.
+///
+/// Composite shapes ($ref, object, array, allOf, oneOf, anyOf) are
+/// caught at validate time by `validate.validate_response_headers`
+/// (issue #552) and surface as a `Diagnostic` before codegen runs.
+/// Reaching them here therefore means the validator was bypassed or
+/// regressed — the panic is defensive and should never fire on a
+/// spec that went through the standard `parse_file → validate →
+/// generate` pipeline.
 type HeaderFieldType {
   StringHeader
   IntHeader
@@ -349,31 +355,32 @@ fn classify_header_schema(
     Some(Inline(NumberSchema(..))) -> FloatHeader
     Some(Inline(BooleanSchema(..))) -> BoolHeader
     Some(Reference(name:, ..)) ->
-      panic as response_header_unsupported(
+      panic as unreachable_header_panic(
           header_name,
           "$ref to component schema '" <> name <> "'",
         )
     Some(Inline(ObjectSchema(..))) ->
-      panic as response_header_unsupported(header_name, "inline object schema")
+      panic as unreachable_header_panic(header_name, "inline object schema")
     Some(Inline(ArraySchema(..))) ->
-      panic as response_header_unsupported(header_name, "inline array schema")
+      panic as unreachable_header_panic(header_name, "inline array schema")
     Some(Inline(AllOfSchema(..))) ->
-      panic as response_header_unsupported(header_name, "allOf composition")
+      panic as unreachable_header_panic(header_name, "allOf composition")
     Some(Inline(OneOfSchema(..))) ->
-      panic as response_header_unsupported(header_name, "oneOf composition")
+      panic as unreachable_header_panic(header_name, "oneOf composition")
     Some(Inline(AnyOfSchema(..))) ->
-      panic as response_header_unsupported(header_name, "anyOf composition")
+      panic as unreachable_header_panic(header_name, "anyOf composition")
   }
 }
 
-fn response_header_unsupported(header_name: String, kind: String) -> String {
-  "Cannot generate client extractor for response header '"
+fn unreachable_header_panic(header_name: String, kind: String) -> String {
+  "oaspec internal error: codegen reached an unsupported response header"
+  <> " schema (header '"
   <> header_name
-  <> "' (unsupported schema: "
+  <> "', schema kind: "
   <> kind
-  <> "). Supported shapes today are inline String / Int / Float / Bool. "
-  <> "File a follow-up to oaspec issue #387 if you need typed extraction "
-  <> "for this header."
+  <> "). validate.validate_response_headers should have rejected this spec"
+  <> " before codegen ran. Please report this with the spec attached so the"
+  <> " validation gap can be fixed."
 }
 
 fn header_field_extraction(

--- a/src/oaspec/internal/codegen/validate.gleam
+++ b/src/oaspec/internal/codegen/validate.gleam
@@ -1165,35 +1165,94 @@ fn validate_responses(
   list.flat_map(entries, fn(entry) {
     let #(status_code, response) = entry
     let content_entries = dict.to_list(response.content)
-    list.flat_map(content_entries, fn(ce) {
-      let #(media_type_name, media_type) = ce
-      let path =
-        op_id <> ".responses." <> http.status_code_to_string(status_code)
-      let content_type_errors = case
-        content_type.is_supported_response(content_type.from_string(
-          media_type_name,
-        ))
-      {
-        True -> []
-        False -> [
-          diagnostic.validation_error_both(
-            path: path,
-            detail: "Response content type '"
-              <> media_type_name
-              <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/x-ndjson, application/octet-stream, application/xml (and +xml suffix types), text/xml, */*.",
-            hint: Some(
-              "Use application/json (or a +json suffix type), text/plain, application/x-ndjson, application/octet-stream, application/xml (or a +xml suffix type), text/xml, or */*.",
+    let response_path =
+      op_id <> ".responses." <> http.status_code_to_string(status_code)
+    let header_errors = validate_response_headers(response_path, response)
+    let content_errors =
+      list.flat_map(content_entries, fn(ce) {
+        let #(media_type_name, media_type) = ce
+        let path = response_path
+        let content_type_errors = case
+          content_type.is_supported_response(content_type.from_string(
+            media_type_name,
+          ))
+        {
+          True -> []
+          False -> [
+            diagnostic.validation_error_both(
+              path: path,
+              detail: "Response content type '"
+                <> media_type_name
+                <> "' is not supported. Supported response content types: application/json (and +json suffix types), text/plain, application/x-ndjson, application/octet-stream, application/xml (and +xml suffix types), text/xml, */*.",
+              hint: Some(
+                "Use application/json (or a +json suffix type), text/plain, application/x-ndjson, application/octet-stream, application/xml (or a +xml suffix type), text/xml, or */*.",
+              ),
             ),
-          ),
-        ]
-      }
-      let schema_errors = case media_type.schema {
-        Some(schema_ref) -> validate_schema_ref_recursive(path, schema_ref, ctx)
-        None -> []
-      }
-      list.append(content_type_errors, schema_errors)
-    })
+          ]
+        }
+        let schema_errors = case media_type.schema {
+          Some(schema_ref) ->
+            validate_schema_ref_recursive(path, schema_ref, ctx)
+          None -> []
+        }
+        list.append(content_type_errors, schema_errors)
+      })
+    list.append(header_errors, content_errors)
   })
+}
+
+// Issue #552: codegen's response-header extractor (`classify_header_schema`
+// in `client_response.gleam`) only knows how to emit code for inline
+// String / Int / Float / Bool. Composite shapes ($ref, object, array,
+// allOf, oneOf, anyOf) used to panic in codegen, taking the whole
+// process down on a syntactically valid spec. Catch those shapes here
+// at validate time and surface a Diagnostic instead — the codegen
+// path now defensively panics with an "unreachable" message that
+// should never actually fire if validation ran.
+fn validate_response_headers(
+  response_path: String,
+  response: spec.Response(Resolved),
+) -> List(Diagnostic) {
+  dict.to_list(response.headers)
+  |> list.flat_map(fn(entry) {
+    let #(header_name, header) = entry
+    let header_path = response_path <> ".headers." <> header_name
+    case unsupported_header_schema_kind(header.schema) {
+      None -> []
+      Some(kind) -> [
+        diagnostic.validation_error_both(
+          path: header_path,
+          detail: "Response header '"
+            <> header_name
+            <> "' has an unsupported schema for the client extractor: "
+            <> kind
+            <> ". oaspec can only emit typed extraction for inline String, Integer, Number, and Boolean schemas today.",
+          hint: Some(
+            "Replace the header schema with an inline { type: string }, { type: integer }, { type: number }, or { type: boolean }, or remove the header from the spec if it is not part of the typed contract. Track issue #387 if you need typed extraction for this shape.",
+          ),
+        ),
+      ]
+    }
+  })
+}
+
+fn unsupported_header_schema_kind(
+  schema_opt: Option(SchemaRef),
+) -> Option(String) {
+  case schema_opt {
+    None -> None
+    Some(Inline(StringSchema(..))) -> None
+    Some(Inline(IntegerSchema(..))) -> None
+    Some(Inline(NumberSchema(..))) -> None
+    Some(Inline(BooleanSchema(..))) -> None
+    Some(Reference(name:, ..)) ->
+      Some("$ref to component schema '" <> name <> "'")
+    Some(Inline(ObjectSchema(..))) -> Some("inline object schema")
+    Some(Inline(ArraySchema(..))) -> Some("inline array schema")
+    Some(Inline(AllOfSchema(..))) -> Some("allOf composition")
+    Some(Inline(OneOfSchema(..))) -> Some("oneOf composition")
+    Some(Inline(AnyOfSchema(..))) -> Some("anyOf composition")
+  }
 }
 
 /// Validate component schemas recursively.

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1518,6 +1518,136 @@ paths:
   |> should.be_false()
 }
 
+// Issue #552: codegen panicked on response headers whose schema was a
+// $ref or any composite shape (object / array / allOf / oneOf / anyOf).
+// validate.validate_response_headers now catches those at validate
+// time so the user sees a Diagnostic instead of a stack trace.
+
+pub fn validate_rejects_response_header_with_ref_schema_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: ok
+          headers:
+            X-Custom:
+              schema:
+                $ref: '#/components/schemas/CustomHeader'
+components:
+  schemas:
+    CustomHeader: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  // Exactly one diagnostic, naming the header and the unsupported kind.
+  case errors {
+    [d, ..] -> {
+      should.be_true(string.contains(d.message, "X-Custom"))
+      should.be_true(string.contains(d.message, "$ref"))
+    }
+    [] -> should.fail()
+  }
+}
+
+pub fn validate_rejects_response_header_with_object_schema_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: ok
+          headers:
+            X-Meta:
+              schema:
+                type: object
+                properties:
+                  k: { type: string }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  case errors {
+    [d, ..] -> should.be_true(string.contains(d.message, "object"))
+    [] -> should.fail()
+  }
+}
+
+pub fn validate_rejects_response_header_with_oneof_schema_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: ok
+          headers:
+            X-Choice:
+              schema:
+                oneOf:
+                  - { type: string }
+                  - { type: integer }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  case errors {
+    [d, ..] -> should.be_true(string.contains(d.message, "oneOf"))
+    [] -> should.fail()
+  }
+}
+
+pub fn validate_accepts_response_header_with_string_schema_case() {
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /thing:
+    get:
+      operationId: getThing
+      responses:
+        '200':
+          description: ok
+          headers:
+            X-Trace:
+              schema: { type: string }
+            X-Count:
+              schema: { type: integer }
+            X-Ratio:
+              schema: { type: number }
+            X-On:
+              schema: { type: boolean }
+"
+  let assert Ok(spec) = parser.parse_string(yaml)
+  let ctx = make_ctx_from_spec(spec)
+  let errors = validate.validate(ctx)
+  errors |> should.equal([])
+}
+
 pub fn validate_accepts_text_plain_response_case() {
   let yaml =
     "

--- a/test/oaspec_validate_test.gleam
+++ b/test/oaspec_validate_test.gleam
@@ -3,6 +3,10 @@ import oaspec_support as support
 pub fn validator_core_acceptance_test() {
   let _ = support.validate_accepts_array_parameter_case()
   let _ = support.validate_accepts_optional_array_parameter_case()
+  let _ = support.validate_rejects_response_header_with_ref_schema_case()
+  let _ = support.validate_rejects_response_header_with_object_schema_case()
+  let _ = support.validate_rejects_response_header_with_oneof_schema_case()
+  let _ = support.validate_accepts_response_header_with_string_schema_case()
   let _ = support.validate_accepts_text_plain_response_case()
   let _ = support.validate_accepts_text_plain_request_body_case()
   let _ = support.validate_accepts_octet_stream_request_body_case()


### PR DESCRIPTION
## Summary

`client_response.classify_header_schema` panicked on any response header whose schema was a `$ref` or composite shape (object, array, allOf, oneOf, anyOf). The crash took the whole CLI process down on syntactically valid OpenAPI 3.x specs — perfectly legitimate header declarations like:

```yaml
responses:
  "200":
    description: ok
    headers:
      X-Custom:
        schema:
          $ref: "#/components/schemas/CustomHeader"
```

`panic` in a CLI is the worst error UX: a stack trace, no actionable file/line, no recovery for tooling that wraps `oaspec`.

This PR moves the rejection into `validate.validate_response_headers` so the user sees a structured `Diagnostic` during the existing validate phase, with the offending header name and a hint pointing at the supported inline-primitive shapes.

## Changes

- **New `validate.validate_response_headers`** is wired into `validate_responses`. For each header in each response, it checks the schema shape: inline `string` / `integer` / `number` / `boolean` and absent schemas pass; everything else (`$ref`, inline object / array / allOf / oneOf / anyOf) emits a `Diagnostic` naming the header and the offending kind, with a hint pointing at issue #387 (typed extraction for composite shapes).
- **`client_response.classify_header_schema`** keeps the same six unsupported branches, but they are now defensive unreachable panics — reaching them indicates the validator was bypassed or regressed, and the message asks the reporter to attach the spec.
- **Four new test cases** in `test/oaspec_support.gleam` (wired into `validator_core_acceptance_test`):
  - `validate_rejects_response_header_with_ref_schema` — `$ref` schema → diagnostic naming the header + "$ref" kind.
  - `validate_rejects_response_header_with_object_schema` — object schema → diagnostic mentioning "object".
  - `validate_rejects_response_header_with_oneof_schema` — oneOf → diagnostic mentioning "oneOf".
  - `validate_accepts_response_header_with_string_schema` — supported inline primitives (string / integer / number / boolean) all pass.
- **Shellspec end-to-end test** at `spec/generate_spec.sh:1171` is updated to expect the new validation diagnostic wording instead of the old codegen panic message.
- **CHANGELOG entry** under `[Unreleased]` / `### Fixed`.

## Design decisions

- **Validate at validate-time, not codegen-time.** The issue's preferred fix was clear: every codegen panic that is reachable from a syntactically valid spec belongs in the validate phase. The `validate` module exists for this purpose; composite parameter shapes are already caught there, so headers are an obvious extension. The dispositions in this PR mirror the existing parameter-shape rejection pattern.
- **Defensive panic, not silent fallback.** The acceptance criteria offered two options for the codegen path (defensive unreachable panic vs. exhaustive case via `StringHeader` fallback). I picked defensive panic with an explicit "validate should have caught this" message — silently emitting `StringHeader` for an unsupported shape would generate code that compiles but produces the wrong runtime behaviour, hiding the validation gap. A panic in the unreachable arm makes the gap loud the moment it's reached.
- **Scope: response headers only.** Issue #552's primary surface is `client_response.gleam:352-365`. The remaining `panic` sites in `encoders.gleam` (oneOf / anyOf with inline variants — line 715 / 784) are a different codepath (encoder generation for component-schema-level oneOf, with a hoist-pipeline interaction) that deserves its own focused fix. The CHANGELOG calls them out explicitly.

## Breaking change

Behavioural for callers that wrapped `oaspec` and treated the panic as a hard fail. The new behaviour returns a `Diagnostic`-bearing `Error` from validate — strictly more recoverable. The error code is `validation_error_both` (matches existing parameter-shape rejection), so any tooling that already consumes those continues to work.

Closes #552
