### PR TITLE
docs(readme): add a library-only usage section to the quick-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Documentation
+
+- README quick-start now includes a "Using oaspec as a library (without the CLI)" subsection with a runnable end-to-end snippet built on `oaspec/openapi/parser.parse_string` and `parser.parse_error_to_string`. The CLI quick-start above stays — the new section is the companion path for callers who want a runtime validate / inspect step from in-process Gleam code without installing the escript or wiring `oaspec.yaml`. (#609)
+
 ## [0.65.0] - 2026-05-11
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -96,6 +96,38 @@ the current working directory when `oaspec` runs, not the config file
 location. See [doc/configuration.md](./doc/configuration.md) for the
 full set of fields, CLI flags, multi-target codegen, and validate mode.
 
+### Using oaspec as a library (without the CLI)
+
+If you only want to load and inspect a spec — no codegen, no `oaspec.yaml`,
+no escript install — call `oaspec/openapi/parser.parse_string` directly
+from your Gleam code. The function returns
+`Result(OpenApiSpec(Unresolved), Diagnostic)`; render the diagnostic with
+`parser.parse_error_to_string` for human-readable output.
+
+```gleam
+import gleam/io
+import oaspec/openapi/parser
+
+pub fn main() {
+  let spec_yaml =
+    "openapi: \"3.0.3\"\n"
+    <> "info:\n"
+    <> "  title: Demo\n"
+    <> "  version: \"1.0.0\"\n"
+    <> "paths: {}\n"
+
+  case parser.parse_string(spec_yaml) {
+    Ok(_spec) -> io.println("parsed OK")
+    Error(diagnostic) -> io.println(parser.parse_error_to_string(diagnostic))
+  }
+}
+```
+
+Use this path when you want a runtime validate / inspect step (for
+example, validating a spec uploaded via an HTTP endpoint). Reach for the
+CLI quick-start above when you want generated client / server / schema
+modules committed to your repository.
+
 ## Generated files
 
 Given one OpenAPI spec, `oaspec` writes modules you can keep in your


### PR DESCRIPTION
## Summary

Adds a "Using oaspec as a library (without the CLI)" subsection to the README quick-start with a runnable end-to-end snippet built on `oaspec/openapi/parser.parse_string`. The CLI path is the only one signposted today; the library-only path — calling `parse_string` from in-process Gleam code for a validate or inspect step — is invisible to a reader who doesn't already know to look in `src/oaspec/openapi/parser.gleam`.

## Changes

- `README.md`: insert a `### Using oaspec as a library (without the CLI)` subsection between the CLI quick-start and `## Generated files`. The snippet calls `parser.parse_string` with a literal `"openapi: ..."` YAML, branches on the `Result`, and renders the diagnostic via `parser.parse_error_to_string` — the same error-rendering function the CLI uses, so library callers stay aligned with the CLI's wording. Two short sentences below the snippet contrast "I want a runtime validate / inspect step" (this path) with "I want generated client / server / schema modules" (the existing CLI path) so a reader picks the right entry point on first contact.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Documentation` describing the new section.

## Design Decisions

The snippet uses `parse_string/1` (single-argument YAML entry point) rather than `parse_string_with_locations` or `parse_json_string`. The first call any library caller makes is "parse YAML and tell me if it's an OpenAPI spec" — `parse_string` is the smallest match for that question, and the doc-comment above the function already cross-references `parse_json_string` for JSON callers. Showing the simplest entry point keeps the README screen-readable; readers who need richer shapes (locations, JSON auto-route, DoS limits) find them in the parser module's doc page.

The new section lives inside `## Quickstart` rather than as a standalone top-level section. A reader scanning the table of contents now sees "Quickstart → CLI / library" instead of two separate entry points, which mirrors how downstream callers actually pick: one or the other, not both.

## Test plan

- [x] README renders correctly on GitHub (one-screen-tall snippet, no broken anchors)
- [x] Snippet matches the actual `parse_string/1` signature in `src/oaspec/openapi/parser.gleam:275`
- [x] `parse_error_to_string` exists at `src/oaspec/openapi/parser.gleam:2388` and is `pub`

Closes #609
