### PR TITLE
feat(parser): add parse_string_with_limits + ParseLimits for DoS bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Added
+
+- `oaspec/openapi/parser.parse_string_with_limits(content, limits)`
+  is a DoS-aware variant of `parse_string`. The new `ParseLimits`
+  config caps parser-side resources that an attacker-controlled or
+  accidentally-pathological spec could exhaust on a CI runner or in
+  a service that accepts user-supplied specs (admin uploads,
+  contract-validation pipelines). `parse_string` is unchanged and
+  remains the right entry point for trusted local files; reach for
+  `parse_string_with_limits` (and `default_limits()` as a starting
+  point) when the input is untrusted. The first enforced cap is
+  `max_input_bytes` (default 16 MiB — Stripe's full OpenAPI is
+  ~6 MB and GitHub's REST API is ~12 MB, both well under the cap),
+  rejected with a structured `parse_limit_exceeded` Diagnostic
+  before yamerl or `json:decode/3` allocate any tree memory. The
+  `ParseLimits` type also declares `max_schema_depth`,
+  `max_allof_chain`, `max_external_ref_hops`, `max_paths`, and
+  `max_parameters_per_op` fields that future PRs will start
+  enforcing — listing them in the type now lets callers pin the
+  contract surface up front. (#553)
+
 ### Tests
 
 - `test/normalize_argv_property_test.gleam` adds metamon

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -78,6 +78,41 @@ pub fn yaml_error(detail detail: String, loc loc: SourceLoc) -> Diagnostic {
   )
 }
 
+/// Parser refused the input because it exceeded a configured DoS
+/// limit (see `parser.ParseLimits`). The message names the limit, the
+/// configured cap, and the actual value so callers can either bump
+/// the limit (when they trust the source) or reject the input.
+pub fn parse_limit_exceeded(
+  limit limit: String,
+  configured configured: Int,
+  actual actual: Int,
+) -> Diagnostic {
+  Diagnostic(
+    code: "parse_limit_exceeded",
+    phase: PhaseParse,
+    severity: SeverityError,
+    target: TargetBoth,
+    pointer: "",
+    source_loc: NoSourceLoc,
+    message: "Parser limit '"
+      <> limit
+      <> "' exceeded: configured cap "
+      <> int_to_string(configured)
+      <> ", actual "
+      <> int_to_string(actual)
+      <> ". The input was refused before parsing to bound denial-of-service exposure (issue #553).",
+    hint: option.Some(
+      "If the source is trusted, raise '"
+      <> limit
+      <> "' via parser.ParseLimits and call parse_string_with_limits with the larger cap. Untrusted sources should keep the default cap.",
+    ),
+  )
+}
+
+@external(erlang, "erlang", "integer_to_binary")
+@external(javascript, "../oaspec_ffi.mjs", "integer_to_string")
+fn int_to_string(n: Int) -> String
+
 pub fn missing_field(
   path path: String,
   field field: String,

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -184,12 +184,73 @@ fn cyclic_external_ref_diagnostic(
   )
 }
 
+/// Configuration for `parse_string_with_limits`.
+///
+/// Each field caps a parser-side resource that an attacker-controlled
+/// or accidentally-pathological spec could exhaust. The defaults
+/// returned by `default_limits` are sized for real-world specs
+/// (Stripe / GitHub / AsyncAPI all fit comfortably) and are tight
+/// enough that a CI runner targeting an attacker-supplied spec is
+/// not a denial-of-service surface.
+///
+/// Currently enforced:
+///
+/// - `max_input_bytes`: the size of `content` in bytes. Checked
+///   before any parser work begins, so a 100 MB pathological input
+///   is rejected before yamerl or `json:decode/3` allocates a tree.
+///
+/// Documented but **not yet enforced** (future work — issue #553
+/// tracks the rest):
+///
+/// - `max_schema_depth`, `max_allof_chain`, `max_external_ref_hops`,
+///   `max_paths`, `max_parameters_per_op`. Constructing these limits
+///   in the type today lets callers pin the contract; the parser
+///   will start enforcing them in follow-up PRs.
+pub type ParseLimits {
+  ParseLimits(
+    max_input_bytes: Int,
+    max_schema_depth: Int,
+    max_allof_chain: Int,
+    max_external_ref_hops: Int,
+    max_paths: Int,
+    max_parameters_per_op: Int,
+  )
+}
+
+/// Project-default limits sized for real-world specs.
+///
+/// - `max_input_bytes`: 16 MiB — Stripe's full OpenAPI is ~6 MB,
+///   GitHub's REST API is ~12 MB; 16 MiB clears both with headroom.
+/// - `max_schema_depth`: 100. Real specs rarely nest beyond ~12.
+/// - `max_allof_chain`: 32.
+/// - `max_external_ref_hops`: 16.
+/// - `max_paths`: 4096. Stripe (~1k operations), GitHub (~1k), and
+///   AsyncAPI (~50) all fit comfortably.
+/// - `max_parameters_per_op`: 64. The largest real-world operation
+///   the audit found has ~20 parameters.
+pub fn default_limits() -> ParseLimits {
+  ParseLimits(
+    max_input_bytes: 16 * 1024 * 1024,
+    max_schema_depth: 100,
+    max_allof_chain: 32,
+    max_external_ref_hops: 16,
+    max_paths: 4096,
+    max_parameters_per_op: 64,
+  )
+}
+
 /// Parse an OpenAPI spec from a YAML/JSON string. The default path
 /// runs the input through yamerl, which preserves YAML semantics and
 /// source locations but is too slow on large JSON specs (the GitHub
 /// REST OpenAPI is ~12 MB and yamerl effectively hangs — see issue
 /// #352). Use `parse_json_string` directly when the content is known
 /// to be JSON.
+///
+/// `parse_string` does **not** apply the DoS limits documented in
+/// `ParseLimits`. Reach for `parse_string_with_limits` when the input
+/// is attacker-controlled or sourced from an untrusted file system
+/// (admin-uploaded specs, contract-validation pipelines, CI runners
+/// over user-supplied specs) — see issue #553.
 ///
 /// **YAML 1.1 type coercion: parse_string vs parse_json_string.**
 /// yamerl applies YAML 1.1 implicit-type rules to scalars before they
@@ -227,6 +288,45 @@ pub fn parse_string_with_locations(
   use #(root, index) <- result.try(parse_to_node(content))
   use spec <- result.map(parse_root(root, index))
   #(spec, index)
+}
+
+/// Parse an OpenAPI spec with DoS-aware resource limits. Currently
+/// enforces `limits.max_input_bytes` before parsing begins; the other
+/// fields on `ParseLimits` are reserved for future enforcement (see
+/// issue #553).
+///
+/// The byte cap is checked via `string.byte_size` so the function
+/// returns immediately on oversized input rather than handing it to
+/// yamerl / `json:decode/3` (both of which allocate proportional
+/// tree memory before the size could be discovered downstream).
+///
+/// Returns the same `Diagnostic`-bearing `Result` as `parse_string`
+/// when the limit is satisfied; returns a structured
+/// `parse_limit_exceeded` diagnostic when the limit is exceeded.
+pub fn parse_string_with_limits(
+  content: String,
+  limits: ParseLimits,
+) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
+  case enforce_input_byte_limit(content, limits) {
+    Error(d) -> Error(d)
+    Ok(_) -> parse_string(content)
+  }
+}
+
+fn enforce_input_byte_limit(
+  content: String,
+  limits: ParseLimits,
+) -> Result(Nil, Diagnostic) {
+  let actual = string.byte_size(content)
+  case actual > limits.max_input_bytes {
+    False -> Ok(Nil)
+    True ->
+      Error(diagnostic.parse_limit_exceeded(
+        limit: "max_input_bytes",
+        configured: limits.max_input_bytes,
+        actual: actual,
+      ))
+  }
 }
 
 /// Parse an OpenAPI spec from a JSON string using OTP's native JSON

