### PR TITLE
fix(parser): catch yay FFI tuple shape mismatch on YAML alias errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`openapi.parser.parse_string` no longer crashes the BEAM with a
+  `case_clause` for YAML containing an alias (`*foo`) whose anchor
+  (`&foo`) is missing or unresolved.** yay v2.0.x's FFI returns
+  `{error, {yaml_error, Msg, {Line, Col}}}` for yamerl errors that
+  surface a structured message, which doesn't match the documented
+  `yay.YamlError` Gleam encoding (`{parsing_error, Msg,
+  {yaml_error_loc, Line, Col}}`); the runtime case match in
+  `parse_to_node` then falls through to a BEAM `case_clause`. A
+  one-line malformed YAML payload was enough to DoS any server-side
+  parser context (CI plugins, public spec linters, multi-tenant
+  gateways). Add a small Erlang FFI shim
+  (`oaspec_yaml_safe_ffi.erl`) that normalises the FFI tuple shape
+  to the Gleam encoding before it reaches the case match. Same
+  family as #524 (non-YAML config) and #553 (DoS-limit config).
+  (#576)
+
 ### Added
 
 - Property-based tests for `oaspec/internal/util/naming` using

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -404,11 +404,26 @@ fn looks_like_json(content: String) -> Bool {
 /// Run yamerl on `content` and return the root node plus a
 /// location index built from the same content. Both pieces are
 /// consumed by `parse_root` to produce the OpenApiSpec.
+@external(erlang, "oaspec_yaml_safe_ffi", "parse_string")
+fn ffi_parse_yaml_safe(
+  content: String,
+) -> Result(List(yay.Document), yay.YamlError)
+
 fn parse_to_node(
   content: String,
 ) -> Result(#(yay.Node, LocationIndex), Diagnostic) {
   use docs <- result.try(
-    yay.parse_string(content)
+    // `oaspec_yaml_safe_ffi.parse_string` is a thin adapter over
+    // `yay:parse_string/1` that normalises yay v2.0.x's raw
+    // `{yaml_error, Msg, {Line, Col}}` FFI tuple into the Gleam
+    // encoding `yay.YamlError` is documented to carry. Calling
+    // `yay.parse_string` directly here would crash the BEAM with a
+    // `case_clause` for any input that triggers the alias /
+    // anchor resolution path (Issue #576) — a one-line malformed
+    // YAML payload can DoS a server-side spec validator. The
+    // adapter is local to this module; the rest of the parser
+    // keeps consuming the documented `yay.YamlError` surface.
+    ffi_parse_yaml_safe(content)
     |> result.map_error(fn(e) {
       case e {
         yay.ParsingError(msg:, loc:) ->

--- a/src/oaspec_yaml_safe_ffi.erl
+++ b/src/oaspec_yaml_safe_ffi.erl
@@ -1,0 +1,70 @@
+-module(oaspec_yaml_safe_ffi).
+
+%% Adapter around `yay:parse_string/1` (yay v2.0.x) that normalises
+%% the FFI's raw `{yaml_error, ...}` tuple shape into the Gleam
+%% encoding the upstream `yay.YamlError` Gleam type expects.
+%%
+%% Issue #576: yay's `yaml_ffi.erl` returns
+%% `{error, {yaml_error, Msg, {Line, Col}}}` for yamerl errors that
+%% surface a structured message + line/col (the alias-without-anchor
+%% case being the obvious example). Gleam's runtime pattern match on
+%% `yay.ParsingError(msg:, loc:)` expects
+%% `{parsing_error, Msg, {yaml_error_loc, Line, Col}}` instead, so
+%% `case e { ParsingError(...) -> _ }` falls through to a BEAM
+%% case_clause crash for any input that exercises this code path.
+%%
+%% A representative crash payload from a self-referential alias:
+%%   YamlError("No anchor corresponds to alias \"a\"", #(7, 10))
+%%
+%% This is server-side DoS in any context where a user controls the
+%% YAML input (CI plugins, public spec linters, multi-tenant
+%% gateways) — a 9-line malformed YAML payload is enough to crash
+%% the parsing process. Rather than vendor yay or wait for an
+%% upstream fix, we adapt the tuple shape at the FFI boundary so
+%% the rest of the parser keeps using the documented `yay.YamlError`
+%% surface unchanged.
+
+-export([parse_string/1]).
+
+-spec parse_string(binary()) ->
+    {ok, list(term())}
+    | {error, unexpected_parsing_error
+            | {parsing_error, binary(), {yaml_error_loc, integer(), integer()}}}.
+parse_string(Content) when is_binary(Content) ->
+    try yay:parse_string(Content) of
+        {ok, _} = Ok ->
+            Ok;
+        {error, Reason} ->
+            {error, normalise_error(Reason)}
+    catch
+        error:Reason:_ ->
+            %% Defence in depth: even if a future yay version
+            %% raises rather than returns, we surface a sensible
+            %% Gleam-shaped error instead of propagating the BEAM
+            %% exception out of the parsing process.
+            {error, normalise_error(Reason)}
+    end.
+
+%% Map every observed yay-FFI error tuple shape onto the canonical
+%% Gleam encoding for `yay.YamlError`:
+%%   - `UnexpectedParsingError`         → atom `unexpected_parsing_error`
+%%   - `ParsingError(msg, loc)`         → `{parsing_error, Msg, {yaml_error_loc, Line, Col}}`
+%%
+%% Anything we cannot classify falls through to
+%% `unexpected_parsing_error` so the upstream error path keeps
+%% working without a new variant.
+
+normalise_error(unexpected_parsing_error) ->
+    unexpected_parsing_error;
+normalise_error({yaml_error, unexpected_parsing_error}) ->
+    %% Inner-tagged variant from yay's `error:_` catch-all.
+    unexpected_parsing_error;
+normalise_error({yaml_error, Msg, {Line, Col}})
+        when is_binary(Msg), is_integer(Line), is_integer(Col) ->
+    %% The shape that triggers #576.
+    {parsing_error, Msg, {yaml_error_loc, Line, Col}};
+normalise_error({parsing_error, _, _} = Already) ->
+    %% Already in the documented Gleam shape — pass through.
+    Already;
+normalise_error(_Other) ->
+    unexpected_parsing_error.

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -15,6 +15,8 @@ pub fn parser_smoke_test() {
   let _ = support.parse_json_string_preserves_dotted_version_literal_case()
   let _ = support.parser_rejects_duplicate_response_status_code_case()
   let _ = support.parser_rejects_duplicate_components_response_name_case()
+  let _ = support.parser_rejects_yaml_alias_without_anchor_case()
+  let _ = support.parser_rejects_yaml_alias_with_no_matching_anchor_path_case()
   let _ =
     support.parse_string_with_limits_accepts_input_under_default_cap_case()
   let _ = support.parse_string_with_limits_rejects_input_over_byte_cap_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -966,6 +966,46 @@ paths:
   should.be_true(string.contains(d.message, "responses"))
 }
 
+pub fn parser_rejects_yaml_alias_without_anchor_case() {
+  // Issue #576: YAML aliases (`*foo`) that reference a missing
+  // anchor (`&foo`) must surface a `yaml_error` Diagnostic instead
+  // of crashing the parsing process with a BEAM `case_clause`.
+  // Server-side spec validators that accept user-uploaded specs
+  // could be DoS'd by a one-line malformed YAML payload.
+  let yaml =
+    "openapi: 3.0.0
+info:
+  title: t
+  version: \"1\"
+paths:
+  /a: &a
+    get: *a
+"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("yaml_error")
+  // The yamerl message names the unresolved alias so the user can
+  // locate the dangling reference in their spec.
+  should.be_true(string.contains(d.message, "alias"))
+}
+
+pub fn parser_rejects_yaml_alias_with_no_matching_anchor_path_case() {
+  // Variant of the alias-error path: the anchor `&p` would be
+  // defined under `paths:` but on a key whose flow-style is
+  // ambiguous, so yamerl never registers it before `*p` resolves.
+  let yaml =
+    "openapi: 3.0.0
+info:
+  title: t
+  version: \"1\"
+paths:
+  &p
+    a: &q
+    b: *p
+"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("yaml_error")
+}
+
 pub fn parser_rejects_duplicate_components_response_name_case() {
   let yaml =
     "


### PR DESCRIPTION
## Summary

`openapi.parser.parse_string` crashed the BEAM with a `case_clause`
for any YAML input that triggered yamerl's alias-resolution path
without a matching anchor:

```
unmatched value:
  YamlError(\"No anchor corresponds to alias \\\"a\\\"\", #(7, 10))
```

A one-line malformed YAML payload was enough to DoS any server-side
parsing context (CI plugins, public spec linters, multi-tenant
gateways), which is the security shape the issue flagged.

## Root cause

yay v2.0.x's `yaml_ffi.erl` returns
`{error, {yaml_error, Msg, {Line, Col}}}` for yamerl errors that
surface a structured message + line/col. Gleam's runtime pattern
match on:

- `yay.ParsingError(msg:, loc:)` → encoded `{parsing_error, Msg, {yaml_error_loc, Line, Col}}`
- `yay.UnexpectedParsingError` → encoded `unexpected_parsing_error`

does not match the FFI's `{yaml_error, ...}` tuple. The case fell
through with no default arm, raising `case_clause` out of
`parse_to_node`.

This is the same family as closed #524 (non-YAML config) and #553
(DoS-limit config) but for adversarial YAML rather than the
extension / size axes.

## Changes

### `src/oaspec_yaml_safe_ffi.erl` (new)

- Thin Erlang adapter around `yay:parse_string/1`.
- Normalises every observed bad tuple shape onto the Gleam
  encoding `yay.YamlError` is documented to carry:
  - `unexpected_parsing_error` → kept.
  - `{yaml_error, unexpected_parsing_error}` → unwrapped to
    `unexpected_parsing_error`.
  - `{yaml_error, Msg, {Line, Col}}` → rewrapped to
    `{parsing_error, Msg, {yaml_error_loc, Line, Col}}` (the
    shape that triggers #576).
  - `{parsing_error, _, _}` → already correct, passes through.
  - Anything else falls back to `unexpected_parsing_error` so
    the upstream error path keeps working without a new variant.
- `try ... catch error:_:_` for defence in depth: future yay
  versions that *raise* rather than *return* won't propagate a
  BEAM exception out of the parsing process.

### `src/oaspec/openapi/parser.gleam`

- Switch `parse_to_node` to call the safe wrapper instead of
  `yay.parse_string` directly via a local
  `@external(erlang, ..., \"parse_string\")` binding. The rest of
  the parser keeps consuming the documented `yay.YamlError`
  surface unchanged; no caller needed touching.
- Doc-comment near the call site explains why we go through the
  shim (so a future reader doesn't \"helpfully\" inline
  `yay.parse_string` back).

### `test/oaspec_support.gleam` + `test/oaspec_parse_core_test.gleam`

- Two new test cases that exercise the alias-error path:
  - `parser_rejects_yaml_alias_without_anchor_case` — the
    self-referential `&a ... *a` repro from the issue body.
  - `parser_rejects_yaml_alias_with_no_matching_anchor_path_case` —
    the dangling-anchor `&p ... *p` repro from the issue body.
- Both assert that the parser returns
  `Error(Diagnostic(code: \"yaml_error\", ...))` instead of
  crashing the process.

### `CHANGELOG.md`

- Fixed entry under `[Unreleased]`.

## Design Decisions

**Why an FFI shim rather than vendoring or upgrading yay.** A
fresh yay release on hex would take a coordination round-trip the
fix doesn't need; vendoring a private yamerl wrapper would mean
maintaining the document / node / location surface oaspec already
uses. The shim is 60 lines of Erlang, fixes the symptom at the
exact boundary that introduces it, and leaves yay free to fix the
underlying tuple shape upstream when convenient.

**Why fall through to `unexpected_parsing_error` for unknown
shapes.** A new yay version could grow new error variants. Falling
through to the existing `UnexpectedParsingError` keeps the
upstream error path working without a Gleam-side dispatch table
update — at the cost of losing the new variant's message detail,
which the user can recover by upgrading yay-side handling once
yay's encoding stabilises.

**Why catch `error:Reason` and translate it.** The existing
panic was not a `throw` but a runtime `case_clause`, which BEAM
classifies as `error`. The catch ensures that even if a future
yay version moves to raising for some error class, oaspec's
parser surface stays a pure Result.

## Test plan

- [x] `gleam test` — 417 passed (was 415 plus 2 new test cases
      embedded in `parser_smoke_test`)
- [x] `just check` — format-check + glinter + check + build + test
- [x] Manual repro from the issue body (`{ &a ... *a }` and
      `{ &p ... *p }`) returns `Error(yaml_error)` instead of
      crashing the BEAM.

Closes #576.