### PR TITLE
fix(parser): require string `openapi` field in YAML path too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Breaking
+
+- **`parse_string` / `parse_file` (YAML path) now require the `openapi`
+  field to be a YAML string, matching the contract `parse_json_string`
+  has enforced since #580.** Previously the YAML walker fell back to
+  the float-extractor when `openapi` was an unquoted number, so a
+  document with `openapi: 3.0` (parsed by yamerl as the float `3.0`)
+  was silently coerced back to the string `"3.0"` and accepted. The
+  same document via the JSON path was already rejected, producing a
+  surprising format-dependent verdict for users feeding the same spec
+  to both targets. Both paths now reject non-string `openapi` values
+  with the standard `missing_field` diagnostic; authors who relied on
+  the unquoted YAML form must add quotes (`openapi: '3.0'`) or pin a
+  three-segment patch (`openapi: 3.0.3` — yamerl resolves that as a
+  string, no quotes required). The `strict_types` toggle on
+  `parse_root` / `extract_openapi_field` has been removed; both
+  callers share a single string-extraction path. (#583)
+
 ## [0.64.0] - 2026-05-10
 
 ### Fixed

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1,6 +1,5 @@
 import gleam/bool
 import gleam/dict.{type Dict}
-import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -286,7 +285,7 @@ pub fn parse_string_with_locations(
   content: String,
 ) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   use #(root, index) <- result.try(parse_to_node(content))
-  use spec <- result.map(parse_root(root, index, strict_types: False))
+  use spec <- result.map(parse_root(root, index))
   #(spec, index)
 }
 
@@ -364,11 +363,7 @@ pub fn parse_json_string_with_locations(
   content: String,
 ) -> Result(#(OpenApiSpec(Unresolved), LocationIndex), Diagnostic) {
   use root <- result.try(decode_json_to_node(content))
-  use spec <- result.map(parse_root(
-    root,
-    location_index.empty(),
-    strict_types: True,
-  ))
+  use spec <- result.map(parse_root(root, location_index.empty()))
   #(spec, location_index.empty())
 }
 
