### PR TITLE
fix(ffi): replace deprecated catch with try/catch to silence OTP warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ within `Changed` / `Fixed` and stay as-is.
 
 ## [Unreleased]
 
+### Fixed
+
+- `oaspec_ffi`: replaced the deprecated `catch port_close(Port)` form with `try port_close(Port) catch _:_ -> ok end`. The old expression form of `catch` is deprecated in recent OTP releases and emitted a `'catch ...' is deprecated; please use 'try ... catch ... end' instead` warning at every `gleam build` of any project that depends on `oaspec`. The new form preserves the original intent (swallow any error when closing an already-closed port). (#612)
+
 ## [0.66.0] - 2026-05-16
 
 ### Documentation

--- a/src/oaspec_ffi.erl
+++ b/src/oaspec_ffi.erl
@@ -33,7 +33,7 @@ collect_exit(Port) ->
         {Port, {exit_status, Code}} ->
             Code
     after 60000 ->
-        catch port_close(Port),
+        try port_close(Port) catch _:_ -> ok end,
         1
     end.
 


### PR DESCRIPTION
## Summary

`oaspec_ffi:collect_exit/1` used the old `catch Expr` expression form to swallow errors from `port_close/1` on the timeout path. Recent OTP releases deprecated that form and emit a `'catch ...' is deprecated; please use 'try ... catch ... end' instead` warning on every `gleam build` of any project that depends on `oaspec`. This PR rewrites the line to the recommended `try ... catch _:_ -> ok end` form, which preserves the original intent (the port may already have closed via its own exit, in which case `port_close/1` raises and we just want to move on) without using the deprecated syntax.

## Changes

- [src/oaspec_ffi.erl](src/oaspec_ffi.erl) `catch port_close(Port)` replaced with `try port_close(Port) catch _:_ -> ok end` inside the `after` clause of `collect_exit/1`.
- [CHANGELOG.md](CHANGELOG.md) Unreleased Fixed entry.

## Design Decisions

The catch pattern is `_:_` (any class, any reason) rather than the narrower `error:badarg`, because the historical `catch Expr` form swallows everything the old form did — exits, throws, errors. Narrowing the catch would be a behaviour change for callers that today rely on no exception reaching them from a closed port. The `ok` arm intentionally returns `ok` (rather than `Port` or `'undefined'`) because the surrounding code discards the value and immediately returns `1` from `collect_exit/1`.

Closes #612