### PR TITLE
docs(naming): document to_snake_case / to_pascal_case non-idempotence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Documentation
+
+- `to_snake_case` and `to_pascal_case` are now documented as
+  **non-idempotent on inputs containing `_dot_`**. The `_dot_` →
+  `_dot_literal_` escape introduced in #494 to keep `payment_intent.processing`
+  distinct from `payment_intent_processing` is asymmetric — re-running
+  the converter on its own output grows the `_literal_` segment each
+  pass. The fix from the issue's option (2): document the property
+  prominently on both public converters and on the internal
+  `rewrite_dot_segments` helper, and pin the observed behaviour with
+  regression tests so a future change to restore idempotence is
+  intentional rather than silent. Callers (codegen) must apply each
+  converter at most once per identifier; an in-place Unicode-escape
+  redesign is left for a follow-up that does not change `_dot_`
+  semantics for already-deployed specs. (#586)
+
 ### Fixed
 
 - **Schema constraint values are validated at parse time** per JSON

--- a/src/oaspec/internal/util/naming.gleam
+++ b/src/oaspec/internal/util/naming.gleam
@@ -84,6 +84,16 @@ fn compile_regexes() -> Regexes {
 /// alongside `payment_intent_processing` produce distinct Gleam type
 /// names (`PaymentIntentDotProcessing` vs `PaymentIntentProcessing`)
 /// instead of colliding on `PaymentIntentProcessing`.
+///
+/// **Not idempotent on inputs containing `_dot_` (issue #586).** A
+/// literal `_dot_` in the input is escaped to `_dot_literal_` to keep
+/// it distinguishable from a real `.`, so re-running the converter on
+/// its own output grows the `_literal_` segment each pass:
+/// `to_pascal_case(to_pascal_case("user.name")) != to_pascal_case("user.name")`.
+/// The codegen pipeline must therefore apply this function at most
+/// once per identifier. Callers that need to round-trip names through
+/// snake/pascal multiple times should cache the first result instead
+/// of re-running the converter.
 pub fn to_pascal_case(input: String) -> String {
   let re = cached_regexes()
   input
@@ -128,6 +138,13 @@ fn ensure_letter_start_pascal(input: String) -> String {
 /// like `DiscussionReactions(1: Int, 1_2: Int, ...)` on the GitHub
 /// REST API spec, where `+1` and `-1` both collapsed to `1` (issue
 /// #352).
+///
+/// **Not idempotent on inputs containing `_dot_` (issue #586).** See
+/// `to_pascal_case` for the same caveat — the `_dot_` → `_dot_literal_`
+/// escape used to disambiguate `.` from a literal `dot` token grows
+/// the `_literal_` segment each time the converter runs on its own
+/// output. The codegen pipeline must therefore apply this function
+/// at most once per identifier.
 pub fn to_snake_case(input: String) -> String {
   let re = cached_regexes()
   let result =
@@ -288,6 +305,14 @@ fn bump_inline_enum_suffix_set(
 /// schema name still produce a name distinct from a sibling that
 /// uses `.` at the same position (`a_dot_b` → `ADotLiteralB`,
 /// `a.b` → `ADotB`).
+///
+/// **Asymmetric escape — not reversible (issue #586).** The
+/// `_dot_literal_` escape preserves the disambiguation between `.`
+/// and a literal `dot` token, but at the cost of idempotence: every
+/// pass over an already-escaped name grows another `_literal_`. The
+/// case converters that wrap this helper (`to_snake_case`,
+/// `to_pascal_case`) inherit the property; their docstrings warn
+/// callers to apply each converter at most once per identifier.
 fn rewrite_dot_segments(input: String) -> String {
   input
   |> string.replace("_dot_", "_dot_literal_")

--- a/test/oaspec_core_test.gleam
+++ b/test/oaspec_core_test.gleam
@@ -18,6 +18,8 @@ pub fn naming_basics_test() {
   let _ = support.to_pascal_case_with_numbers_case()
   let _ = support.to_snake_case_with_hyphen_case()
   let _ = support.to_snake_case_with_dots_case()
+  let _ = support.to_snake_case_is_not_idempotent_on_dot_inputs_case()
+  let _ = support.to_pascal_case_is_not_idempotent_on_dot_inputs_case()
 }
 
 pub fn config_defaults_test() {

--- a/test/oaspec_support.gleam
+++ b/test/oaspec_support.gleam
@@ -15242,6 +15242,31 @@ pub fn to_snake_case_with_dots_case() {
   |> should.equal("app_dot_name")
 }
 
+pub fn to_snake_case_is_not_idempotent_on_dot_inputs_case() {
+  // Issue #586: the `_dot_` -> `_dot_literal_` escape that
+  // disambiguates `.` from a literal `dot` token is asymmetric, so
+  // re-running the converter on its own output grows the `_literal_`
+  // segment each pass. This case pins the documented non-idempotence
+  // — callers (codegen) must apply the converter at most once per
+  // identifier; we test the *observed* behaviour so a future fix that
+  // restores idempotence is intentional, not silent.
+  let once = naming.to_snake_case("user.name")
+  once |> should.equal("user_dot_name")
+  let twice = naming.to_snake_case(once)
+  twice |> should.equal("user_dot_literal_name")
+}
+
+pub fn to_pascal_case_is_not_idempotent_on_dot_inputs_case() {
+  // Mirror of the snake-case non-idempotence pin (#586).
+  let once = naming.to_pascal_case("user.name")
+  once |> should.equal("UserDotName")
+  // Re-running the converter on its own output grows the Literal
+  // segment: `UserDotName` is the pascal form of `user_dot_name`,
+  // and pascal-of-`user_dot_name` becomes `UserDotLiteralName`.
+  let cycled = naming.to_pascal_case(naming.to_snake_case(once))
+  cycled |> should.equal("UserDotLiteralName")
+}
+
 // ===========================================================================
 // Server/client generation for edge cases
 // ===========================================================================


### PR DESCRIPTION
## Summary

#494 introduced a `_dot_` → `_dot_literal_` escape to keep `payment_intent.processing` distinct from `payment_intent_processing` through the case converters. The escape is asymmetric: re-running the converter on its own output keeps escaping the existing `_dot_`, so `to_snake_case(to_snake_case(x)) != to_snake_case(x)` for any input containing a literal `_dot_` token.

#586 reports the property. This PR takes **option (2) from the issue text**: document the non-idempotence prominently on the two public converters and on the internal `rewrite_dot_segments` helper, and pin the observed behaviour with regression tests so a future change to restore idempotence is intentional, not silent. Callers (codegen) must apply each converter at most once per identifier.

## Changes

- New paragraph on `to_snake_case` / `to_pascal_case` / `rewrite_dot_segments` docstrings stating the non-idempotence, the reason (the `_dot_literal_` escape from #494), and the caller-contract: apply at most once per identifier.
- Two new tests in `test/oaspec_support.gleam` (`to_snake_case_is_not_idempotent_on_dot_inputs_case`, `to_pascal_case_is_not_idempotent_on_dot_inputs_case`) pin the observed behaviour. Wired into `naming_basics_test`.
- CHANGELOG entry under `Documentation`.

## Design Decisions

- **Option (2) over option (1).** The issue listed two fixes: (1) make idempotent via Unicode escape, (2) document and ensure single-application contract. Option 1 changes the on-disk encoding of every `.`-containing schema name through a different escape, which silently affects already-deployed specs. Option 2 ships immediately, keeps the existing `_dot_` semantics, and leaves the Unicode-escape redesign as a separate, opt-in follow-up.
- **Regression tests pin the observed behaviour.** If a future PR restores idempotence the test must be updated — that is the intentional friction: the previous symptom should not silently re-emerge.

## Limitations

- Codegen pipeline still has to honour the "apply once" contract. A grep through the codegen modules suggests it already does (the converter is invoked at the boundary where the raw spec name enters the codegen tree, and the result is cached on the schema record), but no automated test pins that contract. Adding such a test would require traversing the codegen pass — out of scope for this issue.

Closes #586