@@ -496,9 +491,8 @@ fn looks_like_json_path(path: String) -> Bool {
 fn parse_root(
   node: yay.Node,
   index: LocationIndex,
-  strict_types strict_types: Bool,
 ) -> Result(OpenApiSpec(Unresolved), Diagnostic) {
-  use openapi <- result.try(extract_openapi_field(node, index, strict_types))
+  use openapi <- result.try(extract_openapi_field(node, index))
 
   use _ <- result.try(validate_openapi_version(
     openapi,
@@ -574,58 +568,33 @@ fn is_supported_openapi_version(version: String) -> Bool {
         Ok(n) if n >= 0 -> True
         _ -> False
       }
-    // Two-segment "3.0" / "3.1" is tolerated: float-parsed YAML numbers
-    // like `openapi: 3.0` arrive as "3.0" after normalization.
+    // Two-segment "3.0" / "3.1" is tolerated for authors who quote the
+    // short form intentionally (`openapi: '3.0'`). The unquoted YAML
+    // float path that this branch originally served was removed in #583.
     ["3", "0"] | ["3", "1"] -> True
     _ -> False
   }
 }
 
 /// Extract the root `openapi` field. The OAS 3.0 / 3.1 schema requires
-/// this field to be a string. The `strict_types` flag controls whether
-/// we honour the YAML 1.1 number-coercion compatibility path:
-///
-/// - `strict_types: True` (JSON callers) — only `NodeStr` is accepted.
-///   JSON has explicit string syntax; an unquoted number is the
-///   author's mistake, not a yamerl quirk, so we surface it cleanly
-///   rather than silently coercing. (#580 case B)
-/// - `strict_types: False` (YAML callers) — falls back to `extract_float`
-///   so a yamerl-coerced `openapi: 3.0` (no quotes) keeps parsing as
-///   `"3.0"`. The compatibility path is documented and exercised by
-///   `parse_accepts_openapi_3_0_from_yaml_float_case`.
+/// this field to be a string, and both parsers enforce that contract
+/// uniformly. The YAML caller used to fall back to `extract_float` so
+/// an unquoted `openapi: 3.0` (which yamerl resolves as a float) would
+/// coerce back to `"3.0"`; that lenient path was the YAML-side of the
+/// #580 asymmetry and #583 closes it. Authors who relied on unquoted
+/// version numbers must quote them (`openapi: '3.0'`).
 fn extract_openapi_field(
   node: yay.Node,
   index: LocationIndex,
-  strict_types: Bool,
 ) -> Result(String, Diagnostic) {
   let loc = location_index.lookup_field(index, "", "openapi")
-  case strict_types {
-    True ->
-      yay.extract_string(node, "openapi")
-      |> result.map_error(parser_yay_error.missing_field_from_extraction(
-        _,
-        path: "",
-        field: "openapi",
-        loc: loc,
-      ))
-    False ->
-      yay.extract_string(node, "openapi")
-      |> result.lazy_or(fn() {
-        yay.extract_float(node, "openapi")
-        |> result.map(fn(f) {
-          case f == int.to_float(float.truncate(f)) {
-            True -> int.to_string(float.truncate(f)) <> ".0"
-            False -> float.to_string(f)
-          }
-        })
-      })
-      |> result.map_error(parser_yay_error.missing_field_from_extraction(
-        _,
-        path: "",
-        field: "openapi",
-        loc: loc,
-      ))
-  }
+  yay.extract_string(node, "openapi")
+  |> result.map_error(parser_yay_error.missing_field_from_extraction(
+    _,
+    path: "",
+    field: "openapi",
+    loc: loc,
+  ))
 }
 
 /// Mirror of yay's private `node_type_name` for the diagnostic

--- a/test/fixtures/oss_libopenapi_circular.yaml
+++ b/test/fixtures/oss_libopenapi_circular.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0
+openapi: '3.0'
 paths:
   /burgers:
     post:

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -43,7 +43,9 @@ pub fn openapi_version_gate_test() {
   let _ = support.parse_rejects_bare_openapi_3_case()
   let _ = support.parse_accepts_openapi_3_0_3_case()
   let _ = support.parse_accepts_openapi_3_1_0_case()
-  let _ = support.parse_accepts_openapi_3_0_from_yaml_float_case()
+  let _ = support.parse_rejects_unquoted_openapi_float_from_yaml_case()
+  let _ = support.parse_accepts_quoted_openapi_3_0_from_yaml_case()
+  let _ = support.parse_rejects_unquoted_openapi_int_from_yaml_case()
 }
 
 pub fn parser_security_and_shape_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1352,12 +1352,17 @@ pub fn oss_oai_webhook_example_components_match_case() {
 // output, so the parser rejects anything outside 3.0.x / 3.1.x up front.
 
 pub fn parse_rejects_openapi_2_0_case() {
+  // Quoting the version so we reach the version-gate logic; #583 closed
+  // the YAML-float compatibility path that this test originally relied
+  // on. Bare `openapi: 2.0` is now rejected one step earlier as a
+  // missing-field-of-the-right-type, exercised by the YAML-path tests
+  // alongside the #580 / #583 regression block.
   let yaml =
     "
-openapi: 2.0
+openapi: '2.0'
 info:
   title: Wrong API
-  version: 1.0.0
+  version: '1.0.0'
 paths: {}
 "
   let result = parser.parse_string(yaml)
@@ -1484,11 +1489,12 @@ paths: {}
   spec.openapi |> should.equal("3.1.0")
 }
 
-pub fn parse_accepts_openapi_3_0_from_yaml_float_case() {
-  // YAML numbers like `openapi: 3.0` arrive as the float 3.0 and get
-  // normalized to the string "3.0". That two-segment form must still
-  // parse so existing specs that rely on YAML float semantics keep
-  // working.
+pub fn parse_rejects_unquoted_openapi_float_from_yaml_case() {
+  // YAML 1.1 parses an unquoted `openapi: 3.0` as a float. The JSON
+  // path already rejects non-string `openapi` values after #580; the
+  // YAML path now mirrors that contract (#583) so the same document
+  // gets the same verdict regardless of file format. Authors must
+  // quote the version: `openapi: '3.0'`.
   let yaml =
     "
 openapi: 3.0
@@ -1497,8 +1503,41 @@ info:
   version: 1.0.0
 paths: {}
 "
+  let result = parser.parse_string(yaml)
+  let assert Error(Diagnostic(code: "missing_field", pointer: "", ..)) = result
+}
+
+pub fn parse_accepts_quoted_openapi_3_0_from_yaml_case() {
+  // Counterpart to parse_rejects_unquoted_openapi_float_from_yaml_case:
+  // the post-#583 contract is that the version must be a YAML string,
+  // not that the two-segment form is invalid. Quoting the version
+  // keeps the historical short form working.
+  let yaml =
+    "
+openapi: '3.0'
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+"
   let assert Ok(spec) = parser.parse_string(yaml)
   spec.openapi |> should.equal("3.0")
+}
+
+pub fn parse_rejects_unquoted_openapi_int_from_yaml_case() {
+  // `openapi: 3` arrives from yamerl as the integer 3. The OAS 3.0
+  // schema requires a string; reject so downstream `validate` /
+  // `generate` do not operate on a non-string version value. (#583)
+  let yaml =
+    "
+openapi: 3
+info:
+  title: API
+  version: '1.0.0'
+paths: {}
+"
+  let result = parser.parse_string(yaml)
+  let assert Error(Diagnostic(code: "missing_field", pointer: "", ..)) = result
 }
 
 pub fn parse_secure_api_has_security_schemes_case() {
@@ -2294,9 +2333,9 @@ paths: {}
 // #580 regression — strict OAS 3.0 schema enforcement at the document root.
 // Three cases with a shared root cause (parse_root did not enforce
 // schema-required fields / value-types). Each case uses the JSON path,
-// matching the issue reproduction; the YAML path is exercised by the
-// `parse_accepts_openapi_3_0_from_yaml_float_case` regression-protection
-// test which still passes because the YAML lenient path is preserved.
+// matching the issue reproduction; the YAML-path symmetry is covered
+// by `parse_rejects_unquoted_openapi_float_from_yaml_case` and the
+// other YAML-side cases above, added in #583.
 // ---------------------------------------------------------------------------
 
 /// Case A from #580: `paths` is required at the root for OAS 3.0.
@@ -2319,9 +2358,9 @@ pub fn parse_json_oas_30_rejects_missing_paths_case() {
 /// Case B from #580: `openapi` MUST be a string per the OAS 3.0 schema.
 /// `parse_json_string` previously coerced an integer `openapi: 3`
 /// through the lenient float fallback (intended for YAML 1.1 number
-/// coercion only). The JSON path now rejects non-string values up front;
-/// the YAML path keeps the lenient behaviour for unquoted versions like
-/// `openapi: 3.0`.
+/// coercion only). The JSON path rejects non-string values up front,
+/// and after #583 the YAML path mirrors that contract — both targets
+/// require a quoted string.
 pub fn parse_json_rejects_integer_openapi_field_case() {
   let json =
     "{\"openapi\":3,\"info\":{\"title\":\"X\",\"version\":\"1.0.0\"},\"paths\":{}}"


### PR DESCRIPTION
## Summary

The YAML walker fell back to `extract_float` when `openapi` was an unquoted number, so `openapi: 3.0` (which yamerl parses as the float `3.0`) was silently coerced to the string `"3.0"` and accepted. The JSON path rejects the same input since #580. Same document, different verdict per format — the very thing #580 closed for the JSON side. This PR closes the YAML side.

## Changes

- `extract_openapi_field` now has a single string-extraction path; the float fallback (`yay.extract_float` + manual `"X.0"` normalisation) is gone.
- The `strict_types` toggle on `parse_root` and `extract_openapi_field` is removed — both callers shared the same intent and now share the same path.
- Test `parse_accepts_openapi_3_0_from_yaml_float_case` is replaced with three cases: `parse_rejects_unquoted_openapi_float_from_yaml_case`, `parse_accepts_quoted_openapi_3_0_from_yaml_case`, and `parse_rejects_unquoted_openapi_int_from_yaml_case`. They cover the #583 reproduction (yaml int, yaml float) plus the positive case for the now-required quoted form.
- Fixture `test/fixtures/oss_libopenapi_circular.yaml` had `openapi: 3.0` (unquoted, the original yamerl-coercion case); quoted so the test that uses it (`oss_libopenapi_circular_rejects_missing_info_case`) keeps reaching the missing-info diagnostic it actually asserts on.
- `parse_rejects_openapi_2_0_case` used unquoted `openapi: 2.0` to exercise the version gate via the float compatibility path. Quoted to keep the version-gate intent reachable.
- `gleam/float` import dropped from `parser.gleam`; it had no other use.

## Design Decisions

- **Removed the toggle rather than flipping it.** Once both callers want strict-types, the parameter is just a vestigial seam. Keeping it would invite future drift between paths — the asymmetry this PR closes is the exact failure mode the toggle enabled.
- **Kept the two-segment `"3.0"` / `"3.1"` tolerance in `is_supported_openapi_version`.** The motivation for that branch (unquoted YAML floats) is gone, but quoted-short-form (`openapi: '3.0'`) is still a thing some authors write, and the OAS 3.0 schema does not forbid it. The doc comment is updated to reflect the post-#583 rationale.
- **Diagnostic shape unchanged.** Both targets now emit the same `missing_field` diagnostic for non-string `openapi`, so users see a consistent error regardless of file format.

## Breaking

Authors who fed `openapi: 3.0` (unquoted YAML) get a `missing_field` rejection where they used to get a successful parse. Migration is mechanical — add quotes (`openapi: '3.0'`) or pin a three-segment patch (`openapi: 3.0.3`). Documented in CHANGELOG under `Breaking`.

Closes #583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * YAML OpenAPI specifications must now quote the version value (e.g., `openapi: '3.0'` instead of `openapi: 3.0`). Unquoted numeric versions are now rejected, aligning YAML parsing behavior with JSON.

* **Tests**
  * Updated test coverage for version string validation across quoted and unquoted values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/oaspec/pull/595)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->