### PR TITLE
fix(content_type): normalise case + strip parameters before classifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Fixed
 
+- **`content_type.from_string` / `is_json_compatible` /
+  `is_xml_compatible` now normalise the input before classification.**
+  Pre-fix the classifier used case-sensitive direct equality and did
+  not strip media-type parameters, so `application/JSON`,
+  `application/json; charset=utf-8`, `application/json;charset=utf-8`,
+  and `Application/XML` all classified as `UnsupportedContentType` —
+  the codegen then silently skipped JSON / XML decode-encode paths for
+  any endpoint declaring the parameterised form (and `Content-Type:
+  application/json; charset=utf-8` is what every mainstream framework
+  ships by default). The new `normalise/1` helper strips parameters
+  (`; charset=...`, `; q=...`) and lowercases the type/subtype tokens
+  per RFC 7231 §3.1.1.5 before the case-table lookup, so all four
+  shapes route to `ApplicationJson`/`ApplicationXml` as expected. The
+  in-memory `UnsupportedContentType` carrier still receives the
+  pre-normalised string of the fallback path; the wire-level
+  `Content-Type` header keeps the spec's original form because codegen
+  pulls the literal name from the spec, not from `to_string`. (#585)
 - **`parse_string` / `parse_json_string` now reject duplicate keys in
   the top-level `paths` mapping.** yamerl tolerates duplicate YAML
   mapping keys and silently keeps the last entry, so a document with

--- a/src/oaspec/internal/util/content_type.gleam
+++ b/src/oaspec/internal/util/content_type.gleam
@@ -48,8 +48,26 @@ pub type ContentType {
 /// the name from the spec, not from `to_string`), so the wire-level
 /// content type is preserved even though the in-memory typing falls
 /// back. This mirrors the existing `application/x-ndjson` aliasing.
+/// Strip media-type parameters and lowercase the type/subtype tokens
+/// so `application/JSON`, `application/json`, `application/json;
+/// charset=utf-8`, and `application/json;charset=utf-8` all normalise
+/// to `application/json` before classification. Per RFC 7231 §3.1.1.5
+/// the type and subtype tokens are case-insensitive, and §3.1.1.1
+/// excludes parameters from the type identity itself. The previous
+/// case-sensitive direct-equality lookup misclassified every real-world
+/// `application/json; charset=utf-8` declaration as
+/// `UnsupportedContentType`, which then skipped JSON codegen for the
+/// affected endpoints. (#585)
+fn normalise(content_type: String) -> String {
+  case string.split_once(content_type, ";") {
+    Ok(#(head, _)) -> string.trim(head)
+    Error(Nil) -> string.trim(content_type)
+  }
+  |> string.lowercase
+}
+
 pub fn from_string(content_type: String) -> ContentType {
-  case content_type {
+  case normalise(content_type) {
     "application/json" -> ApplicationJson
     "text/plain" -> TextPlain
     // application/x-ndjson (newline-delimited JSON) is widely deployed for
@@ -91,15 +109,22 @@ pub fn from_string(content_type: String) -> ContentType {
 }
 
 /// Check if a content type string is JSON-compatible.
-/// Matches "application/json" and any type with a "+json" suffix.
+/// Matches `application/json` and any type with a `+json` suffix, with
+/// the same case-insensitive and parameter-stripping normalisation
+/// `from_string` applies (#585).
 pub fn is_json_compatible(s: String) -> Bool {
-  s == "application/json" || string.ends_with(s, "+json")
+  let normalised = normalise(s)
+  normalised == "application/json" || string.ends_with(normalised, "+json")
 }
 
 /// Check if a content type string is XML-compatible.
-/// Matches "application/xml", "text/xml", and any type with a "+xml" suffix.
+/// Matches `application/xml`, `text/xml`, and any type with a `+xml`
+/// suffix, with the same normalisation as `is_json_compatible`. (#585)
 pub fn is_xml_compatible(s: String) -> Bool {
-  s == "application/xml" || s == "text/xml" || string.ends_with(s, "+xml")
+  let normalised = normalise(s)
+  normalised == "application/xml"
+  || normalised == "text/xml"
+  || string.ends_with(normalised, "+xml")
 }
 
 /// Convert a ContentType back to its string representation.

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -95,6 +95,12 @@ pub fn include_filter_test() {
 
 pub fn content_type_helpers_test() {
   let _ = support.content_type_from_string_case()
+  let _ = support.content_type_classifier_normalises_case_case()
+  let _ = support.content_type_classifier_strips_charset_parameter_case()
+  let _ =
+    support.content_type_classifier_preserves_structured_suffix_with_param_case()
+  let _ = support.content_type_is_json_compatible_normalised_case()
+  let _ = support.content_type_is_xml_compatible_normalised_case()
   let _ = support.content_type_x_ndjson_is_supported_response_case()
   let _ = support.content_type_text_html_aliases_to_text_plain_case()
   let _ = support.content_type_text_x_markdown_aliases_to_text_plain_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -3474,6 +3474,53 @@ pub fn content_type_from_string_case() {
   |> should.equal(content_type.TextPlain)
 }
 
+// Issue #585: content-type strings carry case-insensitive type/subtype
+// tokens (RFC 7231 §3.1.1.5) and parameters (`; charset=utf-8`) that
+// are NOT part of the type identity. The pre-fix classifier did
+// case-sensitive direct equality and never stripped parameters, so
+// `application/JSON` and `application/json; charset=utf-8` were both
+// misclassified as `UnsupportedContentType`. The cases below pin each
+// shape from the issue.
+
+pub fn content_type_classifier_normalises_case_case() {
+  content_type.from_string("application/JSON")
+  |> should.equal(content_type.ApplicationJson)
+  content_type.from_string("Application/XML")
+  |> should.equal(content_type.ApplicationXml)
+}
+
+pub fn content_type_classifier_strips_charset_parameter_case() {
+  content_type.from_string("application/json; charset=utf-8")
+  |> should.equal(content_type.ApplicationJson)
+  content_type.from_string("application/json;charset=utf-8")
+  |> should.equal(content_type.ApplicationJson)
+  content_type.from_string("application/xml; charset=utf-8")
+  |> should.equal(content_type.ApplicationXml)
+}
+
+pub fn content_type_classifier_preserves_structured_suffix_with_param_case() {
+  content_type.from_string("application/vnd.api+json; charset=utf-8")
+  |> should.equal(content_type.ApplicationJson)
+  content_type.from_string("application/vnd.api+xml; q=1.0")
+  |> should.equal(content_type.ApplicationXml)
+}
+
+pub fn content_type_is_json_compatible_normalised_case() {
+  content_type.is_json_compatible("application/JSON") |> should.be_true()
+  content_type.is_json_compatible("application/json; charset=utf-8")
+  |> should.be_true()
+  content_type.is_json_compatible("application/vnd.api+json; charset=utf-8")
+  |> should.be_true()
+}
+
+pub fn content_type_is_xml_compatible_normalised_case() {
+  content_type.is_xml_compatible("Application/XML") |> should.be_true()
+  content_type.is_xml_compatible("text/XML; charset=utf-8")
+  |> should.be_true()
+  content_type.is_xml_compatible("application/atom+xml; charset=utf-8")
+  |> should.be_true()
+}
+
 pub fn content_type_x_ndjson_is_supported_response_case() {
   content_type.is_supported_response(content_type.from_string(
     "application/x-ndjson",


### PR DESCRIPTION
## Summary

`content_type.from_string` used case-sensitive direct equality and never stripped media-type parameters, so `application/JSON`, `application/json; charset=utf-8`, `application/json;charset=utf-8`, and `Application/XML` all returned `UnsupportedContentType`. The codegen then silently skipped JSON / XML decode-encode paths for the endpoints declaring those forms — and `Content-Type: application/json; charset=utf-8` is what virtually every mainstream framework ships by default, so this is the difference between "your generated client works" and "your generated client emits raw bytes for every JSON response."

## Changes

- New private `normalise/1` helper in `src/oaspec/internal/util/content_type.gleam` strips everything from the first `;` onward, trims surrounding whitespace, and lowercases the result. RFC 7231 §3.1.1.5 says the type/subtype tokens are case-insensitive; §3.1.1.1 puts parameters outside the type identity.
- `from_string`, `is_json_compatible`, and `is_xml_compatible` all route through `normalise/1` before the case-table lookup. The `+json` / `+xml` structured-suffix branches and the `text/` / `application/` fallback branches now see the normalised string too, so `application/vnd.api+json; charset=utf-8` continues to alias to `ApplicationJson` and `text/HTML` to `TextPlain`.
- Five new tests in `test/oaspec_support.gleam` pin the cases from the issue (`application/JSON`, `application/json; charset=utf-8`, `application/xml; charset=utf-8`, `application/vnd.api+json; charset=utf-8`, `Application/XML`) plus the structured-suffix-with-parameter variant. Wired into `content_type_helpers_test`.

## Design Decisions

- **`UnsupportedContentType` carries the normalised string**, not the original. The Issue's existing rationale notes that the wire-level `Content-Type` header is sourced from the spec text (codegen reads the literal media-type name, not `to_string`-of-classification), so losing the parameters in the in-memory representation is harmless. Keeping the normalised string makes equality comparisons across the codebase consistent.
- **Did not introduce a public `normalise` export.** The downstream callers want the classification result, not the normalised string; adding a public helper invites callers to skip the case-table lookup and re-implement it badly.
- **Did not touch the `is_supported*` / `to_string` surface.** Those operate on `ContentType` values, not raw strings; normalisation has already happened by the time they see anything.

## Limitations

- The `q=` and `format=` parameters are stripped entirely. A future content-negotiation feature might want to read them, but it would also want a typed `MediaType` record rather than the current `String` shape.

Closes #585


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content-Type header classification now properly normalizes and recognizes media types regardless of case sensitivity (e.g., `application/JSON` vs `application/json`) and correctly ignores character encoding parameters like `charset=utf-8` during classification. This resolves previous misclassification issues where parameterized Content-Type headers were incorrectly identified as unsupported.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/oaspec/pull/599)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->