### PR TITLE
feat(config): default output dir to ./src so generated code drops into Gleam project layout (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Changed
+- **Default output directory is now `./src` instead of `./gen`.** A
+  freshly-generated project (`oaspec init` + `oaspec generate` with no
+  `output:` block) now writes to `./src/<package>` and
+  `./src/<package>_client`, the standard Gleam project layout that
+  `gleam build` picks up without further config. Previously the default
+  was `./gen/<package>`, outside `./src`, which produced the worst-of-
+  both first-contact friction: the generator reported success but the
+  freshly-built project couldn't see the modules. Callers who set
+  `output.dir` / `output.server` / `output.client` explicitly are
+  unaffected. The `init` template's commented-out `output:` block is
+  refreshed with the new defaults; `doc/configuration.md` and
+  `doc/library-api.md` updated. (#568)
+
 ## [0.60.0] - 2026-05-07
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Given one OpenAPI spec, `oaspec` writes modules you can keep in your
 repository:
 
 ```text
-gen/my_api/                  # server (mode: server | both)
+src/my_api/                  # server (mode: server | both)
   types.gleam
   decode.gleam
   encode.gleam
@@ -113,7 +113,7 @@ gen/my_api/                  # server (mode: server | both)
   handlers_generated.gleam
   router.gleam
 
-gen/my_api_client/           # client (mode: client | both)
+src/my_api_client/           # client (mode: client | both)
   types.gleam
   decode.gleam
   encode.gleam
@@ -122,6 +122,12 @@ gen/my_api_client/           # client (mode: client | both)
   guards.gleam
   client.gleam
 ```
+
+The default base directory is `./src` so the generated modules drop
+straight into the standard Gleam project layout — `gleam build` picks
+them up immediately. Override via `output.dir` (or per-target
+`output.server` / `output.client`) in `oaspec.yaml` if you want them
+elsewhere.
 
 `handlers.gleam` is the one user-owned file — the generator writes panic
 stubs on the first run and skips it afterwards, so your implementations

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -17,7 +17,7 @@ projects, set `output.server` and/or `output.client` explicitly.
 | `package` | no | `api` | Gleam module namespace prefix |
 | `mode` | no | `both` | `server`, `client`, or `both` |
 | `validate` | no | mode-dependent (`true` for `server` / `both`, `false` for `client`) | Enable guard validation in generated server/client code |
-| `output.dir` | no | `./gen` | Base output directory |
+| `output.dir` | no | `./src` | Base output directory (defaults inside `./src` so generated modules drop into the standard Gleam project layout — #568) |
 | `output.server` | no | `<dir>/<package>` | Server output path |
 | `output.client` | no | `<dir>/<package>_client` | Client output path |
 | `include.tags` | no | `[]` | Operation tag allowlist (filter) |

--- a/doc/library-api.md
+++ b/doc/library-api.md
@@ -41,8 +41,8 @@ import oaspec/openapi/parser
 let assert Ok(spec) = parser.parse_file("openapi.yaml")
 let cfg = config.new(
   input: "openapi.yaml",
-  output_server: "./gen/my_api",
-  output_client: "./gen/my_api_client",
+  output_server: "./src/my_api",
+  output_client: "./src/my_api_client",
   package: "my_api",
   mode: config.Both,
   validate: False,

--- a/src/oaspec/config.gleam
+++ b/src/oaspec/config.gleam
@@ -315,7 +315,15 @@ fn parse_target_node(
 
   // Determine output base directory, then derive mode-aware
   // server/client defaults. Priority: output.server/client
-  // (explicit) > output.dir (base) > default "./gen".
+  // (explicit) > output.dir (base) > default "./src".
+  //
+  // The default lands inside `./src` so a freshly-generated project
+  // is buildable by `gleam build` in one step — `./src` is the
+  // standard location Gleam picks modules from. Earlier versions
+  // defaulted to `./gen`, which produced the worst-of-both first-
+  // contact friction: the generator reported success but
+  // `gleam build` could not see the generated modules until the
+  // user added an `output:` block. (Issue #568.)
   //
   // The `_client` suffix is only needed in `Both` mode to
   // disambiguate the two output trees inside a single `<dir>`. In
@@ -329,7 +337,7 @@ fn parse_target_node(
   // for diagnostics; it is never read by the writer or codegen.
   let output_dir =
     extract_nested_string(node, "output", "dir")
-    |> option.unwrap("./gen")
+    |> option.unwrap("./src")
 
   let server_default = output_dir <> "/" <> package
   let client_default = case mode {

--- a/src/oaspec/internal/cli.gleam
+++ b/src/oaspec/internal/cli.gleam
@@ -220,15 +220,19 @@ package: api
 # override the mode-dependent default.
 # validate: true
 
-# Output settings (optional).
+# Output settings (optional). Defaults land inside ./src so a
+# freshly-generated project is buildable by `gleam build` without
+# any further config (#568):
+#   server -> ./src/<package>
+#   client -> ./src/<package>_client (Both mode) or ./src/<package> (Client mode)
+# Override individual targets via output.server / output.client, or
+# set output.dir to change the base directory for both at once.
 # output:
-#   dir: ./gen                    # Base directory; default paths are
-#                                 #   server -> <dir>/<package>
-#                                 #   client -> <dir>/<package>_client
-#                                 # so a single `gleam build` rooted at <dir>
-#                                 # picks up both.
-#   server: ./gen/api             # Override server output path
-#   client: ./gen/api_client      # Override client output path
+#   dir: ./src                    # Base directory; defaults to ./src
+#                                 # so generated modules drop into the
+#                                 # standard Gleam project layout.
+#   server: ./src/api             # Override server output path
+#   client: ./src/api_client      # Override client output path
 
 # Operation filter (optional, Issue #387). When set, codegen only
 # emits operations whose tag list intersects `tags` OR whose path

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -199,6 +199,9 @@ pub fn config_validate_default_client_case() {
 pub fn config_client_only_default_drops_client_suffix_case() {
   let assert Ok(cfg) =
     config.load("test/fixtures/oaspec_client_default_path.yaml")
+  // Fixture explicitly sets `output.dir: ./gen`. The test name says
+  // "default" because it pins the **client mode default** of dropping
+  // the `_client` suffix (#262) — `output.dir` itself is supplied.
   config.output_client(cfg) |> should.equal("./gen/api")
 }
 


### PR DESCRIPTION
## Summary

Changes the default output base directory from `./gen` to `./src` so a freshly-generated project (`oaspec init` + `oaspec generate` with no `output:` block) is buildable by `gleam build` in one step. Previously the default landed outside Gleam's standard `./src/` lookup path, producing the worst-of-both first-contact friction: the generator reported success but the freshly-built project couldn't see the modules. Closes #568.

## Changes

- `src/oaspec/config.gleam`: `output.dir` default flipped from `"./gen"` to `"./src"`. The `_client` suffix logic is unchanged (server/client mode rules from #262 still hold). Doc comment expanded to explain the rationale.
- `src/oaspec/internal/cli.gleam`: the `init` template's commented-out `output:` block now shows `./src` as the default and explicitly states "defaults inside `./src` so generated modules drop into the standard Gleam project layout".
- `README.md`: "Generated files" tree shows `src/my_api/` / `src/my_api_client/` and a new paragraph spells out that the default `./src` makes `gleam build` Just Work.
- `doc/configuration.md`: `output.dir` default cell updated to `./src` with a one-line rationale.
- `doc/library-api.md`: code sample updated to use `./src/my_api` / `./src/my_api_client`.
- `test/oaspec_support.gleam`: clarifying comment in `config_client_only_default_drops_client_suffix_case` (the fixture explicitly sets `output.dir: ./gen`, so the assertion stays at `./gen/api` — the test is about the client-mode `_client`-drop default from #262, not the base-dir default this PR changes).

## Design Decisions

- **Default change, not deprecation cycle.** Calling code that sets `output.dir` / `output.server` / `output.client` explicitly is unaffected — only the unset-default path moves. This is the smallest possible visible change for the largest first-contact win, and the previous behaviour is one config line away.
- **`./src` as the base, not `./src/gen`.** `./src/<package>` is what callers naturally want — the package name is already namespaced inside `src/`, no extra `gen/` segment buys anything. The `_client` suffix in `Both` mode is the only disambiguator needed and is retained.
- **Init template stays commented.** With the right defaults, the `output:` block in `oaspec.yaml` is opt-in; there's no need to ship a stamped one. The comment block is retained so users discover the override surface.
- **No deprecation banner / error path for the old default.** Existing config files with `output.dir: ./gen` continue to work unchanged. Anyone relying on the implicit `./gen` will hit it once when their project regenerates and one config line solves it.

## Test plan

- All 400 existing tests pass on the Erlang target (`gleam test --target erlang`). The one test that previously asserted the literal `./gen/api` path (`config_client_only_default_drops_client_suffix_case`) was using a fixture that explicitly sets `output.dir: ./gen`; the comment is updated to make that intent explicit.
- Manual sandbox: re-ran the `gleam-oss-test` workdir's oaspec workflow without an explicit `output:` block — generated files now land in `./src/api/` and `./src/api_client/` and `gleam build` picks them up immediately.

## Limitations

- Users who set `output.dir: ./gen` explicitly in their `oaspec.yaml` continue to get the old behaviour — this PR only changes the implicit default.
- The closed prior issues around output paths (#319 / #248 / #262 / #393) collectively fixed pieces of this story; this PR closes the remaining "default doesn't drop in" gap that #568 surfaced.

Closes #568