### PR TITLE
fix(parser): reject duplicate response keys in responses and components.responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`oaspec validate` and `oaspec generate` now reject specs that
+  contain duplicate keys in `responses` or `components.responses`**
+  with a `duplicate_key` diagnostic, instead of silently dropping one
+  of the two definitions. yamerl tolerates duplicate mapping keys, so
+  before this change two `'200':` entries on the same operation (or
+  two same-named entries under `components.responses`) would silently
+  overwrite — only the last value survived, and `validate` printed
+  `Validation passed.`. The check runs at parse time so both `validate`
+  and `generate` surface the diagnostic. (#573)
+
 ## [0.61.0] - 2026-05-08
 
 ### Changed

--- a/src/oaspec/openapi/diagnostic.gleam
+++ b/src/oaspec/openapi/diagnostic.gleam
@@ -147,6 +147,34 @@ pub fn invalid_value(
   )
 }
 
+/// Issue #573: a YAML mapping at `path` contains the same key twice.
+/// yamerl tolerates duplicate mapping keys (only the last value
+/// survives), so this is the only signal users get that their spec
+/// silently dropped one of two definitions. Surfaced as a parse-phase
+/// error so `oaspec validate` rejects the file before generation.
+///
+/// `key` is the duplicated key as it appears in the source (e.g.
+/// `"200"` for a duplicated response status code, `"foo"` for a
+/// duplicated component name).
+pub fn duplicate_key(
+  path path: String,
+  key key: String,
+  loc loc: SourceLoc,
+) -> Diagnostic {
+  Diagnostic(
+    code: "duplicate_key",
+    phase: PhaseParse,
+    severity: SeverityError,
+    target: TargetBoth,
+    pointer: path,
+    source_loc: loc,
+    message: "Duplicate key '" <> key <> "' in " <> path,
+    hint: Some(
+      "OpenAPI inherits JSON-object key uniqueness; YAML 1.2 §3.2.1.3 leaves duplicate mapping keys undefined. Remove or rename the duplicate so the spec parses unambiguously.",
+    ),
+  )
+}
+
 // ============================================================================
 // Convenience constructors for resolve phase
 // ============================================================================

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1274,6 +1274,15 @@ fn parse_responses(
 ) -> Result(Dict(http.HttpStatusCode, RefOr(Response(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
+      // Issue #573: yamerl tolerates duplicate mapping keys, so two
+      // `'200':` entries on the same operation would silently overwrite
+      // (later wins). Reject duplicates explicitly before the
+      // dict.insert loop so users see a parse-time error.
+      use _ <- result.try(check_unique_yaml_keys(
+        entries: entries,
+        path: "responses",
+        index: index,
+      ))
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {
@@ -1303,6 +1312,57 @@ fn parse_responses(
       })
     }
     _ -> Ok(dict.new())
+  }
+}
+
+/// Issue #573: detect duplicate keys in a YAML mapping before consuming
+/// it into a `Dict`. yamerl preserves the original `entries` list with
+/// both occurrences of a duplicate key, but `dict.insert` silently
+/// overwrites — so without this check, duplicates disappear into
+/// undefined behavior (whichever entry happens to be inserted last
+/// wins). Returns the *first* duplicate as a `Diagnostic`; we don't
+/// accumulate every duplicate to keep the parse-phase contract
+/// (one error stops parsing).
+///
+/// The `index` argument is reserved for a future source-location
+/// lookup (so the diagnostic can name the line of the second
+/// occurrence). For now the location index does not retain per-key
+/// positions inside arbitrary maps, so the diagnostic carries
+/// `NoSourceLoc` and the user-facing message names the path
+/// (`responses`, `components.responses`) instead.
+fn check_unique_yaml_keys(
+  entries entries: List(#(yay.Node, yay.Node)),
+  path path: String,
+  index index: LocationIndex,
+) -> Result(Nil, Diagnostic) {
+  let loc = location_index.lookup(index, path)
+  list.try_fold(entries, [], fn(seen, entry) {
+    let #(key_node, _) = entry
+    case key_node_to_string(key_node) {
+      Some(key) ->
+        case list.contains(seen, key) {
+          True ->
+            Error(diagnostic.duplicate_key(path: path, key: key, loc: loc))
+          False -> Ok([key, ..seen])
+        }
+      None -> Ok(seen)
+    }
+  })
+  |> result.map(fn(_) { Nil })
+}
+
+/// Render a `yay` key node as a comparable string for duplicate
+/// detection. Returns `None` for node types that cannot occur as
+/// OpenAPI map keys (lists, maps, etc.); those positions are handled
+/// elsewhere as `invalid_value` errors and do not need duplicate
+/// checking.
+fn key_node_to_string(node: yay.Node) -> Option(String) {
+  case node {
+    yay.NodeStr(s) -> Some(s)
+    yay.NodeInt(n) -> Some(int.to_string(n))
+    yay.NodeBool(True) -> Some("true")
+    yay.NodeBool(False) -> Some("false")
+    _ -> None
   }
 }
 
@@ -1522,6 +1582,14 @@ fn parse_responses_map(
 ) -> Result(Dict(String, RefOr(Response(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: components_node, selector: "responses") {
     Ok(yay.NodeMap(entries)) -> {
+      // Issue #573: same duplicate-key concern as `parse_responses` —
+      // duplicate component names would silently overwrite without this
+      // check.
+      use _ <- result.try(check_unique_yaml_keys(
+        entries: entries,
+        path: "components.responses",
+        index: index,
+      ))
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -13,6 +13,8 @@ pub fn parser_smoke_test() {
   let _ = support.parse_file_dispatches_json_path_for_json_extension_case()
   let _ = support.parse_json_string_preserves_yes_no_string_values_case()
   let _ = support.parse_json_string_preserves_dotted_version_literal_case()
+  let _ = support.parser_rejects_duplicate_response_status_code_case()
+  let _ = support.parser_rejects_duplicate_components_response_name_case()
   let _ =
     support.parse_string_with_limits_accepts_input_under_default_cap_case()
   let _ = support.parse_string_with_limits_rejects_input_over_byte_cap_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -939,6 +939,54 @@ pub fn parse_file_dispatches_json_path_for_json_extension_case() {
 
 // parse_string_with_limits / ParseLimits (#553) — DoS-aware parser limits
 
+// Issue #573: a YAML mapping must not silently accept duplicate keys.
+// yamerl tolerates them (later wins), but `oaspec validate` is the
+// "is my spec OK?" surface and should catch this class of error.
+pub fn parser_rejects_duplicate_response_status_code_case() {
+  let yaml =
+    "
+openapi: 3.0.0
+info:
+  title: Broken
+  version: 1.0.0
+paths:
+  /broken:
+    get:
+      responses:
+        '200':
+          description: OK
+        '200':
+          description: dup
+"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("duplicate_key")
+  // Diagnostic must name the duplicated key so the user knows which
+  // entry to remove.
+  should.be_true(string.contains(d.message, "200"))
+  should.be_true(string.contains(d.message, "responses"))
+}
+
+pub fn parser_rejects_duplicate_components_response_name_case() {
+  let yaml =
+    "
+openapi: 3.0.0
+info:
+  title: DupComponents
+  version: 1.0.0
+paths: {}
+components:
+  responses:
+    NotFound:
+      description: A
+    NotFound:
+      description: B
+"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("duplicate_key")
+  should.be_true(string.contains(d.message, "NotFound"))
+  should.be_true(string.contains(d.message, "components.responses"))
+}
+
 pub fn parse_string_with_limits_accepts_input_under_default_cap_case() {
   // A small inline spec is well under the 16 MiB default cap; the
   // limit-aware entry point must accept it and produce the same spec


### PR DESCRIPTION
## Summary

Issue #573: yamerl tolerates duplicate mapping keys (later wins), so two `'200':` entries on the same operation — or two same-named entries under `components.responses` — would silently overwrite when the parser fed them through `dict.insert`. `oaspec validate` printed `Validation passed.` and `oaspec generate` emitted code from one of the two definitions with no warning. This PR detects duplicates at parse time and surfaces a `duplicate_key` diagnostic before the dict.insert loop.

The check is targeted at the two paths the issue specifically calls out (`responses` on operations, `components.responses`). Extending the same check to `paths`, `components.schemas`, `components.parameters`, etc. is a natural follow-up but kept out of scope here so the fix stays minimal and focused.

## Changes

- `src/oaspec/openapi/diagnostic.gleam` — new `duplicate_key/3` constructor producing a parse-phase `Diagnostic` with code `"duplicate_key"`. The hint references YAML 1.2 §3.2.1.3 and tells the user to remove or rename the duplicate.
- `src/oaspec/openapi/parser.gleam`:
  - New private `check_unique_yaml_keys/3` helper that walks the `yay.NodeMap` entries list, tracks seen keys, and emits the diagnostic on the first duplicate.
  - New private `key_node_to_string/1` helper that renders `NodeStr` / `NodeInt` / `NodeBool` keys as comparable strings (other node types are accepted as `None` since they cannot occur as OpenAPI map keys and would already fail elsewhere).
  - `parse_responses` and `parse_responses_map` call the helper before iterating entries.
  - `SourceLoc` is looked up via the existing `LocationIndex` so the diagnostic carries line/column info when available.
- `test/oaspec_support.gleam` — two new test cases:
  - `parser_rejects_duplicate_response_status_code_case` — exact reproduction from the issue (two `'200':` on a single operation).
  - `parser_rejects_duplicate_components_response_name_case` — same shape under `components.responses`.
- `test/oaspec_parse_core_test.gleam` — wires both into `parser_smoke_test`.
- `CHANGELOG.md` — Unreleased entry under `### Fixed`.

## Design Decisions

- **Parse-time, not validate-time.** The duplicate-key issue is structural to the input; catching it at parse time means both `oaspec validate` and `oaspec generate` surface the same diagnostic without each having to plumb the check separately.
- **Targeted, not blanket.** A general "reject duplicates in any YAML mapping" pass would be the most thorough fix (and the issue does propose option 1 along these lines), but it touches every parse path and risks rejecting input that older oaspec versions accepted. The two responses paths are the user-visible case the issue calls out; we can extend to other map locations as separate, smaller follow-ups if/when they show up in the wild.
- **First-duplicate semantics.** The helper returns the first duplicate it finds rather than aggregating every one. This matches the parse-phase contract elsewhere in oaspec (one error stops parsing) and keeps the diagnostic readable; if the user has multiple duplicates, they'll see them one rerun at a time, which is fine for typo-class errors.

## Limitations

- The check covers `responses` and `components.responses` only. Duplicate keys in `paths`, `components.schemas`, `components.parameters`, etc. still silently overwrite. Those are natural follow-up issues; flagging here so the scope is explicit.
- The diagnostic carries the path of the parent map (e.g. `responses`) but not the operation method/path that owns it, since the call site does not currently thread that context. Acceptable given the duplicate key is named in the message.

Closes #573