### PR TITLE
fix(parser): reject duplicate keys in the top-level paths mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Fixed
 
+- **`parse_string` / `parse_json_string` now reject duplicate keys in
+  the top-level `paths` mapping.** yamerl tolerates duplicate YAML
+  mapping keys and silently keeps the last entry, so a document with
+  two `/users:` definitions would discard the earlier one without
+  warning. Path keys are URL templates that MUST be unique per OAS, so
+  the parser now surfaces a `duplicate_key` diagnostic naming the
+  offending path — same shape as the #573 fix on the responses
+  surface. (#584)
 - **`parse_string` / `parse_json_string` now reject `paths:` keys that
   do not match the OAS 3.0 §4.7.9.1 path-template grammar.** The walker
   forwarded any string to downstream codegen, which then emitted Gleam

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -752,6 +752,16 @@ fn parse_paths(
 ) -> Result(Dict(String, RefOr(PathItem(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: root, selector: "paths") {
     Ok(yay.NodeMap(entries)) -> {
+      // Path keys are URL templates that MUST be unique per OAS.
+      // yamerl silently keeps the last duplicate, so without this check
+      // the user's earlier definition disappears into undefined
+      // behaviour. Mirror of the #573 duplicate-key guard on the
+      // responses surface. (#584)
+      use _ <- result.try(check_unique_yaml_keys(
+        entries: entries,
+        path: "paths",
+        index: index,
+      ))
       list.try_fold(entries, dict.new(), fn(acc, entry) {
         let #(key_node, value_node) = entry
         case key_node {

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -36,6 +36,7 @@ pub fn parser_smoke_test() {
   let _ = support.parser_rejects_query_in_path_case()
   let _ = support.parser_rejects_fragment_in_path_case()
   let _ = support.parser_rejects_space_in_path_case()
+  let _ = support.parser_rejects_duplicate_path_key_case()
   let _ = support.parser_accepts_canonical_path_with_placeholder_case()
   let _ = support.parser_rejects_duplicate_components_response_name_case()
   let _ = support.parser_rejects_yaml_alias_without_anchor_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1145,6 +1145,25 @@ pub fn parser_rejects_space_in_path_case() {
   should.be_true(string.contains(d.message, "space"))
 }
 
+pub fn parser_rejects_duplicate_path_key_case() {
+  // Issue #584: yamerl silently keeps the last duplicate path entry,
+  // dropping the earlier one without warning. Per OAS, path keys are
+  // URL templates that MUST be unique. Same UX class as #573 but on
+  // the paths surface.
+  let yaml =
+    "openapi: 3.0.0\n"
+    <> "info:\n  title: x\n  version: '1.0'\n"
+    <> "paths:\n"
+    <> "  /a:\n    get:\n      summary: first\n      responses:\n"
+    <> "        '200':\n          description: ok\n"
+    <> "  /a:\n    get:\n      summary: dup\n      responses:\n"
+    <> "        '200':\n          description: ok\n"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("duplicate_key")
+  should.be_true(string.contains(d.message, "/a"))
+  should.be_true(string.contains(d.message, "paths"))
+}
+
 pub fn parser_accepts_canonical_path_with_placeholder_case() {
   // Sanity: the canonical happy path still parses. Placeholders with
   // letters / digits / underscores / hyphens are all allowed by


### PR DESCRIPTION
## Summary

yamerl tolerates duplicate YAML mapping keys and silently keeps the last entry. A document with two `/users:` definitions therefore parsed cleanly while the earlier definition disappeared. Path keys are URL templates that MUST be unique per OAS, so the silent drop is a bug — same UX class as the duplicate-response-status-code path #573 closed, but on a different surface.

## Changes

- `parse_paths` now runs `check_unique_yaml_keys/3` over the `paths` mapping before the `dict.insert` loop. The diagnostic comes through with code `duplicate_key`, names the offending path, and carries the source location of the `paths` field.
- One new test, `parser_rejects_duplicate_path_key_case`, pins the behaviour and is wired into `parser_special_cases_test`.

## Design Decisions

- **Reused the existing `check_unique_yaml_keys/3` helper** that #573 introduced for the responses surface. That helper already returns the right `Diagnostic` shape and there is no value in forking a second copy for paths.
- **Diagnostic source location is the `paths` field, not the duplicate-key line.** yamerl's mapping entries do not carry per-entry locations through this code path; future work could thread a per-entry index but it is out of scope here.

Closes #584