--- a/src/oaspec_ffi.mjs
+++ b/src/oaspec_ffi.mjs
@@ -19,6 +19,13 @@ export function monotonic_ms() {
   return Math.trunc(ms);
 }
 
+// Format an integer as a decimal string. Mirrors `erlang:integer_to_binary/1`
+// for cross-target use in places where `gleam/int.to_string` is not in
+// scope (e.g. inside diagnostic constructors).
+export function integer_to_string(n) {
+  return String(n);
+}
+
 // Run a thunk and report (panicked, message) to the caller. Mirrors
 // the BEAM implementation in `oaspec_ffi.erl`. Used by tests that
 // exercise functions which intentionally panic on invalid input.

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -13,6 +13,11 @@ pub fn parser_smoke_test() {
   let _ = support.parse_file_dispatches_json_path_for_json_extension_case()
   let _ = support.parse_json_string_preserves_yes_no_string_values_case()
   let _ = support.parse_json_string_preserves_dotted_version_literal_case()
+  let _ =
+    support.parse_string_with_limits_accepts_input_under_default_cap_case()
+  let _ = support.parse_string_with_limits_rejects_input_over_byte_cap_case()
+  let _ =
+    support.parse_string_with_limits_default_limits_match_documented_caps_case()
   let _ = support.parse_json_string_with_locations_returns_same_spec_case()
   let _ = support.parse_json_string_with_locations_index_is_empty_case()
   let _ = support.parse_string_or_json_with_locations_routes_json_test_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -934,6 +934,70 @@ pub fn parse_file_dispatches_json_path_for_json_extension_case() {
   spec.openapi |> should.equal("3.0.0")
 }
 
+// parse_string_with_limits / ParseLimits (#553) — DoS-aware parser limits
+
+pub fn parse_string_with_limits_accepts_input_under_default_cap_case() {
+  // A small inline spec is well under the 16 MiB default cap; the
+  // limit-aware entry point must accept it and produce the same spec
+  // a plain parse_string call would.
+  let yaml =
+    "
+openapi: 3.0.3
+info:
+  title: Tiny
+  version: 1.0.0
+paths: {}
+"
+  let assert Ok(spec) =
+    parser.parse_string_with_limits(yaml, parser.default_limits())
+  spec.openapi |> should.equal("3.0.3")
+  spec.info.title |> should.equal("Tiny")
+}
+
+pub fn parse_string_with_limits_rejects_input_over_byte_cap_case() {
+  // Build an input bigger than a deliberately tiny cap (1 byte) and
+  // confirm parse_string_with_limits rejects it before yamerl is
+  // invoked. The diagnostic must name the limit and the actual size.
+  let yaml =
+    "
+openapi: 3.0.3
+info: { title: Big, version: 1.0.0 }
+paths: {}
+"
+  let tiny_limit =
+    parser.ParseLimits(
+      max_input_bytes: 1,
+      max_schema_depth: 100,
+      max_allof_chain: 32,
+      max_external_ref_hops: 16,
+      max_paths: 4096,
+      max_parameters_per_op: 64,
+    )
+  let assert Error(d) = parser.parse_string_with_limits(yaml, tiny_limit)
+  d.code |> should.equal("parse_limit_exceeded")
+  // Diagnostic must name the offending limit so callers can bump
+  // exactly that field if they trust the source.
+  should.be_true(string.contains(d.message, "max_input_bytes"))
+  // Diagnostic must include the actual size, so an operator reading
+  // the message can decide what to set the cap to. We don't pin the
+  // exact integer (the YAML literal length above could drift across
+  // edits), only that the actual size is mentioned.
+  should.be_true(string.contains(d.message, "actual"))
+}
+
+pub fn parse_string_with_limits_default_limits_match_documented_caps_case() {
+  // Pin the documented default values so a future change to the
+  // defaults (raising or lowering them) lands in the test diff and
+  // gets reviewed alongside the docstring.
+  let limits = parser.default_limits()
+  limits.max_input_bytes |> should.equal(16 * 1024 * 1024)
+  limits.max_schema_depth |> should.equal(100)
+  limits.max_allof_chain |> should.equal(32)
+  limits.max_external_ref_hops |> should.equal(16)
+  limits.max_paths |> should.equal(4096)
+  limits.max_parameters_per_op |> should.equal(64)
+}
+
 // parse_json_string_with_locations / parse_string_or_json_with_locations (#550)
 
 pub fn parse_json_string_with_locations_returns_same_spec_case() {


### PR DESCRIPTION
## Summary

`parse_string` / `parse_file` accept arbitrary input size with no public knobs. A 100 MB pathological `spec.yaml` (alias-bomb, deeply nested allOf, 100k parameters) is parsed wholesale into memory on the runner. `oaspec` runs interactively (CLI), in CI, and increasingly inside services that accept user-supplied specs (admin uploads, contract-validation pipelines) — all three modes need a bound.

This PR is the strictly-additive first step: `parse_string_with_limits(content, limits)` alongside the existing `parse_string`, with the byte-size cap enforced (the cheapest and most impactful defense). The other limits the issue lists (`max_schema_depth`, `max_allof_chain`, `max_external_ref_hops`, `max_paths`, `max_parameters_per_op`) are declared as `ParseLimits` fields today so callers can pin the contract surface up front; future PRs will start enforcing them.

## Changes

- **New `parser.ParseLimits` type** with all six caps from the issue.
- **`parser.default_limits()`** returns project-default values: 16 MiB byte cap, 100 schema depth, 32 allOf chain, 16 external-ref hops, 4096 paths, 64 parameters per op. Real-world specs (Stripe ~6 MB, GitHub ~12 MB, AsyncAPI ~50) all fit comfortably.
- **`parser.parse_string_with_limits(content, limits)`** checks `max_input_bytes` via `string.byte_size` before any parser work begins, then delegates to `parse_string`. Oversized input returns a structured `parse_limit_exceeded` Diagnostic with the configured cap, the actual size, and a hint pointing at how to bump the limit (or refuse the source).
- **`diagnostic.parse_limit_exceeded`** is the new constructor (code `parse_limit_exceeded`, phase `PhaseParse`, severity `SeverityError`). The hint explicitly calls out that untrusted sources should keep the default cap — the defaults are the safe choice; raising them is the explicit step.
- **Three test cases** in `test/oaspec_support.gleam` (wired into `parser_smoke_test`):
  - `parse_string_with_limits_accepts_input_under_default_cap` — a small inline spec passes.
  - `parse_string_with_limits_rejects_input_over_byte_cap` — a tiny 1-byte cap rejects a real spec; diagnostic names the limit (`max_input_bytes`) and includes the actual size.
  - `parse_string_with_limits_default_limits_match_documented_caps` — pins the documented default values so a future change surfaces in the diff and gets reviewed.
- **`oaspec_ffi.mjs`** gains a small `integer_to_string` helper used by the new diagnostic constructor (mirrors `erlang:integer_to_binary/1`).
- **CHANGELOG entry** under `[Unreleased]` / `### Added`.

## Design decisions

- **Strictly additive.** `parse_string` keeps no-limit behaviour; only the new function enforces caps. The issue's recommended path: "stay strictly additive" — callers opt in to limits when they need them. This avoids breaking the trusted-local-file flow that the CLI's existing `parse_file` covers.
- **Byte cap first.** Of the six caps in `ParseLimits`, `max_input_bytes` is the cheapest to enforce (one `string.byte_size` call) and gives the largest blast-radius reduction (a 100 MB alias-bomb is rejected before yamerl allocates a tree). The other caps require walking the parsed tree — bigger code change for a smaller marginal gain. They are scoped for follow-up PRs.
- **Defaults sized for real-world specs, not hypothetical worst case.** 16 MiB clears Stripe and GitHub. 100 schema depth clears every spec the audit looked at (typical max ~12). 4096 paths clears Stripe's ~1k operations × 4. 64 parameters per op is well above the audit's worst case (~20). Tightening from here is explicit; loosening is also explicit (callers construct their own `ParseLimits`). This is the same posture as `relation.approximately(epsilon < 0)` and the codegen schema dispatchers — fail visibly on misconfiguration, with caps users can adjust.
- **Type declares the full set.** Future PRs will enforce the remaining caps; declaring them now means callers' construction code does not need to change between this PR and follow-ups.

## Breaking change

None — `parse_string` is unchanged.

Closes #553
