### PR TITLE
test(normalize_argv): pin algebraic invariants with metamon properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Tests
+
+- `test/normalize_argv_property_test.gleam` adds metamon
+  property-based tests pinning `oaspec.normalize_argv`'s algebraic
+  invariants: idempotency (a second pass is a no-op), length
+  non-increasing (pair-collapse can only shrink the list), bit-for-bit
+  pass-through when the argv contains no value-bearing long flags,
+  equivalence between `--name value` and `--name=value` for the
+  flags listed in `cli.value_flag_names`, the absence of any bare
+  `--name <value>` pair in the output, and commutation with
+  appending an unrelated bool flag. The generators draw from
+  `cli.value_flag_names` directly rather than duplicating the list,
+  so adding a new value flag automatically extends the property's
+  input space. metamon is added to `[dev-dependencies]`. (#551)
+
 ### Fixed
 
 - `oaspec generate` no longer panics on a response header whose

--- a/gleam.toml
+++ b/gleam.toml
@@ -20,6 +20,7 @@ filepath = ">= 1.1.0 and < 2.0.0"
 gleeunit = ">= 1.0.0 and < 2.0.0"
 gleescript = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.14.0 and < 3.0.0"
+metamon = ">= 0.5.0 and < 1.0.0"
 
 [tools.glinter]
 stats = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -17,6 +17,7 @@ packages = [
   { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
   { name = "glinter", version = "2.14.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "F4FA6B575FA9ED293B3BCCCEA4ED2612EAFC8AAB4305638DB5680FFF84C6972B" },
+  { name = "metamon", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "simplifile"], otp_app = "metamon", source = "hex", outer_checksum = "AB0724A0D7518FB6F96FE4CBEE2752ABA6CFFF804BEDA132E710CE90C19F4ABC" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
@@ -35,5 +36,6 @@ gleescript = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glint = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }
+metamon = { version = ">= 0.5.0 and < 1.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 yay = { version = ">= 2.0.0 and < 3.0.0" }

--- a/test/normalize_argv_property_test.gleam
+++ b/test/normalize_argv_property_test.gleam
@@ -1,0 +1,187 @@
+//// metamon property tests for `oaspec.normalize_argv`. Pin the
+//// algebraic invariants the function is documented to hold so a
+//// future refactor (or a new value-flag added to `cli.value_flag_names`)
+//// surfaces a regression here instead of breaking the CLI for end
+//// users. Issue #551.
+
+import gleam/list
+import gleam/string
+import metamon
+import metamon/generator
+import metamon/generator/range
+import metamon/relation
+import oaspec
+import oaspec/internal/cli
+
+// ---------- argv generators ----------
+
+// A long-form value flag drawn from the project's actual list. The
+// test imports `cli.value_flag_names` rather than duplicating the
+// constant, so adding `--strict` (or any future flag) extends the
+// property's input space automatically.
+fn value_flag_gen() -> generator.Generator(String) {
+  let flag_name_gen = generator.element_of(cli.value_flag_names)
+  generator.map(flag_name_gen, fn(name) { "--" <> name })
+}
+
+// A bool-style long flag (no value). These are NOT in the value-flag
+// list, so normalize_argv must pass them through untouched.
+fn bool_flag_gen() -> generator.Generator(String) {
+  generator.element_of([
+    "--help", "--version", "--check", "--fail-on-warnings", "--list-targets",
+    "--verbose",
+  ])
+}
+
+// A value-shaped argv token: starts with a non-`-` byte (so
+// normalize_argv treats it as a value rather than a flag).
+fn value_token_gen() -> generator.Generator(String) {
+  // string_alpha guarantees the first character is alphabetic — never
+  // `-` — so the token always satisfies value_is_value internally.
+  generator.string_alpha(range.constant(1, 8))
+}
+
+// A short-form `-X` flag — nothing in the value-flag list starts with
+// a single dash, so these are pass-through. Mixing them in shakes out
+// "is_value_long_flag should reject single-dash" regressions.
+fn short_flag_gen() -> generator.Generator(String) {
+  generator.element_of(["-h", "-v", "-V", "-x", "-y"])
+}
+
+// A free-form positional argument — alphanumeric, no leading `-`.
+fn positional_gen() -> generator.Generator(String) {
+  generator.string_alphanumeric(range.constant(1, 8))
+}
+
+// An argv element drawn from any of the four shapes above. The
+// resulting list is the property's primary fuzz surface.
+fn argv_token_gen() -> generator.Generator(String) {
+  generator.one_of([
+    value_flag_gen(),
+    bool_flag_gen(),
+    short_flag_gen(),
+    positional_gen(),
+    value_token_gen(),
+  ])
+}
+
+fn argv_gen() -> generator.Generator(List(String)) {
+  generator.list_of(argv_token_gen(), range.constant(0, 8))
+}
+
+// An argv that contains no value-bearing long flags. normalize_argv
+// is documented to pass these through untouched.
+fn argv_without_value_flags_gen() -> generator.Generator(List(String)) {
+  let token =
+    generator.one_of([
+      bool_flag_gen(),
+      short_flag_gen(),
+      positional_gen(),
+      value_token_gen(),
+    ])
+  generator.list_of(token, range.constant(0, 8))
+}
+
+// ---------- properties ----------
+
+// 1. Idempotent: normalising an already-normalised argv is a no-op.
+//    A second pass cannot collapse new pairs because `--name=value`
+//    has the `=` baked in and is not in the value-flag list anymore.
+pub fn normalize_argv_idempotent_test() {
+  let mr =
+    metamon.idempotency_of(
+      name: "normalize_argv_idempotent",
+      of: oaspec.normalize_argv,
+    )
+  metamon.forall_morph(argv_gen(), mr, oaspec.normalize_argv)
+}
+
+// 2. Length non-increasing: each pair-collapse turns two argv elements
+//    into one, and no other shape grows the list.
+pub fn normalize_argv_length_non_increasing_test() {
+  metamon.forall(argv_gen(), fn(args) {
+    list.length(oaspec.normalize_argv(args)) <= list.length(args)
+  })
+}
+
+// 3. Pass-through for argv with no value-flags. The function must
+//    return the input bit-for-bit when there is nothing to collapse.
+pub fn normalize_argv_passthrough_when_no_value_flags_test() {
+  metamon.forall(argv_without_value_flags_gen(), fn(args) {
+    oaspec.normalize_argv(args) == args
+  })
+}
+
+// 4. `--name value` and `--name=value` are equivalent on the output
+//    side — that is the whole point of the function.
+pub fn normalize_argv_value_flag_equivalence_test() {
+  metamon.forall(
+    generator.tuple2(value_flag_gen(), value_token_gen()),
+    fn(pair) {
+      let #(flag, value) = pair
+      oaspec.normalize_argv([flag, value])
+      == oaspec.normalize_argv([flag <> "=" <> value])
+    },
+  )
+}
+
+// 5. Output should never contain a value-bearing long flag in the
+//    bare `--name` form (without `=`) followed by a value-shaped
+//    token. If it did, the user would still see glint's "invalid
+//    flag" error. This is the round-trip end of property 4.
+pub fn normalize_argv_output_has_no_unjoined_value_flag_pairs_test() {
+  metamon.forall(argv_gen(), fn(args) {
+    let normalised = oaspec.normalize_argv(args)
+    !contains_unjoined_value_flag_pair(normalised)
+  })
+}
+
+// Helper: scan a normalised argv for a `--name` token (where `name` is
+// a value-bearing flag without `=`) followed by a value-shaped token.
+fn contains_unjoined_value_flag_pair(args: List(String)) -> Bool {
+  case args {
+    [] -> False
+    [_] -> False
+    [first, second, ..rest] ->
+      case is_bare_value_flag(first), is_value_token(second) {
+        True, True -> True
+        _, _ -> contains_unjoined_value_flag_pair([second, ..rest])
+      }
+  }
+}
+
+fn is_bare_value_flag(arg: String) -> Bool {
+  // "--config" matches; "--config=foo" does not (the second branch
+  // here intentionally excludes `=`-bearing forms via element_of).
+  list.any(cli.value_flag_names, fn(name) { arg == "--" <> name })
+}
+
+fn is_value_token(arg: String) -> Bool {
+  case arg {
+    "" -> False
+    _ -> !string.starts_with(arg, "-")
+  }
+}
+
+// 6. forall_morph: the list-as-multiset of normalised tokens does
+//    NOT need to equal the input multiset (pair-collapse changes
+//    elements), but appending an unrelated bool flag commutes with
+//    normalisation — adding it before or after normalising should not
+//    change the result.
+pub fn normalize_argv_appending_bool_flag_commutes_test() {
+  metamon.forall(generator.tuple2(argv_gen(), bool_flag_gen()), fn(pair) {
+    let #(args, bool_flag) = pair
+    oaspec.normalize_argv(list.append(args, [bool_flag]))
+    == list.append(oaspec.normalize_argv(args), [bool_flag])
+  })
+}
+
+// Sanity: the all_equal relation is satisfied trivially when both
+// branches return the same shape — used here so `relation` has a
+// referenced symbol to keep the import alive even if the file is
+// pruned to a single property in the future.
+pub fn normalize_argv_pure_smoke_test() {
+  let all_equal = relation.all_equal()
+  let assert True = all_equal.holds([1, 1, 1])
+  Nil
+}


### PR DESCRIPTION
## Summary

`oaspec.normalize_argv` translates `--name value` into `--name=value` for the value-bearing long options listed in `cli.value_flag_names`. The existing tests cover example cases but did not pin the function's algebraic invariants — a future refactor (or adding a new flag to `value_flag_names`) could regress those without surfacing until a real user hit it.

This PR adds metamon property tests pinning six invariants and adds `metamon` to `[dev-dependencies]`.

## Changes

- **`metamon` is now a dev-dependency** (`>= 0.5.0 and < 1.0.0`).
- **New file `test/normalize_argv_property_test.gleam`** with six property tests:
  1. **Idempotent** (`normalize_argv |> normalize_argv == normalize_argv`) — pinned via `metamon.idempotency_of`.
  2. **Length non-increasing** — output length ≤ input length.
  3. **Pass-through** — when argv contains no value-bearing long flags, the output is bit-for-bit equal to the input.
  4. **Equivalence** — `[--name, value]` and `[--name=value]` normalise to the same list.
  5. **No unjoined value-flag pairs** in the output — the round-trip end of #4: there should never be a bare `--name <value>` left in the output.
  6. **Commutation with appending a bool flag** — adding `--help` before vs after normalisation produces the same result.
- **The generators reference `cli.value_flag_names` directly** rather than duplicating the list, so adding a new value flag automatically extends the property's input space.
- **CHANGELOG entry** under `[Unreleased]` / `### Tests`.

## Design decisions

- **Generators** combine the four argv shapes the function's docstring lists: value-bearing long flags, bool-style long flags, short `-X` flags, value tokens (alphanumeric, no leading `-`), and free-form positional args. The composite `argv_gen` draws from each of those uniformly so any single test exercises every code path in the same run.
- **`generator.string_alpha`** for value-token generation guarantees the first byte is alphabetic — never `-` — so the token always satisfies `value_is_value` internally. This avoids generators that produce `--`-prefixed values that would be misclassified as flags.
- **Length bounds 0..8** for the argv list keeps each property's expected work small enough to run quickly under metamon's default 100 runs (each forall hits the function 100× plus shrinking attempts).
- **Property 5 (no-unjoined-pairs)** is the dual of property 4. Property 4 shows that the two forms produce the same output; property 5 shows the output is in canonical form. Both are needed because property 4 alone could be satisfied by a function that left both inputs alone (which is wrong for the audit's failure case).

## Breaking change

None. Test-only.

Closes #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive property-based tests with extensive invariant verification, including idempotency validation, length constraint checks, flag equivalence testing, commutativity analysis, and edge case coverage to enhance code reliability.

* **Chores**
  * Integrated new testing framework dependency to support advanced testing methodologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->