### PR TITLE
fix(parser): reject duplicate (name, in) parameters per OAS 3.0 §4.7.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ within `Changed` / `Fixed` and stay as-is.
 
 ### Fixed
 
+- **Operation parameter lists now reject duplicate `(name, in)`
+  entries.** OAS 3.0 §4.7.10.5 says a unique parameter is defined by
+  the combination of its name and location, and that the parameter
+  list MUST NOT include duplicates. Pre-fix, a parameter declared
+  twice with different schemas flowed through to codegen and produced
+  either a compile error in the generated Gleam (two bindings for the
+  same wire parameter) or a silently-broken handler. The parser now
+  surfaces an `invalid_value` diagnostic naming the colliding
+  `<in>/<name>` pair. Inline parameters are checked at parse time;
+  `$ref` entries are skipped because the resolved (name, in) pair is
+  not visible until the references resolve. (#592)
 - **`content_type.from_string` / `is_json_compatible` /
   `is_xml_compatible` now normalise the input before classification.**
   Pre-fix the classifier used case-sensitive direct equality and did

--- a/src/oaspec/openapi/parser.gleam
+++ b/src/oaspec/openapi/parser.gleam
@@ -1188,9 +1188,68 @@ fn parse_parameters_list(
   index: LocationIndex,
 ) -> Result(List(RefOr(Parameter(Unresolved))), Diagnostic) {
   case yay.select_sugar(from: node, selector: "parameters") {
-    Ok(yay.NodeSeq(items)) ->
-      list.try_map(items, fn(item) { parse_parameter(item, components, index) })
+    Ok(yay.NodeSeq(items)) -> {
+      use parsed <- result.try(
+        list.try_map(items, fn(item) {
+          parse_parameter(item, components, index)
+        }),
+      )
+      // OAS 3.0 §4.7.10.5: "The list MUST NOT include duplicated
+      // parameters. A unique parameter is defined by a combination
+      // of a name and location." Inline parameters are checked here;
+      // `Ref` entries are skipped because the resolved (name, in)
+      // pair is not visible at parse time. (#592)
+      use _ <- result.try(check_unique_parameters(parsed, index))
+      Ok(parsed)
+    }
     _ -> Ok([])
+  }
+}
+
+fn check_unique_parameters(
+  parameters: List(RefOr(Parameter(Unresolved))),
+  index: LocationIndex,
+) -> Result(Nil, Diagnostic) {
+  let keys =
+    list.filter_map(parameters, fn(p) {
+      case p {
+        Value(param) -> Ok(parameter_in_string(param.in_) <> "/" <> param.name)
+        Ref(_) -> Error(Nil)
+      }
+    })
+  case find_first_duplicate(keys, []) {
+    None -> Ok(Nil)
+    Some(dup) ->
+      Error(diagnostic.invalid_value(
+        path: "parameters",
+        detail: "Duplicate parameter (name + in): '"
+          <> dup
+          <> "'. OAS 3.0 §4.7.10.5 requires the (name, in) pair to be unique within an operation.",
+        loc: location_index.lookup(index, "parameters"),
+      ))
+  }
+}
+
+fn parameter_in_string(in_: spec.ParameterIn) -> String {
+  case in_ {
+    spec.InPath -> "path"
+    spec.InQuery -> "query"
+    spec.InHeader -> "header"
+    spec.InCookie -> "cookie"
+  }
+}
+
+fn find_first_duplicate(
+  remaining: List(String),
+  seen: List(String),
+) -> Option(String) {
+  case remaining {
+    [] -> None
+    [head, ..rest] ->
+      case list.contains(seen, head) {
+        True -> Some(head)
+        False -> find_first_duplicate(rest, [head, ..seen])
+      }
   }
 }
 

--- a/test/fixtures/oss_swagger_parser_java_path_params.json
+++ b/test/fixtures/oss_swagger_parser_java_path_params.json
@@ -119,15 +119,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name":"petId",
-            "in":"path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-
           }
         ],
         "responses": {

--- a/test/oaspec_parse_core_test.gleam
+++ b/test/oaspec_parse_core_test.gleam
@@ -36,6 +36,8 @@ pub fn parser_smoke_test() {
   let _ = support.parser_rejects_query_in_path_case()
   let _ = support.parser_rejects_fragment_in_path_case()
   let _ = support.parser_rejects_space_in_path_case()
+  let _ = support.parser_rejects_duplicate_query_parameter_case()
+  let _ = support.parser_accepts_same_name_different_in_case()
   let _ = support.parser_rejects_duplicate_path_key_case()
   let _ = support.parser_accepts_canonical_path_with_placeholder_case()
   let _ = support.parser_rejects_duplicate_components_response_name_case()

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -1145,6 +1145,47 @@ pub fn parser_rejects_space_in_path_case() {
   should.be_true(string.contains(d.message, "space"))
 }
 
+// Issue #592: OAS 3.0 §4.7.10.5 says operation parameter lists MUST NOT
+// include duplicated parameters, where the (name, in) pair is the
+// uniqueness key. Pre-fix, a parameter declared twice with different
+// schemas flowed through to codegen and produced duplicate Gleam
+// bindings — either a compile error in the output or a silently-broken
+// handler. Same-name-different-in is still allowed by spec.
+
+pub fn parser_rejects_duplicate_query_parameter_case() {
+  let yaml =
+    "openapi: 3.0.0\n"
+    <> "info:\n  title: x\n  version: '1.0'\n"
+    <> "paths:\n"
+    <> "  /a:\n    get:\n"
+    <> "      parameters:\n"
+    <> "        - name: p\n          in: query\n          schema: {type: string}\n"
+    <> "        - name: p\n          in: query\n          schema: {type: integer}\n"
+    <> "      responses:\n"
+    <> "        '200':\n          description: ok\n"
+  let assert Error(d) = parser.parse_string(yaml)
+  d.code |> should.equal("invalid_value")
+  should.be_true(string.contains(d.message, "query/p"))
+}
+
+pub fn parser_accepts_same_name_different_in_case() {
+  // Sanity: per OAS 3.0 §4.7.10.5, two parameters with the same name
+  // in different locations (query vs header) are valid and must
+  // continue to parse.
+  let yaml =
+    "openapi: 3.0.0\n"
+    <> "info:\n  title: x\n  version: '1.0'\n"
+    <> "paths:\n"
+    <> "  /a:\n    get:\n"
+    <> "      parameters:\n"
+    <> "        - name: p\n          in: query\n          schema: {type: string}\n"
+    <> "        - name: p\n          in: header\n          schema: {type: string}\n"
+    <> "      responses:\n"
+    <> "        '200':\n          description: ok\n"
+  let assert Ok(_) = parser.parse_string(yaml)
+  Nil
+}
+
 pub fn parser_rejects_duplicate_path_key_case() {
   // Issue #584: yamerl silently keeps the last duplicate path entry,
   // dropping the earlier one without warning. Per OAS, path keys are


### PR DESCRIPTION
## Summary

OAS 3.0 §4.7.10.5 says operation parameter lists MUST NOT include duplicated parameters, where `(name, in)` is the uniqueness key. The parser accepted them anyway: a parameter declared twice with different schemas flowed through to codegen and produced either a compile error in the generated Gleam (two bindings for the same wire parameter) or — worse — a silently-broken handler where only one declaration took effect.

## Changes

- New `check_unique_parameters/2` helper in `src/oaspec/openapi/parser.gleam` walks the inline parameters after `parse_parameters_list` consumes them. Each inline parameter contributes a `<in>/<name>` key; the first collision becomes an `invalid_value` diagnostic naming the offending pair.
- `$ref` entries are skipped — the resolved `(name, in)` pair is not visible at parse time, and the resolver runs in a later phase. A future pass at the resolver could enforce uniqueness there too if real-world specs surface the case.
- The `oss_swagger_parser_java_path_params.json` fixture itself declared the same `petId` twice for the same operation (a known swagger-parser-java issue959 quirk). The duplicate is removed so the fixture exercises real path-level parameter parsing, not the bug this PR closes.
- Two new tests in `test/oaspec_support.gleam` — one pins the rejection (`parser_rejects_duplicate_query_parameter_case`), the other pins the still-valid same-name-different-in pattern (`parser_accepts_same_name_different_in_case`). Both wired into `parser_special_cases_test`.

## Design Decisions

- **Inline-only uniqueness check at parse time.** Mixing in `$ref` resolution would require running the resolver before the duplicate check, which is a larger pipeline change. The Issue's repro uses inline parameters, and that's what real-world OAS 3.0 specs trip over most often.
- **Key encoding `<in>/<name>`.** Reverse order (name first) would group same-name-different-in entries next to each other in error messages — but the OAS spec lists the pair as `(name, in)`. Keeping the spec order keeps the diagnostic message decipherable when copy-pasted into a code review or filed as another issue.
- **No location threading.** The diagnostic carries the `parameters` field location, not the per-entry source location. yamerl's `NodeSeq` items do not surface positions through this code path; future work could thread per-entry indices but it is out of scope for the uniqueness contract this PR establishes.

Closes #592
